### PR TITLE
feat(config): CORTEX_{CONFIG,EVENTS}_DIR env seams — hermetic path resolution (#1908)

### DIFF
--- a/src/common/__tests__/events-path.test.ts
+++ b/src/common/__tests__/events-path.test.ts
@@ -1,0 +1,79 @@
+/**
+ * XDG wave-1 (cortex#1908, EPIC cortex#1867 X-03) — CORTEX_EVENTS_DIR seam.
+ *
+ * Proves the two contract halves:
+ *   - UNSET  ⇒ byte-identical to the previous inline
+ *     `join(<home>, ".claude", "events")` at every call site.
+ *   - SET    ⇒ the events buffer (root / raw / published) resolves ENTIRELY
+ *     inside the override, winning over the `home` source — so a hermetic
+ *     guard (#1870) can point the hook→relay→MC pipeline at a scratch dir.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  eventsDir,
+  eventsDirOverride,
+  publishedEventsDir,
+  rawEventsDir,
+} from "../events-path";
+
+const FAKE_HOME = "/fake/home";
+
+describe("events-path — CORTEX_EVENTS_DIR seam (XDG wave-1 cortex#1908)", () => {
+  let scratch: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.CORTEX_EVENTS_DIR;
+    delete process.env.CORTEX_EVENTS_DIR; // known-unset baseline
+    scratch = mkdtempSync(join(tmpdir(), "x1908-ev-"));
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CORTEX_EVENTS_DIR;
+    else process.env.CORTEX_EVENTS_DIR = savedEnv;
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  describe("unset ⇒ byte-identical to <home>/.claude/events", () => {
+    test("root/raw/published derive from the passed home", () => {
+      expect(eventsDirOverride()).toBeUndefined();
+      expect(eventsDir(FAKE_HOME)).toBe(join(FAKE_HOME, ".claude", "events"));
+      expect(rawEventsDir(FAKE_HOME)).toBe(join(FAKE_HOME, ".claude", "events", "raw"));
+      expect(publishedEventsDir(FAKE_HOME)).toBe(
+        join(FAKE_HOME, ".claude", "events", "published"),
+      );
+    });
+
+    test("no home arg ⇒ defaults to process.env.HOME (the hook/relay spelling)", () => {
+      const savedHome = process.env.HOME;
+      process.env.HOME = "/env/home";
+      try {
+        expect(eventsDir()).toBe(join("/env/home", ".claude", "events"));
+      } finally {
+        if (savedHome === undefined) delete process.env.HOME;
+        else process.env.HOME = savedHome;
+      }
+    });
+  });
+
+  describe("set ⇒ resolves inside CORTEX_EVENTS_DIR (hermetic)", () => {
+    test("override wins over home for root/raw/published", () => {
+      process.env.CORTEX_EVENTS_DIR = scratch;
+      expect(eventsDirOverride()).toBe(scratch);
+      expect(eventsDir(FAKE_HOME)).toBe(scratch);
+      expect(rawEventsDir(FAKE_HOME)).toBe(join(scratch, "raw"));
+      expect(publishedEventsDir(FAKE_HOME)).toBe(join(scratch, "published"));
+      expect(rawEventsDir(FAKE_HOME).startsWith(scratch)).toBe(true);
+      expect(publishedEventsDir(FAKE_HOME).startsWith(scratch)).toBe(true);
+    });
+
+    test("empty CORTEX_EVENTS_DIR is treated as unset (not '/')", () => {
+      process.env.CORTEX_EVENTS_DIR = "";
+      expect(eventsDirOverride()).toBeUndefined();
+      expect(eventsDir(FAKE_HOME)).toBe(join(FAKE_HOME, ".claude", "events"));
+    });
+  });
+});

--- a/src/common/config/__tests__/config-path.test.ts
+++ b/src/common/config/__tests__/config-path.test.ts
@@ -15,6 +15,8 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, st
 import { tmpdir } from "os";
 import { join } from "path";
 import {
+  cortexConfigDir,
+  cortexConfigDirOverride,
   cortexConfigPath,
   groveConfigPath,
   migrateGroveConfigFile,
@@ -22,6 +24,7 @@ import {
 } from "../config-path";
 
 let home: string;
+let savedConfigDirEnv: string | undefined;
 const FILE = "cli.yaml";
 
 function cortexFile() {
@@ -32,10 +35,18 @@ function groveFile() {
 }
 
 beforeEach(() => {
+  // Isolate the default-behavior tests from an ambient `CORTEX_CONFIG_DIR`
+  // (cortex#1908): the issue's own verification command exports it globally
+  // (`CORTEX_CONFIG_DIR=/tmp/x bun test src/common/config`), which would
+  // otherwise redirect these home-injected assertions off `~/.config/cortex`.
+  savedConfigDirEnv = process.env.CORTEX_CONFIG_DIR;
+  delete process.env.CORTEX_CONFIG_DIR;
   home = mkdtempSync(join(tmpdir(), "gv1-home-"));
 });
 
 afterEach(() => {
+  if (savedConfigDirEnv === undefined) delete process.env.CORTEX_CONFIG_DIR;
+  else process.env.CORTEX_CONFIG_DIR = savedConfigDirEnv;
   rmSync(home, { recursive: true, force: true });
 });
 
@@ -140,5 +151,82 @@ describe("migrateGroveConfigFile — auto-migrate preserving mode", () => {
   test("no-op (returns false) when neither exists", () => {
     expect(migrateGroveConfigFile(FILE, home)).toBe(false);
     expect(existsSync(cortexFile())).toBe(false);
+  });
+});
+
+// XDG wave-1 (cortex#1908, EPIC cortex#1867 X-03) — CORTEX_CONFIG_DIR env seam.
+// When set it relocates the whole config tree; when unset, everything above
+// this block already proves byte-identical `~/.config/{cortex,grove}` behavior.
+describe("CORTEX_CONFIG_DIR override (XDG wave-1 cortex#1908)", () => {
+  let scratch: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.CORTEX_CONFIG_DIR;
+    delete process.env.CORTEX_CONFIG_DIR; // start from a known-unset baseline
+    scratch = mkdtempSync(join(tmpdir(), "x1908-cfg-"));
+  });
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.CORTEX_CONFIG_DIR;
+    else process.env.CORTEX_CONFIG_DIR = savedEnv;
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  test("unset ⇒ default dir is ~/.config/cortex (byte-identical) and override is undefined", () => {
+    expect(cortexConfigDirOverride()).toBeUndefined();
+    expect(cortexConfigDir(home)).toBe(join(home, ".config", "cortex"));
+    expect(cortexConfigPath(FILE, home)).toBe(cortexFile());
+  });
+
+  test("set ⇒ config dir is the override verbatim, ignoring home", () => {
+    process.env.CORTEX_CONFIG_DIR = scratch;
+    expect(cortexConfigDirOverride()).toBe(scratch);
+    expect(cortexConfigDir(home)).toBe(scratch);
+    expect(cortexConfigPath(FILE, home)).toBe(join(scratch, FILE));
+  });
+
+  test("empty CORTEX_CONFIG_DIR is treated as unset (not '/')", () => {
+    process.env.CORTEX_CONFIG_DIR = "";
+    expect(cortexConfigDirOverride()).toBeUndefined();
+    expect(cortexConfigDir(home)).toBe(join(home, ".config", "cortex"));
+  });
+
+  test("resolveConfigFile returns the in-override file when it exists", () => {
+    process.env.CORTEX_CONFIG_DIR = scratch;
+    writeFileSync(join(scratch, FILE), "from-override");
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(join(scratch, FILE));
+    expect(r.source).toBe("cortex");
+    expect(r.path.startsWith(scratch)).toBe(true);
+  });
+
+  // The acceptance criterion: with the override set, resolution lands ENTIRELY
+  // inside it with ZERO real-home access. A grove copy under the (fake) home is
+  // planted precisely to prove the legacy fallback is NOT probed.
+  test("hermetic: absent file ⇒ default target inside override, grove/home never probed", () => {
+    process.env.CORTEX_CONFIG_DIR = scratch;
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(groveFile(), "from-grove"); // MUST be ignored under the override
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(join(scratch, FILE));
+    expect(r.source).toBe("default"); // grove skipped → default, never "grove"
+    expect(r.path.startsWith(scratch)).toBe(true);
+  });
+
+  test("migrateGroveConfigFile is a no-op under the override (never reads real grove)", () => {
+    process.env.CORTEX_CONFIG_DIR = scratch;
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(groveFile(), "from-grove");
+    expect(migrateGroveConfigFile(FILE, home)).toBe(false);
+    expect(existsSync(join(scratch, FILE))).toBe(false);
+  });
+
+  test("unset restores the grove read-fallback (regression guard for the skip)", () => {
+    // env already deleted in beforeEach
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(groveFile(), "from-grove");
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(groveFile());
+    expect(r.source).toBe("grove");
   });
 });

--- a/src/common/config/config-path.ts
+++ b/src/common/config/config-path.ts
@@ -22,6 +22,17 @@
  *
  * Also out of scope: the `GROVE_*` → `CORTEX_*` ENV-VAR tier (separate shim,
  * cortex#774) and any `grove`-as-guild-name / `the-metafactory/grove` repo refs.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * XDG wave-1 (cortex#1908, EPIC cortex#1867 X-03) — CONFIG_DIR env seam.
+ *
+ * `CORTEX_CONFIG_DIR`, when set, is the cortex config directory VERBATIM (the
+ * `~/.config/cortex` default is bypassed), so a hermetic guard (#1870) can
+ * point config resolution at a scratch dir with ZERO real-home access. When
+ * UNSET, every path here is byte-identical to before. This is JUST the env
+ * read; honoring `$XDG_CONFIG_HOME` and moving files is #1869/#1903 — out of
+ * scope. `CORTEX_STATE_DIR` (the `pidfile.ts` state dir) is owned by #1900
+ * this wave (G-21 serialization); `CORTEX_EVENTS_DIR` lives in `events-path.ts`.
  */
 
 import { copyFileSync, existsSync, mkdirSync, statSync, chmodSync } from "fs";
@@ -51,9 +62,31 @@ function homeDir(home?: string): string {
   return home ?? process.env.HOME ?? "~";
 }
 
-/** Build `~/.config/cortex/<filename>` (canonical). */
+/**
+ * The `CORTEX_CONFIG_DIR` override, or `undefined` when unset/empty.
+ *
+ * When set it is the config directory verbatim (an absolute or relative path
+ * the caller controls) — it wins over both the `~/.config/cortex` default and
+ * any `home` test override. An empty string is treated as unset so a caller
+ * that exports `CORTEX_CONFIG_DIR=` (blank) gets today's behavior, not `/`.
+ */
+export function cortexConfigDirOverride(): string | undefined {
+  const v = process.env.CORTEX_CONFIG_DIR;
+  return v !== undefined && v.length > 0 ? v : undefined;
+}
+
+/**
+ * The cortex config DIRECTORY: `$CORTEX_CONFIG_DIR` if set, else the canonical
+ * `~/.config/cortex`. This is the single seam every config-file path is built
+ * on, so overriding the env var relocates the whole config tree at once.
+ */
+export function cortexConfigDir(home?: string): string {
+  return cortexConfigDirOverride() ?? join(homeDir(home), ".config", CORTEX_CONFIG_DIRNAME);
+}
+
+/** Build `~/.config/cortex/<filename>` (canonical, or under `$CORTEX_CONFIG_DIR`). */
 export function cortexConfigPath(filename: string, home?: string): string {
-  return join(homeDir(home), ".config", CORTEX_CONFIG_DIRNAME, filename);
+  return join(cortexConfigDir(home), filename);
 }
 
 /** Build `~/.config/grove/<filename>` (legacy / fallback). */
@@ -75,8 +108,14 @@ export function resolveConfigFile(filename: string, home?: string): ResolvedConf
   const cortex = cortexConfigPath(filename, home);
   if (existsSync(cortex)) return { path: cortex, source: "cortex" };
 
-  const grove = groveConfigPath(filename, home);
-  if (existsSync(grove)) return { path: grove, source: "grove" };
+  // With an explicit `CORTEX_CONFIG_DIR` the legacy grove read-fallback is
+  // SKIPPED: the override is a self-contained config root, and probing the
+  // real `~/.config/grove` would both break hermeticity (a real-home stat)
+  // and be meaningless (grove has no counterpart under an explicit root).
+  if (cortexConfigDirOverride() === undefined) {
+    const grove = groveConfigPath(filename, home);
+    if (existsSync(grove)) return { path: grove, source: "grove" };
+  }
 
   return { path: cortex, source: "default" };
 }
@@ -110,6 +149,10 @@ export function resolveConfigFilePath(filename: string, home?: string): string {
 export function migrateGroveConfigFile(filename: string, home?: string): boolean {
   const cortex = cortexConfigPath(filename, home);
   if (existsSync(cortex)) return false; // cortex copy is canonical — never clobber
+
+  // An explicit `CORTEX_CONFIG_DIR` root has no grove side — never reach into
+  // the real `~/.config/grove` to migrate (would break the hermetic guard).
+  if (cortexConfigDirOverride() !== undefined) return false;
 
   const grove = groveConfigPath(filename, home);
   if (!existsSync(grove)) return false; // nothing to migrate

--- a/src/common/events-path.ts
+++ b/src/common/events-path.ts
@@ -1,0 +1,58 @@
+/**
+ * XDG wave-1 (cortex#1908, EPIC cortex#1867 X-03) — EVENTS_DIR path seam.
+ *
+ * The Claude Code event buffer lives at `~/.claude/events/{raw,published}` and
+ * is touched from THREE independent sites that must all agree byte-for-byte
+ * (the #1870 guard's "byte-identical events dir across hook/relay/MC"
+ * invariant): the event-logger hook (writer), the relay (reader→publisher),
+ * and Mission Control's hook poller (reader). Before this module each site
+ * inlined its own `join(process.env.HOME ?? "~", ".claude", "events")`, so
+ * there was nowhere to point a hermetic guard.
+ *
+ * This is the single seam for `CORTEX_EVENTS_DIR`:
+ *   - UNSET  ⇒ `~/.claude/events` — byte-identical to the previous inline
+ *     spelling at each call site (callers pass their own `home` source so an
+ *     `os.homedir()`-based site stays `os.homedir()`-based).
+ *   - SET    ⇒ that directory VERBATIM, so a guard (#1870) can point the whole
+ *     hook→relay→MC pipeline at a scratch dir with zero real-home access.
+ *
+ * SCOPE — this is JUST the env read. It does NOT honor `$XDG_DATA_HOME` /
+ * `$XDG_STATE_HOME` or move the buffer (that classification is #1867 P3 /
+ * #1902). No `GROVE_*` dual-read: `CORTEX_EVENTS_DIR` is a newly-introduced
+ * var, not a name being migrated (cortex#774's dual-read is only for renames).
+ */
+
+import { join } from "path";
+
+function homeDir(home?: string): string {
+  return home ?? process.env.HOME ?? "~";
+}
+
+/**
+ * The `CORTEX_EVENTS_DIR` override, or `undefined` when unset/empty. An empty
+ * string is treated as unset so `CORTEX_EVENTS_DIR=` (blank) keeps today's
+ * behavior rather than resolving to `/`.
+ */
+export function eventsDirOverride(): string | undefined {
+  const v = process.env.CORTEX_EVENTS_DIR;
+  return v !== undefined && v.length > 0 ? v : undefined;
+}
+
+/**
+ * The events-buffer ROOT: `$CORTEX_EVENTS_DIR` if set, else `~/.claude/events`.
+ * @param home Override for `$HOME` (tests / call sites that resolve home via
+ *   `os.homedir()`); ignored when `CORTEX_EVENTS_DIR` is set.
+ */
+export function eventsDir(home?: string): string {
+  return eventsDirOverride() ?? join(homeDir(home), ".claude", "events");
+}
+
+/** The raw event buffer: `<eventsDir>/raw`. */
+export function rawEventsDir(home?: string): string {
+  return join(eventsDir(home), "raw");
+}
+
+/** The published event buffer: `<eventsDir>/published`. */
+export function publishedEventsDir(home?: string): string {
+  return join(eventsDir(home), "published");
+}

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -28,6 +28,7 @@
 import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
 import { join } from "path";
 import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
+import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
 
@@ -287,7 +288,9 @@ function deny(reason: string): void {
 // full test run). Production leaves the env unset → unchanged behaviour.
 const INGEST_URL =
   process.env.CORTEX_INGEST_URL ?? "http://localhost:8766/api/events/ingest";
-const EVENTS_DIR = join(process.env.HOME ?? "~", ".claude", "events");
+// cortex#1908: single seam for the events buffer root — honors
+// CORTEX_EVENTS_DIR, else `~/.claude/events` (byte-identical when unset).
+const EVENTS_DIR = eventsDir();
 const RAW_DIR = join(EVENTS_DIR, "raw");
 
 /** Shape mirrors `RawEvent` from src/taps/cc-events/hooks/lib/event-types.ts. */

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -6,6 +6,7 @@ import { readFileSync, existsSync } from "fs";
 import { parse as parseYaml } from "yaml";
 import { join } from "path";
 import { homedir } from "os";
+import { rawEventsDir as resolveRawEventsDir } from "../../common/events-path";
 import type { Config, LogLevel, CfAccessConfig, GovernanceConfig } from "./types";
 import { resolveConfigFilePath } from "../../common/config/config-path";
 
@@ -26,7 +27,9 @@ export const DEFAULT_CONFIG: Config = {
     level: "info",
   },
   hooks: {
-    rawEventsDir: join(homedir(), ".claude", "events", "raw"),
+    // cortex#1908: honors CORTEX_EVENTS_DIR; passing `homedir()` keeps the
+    // unset default byte-identical to the previous `join(homedir(), …)`.
+    rawEventsDir: resolveRawEventsDir(homedir()),
     cursorPath: join(
       homedir(),
       ".local",

--- a/src/taps/cc-events/hooks/event-logger.hook.ts
+++ b/src/taps/cc-events/hooks/event-logger.hook.ts
@@ -9,6 +9,7 @@
 import { appendFileSync, mkdirSync, chmodSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { createRawEvent, type RawEvent } from "./lib/event-types";
+import { eventsDir } from "../../../common/events-path";
 import { mapHookToEventType, EVENT_TYPES } from "./lib/event-taxonomy";
 import { resolvePrincipalEnv } from "./lib/principal-env";
 import { resolveSurfaceEnv } from "./lib/surface-env";
@@ -79,7 +80,9 @@ function isHookEventName(v: string): v is HookEventName {
 // Configuration
 // =============================================================================
 
-const EVENTS_DIR = join(process.env.HOME ?? "~", ".claude", "events");
+// cortex#1908: single seam for the events buffer root — honors
+// CORTEX_EVENTS_DIR, else `~/.claude/events` (byte-identical when unset).
+const EVENTS_DIR = eventsDir();
 const RAW_DIR = join(EVENTS_DIR, "raw");
 // cortex#1677: the relay is OPTIONAL. The env var below overrides the
 // default target for a moved/rebound relay; when unset, the literal

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -13,6 +13,7 @@ import { processEvent } from "./lib/policy-engine";
 import { EventProcessor } from "./lib/event-processor";
 import { watchRawEvents } from "./lib/file-watcher";
 import { RawEventSchema } from "./hooks/lib/event-types";
+import { eventsDir } from "../../common/events-path";
 import { resolvePrincipalEnv } from "./hooks/lib/principal-env";
 import { NatsLink } from "../../bus/nats/connection";
 import { createCcEventPublisher } from "./cc-events";
@@ -46,7 +47,9 @@ interface TestOptions {
 // Paths
 // =============================================================================
 
-const EVENTS_DIR = join(process.env.HOME ?? "~", ".claude", "events");
+// cortex#1908: single seam for the events buffer root — honors
+// CORTEX_EVENTS_DIR, else `~/.claude/events` (byte-identical when unset).
+const EVENTS_DIR = eventsDir();
 const RAW_DIR = join(EVENTS_DIR, "raw");
 const PUBLISHED_DIR = join(EVENTS_DIR, "published");
 const DEFAULT_POLICY = join(


### PR DESCRIPTION
Closes #1908 (STATE criterion transfers to #1900 — see below). Part of epic #1867, wave 1 (X-03 cortex half).

## What
- `CORTEX_CONFIG_DIR`: config resolves verbatim inside it; the grove read-fallback AND grove→cortex migrate-on-touch are **skipped** under the override, so an absent file is `source=default` inside scratch — never a real-home stat. Unset ⇒ byte-identical.
- `CORTEX_EVENTS_DIR`: new shared `events-path.ts` seam wired through all three event-buffer constructors (writer hook, bash-guard, relay) + MC's rawEventsDir (home-source preserved).
- Zero behavior change with both unset (tested).

## Deliberate scope cuts
- **`CORTEX_STATE_DIR` → #1900** (G-21): the sole state-dir constructor is `pidfile.ts`, which #1900 owns this wave; splitting the env read across files would desync `cortex.ts`'s `mkdir(STATE_DIR)` from `PID_FILE` derivation. #1900's builder has the addendum.
- zod `publishedEventsDir` defaults untouched — that's a persisted config VALUE (trap T3); #1902's value migrator owns it, not an env var.

## Verification
- `CORTEX_CONFIG_DIR=/tmp/x bun test src/common/config`: 278 pass / 0 fail
- Unset baseline: 282 pass / 0 fail · mc+bash-guard: 119 pass · cc-events: 38 pass
- tsc: no errors in changed files · eslint: clean · `pidfile.ts` not in diff (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)