### PR TITLE
fix(pidfile): full config-path hash identity + continuity migration + STATE_DIR seam (#1900)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -24,7 +24,17 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, chmodSync, symlinkSync } from "fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  chmodSync,
+  symlinkSync,
+  existsSync,
+  unlinkSync,
+  mkdirSync,
+} from "fs";
 // Hermetic agents.d/ (R26 P1 PR hygiene, cortex#1371): every `startCortex`
 // boot in this file points `agentsDir` at an EMPTY tmp dir. Without it the
 // boot path falls back to the principal's LIVE `~/.config/cortex/agents.d/`
@@ -37,6 +47,7 @@ import { tmpdir } from "os";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
 import { pidFileFor, runDryRun, startCortex } from "../cortex";
+import { migrateLegacyPidFile } from "../common/pidfile";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 
@@ -884,9 +895,15 @@ describe("pidFileFor — per-config PID file derivation", () => {
     expect(pidFileFor(DEFAULT_CONFIG)).toBe(LEGACY_PID);
   });
 
-  test("custom config in same dir → derived from basename", () => {
+  // cortex#1900 — the pidfile name is `cortex-<basename>-<hash8>.pid`: it keeps
+  // the human-readable slug (continuity requirement #2) AND appends 8 hex chars
+  // of sha256(canonical full path) so two trees can never collide.
+  const STATE_DIR = join(process.env.HOME ?? "~", ".config", "grove", "state");
+
+  test("custom config → cortex-<basename>-<hash8>.pid (slug preserved + path hash)", () => {
     const result = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
-    expect(result).toBe(join(process.env.HOME ?? "~", ".config", "grove", "state", "cortex-cortex.work.pid"));
+    expect(basename(result)).toMatch(/^cortex-cortex\.work-[0-9a-f]{8}\.pid$/);
+    expect(result.startsWith(STATE_DIR)).toBe(true);
   });
 
   test("two distinct custom configs → two distinct PID files", () => {
@@ -895,28 +912,35 @@ describe("pidFileFor — per-config PID file derivation", () => {
     expect(a).not.toBe(b);
   });
 
-  test("config with .yml extension also normalises", () => {
+  test("config with .yml extension also normalises (extension stripped)", () => {
     const result = pidFileFor("/tmp/foo.yml");
-    expect(result).toBe(join(process.env.HOME ?? "~", ".config", "grove", "state", "cortex-foo.pid"));
+    expect(basename(result)).toMatch(/^cortex-foo-[0-9a-f]{8}\.pid$/);
   });
 
-  test("config path moves don't change the PID file (basename-only derivation)", () => {
-    const a = pidFileFor("/somewhere/cortex.work.yaml");
-    const b = pidFileFor("/elsewhere/cortex.work.yaml");
-    expect(a).toBe(b);
+  // cortex#1900 core property (AC: "two distinct config trees for the same
+  // stack resolve to DISTINCT pidfiles"). Under the OLD basename-only scheme
+  // these two collided on `cortex-stack.pid` — the exact X-07 copy-keep-original
+  // hazard. The full-path hash forces them apart.
+  test("two trees sharing a stack filename → DISTINCT PID files (path-full identity)", () => {
+    const a = pidFileFor("/config-tree-old/stack/stack.yaml");
+    const b = pidFileFor("/config-tree-new/stack/stack.yaml");
+    expect(a).not.toBe(b);
+    // both still carry the same readable slug — only the hash differs
+    expect(basename(a)).toMatch(/^cortex-stack-[0-9a-f]{8}\.pid$/);
+    expect(basename(b)).toMatch(/^cortex-stack-[0-9a-f]{8}\.pid$/);
   });
 
-  test("relative config path → same PID file as absolute (basename match)", () => {
-    const rel = pidFileFor("./cortex.work.yaml");
-    const abs = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
-    expect(rel).toBe(abs);
+  test("resolution is deterministic (same path → same PID file across calls)", () => {
+    const p = "/config-tree-old/stack/stack.yaml";
+    expect(pidFileFor(p)).toBe(pidFileFor(p));
   });
 
   // Sage cortex#1027 — different SPELLINGS of the same on-disk config must
   // resolve to one PID identity (otherwise `cortex agents reload` signals the
-  // wrong/no daemon). These probes use a real tmp file + a symlink so
+  // wrong/no daemon). Preserved under the hash: identical canonical path →
+  // identical hash. These probes use a real tmp file + a symlink so
   // realpathSync actually canonicalizes.
-  describe("spelling stability (Sage cortex#1027)", () => {
+  describe("spelling stability (Sage cortex#1027, preserved under path-hash)", () => {
     let dir: string;
     let configPath: string;
 
@@ -942,21 +966,171 @@ describe("pidFileFor — per-config PID file derivation", () => {
     test("symlink to the config resolves to the same PID file as the target", () => {
       const link = join(dir, "alias.yaml");
       symlinkSync(configPath, link);
-      // Without canonicalization these would key two daemons (stack.pid vs
-      // alias.pid); realpathSync collapses the symlink onto its target.
+      // Without canonicalization these would key two daemons; realpathSync
+      // collapses the symlink onto its target so the hash matches.
       expect(pidFileFor(link)).toBe(pidFileFor(configPath));
     });
 
-    test("non-existent config still derives a stable basename PID (fallback path)", () => {
+    test("non-existent config still derives a stable hashed PID (fallback path)", () => {
       const ghost = join(dir, "never-created.yaml");
-      const expected = join(
-        process.env.HOME ?? "~",
-        ".config",
-        "grove",
-        "state",
-        "cortex-never-created.pid",
-      );
-      expect(pidFileFor(ghost)).toBe(expected);
+      const result = pidFileFor(ghost);
+      expect(basename(result)).toMatch(/^cortex-never-created-[0-9a-f]{8}\.pid$/);
+      // stable across calls even though realpath can't resolve it
+      expect(pidFileFor(ghost)).toBe(result);
+    });
+  });
+
+  // cortex#1900 kill-site safety AC: "a `stop` invoked with the wrong tree's
+  // config path cannot SIGTERM a daemon started from the other tree." Because
+  // `stop` reads ONLY `pidFileFor(config)` (see src/cortex.ts stop action) and
+  // the two trees resolve to distinct files, a mis-targeted stop finds no file
+  // and never touches the live daemon. Exercised against a real child process.
+  describe("kill-site safety — stop targets only its own tree (cortex#1900)", () => {
+    let stateDir: string;
+    let dirA: string;
+    let dirB: string;
+    let cfgA: string;
+    let cfgB: string;
+    let sleeper: ReturnType<typeof Bun.spawn> | undefined;
+
+    beforeEach(() => {
+      // Hermetic STATE_DIR: never write pidfiles into the real ~/.config.
+      stateDir = mkdtempSync(join(tmpdir(), "cortex-killsite-state-"));
+      // Two DISTINCT trees, SAME stack filename — the X-07 copy-keep window.
+      dirA = mkdtempSync(join(tmpdir(), "cortex-killsite-treeA-"));
+      dirB = mkdtempSync(join(tmpdir(), "cortex-killsite-treeB-"));
+      cfgA = join(dirA, "stack.yaml");
+      cfgB = join(dirB, "stack.yaml");
+      writeFileSync(cfgA, "agent:\n  name: x\n");
+      writeFileSync(cfgB, "agent:\n  name: x\n");
+    });
+
+    afterEach(() => {
+      if (sleeper !== undefined) {
+        try {
+          sleeper.kill("SIGKILL");
+        } catch {
+          /* already gone */
+        }
+        sleeper = undefined;
+      }
+      rmSync(stateDir, { recursive: true, force: true });
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    });
+
+    // Relocate the REAL pidFileFor filename (hash included) into the temp
+    // STATE_DIR, so distinctness is driven by production derivation.
+    function pidPathIn(config: string): string {
+      return join(stateDir, basename(pidFileFor(config)));
+    }
+
+    // Mirrors the stop action (src/cortex.ts stop command): resolve THIS
+    // config's pidfile, bail if absent, else SIGTERM the recorded PID.
+    function simulateStop(config: string): "not-running" | number {
+      const pidFile = pidPathIn(config);
+      if (!existsSync(pidFile)) return "not-running";
+      const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+      process.kill(pid, "SIGTERM");
+      unlinkSync(pidFile);
+      return pid;
+    }
+
+    test("two trees sharing a stack filename resolve to distinct pidfiles", () => {
+      expect(pidPathIn(cfgA)).not.toBe(pidPathIn(cfgB));
+    });
+
+    test("stop --config treeB does NOT signal treeA's live daemon", () => {
+      // Stand up a real, live "treeA daemon" and record its PID under treeA.
+      sleeper = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+      const pidValue = sleeper.pid;
+      const treeAPid = pidPathIn(cfgA);
+      writeFileSync(treeAPid, String(pidValue));
+
+      // treeB owns no pidfile → stop reports not-running and MUST NOT fall
+      // through to treeA's file (the pre-#1900 basename collision).
+      expect(existsSync(pidPathIn(cfgB))).toBe(false);
+      expect(simulateStop(cfgB)).toBe("not-running");
+
+      // treeA's daemon is untouched: its pidfile survives and the process
+      // is still alive (signal-0 probe throws only if the pid is gone).
+      expect(existsSync(treeAPid)).toBe(true);
+      expect(() => process.kill(pidValue, 0)).not.toThrow();
+
+      // Positive control: stop --config treeA DOES target it and clears the file.
+      expect(simulateStop(cfgA)).toBe(pidValue);
+      expect(existsSync(treeAPid)).toBe(false);
+    });
+  });
+
+  // cortex#1900 continuity AC: an existing fleet must not orphan its pidfiles
+  // mid-upgrade. `migrateLegacyPidFile` renames the pre-hash `cortex-<slug>.pid`
+  // onto the new hashed name on daemon start. Runs against a temp STATE_DIR.
+  describe("continuity migration (cortex#1900 continuity AC)", () => {
+    let stateDir: string;
+    let dir: string;
+    let cfg: string;
+    let legacyName: string;
+    let newName: string;
+
+    beforeEach(() => {
+      stateDir = mkdtempSync(join(tmpdir(), "cortex-pidmig-state-"));
+      dir = mkdtempSync(join(tmpdir(), "cortex-pidmig-tree-"));
+      cfg = join(dir, "work.yaml");
+      writeFileSync(cfg, "agent:\n  name: x\n");
+      newName = basename(pidFileFor(cfg)); // cortex-work-<hash>.pid
+      legacyName = `cortex-${basename(cfg).replace(/\.ya?ml$/i, "")}.pid`; // cortex-work.pid
+      mkdirSync(stateDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(stateDir, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("adopts an existing old-format pidfile → renames to new-format, PID preserved", () => {
+      const legacyPath = join(stateDir, legacyName);
+      const newPath = join(stateDir, newName);
+      writeFileSync(legacyPath, "12345");
+
+      const adopted = migrateLegacyPidFile(cfg, stateDir);
+
+      expect(adopted).toBe(legacyPath);
+      expect(existsSync(legacyPath)).toBe(false); // old name gone
+      expect(existsSync(newPath)).toBe(true); // adopted under new name
+      expect(readFileSync(newPath, "utf-8")).toBe("12345"); // live PID carried over
+    });
+
+    test("no-op when the new-format pidfile already exists (already migrated)", () => {
+      const legacyPath = join(stateDir, legacyName);
+      const newPath = join(stateDir, newName);
+      writeFileSync(legacyPath, "111");
+      writeFileSync(newPath, "222");
+
+      expect(migrateLegacyPidFile(cfg, stateDir)).toBeUndefined();
+      expect(readFileSync(newPath, "utf-8")).toBe("222"); // new-format untouched
+      expect(existsSync(legacyPath)).toBe(true); // legacy left as-is (readers ignore it)
+    });
+
+    test("no-op on a fresh install (no old-format pidfile present)", () => {
+      expect(migrateLegacyPidFile(cfg, stateDir)).toBeUndefined();
+      expect(existsSync(join(stateDir, newName))).toBe(false);
+    });
+
+    test("no-op for the default / unspecified config (legacy cortex.pid, never suffixed)", () => {
+      // A stray cortex.pid must never be renamed away by the migration.
+      writeFileSync(join(stateDir, "cortex.pid"), "555");
+      expect(migrateLegacyPidFile(DEFAULT_CONFIG, stateDir)).toBeUndefined();
+      expect(migrateLegacyPidFile(undefined, stateDir)).toBeUndefined();
+      expect(existsSync(join(stateDir, "cortex.pid"))).toBe(true);
+    });
+
+    test("migrated file IS the identity stop/status later resolve", () => {
+      const legacyPath = join(stateDir, legacyName);
+      writeFileSync(legacyPath, "999");
+      migrateLegacyPidFile(cfg, stateDir);
+      // readers key on basename(pidFileFor(cfg)); it must now exist.
+      expect(existsSync(join(stateDir, basename(pidFileFor(cfg))))).toBe(true);
     });
   });
 });

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -1072,8 +1072,13 @@ describe("pidFileFor — per-config PID file derivation", () => {
     let cfg: string;
     let legacyName: string;
     let newName: string;
+    // A guaranteed-DEAD pid — a real process spawned then reaped. The liveness
+    // gate (adv PR#1923) probes process.kill(pid, 0), so adoption cases must use
+    // a pid that is provably not alive rather than a synthetic literal (which
+    // could collide with a live process on the host and flakily be refused).
+    let deadPid: number;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       stateDir = mkdtempSync(join(tmpdir(), "cortex-pidmig-state-"));
       dir = mkdtempSync(join(tmpdir(), "cortex-pidmig-tree-"));
       cfg = join(dir, "work.yaml");
@@ -1081,6 +1086,9 @@ describe("pidFileFor — per-config PID file derivation", () => {
       newName = basename(pidFileFor(cfg)); // cortex-work-<hash>.pid
       legacyName = `cortex-${basename(cfg).replace(/\.ya?ml$/i, "")}.pid`; // cortex-work.pid
       mkdirSync(stateDir, { recursive: true });
+      const reaped = Bun.spawn([process.execPath, "-e", ""], { stdout: "ignore", stderr: "ignore" });
+      deadPid = reaped.pid;
+      await reaped.exited; // exits + is reaped → process.kill(deadPid, 0) throws ESRCH
     });
 
     afterEach(() => {
@@ -1088,17 +1096,74 @@ describe("pidFileFor — per-config PID file derivation", () => {
       rmSync(dir, { recursive: true, force: true });
     });
 
-    test("adopts an existing old-format pidfile → renames to new-format, PID preserved", () => {
+    // Capture console.error so the liveness-gate / guard warnings are assertable.
+    function captureStderr(): { lines: string[]; restore: () => void } {
+      const lines: string[] = [];
+      const orig = console.error;
+      console.error = (...args: unknown[]) => {
+        lines.push(args.map(String).join(" "));
+      };
+      return { lines, restore: () => { console.error = orig; } };
+    }
+
+    test("adopts a DEAD-pid old-format pidfile → renames to new-format, PID preserved", () => {
       const legacyPath = join(stateDir, legacyName);
       const newPath = join(stateDir, newName);
-      writeFileSync(legacyPath, "12345");
+      writeFileSync(legacyPath, String(deadPid));
 
       const adopted = migrateLegacyPidFile(cfg, stateDir);
 
       expect(adopted).toBe(legacyPath);
       expect(existsSync(legacyPath)).toBe(false); // old name gone
       expect(existsSync(newPath)).toBe(true); // adopted under new name
-      expect(readFileSync(newPath, "utf-8")).toBe("12345"); // live PID carried over
+      expect(readFileSync(newPath, "utf-8")).toBe(String(deadPid)); // PID carried over
+    });
+
+    // adv PR#1923 (blocking): a LIVE legacy pidfile is the cross-tree-kill
+    // hazard signature — refuse it. Stand up a real live process, record its PID
+    // under the old name, and assert migration does NOT adopt it.
+    test("LIVE-pid old-format pidfile → NOT adopted, file untouched, warns", () => {
+      const legacyPath = join(stateDir, legacyName);
+      const newPath = join(stateDir, newName);
+      const sleeper = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+      const livePid = sleeper.pid;
+      const cap = captureStderr();
+      let result: string | undefined;
+      try {
+        writeFileSync(legacyPath, String(livePid));
+        result = migrateLegacyPidFile(cfg, stateDir);
+      } finally {
+        cap.restore();
+        try { sleeper.kill("SIGKILL"); } catch { /* already gone */ }
+      }
+      expect(result).toBeUndefined(); // refused adoption
+      expect(existsSync(legacyPath)).toBe(true); // old file left exactly as-is
+      expect(existsSync(newPath)).toBe(false); // nothing created under the new name
+      expect(
+        cap.lines.some((l) => l.includes("not adopting") && l.includes(String(livePid))),
+      ).toBe(true);
+    });
+
+    // adv PR#1923 / both reviewers: the rename must never abort boot. Simulate a
+    // lost migration race — the legacy file vanishes between the pre-flight
+    // checks and renameSync (via the test-only onBeforeRename seam) → ENOENT.
+    test("lost migration race (legacy vanishes before rename) → no throw, boot continues", () => {
+      const legacyPath = join(stateDir, legacyName);
+      writeFileSync(legacyPath, String(deadPid));
+      const cap = captureStderr();
+      let result: string | undefined;
+      try {
+        expect(() => {
+          result = migrateLegacyPidFile(cfg, stateDir, () => {
+            unlinkSync(legacyPath); // pre-delete → renameSync sees ENOENT
+          });
+        }).not.toThrow();
+      } finally {
+        cap.restore();
+      }
+      expect(result).toBeUndefined(); // benign race → nothing adopted
+      expect(existsSync(join(stateDir, newName))).toBe(false); // no partial new file
+      expect(cap.lines.some((l) => l.includes("could not migrate"))).toBe(false); // ENOENT is silent
     });
 
     test("no-op when the new-format pidfile already exists (already migrated)", () => {
@@ -1127,7 +1192,7 @@ describe("pidFileFor — per-config PID file derivation", () => {
 
     test("migrated file IS the identity stop/status later resolve", () => {
       const legacyPath = join(stateDir, legacyName);
-      writeFileSync(legacyPath, "999");
+      writeFileSync(legacyPath, String(deadPid));
       migrateLegacyPidFile(cfg, stateDir);
       // readers key on basename(pidFileFor(cfg)); it must now exist.
       expect(existsSync(join(stateDir, basename(pidFileFor(cfg))))).toBe(true);
@@ -1204,15 +1269,19 @@ describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
     try {
       const src = [
         `import { pidFileFor, migrateLegacyPidFile } from ${JSON.stringify(modPath)};`,
-        `import { writeFileSync, existsSync } from "fs";`,
+        `import { writeFileSync, existsSync, readFileSync } from "fs";`,
         `import { join } from "path";`,
+        // reap a real child → a guaranteed-DEAD pid the liveness gate will adopt
+        `const reaped = Bun.spawn([process.execPath, "-e", ""], { stdout: "ignore", stderr: "ignore" });`,
+        `await reaped.exited;`,
+        `const wrote = String(reaped.pid);`,
         `const cfg = ${JSON.stringify(CFG)};`,
         // seed the pre-#1900 old-format pidfile INSIDE the override dir
         `const legacy = join(process.env.CORTEX_STATE_DIR, "cortex-stack.pid");`,
-        `writeFileSync(legacy, "4242");`,
+        `writeFileSync(legacy, wrote);`,
         `const adopted = migrateLegacyPidFile(cfg);`, // DEFAULT stateDir = env-aware STATE_DIR
         `const target = pidFileFor(cfg);`,
-        `process.stdout.write(JSON.stringify({ adopted, target, targetExists: existsSync(target), legacyGone: !existsSync(legacy), pid: existsSync(target) ? require("fs").readFileSync(target,"utf-8") : null }));`,
+        `process.stdout.write(JSON.stringify({ adopted, target, targetExists: existsSync(target), legacyGone: !existsSync(legacy), wrote, read: existsSync(target) ? readFileSync(target,"utf-8") : null }));`,
       ].join("\n");
       const proc = Bun.spawnSync([process.execPath, "-e", src], {
         env: { ...process.env, CORTEX_STATE_DIR: dir },
@@ -1228,7 +1297,7 @@ describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
       expect(basename(r.target)).toMatch(/^cortex-stack-[0-9a-f]{8}\.pid$/);
       expect(r.targetExists).toBe(true);
       expect(r.legacyGone).toBe(true);
-      expect(r.pid).toBe("4242"); // live PID carried across the rename
+      expect(r.read).toBe(r.wrote); // PID carried across the rename
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -1191,4 +1191,46 @@ describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
     );
     expect(out).toBe(expectedDefault);
   });
+
+  // Interaction: migrateLegacyPidFile's DEFAULT stateDir is STATE_DIR, which now
+  // honors CORTEX_STATE_DIR — so in production (`start` calls it with no 2nd
+  // arg) the continuity rename lands in the SAME env-overridden dir as
+  // pidFileFor + cortex.ts's mkdirSync(STATE_DIR). Runs in a child (env fixed at
+  // import), seeds the old-format pidfile in the override dir, and migrates with
+  // the default stateDir. (The explicit-stateDir test-isolation seam — used by
+  // the continuity suite above — is unaffected: an explicit arg always wins.)
+  test("migrateLegacyPidFile default stateDir honors CORTEX_STATE_DIR (env seam × continuity)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cortex-statedir-migrate-"));
+    try {
+      const src = [
+        `import { pidFileFor, migrateLegacyPidFile } from ${JSON.stringify(modPath)};`,
+        `import { writeFileSync, existsSync } from "fs";`,
+        `import { join } from "path";`,
+        `const cfg = ${JSON.stringify(CFG)};`,
+        // seed the pre-#1900 old-format pidfile INSIDE the override dir
+        `const legacy = join(process.env.CORTEX_STATE_DIR, "cortex-stack.pid");`,
+        `writeFileSync(legacy, "4242");`,
+        `const adopted = migrateLegacyPidFile(cfg);`, // DEFAULT stateDir = env-aware STATE_DIR
+        `const target = pidFileFor(cfg);`,
+        `process.stdout.write(JSON.stringify({ adopted, target, targetExists: existsSync(target), legacyGone: !existsSync(legacy), pid: existsSync(target) ? require("fs").readFileSync(target,"utf-8") : null }));`,
+      ].join("\n");
+      const proc = Bun.spawnSync([process.execPath, "-e", src], {
+        env: { ...process.env, CORTEX_STATE_DIR: dir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (proc.exitCode !== 0) {
+        throw new Error(`migrate probe failed (exit ${proc.exitCode}): ${proc.stderr.toString()}`);
+      }
+      const r = JSON.parse(proc.stdout.toString());
+      expect(r.adopted).toBe(join(dir, "cortex-stack.pid")); // adopted the old file in the ENV dir
+      expect(r.target.startsWith(`${dir}/`)).toBe(true); // new-format also lands in the ENV dir
+      expect(basename(r.target)).toMatch(/^cortex-stack-[0-9a-f]{8}\.pid$/);
+      expect(r.targetExists).toBe(true);
+      expect(r.legacyGone).toBe(true);
+      expect(r.pid).toBe("4242"); // live PID carried across the rename
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -1134,3 +1134,61 @@ describe("pidFileFor — per-config PID file derivation", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// CORTEX_STATE_DIR env seam (cortex#1908 CONFIG/EVENTS/STATE trio) — #1900
+// carries the STATE read because pidfile.ts is the sole state constructor.
+// ---------------------------------------------------------------------------
+
+describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
+  // STATE_DIR is a module constant read ONCE at import (T1b), so the override
+  // can only be observed in a FRESH process — probe pidFileFor in a child with
+  // the env var set vs. unset. An absolute + never-on-disk config keeps the
+  // canonical path (hence the pidfile basename hash) identical across both
+  // child processes regardless of their cwd.
+  const modPath = join(import.meta.dir, "..", "common", "pidfile.ts");
+  const CFG = "/cortex-1908-state-probe/stack.yaml";
+
+  function probePidFile(override: string | null): string {
+    const env = { ...process.env };
+    if (override === null) delete env.CORTEX_STATE_DIR;
+    else env.CORTEX_STATE_DIR = override;
+    const src =
+      `import { pidFileFor } from ${JSON.stringify(modPath)};` +
+      `process.stdout.write(pidFileFor(${JSON.stringify(CFG)}));`;
+    const proc = Bun.spawnSync([process.execPath, "-e", src], {
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode !== 0) {
+      throw new Error(`state-dir probe failed (exit ${proc.exitCode}): ${proc.stderr.toString()}`);
+    }
+    return proc.stdout.toString();
+  }
+
+  test("CORTEX_STATE_DIR set → pidFileFor resolves inside it", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cortex-statedir-seam-"));
+    try {
+      const out = probePidFile(dir);
+      expect(out.startsWith(`${dir}/`)).toBe(true);
+      expect(basename(out)).toMatch(/^cortex-stack-[0-9a-f]{8}\.pid$/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("CORTEX_STATE_DIR unset → byte-identical to the grove default STATE_DIR path", () => {
+    const out = probePidFile(null);
+    // basename is STATE_DIR-independent (hash is over the config path), so this
+    // reference default holds even if the test process itself set the override.
+    const expectedDefault = join(
+      process.env.HOME ?? "~",
+      ".config",
+      "grove",
+      "state",
+      basename(pidFileFor(CFG)),
+    );
+    expect(out).toBe(expectedDefault);
+  });
+});

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -5,15 +5,33 @@
  *
  * Lives in its own tiny module (no heavy import graph) so the lightweight
  * `agents` CLI can resolve the running runtime's PID without pulling the whole
- * `cortex.ts` module graph in just for `pidFileFor`.
+ * `cortex.ts` module graph in just for `pidFileFor`. Imports stay limited to
+ * Node builtins (`os`/`path`/`fs`/`crypto`) — deliberately NO config-schema
+ * import: keying the pidfile on `stack.id` would need the schema graph, and
+ * (per cortex#1900) the full config PATH is a stricter identity anyway, so we
+ * hash the path here instead of parsing the file.
+ *
+ * PID-file naming (cortex#1900):
+ *   - Default / unspecified config → legacy `cortex.pid` (single-instance
+ *     backward compat, unchanged).
+ *   - Custom config → `cortex-<basename>-<hash8>.pid`, where `<basename>` is
+ *     the config filename without its `.ya?ml` extension (human-readable slug)
+ *     and `<hash8>` is the first 8 hex chars of sha256(canonical FULL path).
+ *     The hash is what makes two config TREES that share a filename (the X-07
+ *     copy-keep-original window) resolve to DISTINCT pidfiles — basename alone
+ *     collided, SIGTERM-ing the wrong tree's daemon.
+ *   - Pre-#1900 custom pidfiles were `cortex-<basename>.pid` (no hash). A live
+ *     fleet upgrading across this change is carried forward by
+ *     {@link migrateLegacyPidFile} (rename-on-start), never orphaned.
  *
  * MIG-7.9 (deferred) flips these to `~/.config/cortex/`. Keeping grove-shaped
  * paths for now so the principal's existing `bot.yaml` continues to work.
  */
 
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 import { join, basename } from "path";
-import { realpathSync } from "fs";
+import { realpathSync, existsSync, renameSync } from "fs";
 
 export const STATE_DIR = join(
   process.env.HOME ?? "~",
@@ -30,14 +48,77 @@ export const DEFAULT_CONFIG = join(
 );
 
 /**
+ * The custom-config identity components: the human-readable `<basename>` slug
+ * and the `canonical` full path it derives from. Returns `undefined` for every
+ * case that collapses to the single-instance legacy `cortex.pid` — unspecified
+ * config, the default config (both by raw compare AND post-canonicalization),
+ * and a degenerate empty basename. Centralizing this keeps `pidFileFor` and
+ * {@link legacyPidFileFor} deriving `<basename>` from the SAME canonical path,
+ * so the new-format and old-format names line up for the continuity migration.
+ */
+function customPidComponents(
+  configPath: string | undefined,
+): { base: string; canonical: string } | undefined {
+  // Preserve the raw default-config short-circuit (cortex#1900 AC): a literal
+  // DEFAULT_CONFIG never touches realpath and always maps to PID_FILE.
+  if (configPath === undefined || configPath === DEFAULT_CONFIG) {
+    return undefined;
+  }
+  const canonical = canonicalizeConfigPath(configPath);
+  if (canonical === DEFAULT_CONFIG) {
+    return undefined;
+  }
+  const base = basename(canonical).replace(/\.ya?ml$/i, "");
+  if (base.length === 0) return undefined;
+  return { base, canonical };
+}
+
+/**
+ * New-format (cortex#1900) pidfile path within an explicit `stateDir`:
+ * `<stateDir>/cortex-<basename>-<hash8>.pid`, or `<stateDir>/cortex.pid` for
+ * the legacy/default case. `stateDir` is a seam so tests can exercise the real
+ * derivation in a temp dir (test-isolation rule: never write into the real
+ * `~/.config/grove/state`); production always uses {@link STATE_DIR}.
+ */
+function pidFileForIn(stateDir: string, configPath: string | undefined): string {
+  const c = customPidComponents(configPath);
+  if (c === undefined) return join(stateDir, "cortex.pid");
+  const hash = createHash("sha256").update(c.canonical).digest("hex").slice(0, 8);
+  return join(stateDir, `cortex-${c.base}-${hash}.pid`);
+}
+
+/**
+ * Pre-cortex#1900 (old-format) pidfile path within `stateDir`:
+ * `<stateDir>/cortex-<basename>.pid`, with NO path hash — or `undefined` when
+ * the config maps to the legacy `cortex.pid` (which never carried a suffix, so
+ * needs no migration).
+ */
+function legacyPidFileForIn(
+  stateDir: string,
+  configPath: string | undefined,
+): string | undefined {
+  const c = customPidComponents(configPath);
+  if (c === undefined) return undefined;
+  return join(stateDir, `cortex-${c.base}.pid`);
+}
+
+/**
  * Resolve the PID file path for a given `--config` value.
  *
  * Resolution:
  *   - Default config (or unspecified) → legacy `cortex.pid` (single-instance
  *     backward compat).
- *   - Custom config → `cortex-<config-basename>.pid` (config filename without
- *     the `.yaml`/`.yml` extension). Two stacks with different `--config`
- *     paths get distinct PID files.
+ *   - Custom config → `cortex-<basename>-<hash8>.pid` — the config filename
+ *     (without the `.yaml`/`.yml` extension) plus the first 8 hex chars of
+ *     sha256(canonical full path). Two config TREES that share a basename get
+ *     DISTINCT PID files because their full paths hash differently.
+ *
+ * cortex#1900 — **keyed on the full config PATH, not the basename.** Under the
+ * old basename-only scheme, `<dirA>/stack.yaml` and `<dirB>/stack.yaml` both
+ * mapped to `cortex-stack.pid`: `start` on one saw the other "already running"
+ * and `stop` on one SIGTERM-ed the other's daemon. Hashing the canonical full
+ * path removes that collision class while the basename slug keeps the file
+ * human-readable.
  *
  * Sage cortex#1027 — **canonicalized against config-path spelling.** The PID
  * file is a lifecycle identity: `cortex start --config X` (writer) and
@@ -48,25 +129,53 @@ export const DEFAULT_CONFIG = join(
  * does not resolve (file missing/unreadable) we fall back to the trimmed
  * literal, so two never-on-disk spellings of the same intended file can still
  * derive different PID files — callers get convergence for real configs, not
- * for hypothetical ones.
- *
- * Keying on `stack.id` would be stricter still (the slug is the real authority
- * per CONTEXT.md §"Stack slug"), but parsing the config here would pull the full
- * schema graph into this deliberately-tiny module that the lightweight `agents`
- * CLI imports. Canonicalizing the locator is the conservative fix that keeps the
- * module dependency-free while killing the spelling-collision class.
+ * for hypothetical ones. The hash is taken over that same canonical value, so
+ * it inherits exactly this convergence (no weaker, no stronger).
  */
 export function pidFileFor(configPath: string | undefined): string {
-  if (configPath === undefined || configPath === DEFAULT_CONFIG) {
-    return PID_FILE;
-  }
-  const canonical = canonicalizeConfigPath(configPath);
-  if (canonical === DEFAULT_CONFIG) {
-    return PID_FILE;
-  }
-  const base = basename(canonical).replace(/\.ya?ml$/i, "");
-  if (base.length === 0) return PID_FILE;
-  return join(STATE_DIR, `cortex-${base}.pid`);
+  return pidFileForIn(STATE_DIR, configPath);
+}
+
+/**
+ * Continuity migration (cortex#1900 continuity AC) — adopt an existing
+ * old-format pidfile so a live fleet is not orphaned mid-upgrade.
+ *
+ * Called once at daemon start, BEFORE the singleton check. If the NEW-format
+ * pidfile is absent but the OLD-format one (`cortex-<basename>.pid`) exists in
+ * `stateDir`, rename old → new. The running daemon's recorded PID travels with
+ * the file, so the subsequent singleton check sees it (and correctly blocks a
+ * duplicate if that PID is still alive, or reaps it if stale), and every reader
+ * (`stop`/`status`/`reload`) now resolves the daemon under its new identity.
+ *
+ * No-op — returns `undefined` — when: the config is default/unspecified (never
+ * suffixed), the new-format file already exists (already migrated / fresh
+ * install), or no old-format file is present. Returns the adopted old path (for
+ * the caller to log) when a rename happened.
+ *
+ * `stateDir` defaults to {@link STATE_DIR}; it is overridable purely for
+ * test isolation (the rename is a real filesystem mutation).
+ *
+ * Safety: this deliberately does NOT run inside `pidFileFor` (a pure resolver
+ * with many read-only callers) — only `start` mutates the filesystem. And ONLY
+ * `start` consults the old name; readers never do, so two trees sharing a
+ * basename can never both be steered back onto the shared `cortex-<basename>.pid`.
+ * The old name is inherently tree-ambiguous (that is the bug #1900 fixes), so
+ * the FIRST tree to start after upgrade claims it. That is safe under the
+ * epic's ordering — #1900 lands BEFORE the X-07 config copy, so at migration
+ * time only ONE tree (hence one old-format pidfile) exists.
+ */
+export function migrateLegacyPidFile(
+  configPath: string | undefined,
+  stateDir: string = STATE_DIR,
+): string | undefined {
+  const target = pidFileForIn(stateDir, configPath);
+  const legacy = legacyPidFileForIn(stateDir, configPath);
+  if (legacy === undefined) return undefined; // default config: never suffixed
+  if (legacy === target) return undefined; // defensive: nothing to rename
+  if (existsSync(target)) return undefined; // already on the new format
+  if (!existsSync(legacy)) return undefined; // nothing to adopt
+  renameSync(legacy, target);
+  return legacy;
 }
 
 /**

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -33,12 +33,22 @@ import { createHash } from "node:crypto";
 import { join, basename } from "path";
 import { realpathSync, existsSync, renameSync } from "fs";
 
-export const STATE_DIR = join(
-  process.env.HOME ?? "~",
-  ".config",
-  "grove",
-  "state",
-);
+/**
+ * State directory holding every pidfile (and the degraded-state markers derived
+ * from them). `CORTEX_STATE_DIR` overrides it — the STATE env seam (cortex#1908
+ * CONFIG/EVENTS/STATE trio). This is the SOLE state constructor in the tree, so
+ * the STATE read lands here rather than being split across files (which would
+ * desync cortex.ts's `mkdirSync(STATE_DIR)` from `PID_FILE`/`pidFileFor`
+ * derivation). Like `HOME`, it is read ONCE at import (T1b): the resolved value
+ * is a module constant, so processes needing an override must set the env
+ * before the module loads — the value does not track later `process.env`
+ * mutation. `.trim()` + `||` means a blank/whitespace override falls back to the
+ * grove default rather than resolving pidfiles into an empty-string path.
+ */
+export const STATE_DIR =
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- `||` is intentional: a blank/whitespace CORTEX_STATE_DIR trims to "" (falsy but not null), and MUST fall back to the grove default; `??` would keep the empty string and resolve pidfiles into a rootless path.
+  process.env.CORTEX_STATE_DIR?.trim() ||
+  join(process.env.HOME ?? "~", ".config", "grove", "state");
 export const PID_FILE = join(STATE_DIR, "cortex.pid");
 export const DEFAULT_CONFIG = join(
   process.env.HOME ?? "~",

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -31,7 +31,7 @@
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import { join, basename } from "path";
-import { realpathSync, existsSync, renameSync } from "fs";
+import { realpathSync, existsSync, renameSync, readFileSync } from "fs";
 
 /**
  * State directory holding every pidfile (and the degraded-state markers derived
@@ -147,36 +147,81 @@ export function pidFileFor(configPath: string | undefined): string {
 }
 
 /**
+ * If `legacyPath` names a process that is still ALIVE, return that PID;
+ * otherwise (dead/stale PID, or the file is unreadable / unparseable) return
+ * `undefined`. A LIVE PID is the adoption hazard (see
+ * {@link migrateLegacyPidFile}): it means a daemon is running RIGHT NOW under
+ * the tree-ambiguous old name, and we must not rename its pidfile out from
+ * under it. A dead/stale/unreadable PID is the legitimate restart-to-migrate
+ * signature and is safe to adopt.
+ *
+ * `EPERM` (a process with that PID exists but is owned by another user) counts
+ * as alive — conservatively refuse to adopt. Only `ESRCH` (no such process) is
+ * treated as dead.
+ */
+function legacyLivePid(legacyPath: string): number | undefined {
+  let pid: number;
+  try {
+    pid = parseInt(readFileSync(legacyPath, "utf-8").trim(), 10);
+  } catch {
+    return undefined; // unreadable → treat as stale → safe to adopt
+  }
+  if (Number.isNaN(pid)) return undefined; // unparseable → stale → safe to adopt
+  try {
+    process.kill(pid, 0); // signal 0 = liveness probe, delivers nothing
+    return pid; // delivered → alive → hazard
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM" ? pid : undefined;
+  }
+}
+
+/**
  * Continuity migration (cortex#1900 continuity AC) — adopt an existing
  * old-format pidfile so a live fleet is not orphaned mid-upgrade.
  *
  * Called once at daemon start, BEFORE the singleton check. If the NEW-format
  * pidfile is absent but the OLD-format one (`cortex-<basename>.pid`) exists in
- * `stateDir`, rename old → new. The running daemon's recorded PID travels with
- * the file, so the subsequent singleton check sees it (and correctly blocks a
- * duplicate if that PID is still alive, or reaps it if stale), and every reader
- * (`stop`/`status`/`reload`) now resolves the daemon under its new identity.
+ * `stateDir` AND names a DEAD/stale PID, rename old → new. Every reader
+ * (`stop`/`status`/`reload`) then resolves the daemon under its new identity.
+ *
+ * **Liveness gate (adv PR#1923, blocking).** The old name is tree-ambiguous —
+ * two config trees that share a basename (a manual `cp -r` of a config tree +
+ * an in-place binary upgrade reaches this with NO X-07 involved) both derive
+ * `cortex-<basename>.pid`. If that file names a LIVE process, adopting it would
+ * rename a *foreign, running* daemon's pidfile under THIS config's identity —
+ * so a later `stop <this>` would SIGTERM the other tree's daemon while
+ * `stop <other>` reports "not running". So: a live legacy PID is REFUSED
+ * (warn + return `undefined`); only a dead/stale/unreadable PID is adopted.
+ * This is sound because the legit restart-to-migrate path never presents a live
+ * legacy PID: a clean shutdown unlinks its own pidfile, and an unclean exit
+ * leaves a DEAD pid — a LIVE pid is the hazard's signature, nothing else.
+ *
+ * **Accepted trade-off (documented).** Restarting the SAME config while its old
+ * daemon is still live now boots toward `checkSingleton` on the NEW name (which
+ * is absent) and may spawn a DUPLICATE rather than block on the old name. That
+ * is strictly less catastrophic than a cross-tree SIGTERM, and the operator is
+ * told to stop the old daemon first.
+ *
+ * **Guarded rename.** The rename is wrapped: `ENOENT`/`EEXIST` = a benign
+ * migration race we lost (a concurrent start already migrated / removed the
+ * file) → nothing to do. Any other error → warn and continue. A continuity
+ * nicety must NEVER abort daemon boot — a throw here becomes `exit(1)` under
+ * launchd KeepAlive, i.e. an invisible crash-loop.
  *
  * No-op — returns `undefined` — when: the config is default/unspecified (never
- * suffixed), the new-format file already exists (already migrated / fresh
- * install), or no old-format file is present. Returns the adopted old path (for
- * the caller to log) when a rename happened.
+ * suffixed), the new-format file already exists, no old-format file is present,
+ * the old-format file names a LIVE process, or the rename lost a race. Returns
+ * the adopted old path (for the caller to log) only when a rename succeeded.
  *
- * `stateDir` defaults to {@link STATE_DIR}; it is overridable purely for
- * test isolation (the rename is a real filesystem mutation).
- *
- * Safety: this deliberately does NOT run inside `pidFileFor` (a pure resolver
- * with many read-only callers) — only `start` mutates the filesystem. And ONLY
- * `start` consults the old name; readers never do, so two trees sharing a
- * basename can never both be steered back onto the shared `cortex-<basename>.pid`.
- * The old name is inherently tree-ambiguous (that is the bug #1900 fixes), so
- * the FIRST tree to start after upgrade claims it. That is safe under the
- * epic's ordering — #1900 lands BEFORE the X-07 config copy, so at migration
- * time only ONE tree (hence one old-format pidfile) exists.
+ * `stateDir` defaults to {@link STATE_DIR} (which now honours `CORTEX_STATE_DIR`)
+ * and is overridable purely for test isolation. `onBeforeRename` is a
+ * test-only seam invoked after the pre-flight checks and immediately before the
+ * rename, so a test can simulate a lost race; never passed in production.
  */
 export function migrateLegacyPidFile(
   configPath: string | undefined,
   stateDir: string = STATE_DIR,
+  onBeforeRename?: () => void,
 ): string | undefined {
   const target = pidFileForIn(stateDir, configPath);
   const legacy = legacyPidFileForIn(stateDir, configPath);
@@ -184,7 +229,31 @@ export function migrateLegacyPidFile(
   if (legacy === target) return undefined; // defensive: nothing to rename
   if (existsSync(target)) return undefined; // already on the new format
   if (!existsSync(legacy)) return undefined; // nothing to adopt
-  renameSync(legacy, target);
+
+  // Liveness gate: refuse to adopt a pidfile whose daemon is still running.
+  const alivePid = legacyLivePid(legacy);
+  if (alivePid !== undefined) {
+    console.error(
+      `cortex: live legacy pidfile ${legacy} (pid ${alivePid}) — not adopting; ` +
+        `stop that daemon first or restart it under the new binary`,
+    );
+    return undefined;
+  }
+
+  onBeforeRename?.(); // test seam only
+  try {
+    renameSync(legacy, target);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT" && code !== "EEXIST") {
+      // Non-race failure (e.g. EACCES): don't crash boot — the daemon still
+      // starts on the new-format name; it just didn't inherit the old file.
+      console.error(
+        `cortex: could not migrate legacy pidfile ${legacy} → ${target}: ${(err as Error).message}`,
+      );
+    }
+    return undefined;
+  }
   return legacy;
 }
 

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -199,7 +199,7 @@ function legacyLivePid(legacyPath: string): number | undefined {
  * **Accepted trade-off (documented).** Restarting the SAME config while its old
  * daemon is still live now boots toward `checkSingleton` on the NEW name (which
  * is absent) and may spawn a DUPLICATE rather than block on the old name. That
- * is strictly less catastrophic than a cross-tree SIGTERM, and the operator is
+ * is strictly less catastrophic than a cross-tree SIGTERM, and the principal is
  * told to stop the old daemon first.
  *
  * **Guarded rename.** The rename is wrapped: `ENOENT`/`EEXIST` = a benign

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -6247,11 +6247,15 @@ if (import.meta.main) {
 
       mkdirSync(STATE_DIR, { recursive: true });
       const pidFile = pidFileFor(options.config);
-      // cortex#1900 continuity AC — adopt a pre-hash `cortex-<basename>.pid`
-      // if this config still owns one, so an existing fleet upgrading across
-      // the path-hash naming change is not orphaned. Runs BEFORE the singleton
-      // check so a still-live daemon's PID travels with the renamed file and
-      // checkSingleton correctly blocks the duplicate (or reaps it if stale).
+      // cortex#1900 continuity AC — adopt a pre-hash `cortex-<basename>.pid` iff
+      // this config still owns one AND it names a DEAD/stale PID, so an existing
+      // fleet upgrading across the path-hash naming change is not orphaned.
+      // adv PR#1923: a LIVE legacy pidfile is REFUSED inside migrateLegacyPidFile
+      // (it may belong to a different tree sharing the basename — adopting it
+      // would let a later `stop` SIGTERM that foreign daemon; the warning is
+      // emitted there). Runs BEFORE the singleton check; on a dead-PID adoption
+      // checkSingleton then reaps the stale entry. The migration is internally
+      // guarded and never throws, so a lost race can't abort boot.
       const adopted = migrateLegacyPidFile(options.config);
       if (adopted !== undefined) {
         console.error(`cortex: migrated PID file ${adopted} → ${pidFile} (cortex#1900 path-hash naming)`);

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -351,7 +351,7 @@ import {
 // the lightweight `cortex agents reload` CLI can resolve the running daemon's
 // PID (to signal a reload) without importing this whole module graph. Re-import
 // here so cortex.ts's lifecycle paths stay on the single source of truth.
-import { STATE_DIR, DEFAULT_CONFIG, pidFileFor } from "./common/pidfile";
+import { STATE_DIR, DEFAULT_CONFIG, pidFileFor, migrateLegacyPidFile } from "./common/pidfile";
 // FS-7 / D-3 (cortex#1839) — last-known-good boot fallback + degraded state.
 import { readLastGoodSnapshotPath, writeLastGoodSnapshot } from "./common/config/last-good";
 import {
@@ -371,18 +371,14 @@ import { formatConfigLoadError } from "./common/config/validate-on-write";
  * singleton check in {@link checkSingleton} only blocks duplicates of
  * the same stack, not unrelated stacks.
  *
- * Resolution:
+ * Resolution (see `./common/pidfile` for the authoritative doc):
  *   - Default config (or unspecified) → legacy `cortex.pid` (preserves
  *     single-instance backward compat — principals on the default path
  *     see no behaviour change).
- *   - Custom config → `cortex-<config-basename>.pid` (derived from the
- *     config filename without the `.yaml`/`.yml` extension). Two stacks
- *     with different `--config` paths get different PID files.
- *
- * The basename derivation deliberately omits the directory portion so
- * `~/.config/cortex/cortex.work.yaml` and `./cortex.work.yaml` resolve
- * to the same PID file — moving a config doesn't accidentally orphan
- * the prior PID file.
+ *   - Custom config → `cortex-<basename>-<hash8>.pid`, keyed on a hash of
+ *     the canonical FULL config path (cortex#1900). Two config trees that
+ *     share a filename resolve to DISTINCT PID files, so `start`/`stop`
+ *     can never collide across trees.
  */
 // B-0 (cortex#1021) — `pidFileFor` is imported from `./common/pidfile` (single
 // source of truth shared with the `cortex agents reload` daemon-signal path)
@@ -6251,6 +6247,15 @@ if (import.meta.main) {
 
       mkdirSync(STATE_DIR, { recursive: true });
       const pidFile = pidFileFor(options.config);
+      // cortex#1900 continuity AC — adopt a pre-hash `cortex-<basename>.pid`
+      // if this config still owns one, so an existing fleet upgrading across
+      // the path-hash naming change is not orphaned. Runs BEFORE the singleton
+      // check so a still-live daemon's PID travels with the renamed file and
+      // checkSingleton correctly blocks the duplicate (or reaps it if stale).
+      const adopted = migrateLegacyPidFile(options.config);
+      if (adopted !== undefined) {
+        console.error(`cortex: migrated PID file ${adopted} → ${pidFile} (cortex#1900 path-hash naming)`);
+      }
       checkSingleton(pidFile);
       writeFileSync(pidFile, String(process.pid));
 


### PR DESCRIPTION
Closes #1900. Also carries #1908's STATE read (deliberate cross-issue split — the sole state-dir constructor lives here; splitting the env read across files would desync mkdir(STATE_DIR) from PID_FILE derivation). Part of epic #1867, wave 1 **TRUST LANE**.

## What
1. **Identity:** `pidFileFor` → `cortex-<basename>-<hash8>.pid` (first 8 hex of sha256(canonicalized FULL config path)). Two config trees with the same stack filename now resolve to DISTINCT pidfiles — closes trap T7′ (two-trees-one-pidfile: wrong-tree `stop` could SIGTERM the live daemon; the kill site has no identity verification). The `stack.id` option from the issue body is deliberately NOT implemented (forbidden per the G-07 amendment: both trees carry the same stack.id during the copy window).
2. **Continuity:** `migrateLegacyPidFile` (wired into `start` before `checkSingleton`): adopts an existing old-format `cortex-<basename>.pid` by rename → the live daemon's PID travels with the file; no-ops on default config / already-migrated / fresh install.
3. **`CORTEX_STATE_DIR` env seam** (module-level, read-once at import, documented; `||` not `??` — a blank override must fall back, justified eslint-disable inline).
4. `:60` default-config short-circuit preserved exactly; no schema imports (node builtins only).

## Stated assumptions (adversarial reviewers: attack these)
- Legacy adoption claims an inherently tree-ambiguous name; safe ONLY under epic ordering (#1900 before X-07's config copy). Documented in module header.
- `stop`/`status`/`reload` have NO legacy fallback (deliberate — a fallback reintroduces the collision); upgrade path is restart-to-migrate (launchd KeepAlive triggers it).
- Hypothetical (non-existent-file) config spellings now diverge per literal; real configs converge via realpathSync (pre-existing Sage #1027 contract).

## Verification
- Focused suite: 40 pass / 0 fail (identity, kill-site with a REAL process, continuity ×5, seam ×2 via child-process env probes)
- Adjacent: 53 pass / 0 fail · tsc: 0 project-wide · eslint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)