### PR TITLE
fix(migrate): stop minting the ~/.config/cortex intermediate (#1898)

### DIFF
--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -703,11 +703,18 @@ describe("convertBotYaml — schema-sourced defaults", () => {
 });
 
 // ---------------------------------------------------------------------------
-// cortex#88 item 1 — paths.* grove → cortex rewrite
+// XDG P0.5 (cortex#1898) — migration no longer mints ~/.config/cortex
+//
+// The grove→cortex `paths:` rewrite (old cortex#88 item 1) was deleted. The
+// plist renderer discovers stacks by walking the config dir; minting the
+// deprecated intermediate `~/.config/cortex/<slug>/` let discovery resurrect
+// a dead stack and render a plist pointing at a config the resolver no longer
+// reads (trap T11). Migration now passes `paths:` through verbatim — moving
+// config to the metafactory tree is X-07/#1869, out of scope here.
 // ---------------------------------------------------------------------------
 
-describe("convertBotYaml — paths rewrite (cortex#88 item 1)", () => {
-  test("rewrites grove path defaults under paths.* to cortex equivalents", () => {
+describe("convertBotYaml — no ~/.config/cortex minting (cortex#1898)", () => {
+  test("passes a grove paths block through verbatim — never mints a cortex path", () => {
     const legacy: LegacyBotYaml = {
       agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
@@ -718,12 +725,31 @@ describe("convertBotYaml — paths rewrite (cortex#88 item 1)", () => {
     };
     const result = convertBotYaml(legacy, {});
     const paths = (result.cortex.paths ?? {}) as Record<string, string>;
-    expect(paths.logDir).toBe("~/.config/cortex/logs");
+    // The grove path is preserved untouched — NOT rewritten/minted to cortex.
+    expect(paths.logDir).toBe("~/.config/grove/logs");
     // Non-grove paths pass through unchanged
     expect(paths.publishedEventsDir).toBe("~/.claude/events/published");
-    // Operator sees a warning surfacing the substitution
-    const pathsWarn = result.warnings.find((w) => w.field === "paths");
-    expect(pathsWarn?.message).toMatch(/grove path\(s\)/);
+    // Behavioural inverse assertion (covers migrate-config-lib + anything it
+    // calls): no emitted path targets the deprecated cortex intermediate.
+    for (const value of Object.values(paths)) {
+      expect(value).not.toContain(".config/cortex");
+    }
+    // The old "paths rewrite" warning is gone — nothing was rewritten.
+    expect(result.warnings.find((w) => w.field === "paths")).toBeUndefined();
+  });
+
+  test("no migration code path mints ~/.config/cortex (static, comment-stripped)", () => {
+    // Static inverse assertion: fail if the minting literal is reintroduced
+    // anywhere in the migration lib. Assert on CODE, not comments — a doc
+    // comment at migrate-config-lib.ts:124 legitimately names the operator's
+    // own ~/.config/cortex/cortex.yaml, and the resolver root stays there
+    // until X-07. Strip comments first so only a real minting literal trips it.
+    const libPath = join(import.meta.dir, "..", "migrate-config-lib.ts");
+    const src = readFileSync(libPath, "utf-8");
+    const codeOnly = src
+      .replace(/\/\*[\s\S]*?\*\//g, "") // block comments
+      .replace(/(^|[^:])\/\/.*$/gm, "$1"); // line comments (leave URLs intact)
+    expect(codeOnly).not.toMatch(/\.config\/cortex/);
   });
 
   test("leaves a paths block that already targets cortex unchanged", () => {

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -1345,7 +1345,12 @@ export function convertBotYaml(
   if (legacy.attachments !== undefined) cortex.attachments = legacy.attachments;
   if (legacy.execution !== undefined) cortex.execution = legacy.execution;
   if (legacy.github !== undefined) cortex.github = legacy.github;
-  if (legacy.paths !== undefined) cortex.paths = rewritePaths(legacy.paths, warnings);
+  // cortex#1898 (XDG P0.5) — pass the operator's `paths:` block through
+  // verbatim. The old grove→cortex rewrite (cortex#88 item 1) was deleted:
+  // minting the deprecated intermediate under the config dir let the plist
+  // renderer's discovery walk resurrect a dead stack (trap T11). Moving
+  // config to the metafactory tree is X-07/#1869; here we only stop minting.
+  if (legacy.paths !== undefined) cortex.paths = legacy.paths;
   if (legacy.networksDir !== undefined) cortex.networksDir = legacy.networksDir;
   if (legacy.networks !== undefined) cortex.networks = legacy.networks;
   if (legacy.nats !== undefined) cortex.nats = convertNats(legacy.nats, warnings);
@@ -1705,44 +1710,6 @@ function buildAgentsFromCortexShape(
     out.push(agentOut);
   }
   return out;
-}
-
-/**
- * Rewrite grove-era path strings (`~/.config/grove/...`) under the legacy
- * `paths:` block to their cortex equivalents (`~/.config/cortex/...`).
- *
- * cortex#88 item 1: legacy `bot.yaml` carries `paths.logDir:
- * ~/.config/grove/logs` (the AgentConfigSchema default in production grove-v2).
- * Without rewriting, the emitted cortex.yaml ships a stale grove path that
- * any consumer of `config.paths.logDir` will then write to — even though
- * the launchd plist's `StandardOutPath` already points at
- * `~/.config/cortex/logs` (per scripts/postinstall.sh). The two diverge,
- * and operators chasing missing logs get sent on a wild grove chase.
- *
- * Strategy: shallow substring rewrite over string-valued fields. Non-string
- * fields (rare, but `unknown` shape leaves the door open) pass through
- * unchanged. A warning surfaces whenever any rewrite fired so the operator
- * sees the substitution in the migrate-config report.
- */
-function rewritePaths(legacyPaths: unknown, warnings: ConversionWarning[]): unknown {
-  if (!legacyPaths || typeof legacyPaths !== "object") return legacyPaths;
-  const paths = { ...(legacyPaths as Record<string, unknown>) };
-  const rewrites: string[] = [];
-  for (const [key, value] of Object.entries(paths)) {
-    if (typeof value !== "string") continue;
-    if (value.includes("/.config/grove/")) {
-      const next = value.replace("/.config/grove/", "/.config/cortex/");
-      paths[key] = next;
-      rewrites.push(`paths.${key}: "${value}" → "${next}"`);
-    }
-  }
-  if (rewrites.length > 0) {
-    warnings.push({
-      field: "paths",
-      message: `rewrote grove path(s) to cortex equivalents: ${rewrites.join("; ")}`,
-    });
-  }
-  return paths;
 }
 
 /**


### PR DESCRIPTION
Closes #1898. Part of epic #1867, wave 1 (P0.5 / X-01).

## What
Deletes the grove→cortex `paths:` rewrite in `migrate-config-lib.ts` (the full `rewritePaths` function, real range :1710-1746 — the issue's cited range was truncated, as its amendment warned). The operator's `paths:` block now passes through **verbatim**: `paths` is a live schema field, so dropping the line would have regressed operator configs; rewriting it minted the deprecated intermediate that the plist renderer's discovery walk can resurrect as a dead stack (trap T11).

## Inverse assertions (G-16 rescope: migration-code-only)
- Behavioural: grove input preserved; no emitted path contains `.config/cortex`
- Static: comment-stripped source of the lib contains no `.config/cortex` literal (the :124 doc-comment false-trip is handled — assert on code, not comments)
- The old minting assertion is deleted, not relocated

Shell minters (postinstall/postupgrade) are explicitly out of scope → #1869's sweep.

## Verification
- `bun test migrate-config.test.ts`: 109 pass / 0 fail · tsc clean · eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)