### PR TITLE
feat(surface-sdk): plugin SDK barrel — PlatformAdapter + Renderer, SURFACE_SDK_VERSION (#1790)

### DIFF
--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -30,7 +30,7 @@ import type {
   PlatformAdapter, InboundMessage, InboundAttachment, AccessDecision,
   ResponseTarget, OutboundFile, ContextMessage, ContextAttachment,
   // Renderer contract
-  Renderer, SurfaceAdapter /* the render-target contract */, Envelope, RendererKind,
+  Renderer, RenderTarget /* the render-target contract */, Envelope, RendererKind,
   // Plugin descriptor contract
   PluginKind, SurfacePlugin, AdapterPlugin, RendererPlugin,
   SurfaceBindingEntry, BindingGroup, GatewayConstructBase,
@@ -73,7 +73,7 @@ grep -rhn "^import" src/renderers/*.ts | grep -E '"\.\./' | sort -u
 ```
 
 Cross-reference against `src/surface-sdk/index.ts`'s export list: anything
-that maps onto `PlatformAdapter`/`Renderer`/`SurfaceAdapter`/`Envelope`/the
+that maps onto `PlatformAdapter`/`Renderer`/`RenderTarget`/`Envelope`/the
 `SurfacePlugin` descriptor family should be imported from the barrel;
 everything else on that list is an acknowledged, intentional exclusion.
 
@@ -176,7 +176,11 @@ export const acmeChatAdapterPlugin: AdapterPlugin = {
 };
 
 // cortex-plugin.yaml declares: kind: adapter, sdkRange: "^1"
-export default { plugin: acmeChatAdapterPlugin, sdkRange: "^1" as const, sdkVersionAtBuild: SURFACE_SDK_VERSION };
+// The default export IS the SurfacePlugin, carrying `sdkRange` as a field
+// (ADR-0024 D1: "sdkRange in its default-exported SurfacePlugin"). The S6
+// loader reads `defaultExport.sdkRange`; the exact default-export contract
+// (this field-on-plugin shape vs a wrapper) is finalized by the S6 loader.
+export default { ...acmeChatAdapterPlugin, sdkRange: "^1" as const };
 ```
 
 ## Compilable skeleton — a renderer plugin
@@ -188,7 +192,7 @@ to stdout):
 
 ```ts
 // log-line-renderer/src/renderer.ts
-import type { Renderer, Envelope, SurfaceAdapter } from "../../surface-sdk";
+import type { Renderer, Envelope, RenderTarget } from "../../surface-sdk";
 
 export interface LogLineRendererConfig {
   id?: string;
@@ -214,7 +218,7 @@ export class LogLineRenderer implements Renderer {
     process.stdout.write(`${envelope.type} <- ${envelope.source}\n`);
   }
 
-  get surfaceConfig(): SurfaceAdapter {
+  get surfaceConfig(): RenderTarget {
     return { id: this.id, subjects: this.subjects, render: (envelope) => this.render(envelope) };
   }
 }
@@ -241,7 +245,7 @@ export const logLineRendererPlugin: RendererPlugin = {
 };
 
 // cortex-plugin.yaml declares: kind: renderer, sdkRange: "^1"
-export default { plugin: logLineRendererPlugin, sdkRange: "^1" as const };
+export default { ...logLineRendererPlugin, sdkRange: "^1" as const };
 ```
 
 ## Boundary-guard test

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -1,0 +1,264 @@
+# Plugin SDK — authoring a surface plugin
+
+**Status:** describes the v1 (S5, cortex#1790) contract surface. Boot-time
+discovery/loading of OUT-OF-TREE bundles is a later slice (S6) — today every
+plugin registered against this SDK is still in-tree (`createDefaultSurfacePluginRegistry`,
+`src/adapters/registry.ts`), dogfooding the same contract an out-of-tree
+bundle will compile against. See [ADR-0024](adr/0024-pluggable-surface-adapters.md)
+for the full decision record and `CONTEXT.md` §Adapter/renderer SDK for the
+canonical vocabulary this doc uses.
+
+## What a surface plugin is
+
+`CONTEXT.md` §Surface plugin: a **platform adapter** or a **renderer**
+packaged as a separately-installable unit the running cortex loads at boot.
+The two are distinct concepts (adapter: agent-bound, inbound *and* outbound,
+one live connection per surface; renderer: non-agent-bound, outbound only,
+`start`/`stop` lifecycle) but share ONE mechanism — one manifest shape, one
+discovery/load path, one compat gate, one fail-isolation policy, one
+`SurfacePluginRegistry` — because those are properties of *loading code into
+the daemon*, not of what the code does (ADR-0024 D5).
+
+## The SDK barrel
+
+`src/surface-sdk/index.ts` is the **one** module a plugin imports the
+contract from:
+
+```ts
+import type {
+  // Adapter contract
+  PlatformAdapter, InboundMessage, InboundAttachment, AccessDecision,
+  ResponseTarget, OutboundFile, ContextMessage, ContextAttachment,
+  // Renderer contract
+  Renderer, SurfaceAdapter /* the render-target contract */, Envelope, RendererKind,
+  // Plugin descriptor contract
+  PluginKind, SurfacePlugin, AdapterPlugin, RendererPlugin,
+  SurfaceBindingEntry, BindingGroup, GatewayConstructBase,
+} from "@cortex/surface-sdk"; // in-tree: "../../surface-sdk" (adapters) / "../surface-sdk" (renderers)
+import { SURFACE_SDK_VERSION } from "@cortex/surface-sdk";
+```
+
+*(The `@cortex/surface-sdk` specifier is illustrative of how an out-of-tree
+bundle resolves the SDK once S6's loader ships it; in-tree code today uses
+the plain relative path shown above and in the skeletons below.)*
+
+### What's IN the barrel, and why nothing else is
+
+The barrel re-exports exactly the types the `PlatformAdapter` / `Renderer` /
+`SurfacePlugin` contracts reference — nothing else. It deliberately does
+**not** re-export cortex's internal implementation machinery: `MyelinRuntime`,
+`PolicyEngine`/`PlatformPrincipalIndex`/`PrincipalRegistry`, `SystemEventSource`,
+`Agent`/`AgentConfig`/per-platform presence types, per-kind renderer config
+schemas (`DashboardRendererSchema`, `PagerDutyRendererSchema`, …), the
+`cc-events` tap reader, or formatting helpers. Those remain genuine
+cross-boundary imports the four in-tree adapters and two in-tree renderers
+still reach for today — ADR-0024's residual couplings (blockers #5–#8/#13),
+not yet resolved. Folding them into "the SDK" would mean a breaking change to
+*any* of them forces an SDK major bump, which is not what's pinned: **only**
+a breaking change to `PlatformAdapter`, `Renderer`, or the `SurfacePlugin`
+descriptor shapes is a major bump (ADR-0024 D1). Full decoupling of an
+adapter's implementation from cortex internals is the S9–S12 extraction work
+for that specific plugin, not a property the barrel enforces up front.
+
+The audit that produced the export list — re-run it any time to check for
+drift:
+
+```bash
+# Adapters: every import reaching two levels above its own platform dir.
+grep -rhn "^import" src/adapters/{discord,slack,mattermost,web}/*.ts | grep "\.\./\.\./" | sort -u
+
+# Renderers: every import leaving src/renderers/ (single "../" — renderers/
+# sits one level under src/, unlike the platform adapters at two levels).
+grep -rhn "^import" src/renderers/*.ts | grep -E '"\.\./' | sort -u
+```
+
+Cross-reference against `src/surface-sdk/index.ts`'s export list: anything
+that maps onto `PlatformAdapter`/`Renderer`/`SurfaceAdapter`/`Envelope`/the
+`SurfacePlugin` descriptor family should be imported from the barrel;
+everything else on that list is an acknowledged, intentional exclusion.
+
+## `SURFACE_SDK_VERSION` — the compat rule
+
+```ts
+export const SURFACE_SDK_VERSION = "1.0.0";
+```
+
+A plugin declares `sdkRange` (e.g. `"^1"`) in its default-exported
+`SurfacePlugin`. The **S6 loader** — not `arc install`, not a `cortex:`
+version range in the bundle's manifest — is the sole authoritative gate: at
+`import()` time it checks `satisfies(SURFACE_SDK_VERSION, plugin.sdkRange)`
+and refuses a non-satisfying plugin with a `system.error` event, leaving the
+daemon and every other plugin live. A `cortex: >=X <Y` range MAY appear in
+`cortex-plugin.yaml` as advisory metadata, never as the load gate (ADR-0024
+D1) — only the running daemon's true `SURFACE_SDK_VERSION` is authoritative,
+and arc-install-time cortex-version checks go stale on every cortex release
+that doesn't touch the contract.
+
+**One SDK, one gate, both kinds** (D5): a breaking change to `PlatformAdapter`
+*or* to `Renderer` bumps the same major, even though that conservatively
+refuses plugins of the *other*, unaffected kind. Accepted as coarse-but-honest
+— two independently-versioned SDKs would reintroduce the two-loaders problem
+D5 exists to prevent.
+
+Bumping `SURFACE_SDK_VERSION` is a disciplined act: a breaking change to any
+type the barrel exports is a MAJOR bump, documented in this file with a
+plugin-author migration note.
+
+## Compilable skeleton — an adapter plugin
+
+The reference is the in-tree web adapter (`src/adapters/web/`) — it's the
+simplest of the four (no token grouping, no secret binding fields). A
+skeleton third-party adapter, `AcmeChatAdapter`:
+
+```ts
+// acme-chat-adapter/src/adapter.ts
+import type { PlatformAdapter, InboundMessage, AccessDecision, ResponseTarget, OutboundFile } from "../../surface-sdk";
+
+export class AcmeChatAdapter implements PlatformAdapter {
+  readonly platform = "acme-chat";
+  readonly instanceId: string;
+
+  constructor(instanceId: string) {
+    this.instanceId = instanceId;
+  }
+
+  async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    // open the platform connection; call onMessage(...) per inbound event
+  }
+  async stop(): Promise<void> {
+    // tear down the connection
+  }
+  async getPlatformUserId(): Promise<string> {
+    return "acme-bot-id"; // resolved post-start, per the PlatformAdapter contract
+  }
+  async fetchContext() {
+    return [];
+  }
+  resolveAccess(_msg: InboundMessage): AccessDecision {
+    return { allowed: true, features: { chat: true, async: false, team: false } };
+  }
+  async postResponse(_target: ResponseTarget, _text: string, _files?: OutboundFile[]): Promise<void> {}
+  async sendTyping(): Promise<void> {}
+  async sendProgress(): Promise<void> {}
+  async clearProgress(): Promise<void> {}
+  async createThread(_msg: InboundMessage, _name: string): Promise<ResponseTarget> {
+    throw new Error("acme-chat: threads not supported");
+  }
+  async resolveLogicalTarget(): Promise<ResponseTarget | null> {
+    return null;
+  }
+  async notifyPrincipal(_text: string): Promise<void> {}
+}
+```
+
+```ts
+// acme-chat-adapter/src/plugin.ts
+import { z } from "zod/v4";
+import type { AdapterPlugin } from "../../surface-sdk";
+import { SURFACE_SDK_VERSION } from "../../surface-sdk";
+import { AcmeChatAdapter } from "./adapter";
+
+const AcmeChatBindingSchema = z.object({
+  agent: z.string().optional(),
+  apiKey: z.string().min(1),
+});
+
+export const acmeChatAdapterPlugin: AdapterPlugin = {
+  kind: "adapter",
+  id: "acme-chat",
+  platform: "acme-chat",
+  bindingSchema: AcmeChatBindingSchema,
+  foldsIntoPresence: false,
+  secretFields: ["apiKey"],
+  demuxKey: (binding) => String(binding.apiKey ?? "default"),
+  buildGatewayConstructArgs: (group, base) => ({ instanceId: base.instanceId }),
+  createAdapter: (args) => new AcmeChatAdapter((args as { instanceId: string }).instanceId),
+};
+
+// cortex-plugin.yaml declares: kind: adapter, sdkRange: "^1"
+export default { plugin: acmeChatAdapterPlugin, sdkRange: "^1" as const, sdkVersionAtBuild: SURFACE_SDK_VERSION };
+```
+
+## Compilable skeleton — a renderer plugin
+
+The reference is the in-tree `DashboardRenderer` (`src/renderers/dashboard.ts`)
+for shape, and `PagerDutyRenderer` for a renderer that actually does I/O. A
+trivial third-party renderer, `LogLineRenderer` (writes one line per envelope
+to stdout):
+
+```ts
+// log-line-renderer/src/renderer.ts
+import type { Renderer, Envelope, SurfaceAdapter } from "../../surface-sdk";
+
+export interface LogLineRendererConfig {
+  id?: string;
+  subscribe: string[];
+}
+
+export class LogLineRenderer implements Renderer {
+  readonly kind = "log-line" as const;
+  readonly id: string;
+  readonly subjects: string[];
+
+  constructor(config: LogLineRendererConfig) {
+    this.id = config.id ?? "log-line"; // OQ10: id defaults to kind
+    this.subjects = config.subscribe;
+  }
+
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+
+  async render(envelope: Envelope): Promise<void> {
+    // MUST NOT throw (surface-router wraps this, but don't rely on it) and
+    // MUST NOT publish on the bus as a side effect of rendering.
+    process.stdout.write(`${envelope.type} <- ${envelope.source}\n`);
+  }
+
+  get surfaceConfig(): SurfaceAdapter {
+    return { id: this.id, subjects: this.subjects, render: (envelope) => this.render(envelope) };
+  }
+}
+```
+
+```ts
+// log-line-renderer/src/plugin.ts
+import { z } from "zod/v4";
+import type { RendererPlugin } from "../../surface-sdk";
+import { LogLineRenderer, type LogLineRendererConfig } from "./renderer";
+
+const LogLineRendererSchema = z.object({
+  kind: z.literal("log-line"),
+  id: z.string().optional(),
+  subscribe: z.array(z.string()).min(1),
+});
+
+export const logLineRendererPlugin: RendererPlugin = {
+  kind: "renderer",
+  id: "log-line",
+  rendererKind: "log-line",
+  configSchema: LogLineRendererSchema,
+  createRenderer: (config) => new LogLineRenderer(config as LogLineRendererConfig),
+};
+
+// cortex-plugin.yaml declares: kind: renderer, sdkRange: "^1"
+export default { plugin: logLineRendererPlugin, sdkRange: "^1" as const };
+```
+
+## Boundary-guard test
+
+`src/surface-sdk/__tests__/boundary-guard.test.ts` walks every in-tree
+platform-adapter file and both registered renderer implementations and fails
+if any of them imports a plugin-contract symbol (the barrel's export list)
+from its pre-SDK location instead of `../surface-sdk` / `../../surface-sdk`.
+It is scoped to the CONTRACT surface only — it does not (and is not meant
+to) forbid the other cross-boundary imports discussed above; those are
+tracked as ADR-0024's residual couplings, resolved plugin-by-plugin as each
+one extracts (S9–S12).
+
+## Out of scope for this doc
+
+- Dynamic bundle loading / the compat-gate loader implementation (S6).
+- Runtime `cortex plugin list|load|unload|reload` verbs (S8).
+- Publishing an npm package for the SDK — a bundle resolves it via S6's
+  loader import mechanism, not `npm install`.
+- Retiring `GatewayAdapterFactory` (tracked separately, cortex#1896).

--- a/src/adapters/discord/context-fetcher.ts
+++ b/src/adapters/discord/context-fetcher.ts
@@ -4,7 +4,7 @@
  */
 
 import type { TextChannel, ThreadChannel, Message, Collection, Snowflake } from "discord.js";
-import type { ContextMessage, ContextAttachment } from "../../common/types/context";
+import type { ContextMessage, ContextAttachment } from "../../surface-sdk";
 import { formatContextForClaude } from "../../common/types/context";
 
 /**

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -13,16 +13,16 @@ import type {
   ResponseTarget,
   OutboundFile,
   ContextMessage,
-} from "../types";
+  Envelope,
+  SurfaceAdapter,
+} from "../../surface-sdk";
 import type { AgentConfig } from "../../common/types/config";
 import type { Agent, DiscordPresence } from "../../common/types/cortex-config";
 import { createDiscordClient, isMentionForBot, extractContent, type ConnectionHealth } from "./client";
 import { fetchContext } from "./context-fetcher";
 import { postToDiscord } from "./response-poster";
 import { isRetryableError } from "./retry";
-import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
-import type { SurfaceAdapter } from "../../bus/surface-router";
 import type { PayloadFilter } from "../../bus/payload-filter";
 import {
   type SystemEventSource,

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -14,7 +14,7 @@ import type {
   OutboundFile,
   ContextMessage,
   Envelope,
-  SurfaceAdapter,
+  RenderTarget,
 } from "../../surface-sdk";
 import type { AgentConfig } from "../../common/types/config";
 import type { Agent, DiscordPresence } from "../../common/types/cortex-config";
@@ -1300,7 +1300,7 @@ export class DiscordAdapter implements PlatformAdapter {
   /**
    * MIG-3b — Surface-adapter face for the surface-router (G-1111.A).
    *
-   * Returns a fresh `SurfaceAdapter` describing the bus-envelope-rendering
+   * Returns a fresh `RenderTarget` describing the bus-envelope-rendering
    * side of this Discord adapter:
    *
    *   - `id`        — the adapter instance ID (matches `this.instanceId`)
@@ -1313,7 +1313,7 @@ export class DiscordAdapter implements PlatformAdapter {
    * a NATS subscription — that's MyelinRuntime's job (per spec §5.1) — so this
    * face is purely the rendering hook.
    */
-  get surfaceConfig(): SurfaceAdapter {
+  get surfaceConfig(): RenderTarget {
     return {
       id: this.instanceId,
       subjects: this.infra.surfaceSubjects ?? [],

--- a/src/adapters/discord/plugin.ts
+++ b/src/adapters/discord/plugin.ts
@@ -27,7 +27,7 @@ import type {
   AdapterPlugin,
   BindingGroup,
   GatewayConstructBase,
-} from "../registry";
+} from "../../surface-sdk";
 import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
 import { groupDiscordBindingsByToken } from "../../gateway/discord-token-groups";
 

--- a/src/adapters/discord/worklog-manager.ts
+++ b/src/adapters/discord/worklog-manager.ts
@@ -24,8 +24,7 @@ import { detectProject, extractGitHubIssue } from "./event-utils";
 function asString(v: unknown): string {
   return typeof v === "string" ? v : "";
 }
-import type { Envelope } from "../../bus/myelin/envelope-validator";
-import type { SurfaceAdapter } from "../../bus/surface-router";
+import type { Envelope, SurfaceAdapter } from "../../surface-sdk";
 
 export class WorklogManager {
   private client: Client;

--- a/src/adapters/discord/worklog-manager.ts
+++ b/src/adapters/discord/worklog-manager.ts
@@ -24,7 +24,7 @@ import { detectProject, extractGitHubIssue } from "./event-utils";
 function asString(v: unknown): string {
   return typeof v === "string" ? v : "";
 }
-import type { Envelope, SurfaceAdapter } from "../../surface-sdk";
+import type { Envelope, RenderTarget } from "../../surface-sdk";
 
 export class WorklogManager {
   private client: Client;
@@ -287,7 +287,7 @@ export class WorklogManager {
     principal: string;
     adapterId?: string;
     stack?: string;
-  }): SurfaceAdapter {
+  }): RenderTarget {
     // cortex#268 — stack-aware subscription. When the caller supplies
     // `stack` (sourced from `deriveStackId(loadedConfig).stack` at boot),
     // emit the 6-segment subject grammar. Otherwise, fall through to the

--- a/src/adapters/mattermost/context.ts
+++ b/src/adapters/mattermost/context.ts
@@ -4,7 +4,7 @@
  */
 
 import type { MattermostPresence } from "../../common/types/cortex-config";
-import type { ContextMessage } from "../../common/types/context";
+import type { ContextMessage } from "../../surface-sdk";
 import { formatContextForClaude } from "../../common/types/context";
 
 export interface MattermostPost {

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -13,7 +13,7 @@ import type {
   OutboundFile,
   ContextMessage,
   Envelope,
-  SurfaceAdapter,
+  RenderTarget,
 } from "../../surface-sdk";
 import type { AgentConfig } from "../../common/types/config";
 import type { Agent, MattermostPresence } from "../../common/types/cortex-config";
@@ -461,7 +461,7 @@ export class MattermostAdapter implements PlatformAdapter {
    * failure mode is "log + drop" rather than "buffer for retry". JetStream
    * replay covers the recovery path per design-cortex.md §3.3.
    */
-  get surfaceConfig(): SurfaceAdapter {
+  get surfaceConfig(): RenderTarget {
     return {
       id: this.instanceId,
       subjects: this.infra.surfaceSubjects ?? [],

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -12,7 +12,9 @@ import type {
   ResponseTarget,
   OutboundFile,
   ContextMessage,
-} from "../types";
+  Envelope,
+  SurfaceAdapter,
+} from "../../surface-sdk";
 import type { AgentConfig } from "../../common/types/config";
 import type { Agent, MattermostPresence } from "../../common/types/cortex-config";
 import type { MattermostInboundMessage } from "./server";
@@ -24,9 +26,7 @@ import {
 } from "./poller";
 import { fetchMattermostContext } from "./context";
 import { fetchBotUserId } from "./bot-user";
-import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
-import type { SurfaceAdapter } from "../../bus/surface-router";
 import type { PayloadFilter } from "../../bus/payload-filter";
 import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
 import { type SystemEventSource } from "../../bus/system-events";

--- a/src/adapters/mattermost/plugin.ts
+++ b/src/adapters/mattermost/plugin.ts
@@ -17,7 +17,7 @@ import { MattermostBindingSchema } from "../../common/types/surfaces";
 import type { SystemEventSource } from "../../bus/system-events";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
-import type { AdapterPlugin } from "../registry";
+import type { AdapterPlugin } from "../../surface-sdk";
 import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
 
 /** Construction args `createAdapter` accepts — the same shape

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -20,12 +20,12 @@ import type {
   ResponseTarget,
   OutboundFile,
   ContextMessage,
-} from "../types";
+  Envelope,
+  SurfaceAdapter,
+} from "../../surface-sdk";
 import type { Agent, SlackPresence } from "../../common/types/cortex-config";
 import type { AgentConfig } from "../../common/types/config";
-import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
-import type { SurfaceAdapter } from "../../bus/surface-router";
 import type { PayloadFilter } from "../../bus/payload-filter";
 import {
   type SystemEventSource,

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -21,7 +21,7 @@ import type {
   OutboundFile,
   ContextMessage,
   Envelope,
-  SurfaceAdapter,
+  RenderTarget,
 } from "../../surface-sdk";
 import type { Agent, SlackPresence } from "../../common/types/cortex-config";
 import type { AgentConfig } from "../../common/types/config";
@@ -645,7 +645,7 @@ export class SlackAdapter implements PlatformAdapter {
    * same shape, same render contract, same failure mode (log + drop;
    * JetStream replay handles recovery per architecture §3.3).
    */
-  get surfaceConfig(): SurfaceAdapter {
+  get surfaceConfig(): RenderTarget {
     return {
       id: this.instanceId,
       subjects: this.infra.surfaceSubjects ?? [],

--- a/src/adapters/slack/plugin.ts
+++ b/src/adapters/slack/plugin.ts
@@ -17,7 +17,7 @@ import { SlackBindingSchema } from "../../common/types/surfaces";
 import type { SystemEventSource } from "../../bus/system-events";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { PolicyEngine, PlatformPrincipalIndex, PrincipalRegistry } from "../../common/policy";
-import type { AdapterPlugin } from "../registry";
+import type { AdapterPlugin } from "../../surface-sdk";
 import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
 
 /** Construction args `createAdapter` accepts — the same shape

--- a/src/adapters/web/index.ts
+++ b/src/adapters/web/index.ts
@@ -74,7 +74,7 @@ import type {
   ResponseTarget,
   OutboundFile,
   ContextMessage,
-} from "../types";
+} from "../../surface-sdk";
 import type { Agent } from "../../common/types/cortex-config";
 import type { WebBinding } from "../../common/types/surfaces";
 import {

--- a/src/adapters/web/plugin.ts
+++ b/src/adapters/web/plugin.ts
@@ -13,7 +13,7 @@ import { WebAdapter } from "./index";
 import { WebBindingSchema, type WebBinding } from "../../common/types/surfaces";
 import type { Agent } from "../../common/types/cortex-config";
 import type { SystemEventSource } from "../../bus/system-events";
-import type { AdapterPlugin } from "../registry";
+import type { AdapterPlugin } from "../../surface-sdk";
 import { resolveFactoryAgent, stringBindingField } from "../plugin-support";
 
 /** Construction args `createAdapter` accepts — the same shape

--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -32,7 +32,7 @@
  * activity-centric, not agent-centric.
  */
 
-import type { Envelope, SurfaceAdapter, RendererPlugin } from "../surface-sdk";
+import type { Envelope, RenderTarget, RendererPlugin } from "../surface-sdk";
 import { DashboardRendererSchema, type DashboardRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
 
@@ -83,7 +83,7 @@ export class DashboardRenderer implements Renderer {
   }
   /* eslint-enable @typescript-eslint/require-await */
 
-  get surfaceConfig(): SurfaceAdapter {
+  get surfaceConfig(): RenderTarget {
     return {
       id: this.id,
       subjects: this.subjects,
@@ -91,7 +91,7 @@ export class DashboardRenderer implements Renderer {
       // declared one. Leaving it `undefined` on the adapter means the
       // router's evaluateVisibility short-circuits to "no constraint",
       // matching pre-A.4 behaviour exactly. Spreading conditionally keeps
-      // the SurfaceAdapter literal clean.
+      // the RenderTarget literal clean.
       ...(this.visibility !== undefined && { visibility: this.visibility }),
       render: (envelope, signal) => this.render(envelope, signal),
     };

--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -32,11 +32,9 @@
  * activity-centric, not agent-centric.
  */
 
-import type { Envelope } from "../bus/myelin/envelope-validator";
-import type { SurfaceAdapter } from "../bus/surface-router";
+import type { Envelope, SurfaceAdapter, RendererPlugin } from "../surface-sdk";
 import { DashboardRendererSchema, type DashboardRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
-import type { RendererPlugin } from "../adapters/registry";
 
 export interface DashboardRendererOptions {
   /** Max envelopes retained in the ring buffer. Default 1000 — generous

--- a/src/renderers/pagerduty.ts
+++ b/src/renderers/pagerduty.ts
@@ -35,11 +35,9 @@
  * are out-of-band (re-trigger on subsequent envelopes).
  */
 
-import type { Envelope } from "../bus/myelin/envelope-validator";
-import type { SurfaceAdapter } from "../bus/surface-router";
+import type { Envelope, SurfaceAdapter, RendererPlugin } from "../surface-sdk";
 import { PagerDutyRendererSchema, type PagerDutyRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
-import type { RendererPlugin } from "../adapters/registry";
 
 const EVENTS_V2_URL = "https://events.pagerduty.com/v2/enqueue";
 const SUMMARY_MAX_LEN = 1024;

--- a/src/renderers/pagerduty.ts
+++ b/src/renderers/pagerduty.ts
@@ -35,7 +35,7 @@
  * are out-of-band (re-trigger on subsequent envelopes).
  */
 
-import type { Envelope, SurfaceAdapter, RendererPlugin } from "../surface-sdk";
+import type { Envelope, RenderTarget, RendererPlugin } from "../surface-sdk";
 import { PagerDutyRendererSchema, type PagerDutyRendererConfig } from "../common/types/cortex-config";
 import type { Renderer } from "./types";
 
@@ -92,7 +92,7 @@ export class PagerDutyRenderer implements Renderer {
     // in-flight requests; stop() doesn't need to drain them.
   }
 
-  get surfaceConfig(): SurfaceAdapter {
+  get surfaceConfig(): RenderTarget {
     return {
       id: this.id,
       subjects: this.subjects,

--- a/src/surface-sdk/__tests__/boundary-guard.test.ts
+++ b/src/surface-sdk/__tests__/boundary-guard.test.ts
@@ -1,0 +1,203 @@
+/**
+ * cortex#1790 (S5, ADR-0024 D5) — plugin SDK boundary-guard test.
+ *
+ * Walks every in-tree platform-adapter file (`src/adapters/{discord,slack,
+ * mattermost,web}/*.ts`, excluding `__tests__`) and both registered renderer
+ * implementations (`src/renderers/{dashboard,pagerduty}.ts`) — deliberately
+ * EXCLUDING the contract-owning files themselves (`adapters/types.ts`,
+ * `adapters/registry.ts`, `renderers/types.ts`, `renderers/index.ts` — the
+ * renderer-factory/registry-glue twin of `adapters/registry.ts` — and
+ * `surface-sdk/` itself) — and fails if any of them imports one of the
+ * PLUGIN-CONTRACT symbols the SDK barrel (`src/surface-sdk/index.ts`)
+ * re-exports from its ORIGINAL location instead of from `../surface-sdk`.
+ *
+ * ## What this test does NOT check
+ *
+ * It does not forbid every cross-boundary (`../../`) import — the four
+ * in-tree adapters and two in-tree renderers still reach into cortex
+ * internals the SDK deliberately does NOT re-export (`MyelinRuntime`,
+ * `PolicyEngine`, `SystemEventSource`, `AgentConfig`/presence types,
+ * per-kind renderer config schemas, tap readers, formatting helpers, …) —
+ * see `src/surface-sdk/index.ts`'s module doc for why those are excluded
+ * from the contract, and `docs/plugin-sdk.md` for the full audit. Those
+ * remain genuine residual couplings (ADR-0024 blockers #5–#8/#13) that the
+ * later S9–S12 extraction slices resolve one plugin at a time — this test
+ * guards the CONTRACT surface only: once the barrel exists, nothing in
+ * cortex may silently drift back to importing `PlatformAdapter`, `Renderer`,
+ * the render-target contract, `Envelope`, or a `SurfacePlugin` descriptor
+ * type from its pre-SDK location.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync } from "fs";
+import { dirname, join, resolve } from "path";
+
+const SRC_ROOT = resolve(import.meta.dir, "..", "..");
+
+/**
+ * Contract modules the SDK barrel re-exports from, keyed by their absolute
+ * path, mapped to the exact symbol names that must be consumed via
+ * `surface-sdk` instead of this original location. A module not listed
+ * here (e.g. `common/policy`, `bus/myelin/runtime`) is intentionally out of
+ * the guard's scope — see the module doc above.
+ */
+const GUARDED_MODULES: readonly { absPath: string; symbols: readonly string[] }[] = [
+  {
+    absPath: resolve(SRC_ROOT, "adapters", "types.ts"),
+    symbols: [
+      "PlatformAdapter",
+      "InboundMessage",
+      "InboundAttachment",
+      "AccessDecision",
+      "ResponseTarget",
+      "OutboundFile",
+      "ContextMessage",
+    ],
+  },
+  // NOTE: `Renderer` (renderers/types.ts) is deliberately NOT in this list.
+  // Its only in-tree consumers (dashboard.ts, pagerduty.ts, renderers/index.ts)
+  // import it via the intra-directory `./types` relative path, which the
+  // slice's scope explicitly leaves alone ("their own intra-directory
+  // relative imports stay") — there is no adapter-side consumer for it to
+  // guard against drifting from.
+  {
+    absPath: resolve(SRC_ROOT, "bus", "surface-router.ts"),
+    symbols: ["SurfaceAdapter"],
+  },
+  {
+    absPath: resolve(SRC_ROOT, "bus", "myelin", "envelope-validator.ts"),
+    symbols: ["Envelope"],
+  },
+  {
+    absPath: resolve(SRC_ROOT, "adapters", "registry.ts"),
+    symbols: [
+      "PluginKind",
+      "SurfacePlugin",
+      "AdapterPlugin",
+      "RendererPlugin",
+      "SurfaceBindingEntry",
+      "BindingGroup",
+      "GatewayConstructBase",
+    ],
+  },
+  {
+    absPath: resolve(SRC_ROOT, "common", "types", "cortex-config.ts"),
+    symbols: ["RendererKind"],
+  },
+  {
+    absPath: resolve(SRC_ROOT, "common", "types", "context.ts"),
+    symbols: ["ContextAttachment", "ContextMessage"],
+  },
+];
+
+const SURFACE_SDK_PATH = resolve(SRC_ROOT, "surface-sdk", "index.ts");
+
+/** Files that OWN a contract (or are the SDK itself) are exempt — they are
+ *  where the guarded symbols are legitimately DEFINED or re-exported, not
+ *  "a plugin importing the contract from the wrong place". Mirrors the
+ *  issue's "excluding registry/types/sdk". `renderers/index.ts` is the
+ *  renderer-side registry glue (resolves `(kind) -> plugin`), the direct
+ *  structural analogue of `adapters/registry.ts` — same exemption. */
+const EXEMPT_ABS_PATHS = new Set<string>([
+  resolve(SRC_ROOT, "adapters", "types.ts"),
+  resolve(SRC_ROOT, "adapters", "registry.ts"),
+  resolve(SRC_ROOT, "renderers", "types.ts"),
+  resolve(SRC_ROOT, "renderers", "index.ts"),
+  SURFACE_SDK_PATH,
+]);
+
+function listPlatformAdapterFiles(): string[] {
+  const platforms = ["discord", "slack", "mattermost", "web"];
+  const files: string[] = [];
+  for (const platform of platforms) {
+    const dir = resolve(SRC_ROOT, "adapters", platform);
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith(".ts")) {
+        files.push(join(dir, entry.name));
+      }
+    }
+  }
+  return files;
+}
+
+function listRendererFiles(): string[] {
+  const dir = resolve(SRC_ROOT, "renderers");
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (
+      entry.isFile() &&
+      entry.name.endsWith(".ts") &&
+      !EXEMPT_ABS_PATHS.has(join(dir, entry.name))
+    ) {
+      files.push(join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+interface ImportStatement {
+  clause: string;
+  specifier: string;
+}
+
+/** Minimal import-statement extraction — good enough for this repo's
+ *  consistent `import type? {...} from "...";` / `import type X from "...";`
+ *  style (matches the pattern `docs/plugin-sdk.md`'s audit command uses).
+ *  Deliberately not a full TS parser: a false negative here just means a
+ *  drift slips through until the next hand audit, not a build break. */
+function extractImports(source: string): ImportStatement[] {
+  const results: ImportStatement[] = [];
+  const importRe = /import\s+(?:type\s+)?([^;]*?)\s+from\s+["']([^"']+)["'];/g;
+  let match: RegExpExecArray | null;
+  while ((match = importRe.exec(source)) !== null) {
+    results.push({ clause: match[1] ?? "", specifier: match[2] ?? "" });
+  }
+  return results;
+}
+
+/** Resolve a relative import specifier against the importing file's
+ *  directory to an absolute `.ts` path (or `null` for a bare/package
+ *  specifier, which is never one of the guarded in-tree modules). */
+function resolveSpecifier(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const resolved = resolve(dirname(fromFile), specifier);
+  return resolved.endsWith(".ts") ? resolved : `${resolved}.ts`;
+}
+
+function violationsForFile(absPath: string): string[] {
+  const source = readFileSync(absPath, "utf-8");
+  const violations: string[] = [];
+  for (const { clause, specifier } of extractImports(source)) {
+    const resolved = resolveSpecifier(absPath, specifier);
+    if (!resolved || resolved === SURFACE_SDK_PATH) continue;
+    const guarded = GUARDED_MODULES.find((m) => m.absPath === resolved);
+    if (!guarded) continue;
+    const hit = guarded.symbols.filter((symbol) => new RegExp(`\\b${symbol}\\b`).test(clause));
+    if (hit.length > 0) {
+      violations.push(
+        `${absPath}: imports [${hit.join(", ")}] from "${specifier}" — ` +
+          `must import from "../surface-sdk" (or "../../surface-sdk") instead`,
+      );
+    }
+  }
+  return violations;
+}
+
+describe("plugin SDK boundary guard (cortex#1790, ADR-0024 D5)", () => {
+  test("no in-tree adapter or renderer imports a plugin-contract symbol from its pre-SDK location", () => {
+    const targets = [
+      ...listPlatformAdapterFiles().filter((f) => !EXEMPT_ABS_PATHS.has(f)),
+      ...listRendererFiles(),
+    ];
+    expect(targets.length).toBeGreaterThan(0);
+
+    const allViolations = targets.flatMap((f) => violationsForFile(f));
+    expect(allViolations).toEqual([]);
+  });
+
+  test("the guarded-module list resolves to real files (catches a stale path before it silently no-ops)", () => {
+    for (const { absPath } of GUARDED_MODULES) {
+      expect(() => readFileSync(absPath, "utf-8")).not.toThrow();
+    }
+  });
+});

--- a/src/surface-sdk/index.ts
+++ b/src/surface-sdk/index.ts
@@ -88,16 +88,17 @@ export type { ContextAttachment } from "../common/types/context";
 export type { Renderer } from "../renderers/types";
 
 /**
- * The surface-router's render-only subscriber contract (`SurfaceAdapter` in
- * code — a historical misnomer, NOT an adapter; `CONTEXT.md` §Render target
- * tracks the rename to `RenderTarget`). Every `Renderer.surfaceConfig`
- * value is one of these; re-exported here under its current code name so
- * the barrel doesn't invent a second name for the same type ahead of the
- * tracked rename.
+ * The surface-router's render-only subscriber contract — `CONTEXT.md`'s
+ * canonical **Render target** (NOT an adapter). The underlying type is still
+ * named `SurfaceAdapter` in `bus/surface-router.ts` (a historical misnomer
+ * whose full-codebase rename is tracked separately), but the SDK is a NEW
+ * versioned public surface with zero consumers, so it ships the canonical
+ * name `RenderTarget` from v1 — a later internal rename then never touches
+ * this contract, and never forces a cosmetic `SURFACE_SDK_VERSION` major.
  */
-export type { SurfaceAdapter } from "../bus/surface-router";
+export type { SurfaceAdapter as RenderTarget } from "../bus/surface-router";
 
-/** The envelope type both `Renderer.render()` and `SurfaceAdapter.render()`
+/** The envelope type both `Renderer.render()` and `RenderTarget.render()`
  *  operate on. */
 export type { Envelope } from "../bus/myelin/envelope-validator";
 

--- a/src/surface-sdk/index.ts
+++ b/src/surface-sdk/index.ts
@@ -1,0 +1,121 @@
+/**
+ * cortex#1790 (S5, ADR-0024 D5) — the plugin SDK barrel.
+ *
+ * `CONTEXT.md` §Adapter/renderer SDK is authoritative vocabulary: "the
+ * stable, versioned contract surface a surface plugin compiles against —
+ * the one barrel of types (`PlatformAdapter`, `Renderer`, and the
+ * envelope/target types they need) plus the version constant the loader
+ * gates on. An out-of-tree plugin imports from here and nowhere else in
+ * cortex."
+ *
+ * ## What belongs here (and what doesn't)
+ *
+ * This barrel re-exports ONLY the shared plugin CONTRACT — the types a
+ * plugin author needs to implement `PlatformAdapter` or `Renderer` and to
+ * describe either as a `SurfacePlugin` the registry can load. It does NOT
+ * re-export cortex's internal implementation machinery (`MyelinRuntime`,
+ * `PolicyEngine`, `SystemEventSource`, config/presence types, per-kind
+ * renderer config schemas, tap readers, formatting helpers, …) — those are
+ * genuine cross-boundary imports the four in-tree adapters and the two
+ * in-tree renderers still reach for today (ADR-0024 residual couplings
+ * #5–#8/#13), and folding them into "the SDK" would make a breaking change
+ * to any of THEM force a plugin-SDK major bump, which is not what D1/D5
+ * pin: only a breaking change to `PlatformAdapter`, `Renderer`, or the
+ * `SurfacePlugin` descriptor shapes is a major bump. Full decoupling of the
+ * in-tree adapters from cortex internals is the S9–S12 extraction work,
+ * not this slice.
+ *
+ * The audit that produced this export list: every `../../` import in
+ * `src/adapters/{discord,slack,mattermost,web}/*.ts` and every `../`
+ * cross-boundary import in `src/renderers/*.ts`, intersected with the
+ * types actually referenced by the `PlatformAdapter` / `Renderer` /
+ * `SurfacePlugin` contracts (`adapters/types.ts`, `renderers/types.ts`,
+ * `bus/surface-router.ts`'s `SurfaceAdapter`, `bus/myelin/envelope-validator.ts`'s
+ * `Envelope`, `adapters/registry.ts`'s descriptor types). See
+ * `docs/plugin-sdk.md` for the worked audit command and the full list of
+ * cross-boundary imports that were deliberately left OUT.
+ *
+ * ## Compat rule (ADR-0024 D1, D5 — pinned)
+ *
+ * `SURFACE_SDK_VERSION` is a single-integer-major semver string. A plugin
+ * declares an `sdkRange` (e.g. `"^1"`) in its default-exported
+ * `SurfacePlugin`; the S6 loader is the SOLE authoritative gate — it checks
+ * `satisfies(SURFACE_SDK_VERSION, plugin.sdkRange)` at `import()` time and
+ * refuses a non-satisfying plugin with a `system.error` event, leaving the
+ * daemon and every other plugin live. **One SDK, one gate, both kinds**
+ * (D5): a breaking change to `PlatformAdapter` OR to `Renderer` bumps the
+ * SAME major, even though that conservatively refuses plugins of the
+ * *other*, unaffected kind — accepted as coarse-but-honest so two
+ * independently-versioned SDKs never reintroduce the two-loaders problem
+ * D5 exists to prevent. A `cortex: >=X <Y` range MAY appear in a bundle's
+ * `cortex-plugin.yaml` as ADVISORY metadata (arc install may surface it)
+ * but is never the load gate — only the running daemon's true
+ * `SURFACE_SDK_VERSION` is authoritative.
+ *
+ * Bumping this value is a disciplined act: a breaking change to
+ * `PlatformAdapter`, `Renderer`, `SurfacePlugin`/`AdapterPlugin`/
+ * `RendererPlugin`, or any type transitively exported below is a MAJOR
+ * bump with a documented plugin-author migration note (OQ5 — SDK changelog
+ * ownership, ratified "as recommended", still applies: record the
+ * migration in this file's history, not just the commit message).
+ */
+export const SURFACE_SDK_VERSION = "1.0.0";
+
+// =============================================================================
+// Platform adapter contract (src/adapters/types.ts)
+// =============================================================================
+
+export type {
+  PlatformAdapter,
+  InboundMessage,
+  InboundAttachment,
+  AccessDecision,
+  ResponseTarget,
+  OutboundFile,
+  ContextMessage,
+} from "../adapters/types";
+
+// `ContextAttachment` is referenced by `ContextMessage.attachments` and is
+// imported directly by adapter context-fetchers (discord/context-fetcher.ts,
+// mattermost/context.ts) alongside `ContextMessage` — part of the same
+// envelope/target type family, so it travels with it.
+export type { ContextAttachment } from "../common/types/context";
+
+// =============================================================================
+// Renderer contract (src/renderers/types.ts + the render-target contract)
+// =============================================================================
+
+export type { Renderer } from "../renderers/types";
+
+/**
+ * The surface-router's render-only subscriber contract (`SurfaceAdapter` in
+ * code — a historical misnomer, NOT an adapter; `CONTEXT.md` §Render target
+ * tracks the rename to `RenderTarget`). Every `Renderer.surfaceConfig`
+ * value is one of these; re-exported here under its current code name so
+ * the barrel doesn't invent a second name for the same type ahead of the
+ * tracked rename.
+ */
+export type { SurfaceAdapter } from "../bus/surface-router";
+
+/** The envelope type both `Renderer.render()` and `SurfaceAdapter.render()`
+ *  operate on. */
+export type { Envelope } from "../bus/myelin/envelope-validator";
+
+/** `Renderer.kind`'s discriminant — the registered renderer-kind key set
+ *  (ADR-0024 D5 turned this from a closed `z.enum` into the registry's key
+ *  set; a plugin's `rendererKind` value must be assignable to this type). */
+export type { RendererKind } from "../common/types/cortex-config";
+
+// =============================================================================
+// Plugin descriptor contract (src/adapters/registry.ts, ADR-0024 D5)
+// =============================================================================
+
+export type {
+  PluginKind,
+  SurfacePlugin,
+  AdapterPlugin,
+  RendererPlugin,
+  SurfaceBindingEntry,
+  BindingGroup,
+  GatewayConstructBase,
+} from "../adapters/registry";


### PR DESCRIPTION
Closes #1790. Epic #1784, W2 lane A (S5). Builds on S3 (registry) + S4 (schemas).

The one stable, versioned contract surface both plugin kinds compile against.

## What landed
- **`src/surface-sdk/index.ts`** — one barrel re-exporting ONLY the contract: `PlatformAdapter` + message/target/access types, `Renderer` + the render-target contract + `Envelope`/`RendererKind`, and the `SurfacePlugin`/`AdapterPlugin`/`RendererPlugin` descriptor types. Plus **`SURFACE_SDK_VERSION = "1.0.0"`** with the ADR-0024 D1/D5 compat rule documented (loader-authoritative `satisfies()` gate; one SDK / one gate / both kinds; `cortex:` range is advisory only).
- **All in-tree plugins rewired** to import the contract from the barrel (4 adapter `plugin.ts` + `index.ts`, both renderers, + a few helpers). Small diff: 13 files (+19/-24) + 3 new.
- **Boundary-guard test** (`surface-sdk/__tests__/boundary-guard.test.ts`) — fails if any in-tree plugin imports a contract symbol from its pre-SDK path instead of the barrel.
- **`docs/plugin-sdk.md`** — authoring guide + two skeletons (adapter + renderer) that were actually compiled with `tsc --noEmit` before being called "compilable".

## ⚠️ Scope call — reviewer, verify (I did)
The original issue body's criterion ("zero non-SDK `../../` imports") was **NOT** built to, because it contradicts ratified **ADR-0024 D1** and **CONTEXT.md**: the SDK is the *contract* (`PlatformAdapter`/`Renderer`/`SurfacePlugin` + the types they need), not every cortex internal an adapter imports. Folding `MyelinRuntime`/`PolicyEngine`/etc. in would make an internal refactor a major SDK bump — the exact re-coupling D1 rejects. Issue #1790 updated to record the superseded criterion. Verified against ADR-0024 D1 + CONTEXT.md:216.

## Forward-looking risk this surfaces (for the reviewer + S9)
The in-tree plugins STILL import injected-dependency types (`MyelinRuntime`, `SystemEventSource`, `AgentConfig`, …) directly — legal because they're in-tree. An **out-of-tree** plugin (S9's web extraction) can't. Open question the review should assess: **is the barrel sufficient for a real out-of-tree plugin's `createAdapter`/`createRenderer` signature, or will S9 need those injected-dependency types added to the SDK as type-only exports?** Not a blocker for S5, but it should be a known input to S9, not a surprise.

## Gates
`bun test src/adapters src/renderers src/surface-sdk src/gateway src/common` → 2423 pass / 0 fail · `tsc --noEmit` 0 · `eslint --quiet` 0 · `check-carveouts.sh` PASS · independently re-verified on branch (tsc 0, boundary-guard 2/2, vocab PASS). Rebased on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)