### PR TITLE
fix(test): deterministic tamper in fetchSealedLeafSecret round-trip — kill ~1/64 flake

### DIFF
--- a/src/common/registry/__tests__/fetch-sealed-secret.test.ts
+++ b/src/common/registry/__tests__/fetch-sealed-secret.test.ts
@@ -94,7 +94,15 @@ describe("fetchSealedLeafSecret — round-trip", () => {
   test("a tampered ciphertext fails soft-closed", async () => {
     const member = newMember();
     const sealed = await sealedFor(member, "PSK-abc", "alice");
-    const tampered = sealed.slice(0, -4) + (sealed.endsWith("A") ? "B" : "A") + sealed.slice(-3);
+    // Deterministic tamper: flip a char inside the sealed box (index 10 sits in
+    // the ephemeral pubkey — any bit flip there breaks crypto_box_seal_open),
+    // chosen by inspecting the char actually being replaced. The old version
+    // checked the LAST char but replaced the len-4 char, so whenever that
+    // position already held "B" (and the string didn't end in "A") the
+    // "tampered" ciphertext was byte-identical to the original, decryption
+    // succeeded, and this test flaked red (~1/64 runs).
+    const i = 10;
+    const tampered = sealed.slice(0, i) + (sealed[i] === "A" ? "B" : "A") + sealed.slice(i + 1);
     const fetchImpl = fakeRegistry([
       { request_id: "r1", principal_id: "alice", peer_pubkey: member.pubkeyB64, network_id: "metafactory", status: "ADMITTED", sealed_secret: tampered },
     ]);


### PR DESCRIPTION
## Why

`fetchSealedLeafSecret — round-trip > a tampered ciphertext fails soft-closed` flakes red roughly 1 run in 64. Confirmed sightings: a recent `fix(federation)` run on `main`, and #1913 (a `scripts/`-only PR that cannot touch crypto).

## Root cause

`fetch-sealed-secret.test.ts:97`:
```js
const tampered = sealed.slice(0, -4) + (sealed.endsWith("A") ? "B" : "A") + sealed.slice(-3);
```
The replacement char is chosen by inspecting the **last** char, but the char being replaced is at **len-4**. Whenever position len-4 already holds `"B"` (and the string doesn't end in `"A"`), the "tampered" ciphertext is byte-identical to the original — decryption succeeds, `res.ok` is `true`, and the assertion fails.

## Fix

Flip an **inspected** char at a fixed index inside the ephemeral-pubkey region of the sealed box — any bit flip there breaks `crypto_box_seal_open` deterministically.

## Verification

- 8/8 local runs green post-fix (was intermittently red)
- The tamper is now provably a real mutation: the replacement is chosen from the char actually replaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)