### PR TITLE
feat(config): registry-contributed binding + renderer schemas (#1789)

### DIFF
--- a/src/adapters/__tests__/registry.test.ts
+++ b/src/adapters/__tests__/registry.test.ts
@@ -13,11 +13,15 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
 import {
   SurfacePluginRegistry,
   createDefaultSurfacePluginRegistry,
   registryFromFactory,
   registryToLegacyFactory,
+  validateSurfacesAgainstRegistry,
+  resolveAdapterPluginOrThrow,
+  resolveRendererPluginOrThrow,
   type AdapterPlugin,
   type RendererPlugin,
 } from "../registry";
@@ -25,13 +29,18 @@ import { discordAdapterPlugin } from "../discord/plugin";
 import { slackAdapterPlugin } from "../slack/plugin";
 import { mattermostAdapterPlugin } from "../mattermost/plugin";
 import { webAdapterPlugin } from "../web/plugin";
+import type { Surfaces } from "../../common/types/surfaces";
 
+// cortex#1789 (S4) — `bindingSchema`/`configSchema` are real `z.ZodType`s
+// now, not inert `unknown` placeholders; stubs use a permissive `z.unknown()`
+// since these tests exercise registry primitives, not schema validation.
 function makeStubAdapterPlugin(id: string): AdapterPlugin {
   return {
     kind: "adapter",
     id,
     platform: id,
-    bindingSchema: undefined,
+    bindingSchema: z.unknown(),
+    foldsIntoPresence: false,
     secretFields: [],
     demuxKey: () => id,
     buildGatewayConstructArgs: (_group, base) => ({ instanceId: base.instanceId }),
@@ -46,7 +55,7 @@ function makeStubRendererPlugin(id: string): RendererPlugin {
     kind: "renderer",
     id,
     rendererKind: id,
-    configSchema: undefined,
+    configSchema: z.unknown(),
     createRenderer: () => {
       throw new Error("stub — never constructed in this test");
     },
@@ -204,5 +213,110 @@ describe("registryFromFactory / registryToLegacyFactory — round trip", () => {
     factory.mattermost({});
     factory.web({});
     expect(calls).toEqual(["discord", "slack", "mattermost", "web"]);
+  });
+});
+
+// =============================================================================
+// cortex#1789 (S4, ADR-0024 D5) — registry-pass validation
+// =============================================================================
+
+describe("in-tree AdapterPlugin descriptors — foldsIntoPresence (ADR-0024 D5 scope item 3)", () => {
+  test("discord/slack/mattermost fold into agents[*].presence.{platform}", () => {
+    expect(discordAdapterPlugin.foldsIntoPresence).toBe(true);
+    expect(slackAdapterPlugin.foldsIntoPresence).toBe(true);
+    expect(mattermostAdapterPlugin.foldsIntoPresence).toBe(true);
+  });
+
+  test("web does NOT fold — preserved exactly (no legacy web presence shape)", () => {
+    expect(webAdapterPlugin.foldsIntoPresence).toBe(false);
+  });
+});
+
+describe("resolveAdapterPluginOrThrow", () => {
+  test("resolves an installed platform", () => {
+    const registry = createDefaultSurfacePluginRegistry();
+    expect(resolveAdapterPluginOrThrow("discord", registry)).toBe(discordAdapterPlugin);
+  });
+
+  test("unknown platform throws, naming the key and the installed set", () => {
+    const registry = createDefaultSurfacePluginRegistry();
+    expect(() => resolveAdapterPluginOrThrow("discrod", registry)).toThrow(
+      /no adapter installed for platform "discrod".*installed: discord, mattermost, slack, web/,
+    );
+  });
+});
+
+describe("resolveRendererPluginOrThrow", () => {
+  test("resolves an installed renderer kind", () => {
+    const registry = createDefaultSurfacePluginRegistry();
+    expect(resolveRendererPluginOrThrow("pagerduty", registry).id).toBe("pagerduty");
+  });
+
+  test("unregistered kind (cli-tail — S6 territory) throws, naming the kind and the installed set", () => {
+    const registry = createDefaultSurfacePluginRegistry();
+    expect(() => resolveRendererPluginOrThrow("cli-tail", registry)).toThrow(
+      /no renderer installed for kind "cli-tail".*installed: dashboard, pagerduty/,
+    );
+  });
+});
+
+describe("validateSurfacesAgainstRegistry", () => {
+  const registry = createDefaultSurfacePluginRegistry();
+
+  test("undefined surfaces is a no-op", () => {
+    expect(() => validateSurfacesAgainstRegistry(undefined, registry)).not.toThrow();
+  });
+
+  test("a valid discord binding passes", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "ivy",
+          binding: { token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" },
+        },
+      ],
+    };
+    expect(() => validateSurfacesAgainstRegistry(surfaces, registry)).not.toThrow();
+  });
+
+  test("an unknown top-level platform key throws — same loudness as the old .strict()", () => {
+    // The STRUCTURAL schema (`SurfacesSchema`) no longer rejects this key on
+    // its own (cortex#1789 catchall change) — this is the seam that now does.
+    const surfaces = { discrod: [{ agent: "ivy", binding: {} }] } as unknown as Surfaces;
+    expect(() => validateSurfacesAgainstRegistry(surfaces, registry)).toThrow(
+      /no adapter installed for platform "discrod"/,
+    );
+  });
+
+  test("a structurally-valid but field-invalid discord binding throws, and never echoes the secret", () => {
+    // Deliberately WRONG TYPE on `token` (a number, not a string) — a cast
+    // is needed since `Surfaces["discord"]` is strongly typed
+    // (DiscordSurfaceBinding) and would reject this at compile time; this
+    // simulates a raw value that has already cleared the STRUCTURAL pass
+    // (any record satisfies `binding: z.record(...)`) but not the REGISTRY
+    // pass this test exercises. NOTE: `guildId`/`agentChannelId`/
+    // `logChannelId` use `z.coerce.string()` on `DiscordBindingSchema` — an
+    // absent value coerces to the (non-empty!) string `"undefined"` rather
+    // than failing requiredness, so a MISSING field doesn't reliably fail
+    // here; `token` (plain `z.string()`, no coerce) is the reliable failure
+    // trigger, and its would-be-secret value (a number, so certainly not the
+    // real secret string) lets this test also confirm the thrown message
+    // never echoes the offending value.
+    const surfaces = {
+      discord: [
+        {
+          agent: "ivy",
+          binding: { token: 999999, guildId: "1", agentChannelId: "2", logChannelId: "3" },
+        },
+      ],
+    } as unknown as Surfaces;
+    expect(() => validateSurfacesAgainstRegistry(surfaces, registry)).toThrow(
+      /surfaces\.discord\[0\]\.binding is invalid/,
+    );
+    try {
+      validateSurfacesAgainstRegistry(surfaces, registry);
+    } catch (err) {
+      expect(err instanceof Error ? err.message : String(err)).not.toContain("999999");
+    }
   });
 });

--- a/src/adapters/discord/plugin.ts
+++ b/src/adapters/discord/plugin.ts
@@ -19,6 +19,7 @@ import {
   type DiscordPresence,
   type Agent,
 } from "../../common/types/cortex-config";
+import { DiscordBindingSchema } from "../../common/types/surfaces";
 import type { SystemEventSource } from "../../bus/system-events";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
@@ -57,9 +58,16 @@ export const discordAdapterPlugin: AdapterPlugin = {
   kind: "adapter",
   id: "discord",
   platform: "discord",
-  // Nearest available schema — S4 decides whether SurfacesSchema composes
-  // from this or a dedicated looser binding schema. Inert in this slice.
-  bindingSchema: DiscordPresenceSchema,
+  // cortex#1789 (S4) — `DiscordBindingSchema`, NOT `DiscordPresenceSchema`:
+  // this is the EXACT schema `surfaces.discord[].binding` validated pre-S4
+  // (`DiscordSurfaceBindingSchema` in `common/types/surfaces.ts`), so the
+  // registry pass is byte-identical to the old `.strict()`-object validation.
+  // `DiscordPresenceSchema` (the fuller presence shape) stays in use below,
+  // in `buildGatewayConstructArgs`, for the separate gateway-path parse.
+  bindingSchema: DiscordBindingSchema,
+  // Discord/Slack/Mattermost fold into `agents[*].presence.{platform}` at
+  // config-compose time (legacy inline-presence shape exists to fold into).
+  foldsIntoPresence: true,
   secretFields: ["token"],
   // Used only as the ungrouped-fallback demux key; `groupBindings` below
   // always runs for discord, so this is a spec-completeness fallback, not a

--- a/src/adapters/mattermost/plugin.ts
+++ b/src/adapters/mattermost/plugin.ts
@@ -13,6 +13,7 @@ import {
   type MattermostPresence,
   type Agent,
 } from "../../common/types/cortex-config";
+import { MattermostBindingSchema } from "../../common/types/surfaces";
 import type { SystemEventSource } from "../../bus/system-events";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
@@ -38,7 +39,12 @@ export const mattermostAdapterPlugin: AdapterPlugin = {
   kind: "adapter",
   id: "mattermost",
   platform: "mattermost",
-  bindingSchema: MattermostPresenceSchema,
+  // cortex#1789 (S4) — `MattermostBindingSchema`, the exact schema
+  // `surfaces.mattermost[].binding` validated pre-S4 (see discord/plugin.ts's
+  // comment for the full rationale). `MattermostPresenceSchema` stays in use
+  // below, in `buildGatewayConstructArgs`, for the gateway-path parse.
+  bindingSchema: MattermostBindingSchema,
+  foldsIntoPresence: true,
   secretFields: ["apiToken"],
   // apiUrl is optional on the presence schema but required on the binding
   // schema; the binding-resolver keys the interim instance on it too.

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -24,6 +24,29 @@
  * is "delete the in-tree registration + move the module out," not "rewire
  * the core."
  *
+ * ## Scope of THIS slice (S4, cortex#1789)
+ *
+ * S4 wires the registry into config validation (ADR-0024 D5, SCOPE AMENDED
+ * comment on #1789). `bindingSchema`/`configSchema` stop being inert `unknown`
+ * placeholders and become real `z.ZodType`s; two-stage validation lands:
+ *
+ *   1. STRUCTURAL pass (loader, no registry in hand) — `SurfacesSchema`
+ *      (`src/common/types/surfaces.ts`) and the renderer entry schema
+ *      (`RendererSchema`, `src/common/types/cortex-config.ts`) validate only
+ *      the generic shape (`{agent, stack?, binding}` / `{kind, ...}`). A
+ *      genuinely unknown platform/kind key is NOT rejected here — it can't
+ *      be, structurally, without knowing what's registered.
+ *   2. REGISTRY pass (wherever config + registry are both in hand —
+ *      `loader.ts`'s `parseSurfaces`/`loadCortexShape` for the default
+ *      in-tree registry, `cortex.ts` boot for the live boot registry,
+ *      `migrate-config-lib.ts` for the synthesis path) — this file's
+ *      {@link resolveAdapterPluginOrThrow} / {@link validateSurfacesAgainstRegistry}
+ *      and `src/renderers/index.ts`'s `resolveRendererPluginAndConfig`
+ *      resolve the plugin by key and parse the RAW entry against its real
+ *      `bindingSchema`/`configSchema`, throwing the same loud "no adapter/
+ *      renderer installed for …" shape a typo used to get from `.strict()`/
+ *      the closed enum.
+ *
  * ## The registry keys plugin CLASSES, not instances
  *
  * `(kind, id)` identifies the *code* — `("adapter", "discord")`,
@@ -35,8 +58,11 @@
  * construct two distinct renderer INSTANCES with distinct `id`s.
  */
 
+import type { z } from "zod/v4";
+
 import type { PlatformAdapter } from "./types";
 import type { Renderer } from "../renderers/types";
+import type { Surfaces } from "../common/types/surfaces";
 
 export type PluginKind = "adapter" | "renderer";
 
@@ -92,13 +118,31 @@ export interface AdapterPlugin {
   /** `surfaces.{platform}` key (e.g. "discord"). */
   readonly platform: string;
   /**
-   * The schema this platform would contribute to `SurfacesSchema` once S4
-   * composes it from the registry instead of 4 hardcoded keys. Carried here
-   * so S4 has somewhere to read from — **inert in this slice**:
-   * `SurfacesSchema` stays `.strict()` over its 4 hardcoded platform keys
-   * (`src/common/types/surfaces.ts:327-341`) until then.
+   * cortex#1789 (S4) — the schema this platform's `surfaces.{platform}[].binding`
+   * must satisfy. Consumed by {@link resolveAdapterPluginOrThrow} /
+   * {@link validateSurfacesAgainstRegistry} (the REGISTRY pass) — the
+   * structural pass (`SurfacesSchema`) only checks the generic
+   * `{agent, stack?, binding}` shape; this schema is where the real
+   * per-platform field validation (required tokens, regex-checked ids, …)
+   * happens. For the four in-tree platforms this is the EXACT schema
+   * `SurfacesSchema`'s old `.strict()` object used pre-S4
+   * (`DiscordBindingSchema`/`SlackBindingSchema`/`MattermostBindingSchema`/
+   * `WebBindingSchema`, `src/common/types/surfaces.ts`) — byte-identical
+   * validation, only the call site moved.
    */
-  readonly bindingSchema: unknown;
+  readonly bindingSchema: z.ZodType;
+  /**
+   * cortex#1789 (S4, ADR-0024 D5 scope item 3) — does this platform's
+   * `surfaces.{platform}[]` fold into `agents[*].presence.{platform}` at
+   * config-compose time (`foldSurfaceBindings`)? `true` for discord/slack/
+   * mattermost (a legacy inline-presence shape exists to fold into); `false`
+   * for web (there is no legacy web presence shape — the gateway factory
+   * consumes `surfaces.web[]` directly). Replaces the hardcoded `PLATFORMS`
+   * fold-list constant in `surfaces.ts` — `loader.ts` derives the fold list
+   * from `registry.listAdapters().filter(p => p.foldsIntoPresence)` instead
+   * of a second list that could drift from the registry.
+   */
+  readonly foldsIntoPresence: boolean;
   /**
    * Binding fields that must be free of unresolved `__ENV__` placeholders
    * before construction (cortex#1209 belt-and-suspenders) — checked against
@@ -141,9 +185,17 @@ export interface RendererPlugin {
   readonly id: string;
   /** `renderers[].kind` discriminant (e.g. "pagerduty"). */
   readonly rendererKind: string;
-  /** The config schema this kind would contribute to `RendererSchema` (S4).
-   *  Inert in this slice. */
-  readonly configSchema: unknown;
+  /**
+   * cortex#1789 (S4) — the schema a `renderers[]` entry of this kind must
+   * satisfy. Consumed by `src/renderers/index.ts`'s `resolveRendererPluginAndConfig`
+   * (the REGISTRY pass) — the structural pass (`RendererSchema` in
+   * `cortex-config.ts`) only checks `{kind, ...}`; this is the real per-kind
+   * schema (`DashboardRendererSchema`/`PagerDutyRendererSchema`/etc,
+   * `src/common/types/cortex-config.ts`) — byte-identical to what the old
+   * discriminated union validated, only the call site moved (and now runs
+   * with the RAW entry, so `parse()` still applies field defaults).
+   */
+  readonly configSchema: z.ZodType;
   /** Construct (never start) the renderer. */
   createRenderer(config: unknown): Renderer;
 }
@@ -226,6 +278,95 @@ export function createDefaultSurfacePluginRegistry(): SurfacePluginRegistry {
   registry.registerRenderer(dashboardRendererPlugin);
   registry.registerRenderer(pagerdutyRendererPlugin);
   return registry;
+}
+
+// =============================================================================
+// cortex#1789 (S4) — registry-pass validation (ADR-0024 D5)
+// =============================================================================
+
+/**
+ * Resolve the `AdapterPlugin` registered for `platform`, or throw the SAME
+ * shape of loud, actionable error the pre-S4 `SurfacesSchema.strict()` gave
+ * on an unknown top-level key — naming the offending key AND every
+ * currently-installed platform, so a typo (`discrod:`) is as debuggable as
+ * it was before the schema became structurally permissive.
+ */
+export function resolveAdapterPluginOrThrow(
+  platform: string,
+  registry: SurfacePluginRegistry,
+): AdapterPlugin {
+  const plugin = registry.getAdapter(platform);
+  if (!plugin) {
+    const installed = registry.listAdapters().map((p) => p.id).sort().join(", ") || "(none)";
+    throw new Error(
+      `no adapter installed for platform "${platform}" (installed: ${installed}). ` +
+        `Check surfaces.${platform} for a typo, or install the plugin that provides it.`,
+    );
+  }
+  return plugin;
+}
+
+/**
+ * Resolve the `RendererPlugin` registered for `kind`, or throw the SAME loud
+ * shape {@link resolveAdapterPluginOrThrow} does for adapters — naming the
+ * offending kind AND every currently-installed renderer kind. Used by
+ * `src/renderers/index.ts` (`createRenderer` / `resolveRendererPluginAndConfig`)
+ * — the renderer-side twin of the adapter registry pass.
+ */
+export function resolveRendererPluginOrThrow(
+  kind: string,
+  registry: SurfacePluginRegistry,
+): RendererPlugin {
+  const plugin = registry.getRenderer(kind);
+  if (!plugin) {
+    const installed = registry.listRenderers().map((p) => p.id).sort().join(", ") || "(none)";
+    throw new Error(
+      `no renderer installed for kind "${kind}" (installed: ${installed}). ` +
+        `Check renderers[].kind for a typo, or install the plugin that provides it.`,
+    );
+  }
+  return plugin;
+}
+
+/**
+ * cortex#1789 (S4) — the REGISTRY pass for `surfaces:` bindings. Structural
+ * validity (`{agent, stack?, binding}` shape) is already established by
+ * `SurfacesSchema` (the structural pass) before this runs; this function
+ * checks the two things only a live registry can check:
+ *
+ *   1. every top-level key names an INSTALLED adapter plugin
+ *      ({@link resolveAdapterPluginOrThrow} — same loudness as the old
+ *      `.strict()`);
+ *   2. every entry's `binding` satisfies THAT plugin's `bindingSchema`
+ *      (the exact per-platform field validation `SurfacesSchema`'s old
+ *      hardcoded schemas used to do inline).
+ *
+ * Throws on the first failure — the same fail-fast contract `.strict()` and
+ * the per-platform binding schemas had pre-S4. Zod issue messages never
+ * include the raw field VALUE (only the path + a static/regex-derived
+ * message), so a rejected `token`/`apiToken`/`botToken` binding never echoes
+ * the secret into the thrown error.
+ *
+ * No-op when `surfaces` is `undefined` (no `surfaces:` block declared).
+ */
+export function validateSurfacesAgainstRegistry(
+  surfaces: Surfaces | undefined,
+  registry: SurfacePluginRegistry,
+): void {
+  if (!surfaces) return;
+  for (const [platform, entries] of Object.entries(surfaces)) {
+    if (!entries) continue;
+    const plugin = resolveAdapterPluginOrThrow(platform, registry);
+    entries.forEach((entry: { readonly binding: Record<string, unknown> }, index: number) => {
+      const result = plugin.bindingSchema.safeParse(entry.binding);
+      if (!result.success) {
+        const issues = result.error.issues
+          .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+          .join("; ");
+        throw new Error(`surfaces.${platform}[${index}].binding is invalid: ${issues}`);
+      }
+    });
+  }
 }
 
 // =============================================================================

--- a/src/adapters/slack/plugin.ts
+++ b/src/adapters/slack/plugin.ts
@@ -13,6 +13,7 @@ import {
   type SlackPresence,
   type Agent,
 } from "../../common/types/cortex-config";
+import { SlackBindingSchema } from "../../common/types/surfaces";
 import type { SystemEventSource } from "../../bus/system-events";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
@@ -41,7 +42,12 @@ export const slackAdapterPlugin: AdapterPlugin = {
   kind: "adapter",
   id: "slack",
   platform: "slack",
-  bindingSchema: SlackPresenceSchema,
+  // cortex#1789 (S4) — `SlackBindingSchema`, the exact schema
+  // `surfaces.slack[].binding` validated pre-S4 (see discord/plugin.ts's
+  // comment for the full rationale). `SlackPresenceSchema` stays in use
+  // below, in `buildGatewayConstructArgs`, for the gateway-path parse.
+  bindingSchema: SlackBindingSchema,
+  foldsIntoPresence: true,
   secretFields: ["botToken", "appToken"],
   demuxKey: (binding) => stringBindingField(binding, "workspaceId"),
   // No groupBindings — one adapter per binding, demuxed on workspaceId.

--- a/src/adapters/web/__tests__/web-adapter.test.ts
+++ b/src/adapters/web/__tests__/web-adapter.test.ts
@@ -646,10 +646,15 @@ describe("SurfacesSchema — web bindings", () => {
     expect(result.web?.[0]?.binding.instanceId).toBe("acme");
   });
 
-  test("unknown top-level key still rejects (strict mode preserved)", () => {
-    expect(() =>
-      SurfacesSchema.parse({ discrod: [] }), // typo
-    ).toThrow();
+  test("unknown top-level key structurally parses (cortex#1789, S4) — the typo guard moved to the registry pass", () => {
+    // cortex#1789 (S4, ADR-0024 D5) — `SurfacesSchema` is now the STRUCTURAL
+    // pass only; a genuinely unregistered platform key is admitted here so a
+    // registry-contributed platform (post-S6) isn't rejected before a
+    // registry can even be consulted. `validateSurfacesAgainstRegistry`
+    // (`src/adapters/registry.ts`) is where "discrod" now fails loudly — see
+    // `registry.test.ts`'s "unknown top-level platform key throws" test.
+    const result = SurfacesSchema.parse({ discrod: [] }); // typo
+    expect(result).toEqual({ discrod: [] });
   });
 
   test("discord + web coexist without error", () => {

--- a/src/adapters/web/plugin.ts
+++ b/src/adapters/web/plugin.ts
@@ -10,7 +10,7 @@
  */
 
 import { WebAdapter } from "./index";
-import type { WebBinding } from "../../common/types/surfaces";
+import { WebBindingSchema, type WebBinding } from "../../common/types/surfaces";
 import type { Agent } from "../../common/types/cortex-config";
 import type { SystemEventSource } from "../../bus/system-events";
 import type { AdapterPlugin } from "../registry";
@@ -32,7 +32,13 @@ export const webAdapterPlugin: AdapterPlugin = {
   kind: "adapter",
   id: "web",
   platform: "web",
-  bindingSchema: undefined,
+  // cortex#1789 (S4) — the exact schema `surfaces.web[].binding` validated
+  // pre-S4 (`WebSurfaceBindingSchema` in `common/types/surfaces.ts`).
+  bindingSchema: WebBindingSchema,
+  // Unlike discord/slack/mattermost, web has no legacy inline-presence shape
+  // to fold into — the gateway factory consumes `surfaces.web[]` directly
+  // (see `WebSurfaceBindingSchema`'s docstring). PRESERVE: web does NOT fold.
+  foldsIntoPresence: false,
   // No secrets in a web binding — auth is CF Access at the edge, not a bot
   // token (`broadcastUrl` is a non-secret endpoint).
   secretFields: [],

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -24,9 +24,10 @@ import {
   MattermostPresenceSchema,
   type PolicyPrincipal,
   type PolicyRole,
-  RendererSchema,
   deriveStackId,
 } from "../../../common/types/cortex-config";
+import { createDefaultSurfacePluginRegistry } from "../../../adapters/registry";
+import { resolveRendererPluginAndConfig } from "../../../renderers";
 import {
   buildPolicy,
   policyPreflight,
@@ -810,20 +811,28 @@ function buildAgents(
  */
 function buildRenderers(legacy: LegacyBotYaml, warnings: ConversionWarning[]): CortexConfig["renderers"] {
   const renderers: CortexConfig["renderers"] = [];
+  // cortex#1789 (S4, ADR-0024 D5) — `RendererSchema` is now the loose
+  // STRUCTURAL pass only (`{kind: string, ...}`); it no longer rejects an
+  // unregistered kind (`kind: "dashbord"` parses fine structurally — any
+  // non-empty string is a valid `kind`). The REGISTRY pass —
+  // `resolveRendererPluginAndConfig`, which resolves the plugin for `kind`
+  // and parses the raw entry through that plugin's real `configSchema` — is
+  // what now gives the same "typo surfaces here with field path renderers[i].kind"
+  // (or, for a genuinely unregistered kind, "no renderer installed for kind …")
+  // guarantee this function has always documented.
+  const rendererRegistry = createDefaultSurfacePluginRegistry();
 
   if (Array.isArray(legacy.renderers)) {
     for (const r of legacy.renderers) {
-      // Parse each entry through the discriminated-union schema rather than
-      // an `as` cast — a typo (`kind: "dashbord"`) surfaces here with field
-      // path "renderers[i].kind" instead of the opaque top-level Zod error
-      // emitted by CortexConfigSchema.parse() at the end of conversion.
-      renderers.push(RendererSchema.parse(r));
+      const { config } = resolveRendererPluginAndConfig(r, rendererRegistry);
+      renderers.push(config);
     }
   }
 
   if (legacy.api?.enabled === true) {
     const port = typeof legacy.api.port === "number" ? legacy.api.port : 8767;
-    renderers.push(RendererSchema.parse({ kind: "dashboard", port }));
+    const { config } = resolveRendererPluginAndConfig({ kind: "dashboard", port }, rendererRegistry);
+    renderers.push(config);
     warnings.push({
       field: "api",
       message: `legacy api.enabled=true synthesized as renderers[].kind=dashboard (port ${port}); cloud-mode api fields (endpoint, apiKey, …) are NOT carried — re-add via networks/`,

--- a/src/common/config/__tests__/surfaces-layer.test.ts
+++ b/src/common/config/__tests__/surfaces-layer.test.ts
@@ -308,12 +308,28 @@ describe("CFG.c.4 — surfaces.yaml schema validates required binding fields", (
     ).toThrow();
   });
 
-  test("unknown top-level platform key fails loudly (typo guard)", () => {
+  test("unknown top-level platform key structurally parses (cortex#1789, S4)", () => {
+    // cortex#1789 (S4, ADR-0024 D5) — `SurfacesSchema` alone is now only the
+    // STRUCTURAL pass; it admits any top-level key shaped like
+    // `{agent, stack?, binding}`. The typo guard moved to the REGISTRY pass
+    // — see the next test, which drives the SAME input through
+    // `loadConfigWithAgents` (the real load path, which runs the registry
+    // check via `parseSurfaces`) and confirms it still fails loudly.
     expect(() =>
       SurfacesSchema.parse({
         discrod: [{ agent: "ivy", binding: { ...DISCORD_BINDING } }],
       }),
-    ).toThrow();
+    ).not.toThrow();
+  });
+
+  test("unknown top-level platform key fails loudly at load (typo guard, registry pass)", () => {
+    const path = writeSurfacesLayout(
+      join(testDir, "typo"),
+      systemBlocks(),
+      { surfaces: { discrod: [{ agent: "ivy", binding: { ...DISCORD_BINDING } }] } },
+      stackNoBindings(),
+    );
+    expect(() => loadConfigWithAgents(path)).toThrow(/no adapter installed for platform "discrod"/);
   });
 
   test("malformed surfaces.yaml fails at load via the composer", () => {

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -25,6 +25,11 @@ import {
   type StackConfig,
 } from "../types/cortex-config";
 import { foldSurfaceBindings, SurfacesSchema, type Surfaces } from "../types/surfaces";
+import {
+  createDefaultSurfacePluginRegistry,
+  validateSurfacesAgainstRegistry,
+} from "../../adapters/registry";
+import { resolveRendererPluginAndConfig } from "../../renderers";
 import { enforceChmod600 } from "./file-permissions";
 import {
   resolveAgentPresenceTokens,
@@ -429,7 +434,7 @@ function composeRawConfigWithSurfaces(configPath: string): {
     const content = readFileSync(expandedPath, "utf-8");
     const single = (parseYaml(content) ?? {}) as Record<string, unknown>;
     const surfaces = parseSurfaces(single.surfaces);
-    return { raw: foldSurfaceBindings(single), surfaces };
+    return { raw: foldSurfaceBindings(single, defaultFoldPlatforms()), surfaces };
   }
 
   // CFG.a.1 — directory layout. Fixed precedence: system → network → surfaces
@@ -452,19 +457,49 @@ function composeRawConfigWithSurfaces(configPath: string): {
   // internally — `parseSurfaces` re-uses the same schema so the parse is
   // redundant but cheap (no I/O). Both share the same validated result shape.
   const surfaces = parseSurfaces(merged.surfaces);
-  return { raw: foldSurfaceBindings(merged), surfaces };
+  return { raw: foldSurfaceBindings(merged, defaultFoldPlatforms()), surfaces };
 }
 
 /**
- * Parse the raw `surfaces:` value against `SurfacesSchema`. Returns `undefined`
- * when the value is absent or null (no surfaces declared). Throws on malformed
- * input — the caller (`composeRawConfigWithSurfaces`) lets this propagate so
- * a bad surfaces.yaml fails loudly at load, matching `foldSurfaceBindings`'s
- * own validation contract.
+ * cortex#1789 (S4, ADR-0024 D5 scope item 3) — the registry-derived
+ * fold-platform list: every registered `AdapterPlugin` that opts into
+ * `foldsIntoPresence`. Replaces the hardcoded `PLATFORMS` const that used to
+ * live in `surfaces.ts` — "which platforms fold" is now a property each
+ * plugin declares (discord/slack/mattermost `true`, web `false` — PRESERVED
+ * exactly) rather than a second list that could drift from the registry.
+ * `surfaces.ts` itself cannot import the registry (would cycle — the
+ * registry's in-tree adapter plugins import `surfaces.ts` for their binding
+ * schemas), so `loader.ts` — which already imports the registry for the
+ * registry-pass validation below — computes this list and passes it down
+ * explicitly. Constructing a fresh `SurfacePluginRegistry` per call is cheap
+ * (pure in-memory registration, no I/O); this is the same "default registry"
+ * every other config-load-time registry check in this file uses.
+ */
+function defaultFoldPlatforms(): readonly string[] {
+  return createDefaultSurfacePluginRegistry()
+    .listAdapters()
+    .filter((p) => p.foldsIntoPresence)
+    .map((p) => p.platform);
+}
+
+/**
+ * Parse the raw `surfaces:` value against `SurfacesSchema` (the STRUCTURAL
+ * pass), then run the REGISTRY pass (cortex#1789, S4) — every top-level key
+ * must name an installed adapter plugin, and every entry's `binding` must
+ * satisfy that plugin's `bindingSchema`. Returns `undefined` when the value
+ * is absent or null (no surfaces declared). Throws on malformed input or an
+ * unregistered platform — the caller (`composeRawConfigWithSurfaces`) lets
+ * this propagate so a bad surfaces.yaml (or a typo'd platform key) fails
+ * loudly at load, matching `foldSurfaceBindings`'s own validation contract
+ * and giving `cortex config validate`/dry-run/`migrate-config` callers (who
+ * never reach `cortex.ts`'s boot-time registry check) the same loud typo
+ * guard `.strict()` used to give directly.
  */
 function parseSurfaces(value: unknown): Surfaces | undefined {
   if (value === undefined || value === null) return undefined;
-  return SurfacesSchema.parse(value);
+  const surfaces = SurfacesSchema.parse(value);
+  validateSurfacesAgainstRegistry(surfaces, createDefaultSurfacePluginRegistry());
+  return surfaces;
 }
 
 /**
@@ -826,6 +861,22 @@ function loadCortexShape(
   // Schema-strict parse. Any legacy field at the top level fails here with
   // the principal-friendly migration message baked into CortexConfigSchema.
   const cortexConfig: CortexConfig = CortexConfigSchema.parse(normalised);
+
+  // cortex#1789 (S4, ADR-0024 D5) — REGISTRY pass for `renderers:`.
+  // Cortex-shape configs are the only shape whose `renderers[]` got STRICT
+  // per-kind validation pre-S4 (`CortexConfigSchema.renderers` used the
+  // closed discriminated union); `RendererSchema` is now the loose
+  // STRUCTURAL pass only (see its docstring in `cortex-config.ts`), so this
+  // restores byte-identical loud-on-typo behavior for cortex.yaml at
+  // config-load — using the same default in-tree registry `parseSurfaces`
+  // uses above. Legacy bot.yaml `renderers[]` stays UNCHECKED here
+  // (unchanged from pre-S4 — see `AgentConfigSchema.renderers`'s docstring in
+  // `common/types/config.ts`): it only ever validated at `cortex.ts` boot,
+  // and that asymmetry is preserved rather than newly tightened.
+  const rendererRegistry = createDefaultSurfacePluginRegistry();
+  for (const entry of cortexConfig.renderers) {
+    resolveRendererPluginAndConfig(entry, rendererRegistry);
+  }
 
   // CortexConfigSchema guarantees `agents.min(1)`, so [0] is always defined
   // at runtime; noUncheckedIndexedAccess still types it as possibly undefined.

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -39,6 +39,7 @@ import {
   PolicyPublicSchema,
   PolicySchema,
   RendererSchema,
+  WebhookOutRendererSchema,
   isFederatedSubjectInOwnScope,
   ownFederatedSubjectScopePrefix,
 } from "../cortex-config";
@@ -540,7 +541,16 @@ describe("RendererSchema", () => {
     expect(parsed.routingKey).toBe("PD-ROUTING-KEY");
   });
 
-  test("discriminated union dispatches on kind", () => {
+  // cortex#1789 (S4, ADR-0024 D5) — `RendererSchema` stopped being a closed
+  // discriminated union and became the loose STRUCTURAL pass
+  // (`{kind: string, ...}`). Per-kind field validation (routingKey required,
+  // url required, port/subscribe defaults, …) now lives ONLY on the
+  // per-kind schemas above (`DashboardRendererSchema` etc, exercised
+  // directly) and is enforced at the REGISTRY pass
+  // (`resolveRendererPluginAndConfig`, `src/renderers/index.ts` —
+  // `factory.test.ts` covers that dispatch). These tests pin the STRUCTURAL
+  // schema's own, deliberately weaker, contract.
+  test("structural pass preserves an arbitrary kind — no per-kind field enforcement", () => {
     const dashboard = RendererSchema.parse({ kind: "dashboard" });
     expect(dashboard.kind).toBe("dashboard");
 
@@ -548,17 +558,36 @@ describe("RendererSchema", () => {
     expect(cliTail.kind).toBe("cli-tail");
   });
 
-  test("unknown kind is rejected", () => {
-    expect(() => RendererSchema.parse({ kind: "telegram" })).toThrow();
+  test("an out-of-tree kind is NOT rejected structurally — registry-contributed kinds must be admissible", () => {
+    // Pre-S4 this threw (closed z.enum). It must NOT throw now: a
+    // registry-contributed (post-S6) kind this static schema has never
+    // heard of has to structurally parse so the REGISTRY pass — not this
+    // schema — gets the chance to say "installed" or "not installed".
+    expect(() => RendererSchema.parse({ kind: "telegram" })).not.toThrow();
+  });
+
+  test("kind is still required and must be a non-empty string", () => {
+    expect(() => RendererSchema.parse({})).toThrow();
+    expect(() => RendererSchema.parse({ kind: "" })).toThrow();
   });
 
   test("webhook-out renderer requires url", () => {
-    expect(() => RendererSchema.parse({ kind: "webhook-out" })).toThrow();
-    const parsed = RendererSchema.parse({
+    expect(() => WebhookOutRendererSchema.parse({ kind: "webhook-out" })).toThrow();
+    const parsed = WebhookOutRendererSchema.parse({
       kind: "webhook-out",
       url: "https://example.com/cortex-hook",
     });
     expect(parsed.kind).toBe("webhook-out");
+  });
+
+  test("webhook-out's missing url is NOT caught by the structural pass — only by the per-kind schema", () => {
+    // Documents the deliberate gap: `RendererSchema` alone will happily
+    // parse `{kind: "webhook-out"}` even though the real
+    // `WebhookOutRendererSchema` requires `url`. This is why the registry
+    // pass exists — see `resolveRendererPluginAndConfig`.
+    const parsed = RendererSchema.parse({ kind: "webhook-out" });
+    expect(parsed.kind).toBe("webhook-out");
+    expect(() => WebhookOutRendererSchema.parse(parsed)).toThrow();
   });
 });
 
@@ -1000,7 +1029,10 @@ describe("DashboardRendererSchema.publicUrl", () => {
 
 describe("WebhookOutRenderer.url", () => {
   test("rejects a non-URL string", () => {
-    expect(() => RendererSchema.parse({
+    // cortex#1789 (S4) — `RendererSchema` (the structural pass) no longer
+    // validates `url`'s format; that's `WebhookOutRendererSchema`'s job now
+    // (the registry pass's per-kind schema — see `resolveRendererPluginAndConfig`).
+    expect(() => WebhookOutRendererSchema.parse({
       kind: "webhook-out",
       url: "not-a-url",
     })).toThrow();

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1009,22 +1009,58 @@ export type Agent = z.infer<typeof AgentSchema>;
 // =============================================================================
 
 /**
- * Renderer kinds enumerated explicitly. Architecture §9.3: renderers never
- * publish on the bus; they're pure sinks. The enum constrains the choice set
- * to known platform classes (dashboard, pagerduty, cli-tail, webhook-out).
+ * cortex#1789 (S4, ADR-0024 D5) — `RendererKindSchema` stops being a closed
+ * `z.enum` over the four in-tree kinds and becomes "any non-empty string" —
+ * the STRUCTURAL half of the two-stage validation this slice introduces.
+ * Architecture §9.3 still holds (renderers never publish on the bus; they're
+ * pure sinks) but "which kinds exist" is now a registry property
+ * (`SurfacePluginRegistry.listRenderers()`), not a schema-closed set: a
+ * registry-contributed renderer's `kind` can't be enumerated here without
+ * importing the registry (`src/adapters/registry.ts` transitively imports
+ * THIS file for `DashboardRendererConfig`/etc, so the reverse import would
+ * cycle). The REGISTRY pass — `resolveRendererPluginOrThrow` /
+ * `resolveRendererPluginAndConfig` (`src/renderers/index.ts`) — is where "is
+ * this kind actually installed" is checked, with the same loud failure shape
+ * the closed enum used to give a typo.
  *
  * The G-1111 §4.6 fail-safe rule requires ≥2 distinct platform classes
  * covering `local.{principal}.system.>` — that check fires at config-load (MIG-1.10),
- * not in the Zod schema.
+ * not in the Zod schema. Unchanged by S4 (ADR-0024 D5, explicitly out of
+ * scope for this slice — S6 extends it to distinguish a config error from an
+ * install-state error, OQ9).
  */
-export const RendererKindSchema = z.enum([
-  "dashboard",
-  "pagerduty",
-  "cli-tail",
-  "webhook-out",
-]);
+export const RendererKindSchema = z.string().min(1, "renderers[].kind is required");
 
 export type RendererKind = z.infer<typeof RendererKindSchema>;
+
+/**
+ * cortex#1789 (S4) — the generic STRUCTURAL renderer entry: every
+ * `renderers[]` array element must be shaped `{kind, ...}` — `kind` a
+ * non-empty string, everything else passed through untouched. This is what
+ * `CortexConfigSchema.renderers` validates at config-LOAD time, before any
+ * `SurfacePluginRegistry` is in hand (`src/common/config/loader.ts`'s
+ * `loadCortexShape` — see that file for where the REGISTRY pass runs
+ * immediately afterward). Per-kind field validation
+ * (`DashboardRendererSchema`/`PagerDutyRendererSchema`/etc, below) now runs
+ * ONLY at the registry pass, via each `RendererPlugin.configSchema`
+ * (`src/adapters/registry.ts`) — this schema intentionally does NOT
+ * discriminate on `kind`, so an out-of-tree kind is structurally welcome
+ * even though nothing in this file (or anywhere pre-S6) can validate its
+ * fields.
+ */
+export const RendererSchema = z.object({
+  kind: RendererKindSchema,
+}).catchall(z.unknown());
+
+/**
+ * MIG-7.2d: renamed from `Renderer` → `RendererConfig` so the unprefixed
+ * `Renderer` name can refer to the runtime class hierarchy in
+ * `src/renderers/`. cortex#1789 (S4) — this is now the LOOSE structural
+ * type (`{kind: string} & Record<string, unknown>`), not a discriminated
+ * union; per-kind typed configs (`DashboardRendererConfig` etc, below) are
+ * what runtime code should reach for when it already knows the kind.
+ */
+export type RendererConfig = z.infer<typeof RendererSchema>;
 
 // ---------------------------------------------------------------------------
 // Renderer visibility — IAW Phase A.4 (cortex#113, cortex#109 §B)
@@ -1208,24 +1244,17 @@ export const WebhookOutRendererSchema = z.object({
 export type WebhookOutRendererConfig = z.infer<typeof WebhookOutRendererSchema>;
 
 /**
- * Discriminated union over renderer kinds. Each variant carries `kind` as a
- * literal so callers can switch on it.
+ * cortex#1789 (S4, ADR-0024 D5) — the pre-S4 discriminated union
+ * (`z.discriminatedUnion("kind", [Dashboard, PagerDuty, CliTail, WebhookOut])`)
+ * lived HERE, exported as `RendererSchema`/`RendererConfig`. It moved to the
+ * top of this section (next to `RendererKindSchema`) and is now the LOOSE
+ * structural `{kind: string} & Record<string, unknown>` schema — see that
+ * definition's docstring for the two-stage-validation rationale. The four
+ * schemas above (`DashboardRendererSchema` etc.) are unchanged and are what
+ * each in-tree `RendererPlugin.configSchema` (`src/adapters/registry.ts`)
+ * now points at for the REGISTRY-pass validation `RendererSchema` no longer
+ * performs on its own.
  */
-export const RendererSchema = z.discriminatedUnion("kind", [
-  DashboardRendererSchema,
-  PagerDutyRendererSchema,
-  CliTailRendererSchema,
-  WebhookOutRendererSchema,
-]);
-
-/**
- * MIG-7.2d: renamed from `Renderer` → `RendererConfig` so the unprefixed
- * `Renderer` name can refer to the runtime class hierarchy in
- * `src/renderers/`. The schema-inferred type represents the CONFIG block
- * for a renderer, not the renderer instance itself, so the new name is
- * more accurate as well.
- */
-export type RendererConfig = z.infer<typeof RendererSchema>;
 
 // =============================================================================
 // NATS — bus runtime config

--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -310,6 +310,27 @@ export const WebSurfaceBindingSchema = z.object({
   binding: WebBindingSchema,
 });
 
+/**
+ * cortex#1789 (S4, ADR-0024 D5) — the generic STRUCTURAL binding entry.
+ * Every `surfaces.{platform}[]` entry is `{agent, stack?, binding}` — this is
+ * the shape any REGISTERED-OR-NOT platform key must satisfy at the structural
+ * pass. `binding` is intentionally a loose record here (not one of the
+ * per-platform binding schemas above): the structural pass's job is "is this
+ * shaped like a binding entry", not "is this a valid Discord/Slack/Mattermost/
+ * Web binding" — that per-platform check is the REGISTRY pass
+ * ({@link resolveAdapterPluginOrThrow} in `src/adapters/registry.ts`), which
+ * runs once a `SurfacePluginRegistry` is in hand and knows which plugin's
+ * `bindingSchema` applies to which key.
+ */
+export const SurfaceBindingEntrySchema = z
+  .object({
+    ...bindingEntryBase,
+    binding: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export type SurfaceBindingEntry = z.infer<typeof SurfaceBindingEntrySchema>;
+
 // =============================================================================
 // Top-level `surfaces:` block
 // =============================================================================
@@ -317,9 +338,24 @@ export const WebSurfaceBindingSchema = z.object({
 /**
  * The `surfaces:` block — the binding map. Keyed by platform; each platform
  * holds a list of `{agent, stack?, binding}` entries. All platforms are
- * optional (a deployment may bind only Discord). `.strict()` rejects an
- * unknown platform key loudly so a typo (`discrod:`) surfaces at load rather
- * than silently contributing nothing to the fold.
+ * optional (a deployment may bind only Discord).
+ *
+ * cortex#1789 (S4, ADR-0024 D5) — two-stage validation. This schema is the
+ * STRUCTURAL pass ONLY: the four in-tree platforms keep their full,
+ * strongly-typed binding schemas (byte-identical validation, zero ripple to
+ * every consumer typed against `Surfaces["discord"]` etc. — `discord-token-
+ * groups.ts`, `gateway-adapters.ts`, the web adapter); any OTHER top-level key
+ * is accepted structurally as a generic {@link SurfaceBindingEntrySchema}
+ * array via `.catchall(...)`, because a registry-contributed platform's key
+ * is not known to this static schema. `.catchall()` replaces the old
+ * `.strict()` — the "is this a REAL platform" check moves to the REGISTRY
+ * pass (`resolveAdapterPluginOrThrow` / `validateSurfacesAgainstRegistry`,
+ * `src/adapters/registry.ts`), which runs wherever a `SurfacePluginRegistry`
+ * is in hand (today: always the in-tree `createDefaultSurfacePluginRegistry`,
+ * since S6's out-of-tree bundle loading hasn't landed) and produces the SAME
+ * loud "no adapter installed for platform …" failure a typo (`discrod:`)
+ * used to get from `.strict()` — see `loader.ts`'s `parseSurfaces` and
+ * `cortex.ts` boot for the two call sites.
  *
  * Note: `web[]` bindings are NOT folded by `foldSurfaceBindings` (there is no
  * legacy presence shape). The gateway factory consumes them directly.
@@ -336,9 +372,16 @@ export const SurfacesSchema = z
      */
     web: z.array(WebSurfaceBindingSchema).optional(),
   })
-  // `.strict()` rejects an unknown platform key loudly so a typo (`discrod:`)
-  // surfaces at load rather than silently contributing nothing to the fold.
-  .strict();
+  // `.optional()` on the catchall element too — NOT a behavior change (a
+  // catchall key, when actually present in the input, is never `undefined`
+  // at runtime; Zod simply omits an absent key rather than storing
+  // `undefined` under it). This is purely so the inferred TS type's index
+  // signature (`X[] | undefined`) matches the four explicit `.optional()`
+  // keys above — TypeScript requires an object's named-optional-property
+  // type to be assignable to its own index-signature type, and `X[] | undefined`
+  // vs a non-optional `X[]` catchall would otherwise conflict
+  // ("Property 'discord' is incompatible with index signature").
+  .catchall(z.array(SurfaceBindingEntrySchema).optional());
 
 export type Surfaces = z.infer<typeof SurfacesSchema>;
 export type DiscordSurfaceBinding = z.infer<typeof DiscordSurfaceBindingSchema>;
@@ -351,7 +394,24 @@ export type WebBinding = z.infer<typeof WebBindingSchema>;
 // The fold — surfaces.yaml bindings → agents[*].presence.{platform}
 // =============================================================================
 
-const PLATFORMS = ["discord", "slack", "mattermost"] as const;
+/**
+ * cortex#1789 (S4, ADR-0024 D5) — the default fold-platform list, byte-
+ * identical to the pre-S4 hardcoded `PLATFORMS` const. `web` is deliberately
+ * absent (it never folds — no legacy presence shape exists for it, see
+ * `WebSurfaceBindingSchema`'s docstring). This is the FALLBACK `foldSurfaceBindings`
+ * uses when called with no explicit `foldPlatforms` — every existing call
+ * site (both `loader.ts` composer paths, every test) keeps this exact
+ * behavior. `loader.ts` additionally computes this list from the registry
+ * (`registry.listAdapters().filter(p => p.foldsIntoPresence)`) and passes it
+ * explicitly — the registry-derived list and this constant agree today
+ * because all four in-tree `AdapterPlugin`s set `foldsIntoPresence` to match
+ * (discord/slack/mattermost `true`, web `false`). `surfaces.ts` itself does
+ * NOT import the registry (`src/adapters/registry.ts` transitively imports
+ * this module for `WebBindingSchema`/`DiscordBindingSchema`/etc — importing
+ * the registry back here would cycle), so this constant is the registry-free
+ * anchor the registry-derived list is checked against.
+ */
+export const DEFAULT_FOLD_PLATFORMS = ["discord", "slack", "mattermost"] as const;
 
 /**
  * CFG.c.1/CFG.c.2 — fold a `surfaces:` block into the composed raw config's
@@ -362,6 +422,14 @@ const PLATFORMS = ["discord", "slack", "mattermost"] as const;
  * BEFORE the result is handed to the parse/flatten path. The result is the
  * exact shape the inline (pre-CFG.c) config produced — so `LoadedConfig` is
  * unchanged and no consumer is touched.
+ *
+ * `foldPlatforms` — cortex#1789 (S4): the set of platform keys that fold into
+ * `agents[*].presence.{platform}`. Defaults to {@link DEFAULT_FOLD_PLATFORMS}
+ * (byte-identical to the pre-S4 hardcoded list) so every existing caller is
+ * unaffected; `loader.ts` passes the REGISTRY-DERIVED list explicitly
+ * (`AdapterPlugin.foldsIntoPresence`), making "which platforms fold" a
+ * property each plugin declares rather than a second hardcoded list that can
+ * drift from the registry (`web` NOT folding is preserved exactly either way).
  *
  * Resolution / precedence (the design fork called out in CFG.c):
  *
@@ -388,6 +456,7 @@ const PLATFORMS = ["discord", "slack", "mattermost"] as const;
  */
 export function foldSurfaceBindings(
   raw: Record<string, unknown>,
+  foldPlatforms: readonly string[] = DEFAULT_FOLD_PLATFORMS,
 ): Record<string, unknown> {
   const surfacesRaw = raw.surfaces;
   if (surfacesRaw === undefined || surfacesRaw === null) {
@@ -419,8 +488,12 @@ export function foldSurfaceBindings(
     }
   }
 
-  for (const platform of PLATFORMS) {
-    const entries = surfaces[platform];
+  // Indexed generically — `foldPlatforms` is a plain `string[]` (registry-
+  // derived by `loader.ts`, or the {@link DEFAULT_FOLD_PLATFORMS} fallback),
+  // not the narrow literal union `SurfacesSchema`'s explicit keys infer to.
+  const surfacesByKey = surfaces as Record<string, readonly SurfaceBindingEntry[] | undefined>;
+  for (const platform of foldPlatforms) {
+    const entries = surfacesByKey[platform];
     if (!entries) continue;
     for (const entry of entries) {
       const agent = agentById.get(entry.agent);

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -131,9 +131,9 @@ import {
 } from "./bus/myelin/envelope-validator";
 
 import { attachLegacyOutboundLog } from "./adapters/discord";
-import { createRenderer, type Renderer } from "./renderers";
-import { createDefaultSurfacePluginRegistry } from "./adapters/registry";
-import { RendererSchema, deriveStackId, DEFAULT_STREAM_MAX_BYTES } from "./common/types/cortex-config";
+import { resolveRendererPluginAndConfig, type Renderer } from "./renderers";
+import { createDefaultSurfacePluginRegistry, validateSurfacesAgainstRegistry } from "./adapters/registry";
+import { deriveStackId, DEFAULT_STREAM_MAX_BYTES } from "./common/types/cortex-config";
 import type {
   Agent,
   BusConfig,
@@ -3113,6 +3113,20 @@ export async function startCortex(
   // out, it never rewires this composition.
   const surfacePluginRegistry = createDefaultSurfacePluginRegistry();
 
+  // cortex#1789 (S4, ADR-0024 D5) — the REGISTRY pass for `surfaces:`
+  // bindings, run here because this is the first point in boot where BOTH
+  // the composed `Surfaces` (`options.surfaces`, structurally validated
+  // already by `SurfacesSchema` at config-load) and a live
+  // `SurfacePluginRegistry` are in hand — symmetric to the renderer boot
+  // loop below. `loader.ts`'s `parseSurfaces` already runs this SAME check
+  // against a freshly-constructed default registry at config-load time (so
+  // `cortex config validate`/dry-run/migrate-config callers that never reach
+  // this boot function still get the loud typo guard); this call is
+  // therefore redundant-but-harmless for the in-tree-only plugin set S4
+  // ships with, and becomes load-bearing once S6 lets a stack opt into
+  // plugins the config-load-time default registry doesn't know about.
+  validateSurfacesAgainstRegistry(options.surfaces, surfacePluginRegistry);
+
   // GW.a.3b.2c (cortex#524) — the surface ownership plan. When
   // `CORTEX_GATEWAY` is set, the shared surface gateway (constructed below via
   // `startGatewayIfEnabled`) builds ONE adapter per `surfaces:` binding on the
@@ -3247,33 +3261,37 @@ export async function startCortex(
   for (const raw of config.renderers ?? []) {
     // AgentConfig types renderers as z.unknown() so legacy bot.yaml loads
     // without breakage (the canonical shape lives on cortex-config's
-    // RendererSchema). Parse each entry strictly here — a typo fails fast
-    // with a Zod error rather than surfacing as a runtime cast failure
-    // inside the factory.
-    const parseResult = RendererSchema.safeParse(raw);
-    if (!parseResult.success) {
-      console.error(
-        `cortex: renderer config rejected by schema:`,
-        parseResult.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
-      );
-      continue;
-    }
-    const rendererConfig = {
-      ...parseResult.data,
-      subscribe: subjectPlaceholderSubstituter(parseResult.data.subscribe),
-    };
+    // RendererSchema). cortex#1789 (S4) — this is now a TWO-STAGE parse:
+    // `resolveRendererPluginAndConfig` runs the structural pass
+    // (`RendererSchema` — `{kind, ...}`) AND the registry pass (kind must
+    // name an INSTALLED renderer plugin; the raw entry must satisfy that
+    // plugin's real `configSchema`) in one call, using the SAME
+    // `surfacePluginRegistry` this boot composed above. A typo or
+    // unregistered kind fails here with a Zod/UnimplementedRendererKindError
+    // — same "log + skip, other renderers still boot" fail-isolation as
+    // before, just resolved through the registry instead of a closed enum.
+    let kindForLog = "(unknown)";
     try {
-      const renderer = createRenderer(rendererConfig, surfacePluginRegistry);
+      const { plugin, config: parsedConfig } = resolveRendererPluginAndConfig(raw, surfacePluginRegistry);
+      kindForLog = plugin.rendererKind;
+      const rawSubscribe = (parsedConfig as { subscribe?: unknown }).subscribe;
+      const rendererConfig = {
+        ...parsedConfig,
+        ...(Array.isArray(rawSubscribe) && {
+          subscribe: subjectPlaceholderSubstituter(rawSubscribe as string[]),
+        }),
+      };
+      const renderer = plugin.createRenderer(rendererConfig);
       await renderer.start();
       router.register(renderer.surfaceConfig);
       renderers.push(renderer);
-      console.log(`cortex: ${rendererConfig.kind} renderer started (id: ${renderer.id})`);
+      console.log(`cortex: ${kindForLog} renderer started (id: ${renderer.id})`);
     } catch (err) {
-      // Renderer construction can throw (UnimplementedRendererKindError)
-      // or `start()` can fail. Per the G-1111 fail-safe rule, ONE broken
+      // Parse failure (structural or registry pass), construction failure,
+      // or `start()` failure. Per the G-1111 fail-safe rule, ONE broken
       // renderer must not prevent the others from coming up — log + skip.
       console.error(
-        `cortex: ${rendererConfig.kind} renderer failed to start:`,
+        `cortex: ${kindForLog} renderer failed to start:`,
         err instanceof Error ? err.message : err,
       );
     }

--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -34,7 +34,7 @@
 
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { SurfaceAdapter } from "../bus/surface-router";
-import type { DashboardRendererConfig } from "../common/types/cortex-config";
+import { DashboardRendererSchema, type DashboardRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
 import type { RendererPlugin } from "../adapters/registry";
 
@@ -154,8 +154,11 @@ export const dashboardRendererPlugin: RendererPlugin = {
   kind: "renderer",
   id: "dashboard",
   rendererKind: "dashboard",
-  // S4 inert placeholder — RendererSchema stays the fixed discriminated
-  // union it is today until then.
-  configSchema: undefined,
+  // cortex#1789 (S4) — the real per-kind schema. `createRenderer`
+  // (`src/renderers/index.ts`) now parses the RAW `renderers[]` entry
+  // through this before construction (registry pass), applying `port`/
+  // `subscribe`/`projections` defaults exactly as the old discriminated
+  // union did.
+  configSchema: DashboardRendererSchema,
   createRenderer: (config) => new DashboardRenderer(config as DashboardRendererConfig),
 };

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -12,10 +12,24 @@
  * SAME `UnimplementedRendererKindError` a config author saw before, so a
  * typo or an unimplemented kind still fails loudly rather than silently
  * producing a no-op renderer.
+ *
+ * cortex#1789 (S4, ADR-0024 D5) — `createRenderer` now accepts the RAW
+ * `renderers[]` entry (`unknown`), not an already-typed `RendererConfig`. It
+ * performs the REGISTRY pass itself: resolve `kind` → look up the plugin →
+ * parse the raw entry through THAT plugin's `configSchema` (the real,
+ * strongly-typed per-kind schema, e.g. `PagerDutyRendererSchema`) → dispatch
+ * to `plugin.createRenderer`. This absorbs what used to be a separate
+ * `RendererSchema.safeParse(raw)` call at each call site (`cortex.ts`'s
+ * renderer boot loop) — `RendererSchema` itself is now only the loose
+ * STRUCTURAL schema (`{kind: string, ...}`, see `cortex-config.ts`), so the
+ * real per-kind validation has to happen here, where a registry is in hand.
+ * {@link resolveRendererPluginAndConfig} exposes the validate-without-
+ * construct half for callers (`migrate-config-lib.ts`) that want a validated
+ * config WITHOUT building a live renderer instance.
  */
 
-import type { RendererConfig } from "../common/types/cortex-config";
-import type { SurfacePluginRegistry } from "../adapters/registry";
+import { RendererSchema, type RendererConfig } from "../common/types/cortex-config";
+import type { RendererPlugin, SurfacePluginRegistry } from "../adapters/registry";
 import type { Renderer } from "./types";
 
 export type { Renderer } from "./types";
@@ -23,20 +37,42 @@ export { DashboardRenderer } from "./dashboard";
 export { PagerDutyRenderer } from "./pagerduty";
 
 export class UnimplementedRendererKindError extends Error {
-  constructor(kind: string) {
+  constructor(kind: string, registry: SurfacePluginRegistry) {
+    const installed = registry.listRenderers().map((p) => p.id).sort().join(", ") || "(none)";
     super(
-      `cortex-renderers: kind "${kind}" is not registered. ` +
-        `Only "dashboard" and "pagerduty" are registered in-tree; "cli-tail" and "webhook-out" ` +
-        `land as bundles (ADR-0024 §8.1 OQ11).`,
+      `cortex-renderers: kind "${kind}" is not registered. Installed renderer kinds: ${installed}. ` +
+        `"cli-tail" and "webhook-out" land as bundles (ADR-0024 §8.1 OQ11) — they are not registered ` +
+        `in-tree until S6.`,
     );
     this.name = "UnimplementedRendererKindError";
   }
 }
 
-export function createRenderer(config: RendererConfig, registry: SurfacePluginRegistry): Renderer {
-  const plugin = registry.getRenderer(config.kind);
+/**
+ * cortex#1789 (S4) — the REGISTRY pass for a single `renderers[]` entry.
+ * Structural validity (`{kind, ...}`) is established by `RendererSchema`
+ * (the structural pass) first; this resolves the plugin for `kind` (throwing
+ * {@link UnimplementedRendererKindError} with the SAME loudness the old
+ * closed enum gave a typo) and parses the RAW entry through that plugin's
+ * `configSchema`, returning the plugin alongside the fully-validated,
+ * defaults-applied config. Split from {@link createRenderer} so a caller
+ * that only wants VALIDATION (no live instance — `migrate-config-lib.ts`'s
+ * `buildRenderers`) doesn't have to construct one.
+ */
+export function resolveRendererPluginAndConfig(
+  raw: unknown,
+  registry: SurfacePluginRegistry,
+): { plugin: RendererPlugin; config: RendererConfig } {
+  const entry = RendererSchema.parse(raw);
+  const plugin = registry.getRenderer(entry.kind);
   if (!plugin) {
-    throw new UnimplementedRendererKindError(config.kind);
+    throw new UnimplementedRendererKindError(entry.kind, registry);
   }
+  const config = plugin.configSchema.parse(raw) as RendererConfig;
+  return { plugin, config };
+}
+
+export function createRenderer(raw: unknown, registry: SurfacePluginRegistry): Renderer {
+  const { plugin, config } = resolveRendererPluginAndConfig(raw, registry);
   return plugin.createRenderer(config);
 }

--- a/src/renderers/pagerduty.ts
+++ b/src/renderers/pagerduty.ts
@@ -37,7 +37,7 @@
 
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { SurfaceAdapter } from "../bus/surface-router";
-import type { PagerDutyRendererConfig } from "../common/types/cortex-config";
+import { PagerDutyRendererSchema, type PagerDutyRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
 import type { RendererPlugin } from "../adapters/registry";
 
@@ -196,8 +196,11 @@ export const pagerdutyRendererPlugin: RendererPlugin = {
   kind: "renderer",
   id: "pagerduty",
   rendererKind: "pagerduty",
-  // S4 inert placeholder — RendererSchema stays the fixed discriminated
-  // union it is today until then.
-  configSchema: undefined,
+  // cortex#1789 (S4) — the real per-kind schema, incl. the REQUIRED
+  // `routingKey` secret field. `createRenderer` parses the raw entry through
+  // this before construction; a Zod validation failure never echoes the
+  // rejected value (only the field path + message), so a malformed
+  // `routingKey` is never leaked into the thrown error.
+  configSchema: PagerDutyRendererSchema,
   createRenderer: (config) => new PagerDutyRenderer(config as PagerDutyRendererConfig),
 };


### PR DESCRIPTION
Closes #1789. Epic #1784, W2 lane A (S4). Builds on S3's `SurfacePluginRegistry`.

Makes config validation registry-aware for BOTH plugin kinds — the inert `bindingSchema`/`configSchema` placeholders S3 shipped are now real `ZodType`s contributed by each plugin descriptor.

## What landed

- **`SurfacesSchema` two-stage validation** (`surfaces.ts:328-357`): structural pass (`z.record(z.string(), z.unknown())`) in the schema; the "is this a REAL platform" check moves to the **registry pass** at boot. A typo (`discrod:`) now fails with a loud `no adapter installed for platform "discrod" (installed: …)` (`registry.ts:302`) — same loudness as the old `.strict()`, better message.
- **Binding + renderer schemas move onto the plugin descriptors** — `SurfacePlugin.bindingSchema`/`configSchema` are real schemas now, for all four adapters + both renderers.
- **`PLATFORMS` fold list is registry-derived** (`registry.listAdapters().filter(p => p.foldsIntoPresence)`), with `DEFAULT_FOLD_PLATFORMS` fallback. **`web` still does NOT fold** — preserved via `foldsIntoPresence` (discord/slack/mattermost `true`, web absent).
- G-1111 §4.6 `system.>` coverage check left at config-load (untouched — S6 extends it for OQ9).
- `migrate-config` + `cortex stack` `SurfacesSchema` callers updated.

## Provenance — salvaged + gate-verified

Built by an implementer that **hit its session limit mid-task and died before running the final gate or reporting.** Its 17-file working tree (+677/-121) was committed as a salvage, then I ran the full gate against it myself:

- `tsc --noEmit` → **0**
- `bun test src/common src/adapters src/renderers src/gateway src/runner` → **3306 pass / 0 fail**
- `bunx eslint --quiet` (17 changed files) → **0**
- `bash scripts/check-carveouts.sh` (vocab gate) → **PASS**
- rebased on `origin/main` (0 behind)

Because it was authored without a final self-review, this PR gets a **full** review pass, not standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)