### PR TITLE
feat(migration): service-manager migration gate — launchctl/systemctl, fail-closed, restore-on-failure (#1901)

### DIFF
--- a/src/common/migration/__tests__/migration-gate.test.ts
+++ b/src/common/migration/__tests__/migration-gate.test.ts
@@ -1,346 +1,489 @@
 /**
  * cortex#1901 — migration gate tests (XDG epic #1867, P3c).
  *
- * The gate proves a stack fleet is stopped before a config/state move, using the
- * SERVICE MANAGER as the oracle (never a pidfile). Every launchctl/systemctl call
- * is faked via an injected {@link GateExec}, so the darwin AND linux paths run on
- * any POSIX CI host (cortex CI is ubuntu) with no real launchd/systemd.
+ * The gate proves a stack fleet is DEAD (not merely deregistered) before a
+ * config/state move, using the SERVICE MANAGER as the oracle and a three-leg
+ * POSITIVE death proof: (1) the RIGHT service — discovered on Linux, never a
+ * derived name; (2) a manager-REACHED down verdict; (3) confirmed PID death via
+ * kill(pid,0). Every subprocess, the liveness probe, sleep, and the clock are
+ * injected, so both platform paths run on ubuntu CI with no real launchd/systemd
+ * and no real processes.
  *
- * The fakes model the two properties that make this issue exist:
- *   - a launchd job stays loaded (`print` → 0) until `bootout`, and a "stubborn"
- *     job models KeepAlive/TOCTOU — it stays loaded even after a bootout attempt,
- *     which the gate MUST catch via its post-stop verify and refuse to clear;
- *   - a systemd unit stays `active` until `stop`, and `is-active` is the oracle.
+ * These tests are the adversarial re-verdict surface for PR#1929's four
+ * fail-opens: A-UNIT (wrong Linux unit), A-ISACTIVE (manager-unreachable),
+ * A-TOCTOU (deregistration ≠ death), A-RESTORE (unpaired stop strands the fleet).
  *
- * Test/describe names all contain "migration gate" so the epic's
- * `bun test … -t "migration gate"` selector picks them up.
+ * All test/describe names contain "migration gate" for `bun test … -t`.
  */
 
 import { describe, test, expect } from "bun:test";
 
+import type { DaemonLocatorIO } from "../../../cli/cortex/commands/daemon-locator";
 import {
   enumerateServiceTargets,
   runMigrationGate,
+  withMigrationGate,
   CORTEX_LABEL_PREFIX,
   RELAY_LABEL,
-  LEGACY_LABELS,
+  type GateEnv,
   type GateExec,
+  type GateExecResult,
+  type DrainPolicy,
   type ServiceTarget,
 } from "../migration-gate";
 
-// =============================================================================
-// Fakes — in-memory launchd + systemd that capture every argv
-// =============================================================================
-
+// A fast drain so the death poll can't hold the runner hostage.
+const FAST_DRAIN: DrainPolicy = { drainTimeoutMs: 100, pollIntervalMs: 10 };
 const LAUNCH_DIR = "/tmp/x1901-LaunchAgents";
+const SYSTEMD_DIR = "/tmp/x1901-systemd-user";
+const CFG_DIR = "/tmp/x1901-config/cortex";
 
-/** Build the gate's target set from a slug list without touching the filesystem. */
-function targetsFor(slugs: string[]): ServiceTarget[] {
-  return enumerateServiceTargets({
-    launchAgentsDir: LAUNCH_DIR,
-    configDir: "/unused",
-    discoverSlugs: () => slugs,
-  });
+// =============================================================================
+// Fakes — in-memory launchd + systemd, plus a controllable GateEnv
+// =============================================================================
+
+/** A GateEnv over a fake exec whose `procAlive` reads a shared `alive` set. The
+ *  clock advances by each `sleep`, so the drain deadline is deterministic. */
+function envOver(exec: GateExec, alive: Set<number>): GateEnv {
+  let clock = 0;
+  return {
+    exec,
+    procAlive: (pid) => alive.has(pid),
+    sleep: (ms) => {
+      clock += ms;
+      return Promise.resolve();
+    },
+    now: () => clock,
+  };
 }
 
-/** launchd fake. `loaded` = jobs currently in the domain; `stubborn` = jobs a
- *  bootout can NOT unload (models KeepAlive / a supervisor respawn / TOCTOU). */
-function makeLaunchd(init?: { loaded?: string[]; stubborn?: string[] }): {
+/** launchd fake. `loaded` = label→pid; `killsProcess` = whether bootout also
+ *  ends the process (true = clean death; false = the PID lingers = A-TOCTOU). */
+function makeLaunchd(init: { loaded?: Record<string, number>; killsProcess?: boolean }): {
   exec: GateExec;
   calls: string[][];
-  loaded: Set<string>;
+  loaded: Map<string, number>;
+  alive: Set<number>;
 } {
-  const loaded = new Set(init?.loaded ?? []);
-  const stubborn = new Set(init?.stubborn ?? []);
+  const loaded = new Map<string, number>(Object.entries(init.loaded ?? {}));
+  const alive = new Set<number>(loaded.values());
+  const killsProcess = init.killsProcess ?? true;
   const calls: string[][] = [];
-  const labelOf = (target: string): string => target.split("/").pop() ?? "";
+  const labelOf = (t: string | undefined): string => (t ?? "").split("/").pop() ?? "";
   const exec: GateExec = (argv) => {
     calls.push(argv);
     const sub = argv[1];
-    if (argv[0] !== "launchctl") throw new Error(`unexpected cmd ${String(argv[0])}`);
     if (sub === "print") {
-      const label = labelOf(argv[2] ?? "");
+      const pid = loaded.get(labelOf(argv[2]));
       return Promise.resolve(
-        loaded.has(label)
-          ? { code: 0, stdout: `${label} = { state = running }`, stderr: "" }
+        pid !== undefined
+          ? { code: 0, stdout: `\tstate = running\n\tpid = ${pid.toString()}\n`, stderr: "" }
           : { code: 113, stdout: "", stderr: "Could not find service" },
       );
     }
     if (sub === "bootout") {
-      const label = labelOf(argv[2] ?? "");
-      const was = loaded.has(label);
-      if (!stubborn.has(label)) loaded.delete(label);
-      return Promise.resolve({ code: was ? 0 : 3, stdout: "", stderr: "" });
+      const label = labelOf(argv[2]);
+      const pid = loaded.get(label);
+      loaded.delete(label);
+      if (killsProcess && pid !== undefined) alive.delete(pid);
+      return Promise.resolve({ code: pid !== undefined ? 0 : 3, stdout: "", stderr: "" });
     }
     if (sub === "bootstrap") {
-      // launchctl bootstrap gui/<uid> <plistPath>
       const label = (argv[3] ?? "").split("/").pop()?.replace(/\.plist$/, "") ?? "";
-      loaded.add(label);
+      const pid = 90000 + loaded.size;
+      loaded.set(label, pid);
+      alive.add(pid);
       return Promise.resolve({ code: 0, stdout: "", stderr: "" });
     }
     if (sub === "kickstart") return Promise.resolve({ code: 0, stdout: "", stderr: "" });
     return Promise.resolve({ code: 1, stdout: "", stderr: `unknown launchctl ${String(sub)}` });
   };
-  return { exec, calls, loaded };
+  return { exec, calls, loaded, alive };
 }
 
-/** systemd fake. `active` = units currently up; `stubborn` = units `stop` can NOT
- *  bring down (models Restart=always defeating a naive stop). */
-function makeSystemd(init?: { active?: string[]; stubborn?: string[] }): {
+/** systemd fake. `active` = unit→MainPID. `isActiveOverride` lets a test force a
+ *  manager-unreachable / weird `is-active` result (A-ISACTIVE). */
+function makeSystemd(init: {
+  active?: Record<string, number>;
+  killsProcess?: boolean;
+  isActiveOverride?: (unit: string) => GateExecResult;
+}): {
   exec: GateExec;
   calls: string[][];
-  active: Set<string>;
+  active: Map<string, number>;
+  alive: Set<number>;
 } {
-  const active = new Set(init?.active ?? []);
-  const stubborn = new Set(init?.stubborn ?? []);
+  const active = new Map<string, number>(Object.entries(init.active ?? {}));
+  const alive = new Set<number>(active.values());
+  const killsProcess = init.killsProcess ?? true;
   const calls: string[][] = [];
   const exec: GateExec = (argv) => {
     calls.push(argv);
-    // systemctl --user <verb> <unit>
     const verb = argv[2];
     const unit = argv[3] ?? "";
     if (verb === "is-active") {
+      if (init.isActiveOverride) return Promise.resolve(init.isActiveOverride(unit));
       return Promise.resolve(
         active.has(unit)
           ? { code: 0, stdout: "active\n", stderr: "" }
           : { code: 3, stdout: "inactive\n", stderr: "" },
       );
     }
+    if (verb === "show") {
+      const pid = active.get(unit) ?? 0;
+      return Promise.resolve({ code: 0, stdout: `${pid.toString()}\n`, stderr: "" });
+    }
     if (verb === "stop") {
-      if (!stubborn.has(unit)) active.delete(unit);
+      const pid = active.get(unit);
+      active.delete(unit);
+      if (killsProcess && pid !== undefined) alive.delete(pid);
       return Promise.resolve({ code: 0, stdout: "", stderr: "" });
     }
     if (verb === "start") {
-      active.add(unit);
+      const pid = 70000 + active.size;
+      active.set(unit, pid);
+      alive.add(pid);
       return Promise.resolve({ code: 0, stdout: "", stderr: "" });
     }
     return Promise.resolve({ code: 1, stdout: "", stderr: `unknown systemctl ${String(verb)}` });
   };
-  return { exec, calls, active };
+  return { exec, calls, active, alive };
 }
 
-/** An exec that always throws — models the service-manager binary being absent
- *  (ENOENT). The gate must FAIL CLOSED against this. */
-const throwingExec: GateExec = () => {
-  throw new Error("spawn systemctl ENOENT");
-};
+/** An in-memory {@link DaemonLocatorIO} over a { path: contents } map. */
+function fakeIO(files: Record<string, string>, dirs: string[]): DaemonLocatorIO {
+  return {
+    exists: (p) => p in files || dirs.includes(p),
+    listDir: (dir) =>
+      Object.keys(files)
+        .filter((p) => p.startsWith(dir + "/"))
+        .map((p) => p.slice(dir.length + 1))
+        .filter((rest) => !rest.includes("/")),
+    readFile: (p) => {
+      const v = files[p];
+      if (v === undefined) throw new Error(`ENOENT ${p}`);
+      return v;
+    },
+  };
+}
+
+/** A systemd `.service` unit body with a given ExecStart. */
+function unit(execStart: string): string {
+  return `[Unit]\nDescription=x\n[Service]\nExecStart=${execStart}\nRestart=always\n[Install]\nWantedBy=default.target\n`;
+}
+
+// Convenience: darwin targets from a slug list (label-by-convention).
+function darwinTargets(slugs: string[]): ServiceTarget[] {
+  return enumerateServiceTargets({
+    platform: "darwin",
+    launchAgentsDir: LAUNCH_DIR,
+    configDir: CFG_DIR,
+    discoverSlugs: () => slugs,
+  });
+}
 
 // =============================================================================
-// Enumeration
+// Enumeration — Linux discovers REAL units (A-UNIT), darwin stays by-convention
 // =============================================================================
 
-describe("migration gate — enumeration (slugs + relay + legacy)", () => {
-  test("migration gate enumerates every stack slug, the relay, and the legacy labels", () => {
-    const targets = targetsFor(["meta-factory", "work"]);
+describe("migration gate — enumeration", () => {
+  test("migration gate (linux) discovers REAL unit ids from ExecStart, not <label>.service", () => {
+    const files = {
+      // Real stack daemon — NON-conventional name, matched by --config.
+      [`${SYSTEMD_DIR}/cortex-bot.service`]: unit(`/usr/bin/bun /opt/cortex/src/cortex.ts --config ${CFG_DIR}/meta-factory/meta-factory.yaml`),
+      // Real relay — matched by the relay.ts entrypoint (no --config).
+      [`${SYSTEMD_DIR}/cortex-relay.service`]: unit(`/usr/bin/bun /opt/cortex/src/taps/cc-events/relay.ts start`),
+      // A non-cortex unit — must be ignored.
+      [`${SYSTEMD_DIR}/postgresql.service`]: unit(`/usr/bin/postgres -D /var/lib/pg`),
+    };
+    const io = fakeIO(files, [SYSTEMD_DIR]);
+    const targets = enumerateServiceTargets({
+      platform: "linux",
+      systemdUserDir: SYSTEMD_DIR,
+      configDir: CFG_DIR,
+      io,
+    });
+    const units = targets.map((t) => t.unit);
+
+    expect(units).toContain("cortex-bot.service"); // the REAL name, discovered
+    expect(units).toContain("cortex-relay.service");
+    expect(units).not.toContain("ai.meta-factory.cortex.meta-factory.service"); // never derived
+    expect(units).not.toContain("postgresql.service"); // non-cortex ignored
+    expect(targets.find((t) => t.unit === "cortex-relay.service")?.kind).toBe("relay");
+    expect(targets.find((t) => t.unit === "cortex-bot.service")?.kind).toBe("stack");
+  });
+
+  test("migration gate (linux) unions legacy units by-name only when the file exists", () => {
+    const files = {
+      [`${SYSTEMD_DIR}/com.grove.bot.service`]: unit(`/usr/bin/bun /opt/grove/bot.ts`),
+    };
+    const io = fakeIO(files, [SYSTEMD_DIR]);
+    const targets = enumerateServiceTargets({
+      platform: "linux",
+      systemdUserDir: SYSTEMD_DIR,
+      configDir: CFG_DIR,
+      io,
+    });
+    const units = targets.map((t) => t.unit);
+    // Present legacy file → unioned; absent legacy files → NOT enumerated.
+    expect(units).toContain("com.grove.bot.service");
+    expect(units).not.toContain("com.grove.relay.service");
+  });
+
+  test("migration gate (darwin) enumerates labels by convention + relay + legacy", () => {
+    const targets = darwinTargets(["meta-factory", "work"]);
     const labels = targets.map((t) => t.label);
-
     expect(labels).toContain(`${CORTEX_LABEL_PREFIX}meta-factory`);
-    expect(labels).toContain(`${CORTEX_LABEL_PREFIX}work`);
     expect(labels).toContain(RELAY_LABEL);
-    for (const legacy of LEGACY_LABELS) expect(labels).toContain(legacy);
-    // com.grove.* legacy set is present (G-35).
     expect(labels).toContain("com.grove.bot");
     expect(labels).toContain("com.grove.relay");
-
-    // Each target carries both platform identities + a bootstrap path.
-    const relay = targets.find((t) => t.label === RELAY_LABEL)!;
-    expect(relay.unit).toBe(`${RELAY_LABEL}.service`);
-    expect(relay.plistPath).toBe(`${LAUNCH_DIR}/${RELAY_LABEL}.plist`);
-    expect(relay.kind).toBe("relay");
-  });
-
-  test("migration gate dedupes a stack slug colliding with relay/bot", () => {
-    const targets = targetsFor(["relay", "bot"]);
-    const labels = targets.map((t) => t.label);
-    const relayCount = labels.filter((l) => l === RELAY_LABEL).length;
-    const botCount = labels.filter((l) => l === `${CORTEX_LABEL_PREFIX}bot`).length;
-    expect(relayCount).toBe(1);
-    expect(botCount).toBe(1);
+    expect(labels).toContain(`${CORTEX_LABEL_PREFIX}bot`);
   });
 });
 
 // =============================================================================
-// macOS — clear vs block, oracle is the service manager
+// A-UNIT — Linux queries the discovered unit, so a name mismatch can't fail-open
 // =============================================================================
 
-describe("migration gate — darwin oracle (launchctl bootout, not pidfile)", () => {
-  test("migration gate (darwin) clears only after bootout of every slug + relay", async () => {
-    const targets = targetsFor(["meta-factory", "work"]);
-    const ld = makeLaunchd({ loaded: targets.map((t) => t.label) });
+describe("migration gate — A-UNIT (right service)", () => {
+  test("migration gate (linux) stops the DISCOVERED unit name, not a derived one", async () => {
+    const files = {
+      [`${SYSTEMD_DIR}/cortex-bot.service`]: unit(`/usr/bin/bun /opt/cortex/src/cortex.ts --config ${CFG_DIR}/meta-factory/meta-factory.yaml`),
+    };
+    const io = fakeIO(files, [SYSTEMD_DIR]);
+    const targets = enumerateServiceTargets({ platform: "linux", systemdUserDir: SYSTEMD_DIR, configDir: CFG_DIR, io });
 
-    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
-
-    expect(res.cleared).toBe(true);
-    expect(res.stillPresent).toHaveLength(0);
-    // Every stack label + relay + legacy was booted out.
-    const bootouts = ld.calls.filter((c) => c[1] === "bootout").map((c) => c[2]);
-    for (const t of targets) expect(bootouts).toContain(`gui/501/${t.label}`);
-    // Oracle is the service manager — every call is launchctl, nothing filesystem.
-    expect(ld.calls.every((c) => c[0] === "launchctl")).toBe(true);
-    // Verification uses `print` (never a pidfile check).
-    expect(ld.calls.some((c) => c[1] === "print")).toBe(true);
-  });
-
-  test("migration gate (darwin) BLOCKS while a KeepAlive daemon stays loaded (pidfile absent is irrelevant)", async () => {
-    const targets = targetsFor(["meta-factory", "work"]);
-    const stubborn = `${CORTEX_LABEL_PREFIX}work`; // KeepAlive: bootout can't unload it
-    const ld = makeLaunchd({ loaded: targets.map((t) => t.label), stubborn: [stubborn] });
-
-    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
-
-    expect(res.cleared).toBe(false);
-    expect(res.stillPresent.map((t) => t.label)).toEqual([stubborn]);
-    expect(res.reason).toContain("fail-closed");
-    expect(res.reason).toContain(stubborn);
-    // The gate DID try to bootout it — the daemon simply survived, so the gate
-    // (correctly) refuses to clear rather than trusting the stop succeeded.
-    expect(ld.calls.some((c) => c[1] === "bootout" && c[2] === `gui/501/${stubborn}`)).toBe(true);
-  });
-
-  test("migration gate (darwin) clears when nothing is loaded (bootout is idempotent)", async () => {
-    const targets = targetsFor(["meta-factory"]);
-    const ld = makeLaunchd({ loaded: [] });
-
-    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
-
-    expect(res.cleared).toBe(true);
-    expect(res.running).toHaveLength(0); // nothing was up → nothing to restore
-  });
-});
-
-// =============================================================================
-// Linux — REQUIRED path + FAIL-CLOSED (G-08). Runs on ubuntu CI via fakes.
-// =============================================================================
-
-describe("migration gate — linux oracle (systemctl stop + is-active)", () => {
-  test("migration gate (linux) stops via systemctl and clears when is-active reports inactive", async () => {
-    const targets = targetsFor(["meta-factory", "work"]);
-    const sd = makeSystemd({ active: targets.map((t) => t.unit) });
-
-    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: sd.exec, targets });
+    const sd = makeSystemd({ active: { "cortex-bot.service": 4321 } });
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, env: envOver(sd.exec, sd.alive), targets, drain: FAST_DRAIN });
 
     expect(res.cleared).toBe(true);
     const stops = sd.calls.filter((c) => c[2] === "stop").map((c) => c[3]);
-    for (const t of targets) expect(stops).toContain(t.unit);
-    // Oracle is `systemctl --user is-active`, never launchctl or a pidfile.
-    expect(sd.calls.every((c) => c[0] === "systemctl" && c[1] === "--user")).toBe(true);
-    expect(sd.calls.some((c) => c[2] === "is-active")).toBe(true);
-  });
-
-  test("migration gate (linux) FAILS CLOSED when systemctl is unavailable (exec throws)", async () => {
-    const targets = targetsFor(["meta-factory"]);
-
-    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: throwingExec, targets });
-
-    // Cannot prove anything down → must refuse to clear (never silently pass).
-    expect(res.cleared).toBe(false);
-    expect(res.stillPresent).toHaveLength(targets.length);
-    expect(res.reason).toContain("fail-closed");
-    // Pre-check also couldn't prove absence, so the whole set is the restore set.
-    expect(res.running).toHaveLength(targets.length);
-  });
-
-  test("migration gate (linux) BLOCKS while a Restart=always unit stays active after stop", async () => {
-    const targets = targetsFor(["meta-factory", "work"]);
-    const stubborn = targets[0]!.unit; // stop can't bring it down
-    const sd = makeSystemd({ active: targets.map((t) => t.unit), stubborn: [stubborn] });
-
-    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: sd.exec, targets });
-
-    expect(res.cleared).toBe(false);
-    expect(res.stillPresent.map((t) => t.unit)).toEqual([stubborn]);
+    expect(stops).toContain("cortex-bot.service"); // real unit — the fail-open fix
+    expect(stops).not.toContain("ai.meta-factory.cortex.meta-factory.service");
   });
 });
 
 // =============================================================================
-// Restore-on-failure (G-36) — bootout is persistent; an abort must bring the fleet back
+// A-ISACTIVE — manager-unreachable must read PRESENT (key on the stdout WORD)
 // =============================================================================
 
-describe("migration gate — restore-on-failure (G-36)", () => {
-  test("migration gate restore brings daemons back after a mid-migration failure (darwin)", async () => {
-    const targets = targetsFor(["meta-factory", "work"]);
-    const originallyUp = targets.map((t) => t.label);
-    const ld = makeLaunchd({ loaded: [...originallyUp] });
+describe("migration gate — A-ISACTIVE (manager-reached verdict)", () => {
+  test("migration gate (linux) FAILS CLOSED when systemctl runs but can't reach the manager (non-zero + empty stdout)", async () => {
+    const targets: ServiceTarget[] = [
+      { id: "meta-factory", kind: "stack", label: "cortex-bot.service", unit: "cortex-bot.service", plistPath: `${SYSTEMD_DIR}/cortex-bot.service` },
+    ];
+    // is-active returns non-zero + EMPTY stdout — the D-Bus-unreachable signature.
+    // An exit-code-keyed impl would wrongly treat this as "down".
+    const sd = makeSystemd({
+      active: { "cortex-bot.service": 555 },
+      isActiveOverride: () => ({ code: 1, stdout: "", stderr: "Failed to connect to bus: No such file or directory" }),
+    });
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, env: envOver(sd.exec, sd.alive), targets, drain: FAST_DRAIN });
 
-    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
+    expect(res.cleared).toBe(false);
+    expect(res.stillPresent.map((t) => t.unit)).toEqual(["cortex-bot.service"]);
+    expect(res.reason).toContain("fail-closed");
+  });
+
+  test("migration gate (linux) treats is-active 'unknown' as PRESENT (not a clean down word)", async () => {
+    const targets: ServiceTarget[] = [
+      { id: "s", kind: "stack", label: "cortex-bot.service", unit: "cortex-bot.service", plistPath: "" },
+    ];
+    const sd = makeSystemd({
+      active: {},
+      isActiveOverride: () => ({ code: 4, stdout: "unknown\n", stderr: "" }),
+    });
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, env: envOver(sd.exec, sd.alive), targets, drain: FAST_DRAIN });
+    expect(res.cleared).toBe(false);
+  });
+
+  test("migration gate (linux) 'activating' + non-zero exit is PRESENT (stdout-property lock)", async () => {
+    // Correlated-fakes gap guard: an exit-code-keyed impl would pass this because
+    // exit is non-zero, but the WORD says the unit is (re)starting → must be PRESENT.
+    const targets: ServiceTarget[] = [
+      { id: "s", kind: "stack", label: "cortex-bot.service", unit: "cortex-bot.service", plistPath: "" },
+    ];
+    const sd = makeSystemd({
+      active: {},
+      isActiveOverride: () => ({ code: 3, stdout: "activating\n", stderr: "" }),
+    });
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, env: envOver(sd.exec, sd.alive), targets, drain: FAST_DRAIN });
+    expect(res.cleared).toBe(false);
+  });
+
+  test("migration gate (linux) clears on a clean 'inactive' word + PID death", async () => {
+    const targets: ServiceTarget[] = [
+      { id: "s", kind: "stack", label: "cortex-bot.service", unit: "cortex-bot.service", plistPath: "" },
+    ];
+    const sd = makeSystemd({ active: { "cortex-bot.service": 999 } }); // stop → inactive + pid dies
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, env: envOver(sd.exec, sd.alive), targets, drain: FAST_DRAIN });
     expect(res.cleared).toBe(true);
-    // After the gate, the whole fleet is DOWN (bootout is persistent).
-    expect(ld.loaded.size).toBe(0);
+  });
+});
 
-    // Caller starts the migration and it THROWS midway — the restore contract.
-    let restoreResult;
+// =============================================================================
+// A-TOCTOU — deregistration ≠ death; the PID must reach ESRCH
+// =============================================================================
+
+describe("migration gate — A-TOCTOU (confirmed process death)", () => {
+  test("migration gate (darwin) does NOT clear while the booted-out PID is still draining", async () => {
+    const targets = darwinTargets(["meta-factory"]);
+    const stackLabel = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    // bootout deregisters (print goes non-zero) but the process LINGERS (drain).
+    const ld = makeLaunchd({ loaded: { [stackLabel]: 4242, [RELAY_LABEL]: 4243, "com.grove.bot": 0 }, killsProcess: false });
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, env: envOver(ld.exec, ld.alive), targets, drain: FAST_DRAIN });
+
+    expect(res.cleared).toBe(false); // print said gone, but kill(pid,0) still alive
+    expect(res.stillPresent.map((t) => t.label)).toContain(stackLabel);
+  });
+
+  test("migration gate (darwin) clears once the PID reaches ESRCH after drain", async () => {
+    const targets = darwinTargets(["meta-factory"]);
+    const stackLabel = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    const ld = makeLaunchd({ loaded: { [stackLabel]: 4242, [RELAY_LABEL]: 4243 }, killsProcess: true });
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, env: envOver(ld.exec, ld.alive), targets, drain: FAST_DRAIN });
+    expect(res.cleared).toBe(true);
+  });
+
+  test("migration gate (linux) requires PID death (from MainPID), not just is-active inactive", async () => {
+    const targets: ServiceTarget[] = [
+      { id: "s", kind: "stack", label: "cortex-bot.service", unit: "cortex-bot.service", plistPath: "" },
+    ];
+    // stop → is-active inactive, but the forked child LINGERS (KillMode=process).
+    const sd = makeSystemd({ active: { "cortex-bot.service": 8080 }, killsProcess: false });
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, env: envOver(sd.exec, sd.alive), targets, drain: FAST_DRAIN });
+    expect(res.cleared).toBe(false);
+    expect(res.stillPresent.map((t) => t.unit)).toEqual(["cortex-bot.service"]);
+  });
+});
+
+// =============================================================================
+// A-RESTORE — withMigrationGate try/finally ALWAYS restores the pre-running set
+// =============================================================================
+
+describe("migration gate — A-RESTORE (finally-guaranteed restore)", () => {
+  test("migration gate withMigrationGate runs the migration after clear and restores in finally", async () => {
+    const stackLabel = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    const ld = makeLaunchd({ loaded: { [stackLabel]: 100, [RELAY_LABEL]: 101 } });
+    let migrated = false;
+
+    const run = await withMigrationGate(
+      { platform: "darwin", uid: 501, env: envOver(ld.exec, ld.alive), launchAgentsDir: LAUNCH_DIR, configDir: CFG_DIR, discoverSlugs: () => ["meta-factory"], drain: FAST_DRAIN },
+      () => {
+        migrated = true;
+        return Promise.resolve("moved");
+      },
+    );
+
+    expect(run.cleared).toBe(true);
+    expect(migrated).toBe(true);
+    expect(run.result).toBe("moved");
+    // Fleet is back up after the (successful) migration — nothing stranded.
+    expect(ld.loaded.has(stackLabel)).toBe(true);
+    expect(ld.loaded.has(RELAY_LABEL)).toBe(true);
+    expect(run.restore.failed).toHaveLength(0);
+  });
+
+  test("migration gate withMigrationGate restores the fleet even when the migration THROWS", async () => {
+    const stackLabel = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    const ld = makeLaunchd({ loaded: { [stackLabel]: 100, [RELAY_LABEL]: 101 } });
+
+    let threw = false;
     try {
-      throw new Error("state move failed midway");
-    } catch {
-      restoreResult = await res.restore();
+      await withMigrationGate(
+        { platform: "darwin", uid: 501, env: envOver(ld.exec, ld.alive), launchAgentsDir: LAUNCH_DIR, configDir: CFG_DIR, discoverSlugs: () => ["meta-factory"], drain: FAST_DRAIN },
+        () => {
+          throw new Error("state move failed midway");
+        },
+      );
+    } catch (err) {
+      threw = true;
+      expect((err as Error).message).toContain("state move failed");
     }
 
-    // Every daemon that was up is loaded again — symmetry preserved.
-    expect(restoreResult.failed).toHaveLength(0);
-    expect(restoreResult.restored.sort()).toEqual([...targets.map((t) => t.id)].sort());
-    for (const label of originallyUp) expect(ld.loaded.has(label)).toBe(true);
+    expect(threw).toBe(true);
+    // The finally restored the fleet despite the throw — the G-36 guarantee.
+    expect(ld.loaded.has(stackLabel)).toBe(true);
+    expect(ld.loaded.has(RELAY_LABEL)).toBe(true);
+  });
+
+  test("migration gate withMigrationGate does NOT run the migration when the gate refuses", async () => {
+    const stackLabel = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    // Draining PID → gate refuses to clear.
+    const ld = makeLaunchd({ loaded: { [stackLabel]: 100, [RELAY_LABEL]: 101 }, killsProcess: false });
+    let migrated = false;
+
+    const run = await withMigrationGate(
+      { platform: "darwin", uid: 501, env: envOver(ld.exec, ld.alive), launchAgentsDir: LAUNCH_DIR, configDir: CFG_DIR, discoverSlugs: () => ["meta-factory"], drain: FAST_DRAIN },
+      () => {
+        migrated = true;
+        return Promise.resolve("nope");
+      },
+    );
+
+    expect(run.cleared).toBe(false);
+    expect(migrated).toBe(false); // migration NEVER ran under a red gate
+    // The pre-running set the gate stopped was restored.
+    expect(ld.loaded.has(stackLabel)).toBe(true);
+  });
+});
+
+// =============================================================================
+// Empty-target guard + restore mechanics
+// =============================================================================
+
+describe("migration gate — guards + restore mechanics", () => {
+  test("migration gate refuses an EMPTY target set (fail-closed, not a vacuous clear)", async () => {
+    const ld = makeLaunchd({ loaded: {} });
+    let threw = false;
+    let msg = "";
+    try {
+      await runMigrationGate({ platform: "darwin", uid: 501, env: envOver(ld.exec, ld.alive), targets: [], drain: FAST_DRAIN });
+    } catch (err) {
+      threw = true;
+      msg = err instanceof Error ? err.message : String(err);
+    }
+    expect(threw).toBe(true);
+    expect(msg).toContain("EMPTY target set");
   });
 
   test("migration gate restore re-bootstraps ONLY the pre-running set (symmetry)", async () => {
-    const targets = targetsFor(["meta-factory", "work"]);
-    const upLabel = `${CORTEX_LABEL_PREFIX}meta-factory`; // only this one is up
-    const ld = makeLaunchd({ loaded: [upLabel] });
-
-    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
+    const targets = darwinTargets(["meta-factory", "work"]);
+    const up = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    const ld = makeLaunchd({ loaded: { [up]: 200, [RELAY_LABEL]: 201 } }); // 'work' is down
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, env: envOver(ld.exec, ld.alive), targets, drain: FAST_DRAIN });
     expect(res.cleared).toBe(true);
-    expect(res.running.map((t) => t.label)).toEqual([upLabel]);
+    expect(res.running.map((t) => t.label).sort()).toEqual([RELAY_LABEL, up].sort());
 
-    const restoreResult = await res.restore();
-
-    // Only the pre-running stack is brought back; the one that was already down
-    // is NOT started (nothing that was down is started).
-    expect(ld.loaded.has(upLabel)).toBe(true);
-    expect(ld.loaded.has(`${CORTEX_LABEL_PREFIX}work`)).toBe(false);
-    expect(restoreResult.restored).toEqual([targets.find((t) => t.label === upLabel)!.id]);
-    // bootstrap targeted the correct plist path.
-    const bootstraps = ld.calls.filter((c) => c[1] === "bootstrap").map((c) => c[3]);
-    expect(bootstraps).toContain(`${LAUNCH_DIR}/${upLabel}.plist`);
+    const restore = await res.restore();
+    expect(restore.failed).toHaveLength(0);
+    expect(ld.loaded.has(up)).toBe(true);
+    expect(ld.loaded.has(RELAY_LABEL)).toBe(true);
+    expect(ld.loaded.has(`${CORTEX_LABEL_PREFIX}work`)).toBe(false); // was down → stays down
   });
 
-  test("migration gate restore restarts the pre-running linux set via systemctl start", async () => {
-    const targets = targetsFor(["meta-factory"]);
-    const sd = makeSystemd({ active: targets.map((t) => t.unit) });
-
-    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: sd.exec, targets });
-    expect(res.cleared).toBe(true);
-
-    const restoreResult = await res.restore();
-    expect(restoreResult.failed).toHaveLength(0);
-    expect(restoreResult.restored).toEqual(targets.map((t) => t.id));
-    for (const t of targets) expect(sd.active.has(t.unit)).toBe(true);
-    // restore used `systemctl --user start` + verified with `is-active`.
-    expect(sd.calls.some((c) => c[2] === "start")).toBe(true);
-  });
-
-  test("migration gate restore reports failure when a daemon refuses to come back (darwin)", async () => {
-    const targets = targetsFor(["meta-factory"]);
+  test("migration gate restore reports failure when a daemon refuses to come back", async () => {
+    const targets = darwinTargets(["meta-factory"]);
     const label = `${CORTEX_LABEL_PREFIX}meta-factory`;
-    // Custom exec: bootout works, but bootstrap does NOT re-load (print stays non-zero).
-    const calls: string[][] = [];
-    const loaded = new Set([label]);
+    const alive = new Set<number>([300]);
+    const loaded = new Map<string, number>([[label, 300]]);
     const exec: GateExec = (argv) => {
-      calls.push(argv);
       const sub = argv[1];
       const lbl = (argv[2] ?? "").split("/").pop() ?? "";
-      if (sub === "print") return Promise.resolve(loaded.has(lbl) ? { code: 0, stdout: "running", stderr: "" } : { code: 113, stdout: "", stderr: "" });
-      if (sub === "bootout") { loaded.delete(lbl); return Promise.resolve({ code: 0, stdout: "", stderr: "" }); }
-      if (sub === "bootstrap") return Promise.resolve({ code: 5, stdout: "", stderr: "Input/output error" }); // fails to load
+      if (sub === "print") {
+        const pid = loaded.get(lbl);
+        return Promise.resolve(pid !== undefined ? { code: 0, stdout: `pid = ${pid.toString()}`, stderr: "" } : { code: 113, stdout: "", stderr: "" });
+      }
+      if (sub === "bootout") { const pid = loaded.get(lbl); loaded.delete(lbl); if (pid !== undefined) alive.delete(pid); return Promise.resolve({ code: 0, stdout: "", stderr: "" }); }
+      if (sub === "bootstrap") return Promise.resolve({ code: 5, stdout: "", stderr: "Input/output error" }); // never re-loads
       if (sub === "kickstart") return Promise.resolve({ code: 3, stdout: "", stderr: "" });
       return Promise.resolve({ code: 1, stdout: "", stderr: "" });
     };
-
-    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec, targets });
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, env: envOver(exec, alive), targets, drain: FAST_DRAIN });
     expect(res.cleared).toBe(true);
 
-    const restoreResult = await res.restore();
-    // The restore is HONEST about not bringing it back — a caller can escalate.
-    expect(restoreResult.restored).toHaveLength(0);
-    expect(restoreResult.failed).toHaveLength(1);
-    expect(restoreResult.failed[0]!.id).toBe(targets[0]!.id);
+    const restore = await res.restore();
+    expect(restore.restored).toHaveLength(0);
+    expect(restore.failed.map((f) => f.id)).toContain("meta-factory");
   });
 });

--- a/src/common/migration/__tests__/migration-gate.test.ts
+++ b/src/common/migration/__tests__/migration-gate.test.ts
@@ -487,3 +487,151 @@ describe("migration gate — guards + restore mechanics", () => {
     expect(restore.failed.map((f) => f.id)).toContain("meta-factory");
   });
 });
+
+// =============================================================================
+// Pidfile-liveness belt — the DEAD claim holds even for hand-started daemons
+// =============================================================================
+
+describe("migration gate — pidfile-liveness belt (out-of-model daemons)", () => {
+  const HAND_CFG = `${CFG_DIR}/meta-factory/meta-factory.yaml`;
+  const HAND_PID_PATH = "/state/cortex-meta-factory-abc12345.pid";
+
+  test("migration gate belt REFUSES when a hand-started stack has a LIVE pidfile and NO service unit", async () => {
+    const targets = darwinTargets(["meta-factory"]);
+    // Every service target is up and cleanly killed by the gate...
+    const stackLabel = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    const ld = makeLaunchd({ loaded: { [stackLabel]: 500, [RELAY_LABEL]: 501 }, killsProcess: true });
+    // ...but a hand-started daemon (pid 9999) runs with NO unit/label — never killed.
+    ld.alive.add(9999);
+    const env = envOver(ld.exec, ld.alive);
+
+    const res = await runMigrationGate({
+      platform: "darwin",
+      uid: 501,
+      env,
+      targets,
+      drain: FAST_DRAIN,
+      belt: {
+        stackConfigPaths: [HAND_CFG],
+        pidFilePathFor: () => HAND_PID_PATH,
+        readPidFile: (p) => (p === HAND_PID_PATH ? 9999 : undefined),
+      },
+    });
+
+    expect(res.stillPresent).toHaveLength(0); // all service targets proven dead
+    expect(res.cleared).toBe(false); // ...yet the gate refuses — the belt caught it
+    expect(res.livePidfiles.map((l) => l.pid)).toEqual([9999]);
+    expect(res.reason).toContain("LIVE pidfile");
+  });
+
+  test("migration gate belt does NOT false-refuse a unit-managed daemon it just killed", async () => {
+    const targets = darwinTargets(["meta-factory"]);
+    const stackLabel = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    // The stack's pidfile holds pid 500 — the SAME process the unit runs. The gate
+    // kills 500 via bootout; the belt (run AFTER the stop) must see it dead.
+    const ld = makeLaunchd({ loaded: { [stackLabel]: 500, [RELAY_LABEL]: 501 }, killsProcess: true });
+    const env = envOver(ld.exec, ld.alive);
+
+    const res = await runMigrationGate({
+      platform: "darwin",
+      uid: 501,
+      env,
+      targets,
+      drain: FAST_DRAIN,
+      belt: {
+        stackConfigPaths: [HAND_CFG],
+        pidFilePathFor: () => HAND_PID_PATH,
+        readPidFile: () => 500, // same pid the gate just killed
+      },
+    });
+
+    expect(res.livePidfiles).toHaveLength(0); // 500 is dead post-stop → no false refusal
+    expect(res.cleared).toBe(true);
+  });
+
+  test("migration gate belt clears when every pidfile is dead + service is down", async () => {
+    const targets = darwinTargets(["meta-factory"]);
+    const ld = makeLaunchd({ loaded: {} }); // nothing loaded → service side trivially clear
+    const env = envOver(ld.exec, ld.alive);
+
+    const res = await runMigrationGate({
+      platform: "darwin",
+      uid: 501,
+      env,
+      targets,
+      drain: FAST_DRAIN,
+      belt: {
+        stackConfigPaths: [HAND_CFG],
+        pidFilePathFor: () => HAND_PID_PATH,
+        readPidFile: () => 4242, // pid exists in the file but is NOT alive (not in `alive`)
+      },
+    });
+
+    expect(res.cleared).toBe(true);
+    expect(res.livePidfiles).toHaveLength(0);
+  });
+
+  test("migration gate belt refuses an EMPTY target set when a live pidfile exists (not a throw)", async () => {
+    const alive = new Set<number>([7777]);
+    const noop: GateExec = () => Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    const res = await runMigrationGate({
+      platform: "linux",
+      uid: 1000,
+      env: envOver(noop, alive),
+      targets: [],
+      drain: FAST_DRAIN,
+      belt: {
+        stackConfigPaths: [HAND_CFG],
+        pidFilePathFor: () => HAND_PID_PATH,
+        readPidFile: () => 7777,
+      },
+    });
+    expect(res.cleared).toBe(false);
+    expect(res.livePidfiles.map((l) => l.pid)).toEqual([7777]);
+  });
+
+  test("migration gate belt reuses pidFileFor semantics: '(default)' cortex.pid is checked too", async () => {
+    // No expected stacks, but the single-instance default daemon (cortex.pid) is live.
+    const alive = new Set<number>([333]);
+    const noop: GateExec = () => Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    const targets = darwinTargets([]); // relay + legacy only
+    const res = await runMigrationGate({
+      platform: "darwin",
+      uid: 501,
+      env: envOver(noop, alive),
+      targets,
+      drain: FAST_DRAIN,
+      belt: {
+        stackConfigPaths: [], // no stacks
+        pidFilePathFor: (cfg) => (cfg === undefined ? "/state/cortex.pid" : `/state/${cfg}.pid`),
+        readPidFile: (p) => (p === "/state/cortex.pid" ? 333 : undefined),
+      },
+    });
+    expect(res.cleared).toBe(false);
+    expect(res.livePidfiles[0]?.configPath).toBe("(default)");
+  });
+});
+
+// =============================================================================
+// XDG — the systemd user dir honours $XDG_CONFIG_HOME (G-38)
+// =============================================================================
+
+describe("migration gate — XDG systemd dir", () => {
+  test("migration gate (linux) discovery honours $XDG_CONFIG_HOME for the systemd user dir", () => {
+    const prev = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = "/xdg";
+    try {
+      const files = {
+        [`/xdg/systemd/user/cortex-bot.service`]: unit(`/usr/bin/bun /opt/cortex/src/cortex.ts --config ${CFG_DIR}/meta-factory/meta-factory.yaml`),
+      };
+      const io = fakeIO(files, ["/xdg/systemd/user"]);
+      // NOTE: systemdUserDir intentionally omitted → default must resolve under $XDG_CONFIG_HOME.
+      const targets = enumerateServiceTargets({ platform: "linux", configDir: CFG_DIR, io });
+      expect(targets.map((t) => t.unit)).toContain("cortex-bot.service");
+      expect(targets.find((t) => t.unit === "cortex-bot.service")?.plistPath).toBe("/xdg/systemd/user/cortex-bot.service");
+    } finally {
+      if (prev === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = prev;
+    }
+  });
+});

--- a/src/common/migration/__tests__/migration-gate.test.ts
+++ b/src/common/migration/__tests__/migration-gate.test.ts
@@ -1,0 +1,346 @@
+/**
+ * cortex#1901 — migration gate tests (XDG epic #1867, P3c).
+ *
+ * The gate proves a stack fleet is stopped before a config/state move, using the
+ * SERVICE MANAGER as the oracle (never a pidfile). Every launchctl/systemctl call
+ * is faked via an injected {@link GateExec}, so the darwin AND linux paths run on
+ * any POSIX CI host (cortex CI is ubuntu) with no real launchd/systemd.
+ *
+ * The fakes model the two properties that make this issue exist:
+ *   - a launchd job stays loaded (`print` → 0) until `bootout`, and a "stubborn"
+ *     job models KeepAlive/TOCTOU — it stays loaded even after a bootout attempt,
+ *     which the gate MUST catch via its post-stop verify and refuse to clear;
+ *   - a systemd unit stays `active` until `stop`, and `is-active` is the oracle.
+ *
+ * Test/describe names all contain "migration gate" so the epic's
+ * `bun test … -t "migration gate"` selector picks them up.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  enumerateServiceTargets,
+  runMigrationGate,
+  CORTEX_LABEL_PREFIX,
+  RELAY_LABEL,
+  LEGACY_LABELS,
+  type GateExec,
+  type ServiceTarget,
+} from "../migration-gate";
+
+// =============================================================================
+// Fakes — in-memory launchd + systemd that capture every argv
+// =============================================================================
+
+const LAUNCH_DIR = "/tmp/x1901-LaunchAgents";
+
+/** Build the gate's target set from a slug list without touching the filesystem. */
+function targetsFor(slugs: string[]): ServiceTarget[] {
+  return enumerateServiceTargets({
+    launchAgentsDir: LAUNCH_DIR,
+    configDir: "/unused",
+    discoverSlugs: () => slugs,
+  });
+}
+
+/** launchd fake. `loaded` = jobs currently in the domain; `stubborn` = jobs a
+ *  bootout can NOT unload (models KeepAlive / a supervisor respawn / TOCTOU). */
+function makeLaunchd(init?: { loaded?: string[]; stubborn?: string[] }): {
+  exec: GateExec;
+  calls: string[][];
+  loaded: Set<string>;
+} {
+  const loaded = new Set(init?.loaded ?? []);
+  const stubborn = new Set(init?.stubborn ?? []);
+  const calls: string[][] = [];
+  const labelOf = (target: string): string => target.split("/").pop() ?? "";
+  const exec: GateExec = (argv) => {
+    calls.push(argv);
+    const sub = argv[1];
+    if (argv[0] !== "launchctl") throw new Error(`unexpected cmd ${String(argv[0])}`);
+    if (sub === "print") {
+      const label = labelOf(argv[2] ?? "");
+      return Promise.resolve(
+        loaded.has(label)
+          ? { code: 0, stdout: `${label} = { state = running }`, stderr: "" }
+          : { code: 113, stdout: "", stderr: "Could not find service" },
+      );
+    }
+    if (sub === "bootout") {
+      const label = labelOf(argv[2] ?? "");
+      const was = loaded.has(label);
+      if (!stubborn.has(label)) loaded.delete(label);
+      return Promise.resolve({ code: was ? 0 : 3, stdout: "", stderr: "" });
+    }
+    if (sub === "bootstrap") {
+      // launchctl bootstrap gui/<uid> <plistPath>
+      const label = (argv[3] ?? "").split("/").pop()?.replace(/\.plist$/, "") ?? "";
+      loaded.add(label);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    }
+    if (sub === "kickstart") return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    return Promise.resolve({ code: 1, stdout: "", stderr: `unknown launchctl ${String(sub)}` });
+  };
+  return { exec, calls, loaded };
+}
+
+/** systemd fake. `active` = units currently up; `stubborn` = units `stop` can NOT
+ *  bring down (models Restart=always defeating a naive stop). */
+function makeSystemd(init?: { active?: string[]; stubborn?: string[] }): {
+  exec: GateExec;
+  calls: string[][];
+  active: Set<string>;
+} {
+  const active = new Set(init?.active ?? []);
+  const stubborn = new Set(init?.stubborn ?? []);
+  const calls: string[][] = [];
+  const exec: GateExec = (argv) => {
+    calls.push(argv);
+    // systemctl --user <verb> <unit>
+    const verb = argv[2];
+    const unit = argv[3] ?? "";
+    if (verb === "is-active") {
+      return Promise.resolve(
+        active.has(unit)
+          ? { code: 0, stdout: "active\n", stderr: "" }
+          : { code: 3, stdout: "inactive\n", stderr: "" },
+      );
+    }
+    if (verb === "stop") {
+      if (!stubborn.has(unit)) active.delete(unit);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    }
+    if (verb === "start") {
+      active.add(unit);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    }
+    return Promise.resolve({ code: 1, stdout: "", stderr: `unknown systemctl ${String(verb)}` });
+  };
+  return { exec, calls, active };
+}
+
+/** An exec that always throws — models the service-manager binary being absent
+ *  (ENOENT). The gate must FAIL CLOSED against this. */
+const throwingExec: GateExec = () => {
+  throw new Error("spawn systemctl ENOENT");
+};
+
+// =============================================================================
+// Enumeration
+// =============================================================================
+
+describe("migration gate — enumeration (slugs + relay + legacy)", () => {
+  test("migration gate enumerates every stack slug, the relay, and the legacy labels", () => {
+    const targets = targetsFor(["meta-factory", "work"]);
+    const labels = targets.map((t) => t.label);
+
+    expect(labels).toContain(`${CORTEX_LABEL_PREFIX}meta-factory`);
+    expect(labels).toContain(`${CORTEX_LABEL_PREFIX}work`);
+    expect(labels).toContain(RELAY_LABEL);
+    for (const legacy of LEGACY_LABELS) expect(labels).toContain(legacy);
+    // com.grove.* legacy set is present (G-35).
+    expect(labels).toContain("com.grove.bot");
+    expect(labels).toContain("com.grove.relay");
+
+    // Each target carries both platform identities + a bootstrap path.
+    const relay = targets.find((t) => t.label === RELAY_LABEL)!;
+    expect(relay.unit).toBe(`${RELAY_LABEL}.service`);
+    expect(relay.plistPath).toBe(`${LAUNCH_DIR}/${RELAY_LABEL}.plist`);
+    expect(relay.kind).toBe("relay");
+  });
+
+  test("migration gate dedupes a stack slug colliding with relay/bot", () => {
+    const targets = targetsFor(["relay", "bot"]);
+    const labels = targets.map((t) => t.label);
+    const relayCount = labels.filter((l) => l === RELAY_LABEL).length;
+    const botCount = labels.filter((l) => l === `${CORTEX_LABEL_PREFIX}bot`).length;
+    expect(relayCount).toBe(1);
+    expect(botCount).toBe(1);
+  });
+});
+
+// =============================================================================
+// macOS — clear vs block, oracle is the service manager
+// =============================================================================
+
+describe("migration gate — darwin oracle (launchctl bootout, not pidfile)", () => {
+  test("migration gate (darwin) clears only after bootout of every slug + relay", async () => {
+    const targets = targetsFor(["meta-factory", "work"]);
+    const ld = makeLaunchd({ loaded: targets.map((t) => t.label) });
+
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
+
+    expect(res.cleared).toBe(true);
+    expect(res.stillPresent).toHaveLength(0);
+    // Every stack label + relay + legacy was booted out.
+    const bootouts = ld.calls.filter((c) => c[1] === "bootout").map((c) => c[2]);
+    for (const t of targets) expect(bootouts).toContain(`gui/501/${t.label}`);
+    // Oracle is the service manager — every call is launchctl, nothing filesystem.
+    expect(ld.calls.every((c) => c[0] === "launchctl")).toBe(true);
+    // Verification uses `print` (never a pidfile check).
+    expect(ld.calls.some((c) => c[1] === "print")).toBe(true);
+  });
+
+  test("migration gate (darwin) BLOCKS while a KeepAlive daemon stays loaded (pidfile absent is irrelevant)", async () => {
+    const targets = targetsFor(["meta-factory", "work"]);
+    const stubborn = `${CORTEX_LABEL_PREFIX}work`; // KeepAlive: bootout can't unload it
+    const ld = makeLaunchd({ loaded: targets.map((t) => t.label), stubborn: [stubborn] });
+
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
+
+    expect(res.cleared).toBe(false);
+    expect(res.stillPresent.map((t) => t.label)).toEqual([stubborn]);
+    expect(res.reason).toContain("fail-closed");
+    expect(res.reason).toContain(stubborn);
+    // The gate DID try to bootout it — the daemon simply survived, so the gate
+    // (correctly) refuses to clear rather than trusting the stop succeeded.
+    expect(ld.calls.some((c) => c[1] === "bootout" && c[2] === `gui/501/${stubborn}`)).toBe(true);
+  });
+
+  test("migration gate (darwin) clears when nothing is loaded (bootout is idempotent)", async () => {
+    const targets = targetsFor(["meta-factory"]);
+    const ld = makeLaunchd({ loaded: [] });
+
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
+
+    expect(res.cleared).toBe(true);
+    expect(res.running).toHaveLength(0); // nothing was up → nothing to restore
+  });
+});
+
+// =============================================================================
+// Linux — REQUIRED path + FAIL-CLOSED (G-08). Runs on ubuntu CI via fakes.
+// =============================================================================
+
+describe("migration gate — linux oracle (systemctl stop + is-active)", () => {
+  test("migration gate (linux) stops via systemctl and clears when is-active reports inactive", async () => {
+    const targets = targetsFor(["meta-factory", "work"]);
+    const sd = makeSystemd({ active: targets.map((t) => t.unit) });
+
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: sd.exec, targets });
+
+    expect(res.cleared).toBe(true);
+    const stops = sd.calls.filter((c) => c[2] === "stop").map((c) => c[3]);
+    for (const t of targets) expect(stops).toContain(t.unit);
+    // Oracle is `systemctl --user is-active`, never launchctl or a pidfile.
+    expect(sd.calls.every((c) => c[0] === "systemctl" && c[1] === "--user")).toBe(true);
+    expect(sd.calls.some((c) => c[2] === "is-active")).toBe(true);
+  });
+
+  test("migration gate (linux) FAILS CLOSED when systemctl is unavailable (exec throws)", async () => {
+    const targets = targetsFor(["meta-factory"]);
+
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: throwingExec, targets });
+
+    // Cannot prove anything down → must refuse to clear (never silently pass).
+    expect(res.cleared).toBe(false);
+    expect(res.stillPresent).toHaveLength(targets.length);
+    expect(res.reason).toContain("fail-closed");
+    // Pre-check also couldn't prove absence, so the whole set is the restore set.
+    expect(res.running).toHaveLength(targets.length);
+  });
+
+  test("migration gate (linux) BLOCKS while a Restart=always unit stays active after stop", async () => {
+    const targets = targetsFor(["meta-factory", "work"]);
+    const stubborn = targets[0]!.unit; // stop can't bring it down
+    const sd = makeSystemd({ active: targets.map((t) => t.unit), stubborn: [stubborn] });
+
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: sd.exec, targets });
+
+    expect(res.cleared).toBe(false);
+    expect(res.stillPresent.map((t) => t.unit)).toEqual([stubborn]);
+  });
+});
+
+// =============================================================================
+// Restore-on-failure (G-36) — bootout is persistent; an abort must bring the fleet back
+// =============================================================================
+
+describe("migration gate — restore-on-failure (G-36)", () => {
+  test("migration gate restore brings daemons back after a mid-migration failure (darwin)", async () => {
+    const targets = targetsFor(["meta-factory", "work"]);
+    const originallyUp = targets.map((t) => t.label);
+    const ld = makeLaunchd({ loaded: [...originallyUp] });
+
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
+    expect(res.cleared).toBe(true);
+    // After the gate, the whole fleet is DOWN (bootout is persistent).
+    expect(ld.loaded.size).toBe(0);
+
+    // Caller starts the migration and it THROWS midway — the restore contract.
+    let restoreResult;
+    try {
+      throw new Error("state move failed midway");
+    } catch {
+      restoreResult = await res.restore();
+    }
+
+    // Every daemon that was up is loaded again — symmetry preserved.
+    expect(restoreResult.failed).toHaveLength(0);
+    expect(restoreResult.restored.sort()).toEqual([...targets.map((t) => t.id)].sort());
+    for (const label of originallyUp) expect(ld.loaded.has(label)).toBe(true);
+  });
+
+  test("migration gate restore re-bootstraps ONLY the pre-running set (symmetry)", async () => {
+    const targets = targetsFor(["meta-factory", "work"]);
+    const upLabel = `${CORTEX_LABEL_PREFIX}meta-factory`; // only this one is up
+    const ld = makeLaunchd({ loaded: [upLabel] });
+
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec: ld.exec, targets });
+    expect(res.cleared).toBe(true);
+    expect(res.running.map((t) => t.label)).toEqual([upLabel]);
+
+    const restoreResult = await res.restore();
+
+    // Only the pre-running stack is brought back; the one that was already down
+    // is NOT started (nothing that was down is started).
+    expect(ld.loaded.has(upLabel)).toBe(true);
+    expect(ld.loaded.has(`${CORTEX_LABEL_PREFIX}work`)).toBe(false);
+    expect(restoreResult.restored).toEqual([targets.find((t) => t.label === upLabel)!.id]);
+    // bootstrap targeted the correct plist path.
+    const bootstraps = ld.calls.filter((c) => c[1] === "bootstrap").map((c) => c[3]);
+    expect(bootstraps).toContain(`${LAUNCH_DIR}/${upLabel}.plist`);
+  });
+
+  test("migration gate restore restarts the pre-running linux set via systemctl start", async () => {
+    const targets = targetsFor(["meta-factory"]);
+    const sd = makeSystemd({ active: targets.map((t) => t.unit) });
+
+    const res = await runMigrationGate({ platform: "linux", uid: 1000, exec: sd.exec, targets });
+    expect(res.cleared).toBe(true);
+
+    const restoreResult = await res.restore();
+    expect(restoreResult.failed).toHaveLength(0);
+    expect(restoreResult.restored).toEqual(targets.map((t) => t.id));
+    for (const t of targets) expect(sd.active.has(t.unit)).toBe(true);
+    // restore used `systemctl --user start` + verified with `is-active`.
+    expect(sd.calls.some((c) => c[2] === "start")).toBe(true);
+  });
+
+  test("migration gate restore reports failure when a daemon refuses to come back (darwin)", async () => {
+    const targets = targetsFor(["meta-factory"]);
+    const label = `${CORTEX_LABEL_PREFIX}meta-factory`;
+    // Custom exec: bootout works, but bootstrap does NOT re-load (print stays non-zero).
+    const calls: string[][] = [];
+    const loaded = new Set([label]);
+    const exec: GateExec = (argv) => {
+      calls.push(argv);
+      const sub = argv[1];
+      const lbl = (argv[2] ?? "").split("/").pop() ?? "";
+      if (sub === "print") return Promise.resolve(loaded.has(lbl) ? { code: 0, stdout: "running", stderr: "" } : { code: 113, stdout: "", stderr: "" });
+      if (sub === "bootout") { loaded.delete(lbl); return Promise.resolve({ code: 0, stdout: "", stderr: "" }); }
+      if (sub === "bootstrap") return Promise.resolve({ code: 5, stdout: "", stderr: "Input/output error" }); // fails to load
+      if (sub === "kickstart") return Promise.resolve({ code: 3, stdout: "", stderr: "" });
+      return Promise.resolve({ code: 1, stdout: "", stderr: "" });
+    };
+
+    const res = await runMigrationGate({ platform: "darwin", uid: 501, exec, targets });
+    expect(res.cleared).toBe(true);
+
+    const restoreResult = await res.restore();
+    // The restore is HONEST about not bringing it back — a caller can escalate.
+    expect(restoreResult.restored).toHaveLength(0);
+    expect(restoreResult.failed).toHaveLength(1);
+    expect(restoreResult.failed[0]!.id).toBe(targets[0]!.id);
+  });
+});

--- a/src/common/migration/migration-gate.ts
+++ b/src/common/migration/migration-gate.ts
@@ -22,7 +22,7 @@
  *     (supervisor races) but bootout-absence is safe (supervisor is out of it).
  *   - **Linux:** `systemctl --user stop <unit>` — an EXPLICIT stop, which
  *     `Restart=always` does NOT override (Restart fires on unexpected exit, not
- *     on an operator stop) — then prove absence with `systemctl --user is-active`
+ *     on a deliberate stop) — then prove absence with `systemctl --user is-active`
  *     returning a non-"up" state. REQUIRED + FAIL-CLOSED (G-08): the epic exists
  *     for a Linux user and CI is ubuntu, so the Linux path is a first-class
  *     implementation, not a stub.

--- a/src/common/migration/migration-gate.ts
+++ b/src/common/migration/migration-gate.ts
@@ -1,0 +1,436 @@
+/**
+ * cortex#1901 (XDG epic #1867, phase P3c gate) — the migration gate that PROVES
+ * a stack fleet is stopped before X-07 (config move) / X-11 (state move) relocate
+ * a running daemon's directories. This issue delivers the REUSABLE gate; the
+ * moves themselves are out of scope (they consume it).
+ *
+ * ## Why the oracle is the SERVICE MANAGER, never a pidfile
+ *
+ * A filesystem/pidfile oracle is wrong on two counts, and both are load-bearing:
+ *   - Stack plists carry `RunAtLoad:true` AND `KeepAlive:true`, so a daemon is
+ *     ALWAYS alive → an "abort if pidfile present" gate is a permanent no-op.
+ *   - `cortex stop` and the singleton check UNLINK the pidfile (seven sites in
+ *     `cortex.ts` — grep `unlinkSync(pidFile)`) while KeepAlive respawns inside
+ *     the throttle window, so "no pidfile" NEVER means "no daemon" (a TOCTOU).
+ *
+ * So the gate drives the service manager and proves absence THROUGH it:
+ *   - **macOS:** `launchctl bootout gui/<uid>/<label>` — the only primitive that
+ *     defeats KeepAlive — then prove absence with `launchctl print …` returning
+ *     NON-ZERO. `bootout` removes the service from the domain, so the supervisor
+ *     will NOT respawn until a matching `bootstrap`. The stop→verify window is
+ *     race-free BY CONSTRUCTION — which is exactly why pidfile-absence is unsafe
+ *     (supervisor races) but bootout-absence is safe (supervisor is out of it).
+ *   - **Linux:** `systemctl --user stop <unit>` — an EXPLICIT stop, which
+ *     `Restart=always` does NOT override (Restart fires on unexpected exit, not
+ *     on an operator stop) — then prove absence with `systemctl --user is-active`
+ *     returning a non-"up" state. REQUIRED + FAIL-CLOSED (G-08): the epic exists
+ *     for a Linux user and CI is ubuntu, so the Linux path is a first-class
+ *     implementation, not a stub.
+ *
+ * ## Fail-closed by construction
+ *
+ * A target is deemed absent ONLY on POSITIVE PROOF (`print` non-zero on macOS /
+ * a definitive down-state from a clean `is-active` on Linux). If the service
+ * manager binary is missing (the injected exec throws), or `print` still
+ * resolves the job, or `is-active` reports an up-state, the target counts as
+ * PRESENT and the gate REFUSES to clear. Absence is proven; it is never assumed.
+ * There is no code path that returns `cleared:true` without every target having
+ * been positively proven down.
+ *
+ * ## Restore-on-failure (G-36)
+ *
+ * `bootout` is PERSISTENT — an aborted migration would otherwise leave the fleet
+ * down with KeepAlive defeated. {@link runMigrationGate} therefore returns a
+ * `restore()` handle that `bootstrap`s (macOS) / `start`s (Linux) exactly the
+ * targets that were UP when the gate ran, and verifies each came back. Callers
+ * MUST invoke `restore()` on ANY failure path — the gate's own non-clear, or
+ * their own migration throwing after a clear. Symmetry (the preupgrade/
+ * postupgrade guarantee): nothing that was down is started; nothing that was up
+ * is left down.
+ *
+ * ## Legacy labels (G-35)
+ *
+ * Enumeration covers not just live stack slugs + the relay, but the legacy label
+ * set `scripts/preupgrade.sh` already boots out (`com.grove.bot`,
+ * `com.grove.relay`, `ai.meta-factory.cortex.bot`) — a `com.grove.*` daemon left
+ * from the grove-v2 era is exactly the KeepAlive process a state move must not
+ * race.
+ *
+ * ## Seams
+ *
+ * Every side effect (the launchctl/systemctl exec), the `platform`, and the
+ * `uid` are injected so the gate is unit-testable on a POSIX CI host with no
+ * real launchd/systemd — mirroring the #763 `NatsServiceManager` ExecRunner seam.
+ */
+
+import { homedir } from "os";
+import { join } from "path";
+
+import { discoverStacks } from "../../cli/cortex/commands/stack-lib";
+import { cortexConfigDir } from "../config/config-path";
+
+// =============================================================================
+// Public types + the injected exec seam
+// =============================================================================
+
+/** macOS (`darwin`) vs Linux — the only two platforms the fleet runs on. */
+export type GatePlatform = "darwin" | "linux";
+
+/** Result of one launchctl/systemctl subprocess. `stdout` is load-bearing on
+ *  Linux (`is-active` prints the state word there). */
+export interface GateExecResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Injected process runner — captured in tests, real `Bun.spawn` in prod. May
+ *  THROW synchronously on ENOENT (binary not on PATH); the gate treats a throw
+ *  as "cannot prove absence" (fail-closed), never letting it escape. */
+export type GateExec = (argv: string[]) => Promise<GateExecResult>;
+
+/** Which family a target belongs to — for logging + restore reasoning. */
+export type ServiceTargetKind = "stack" | "relay" | "legacy";
+
+/**
+ * One service the gate must prove stopped, carrying BOTH platform identities so
+ * a single enumerated target is usable on either OS:
+ *   - `label` — the launchd label (`launchctl bootout/print gui/<uid>/<label>`).
+ *   - `unit`  — the systemd unit id (`systemctl --user stop/is-active <unit>`),
+ *      the `<label>.service` analogue of the launchd Label.
+ *   - `plistPath` — where `launchctl bootstrap` reloads it from on restore.
+ */
+export interface ServiceTarget {
+  id: string;
+  kind: ServiceTargetKind;
+  label: string;
+  unit: string;
+  plistPath: string;
+}
+
+// =============================================================================
+// Label / unit conventions (kept in lockstep with preupgrade.sh)
+// =============================================================================
+
+/** The launchd label prefix every cortex stack + the relay share. */
+export const CORTEX_LABEL_PREFIX = "ai.meta-factory.cortex.";
+
+/** The relay's launchd label — enumerated alongside stack slugs (issue step 1). */
+export const RELAY_LABEL = `${CORTEX_LABEL_PREFIX}relay`;
+
+/**
+ * The legacy label set `scripts/preupgrade.sh:80` already knows (G-35):
+ *   - `com.grove.bot` / `com.grove.relay` — grove-v2 era plists that may linger.
+ *   - `ai.meta-factory.cortex.bot` — the pre-cortex#251 dev-stack plist name.
+ * A KeepAlive daemon under any of these is a process a state move must not race.
+ */
+export const LEGACY_LABELS: readonly string[] = [
+  "com.grove.bot",
+  "com.grove.relay",
+  `${CORTEX_LABEL_PREFIX}bot`,
+];
+
+/** systemd `is-active` states that mean the unit is (still) UP. Everything else
+ *  a clean `is-active` can print (`inactive`/`failed`/`unknown`/`""`) is DOWN. */
+const SYSTEMD_UP_STATES: ReadonlySet<string> = new Set([
+  "active",
+  "activating",
+  "reloading",
+  "deactivating",
+]);
+
+// =============================================================================
+// Enumeration
+// =============================================================================
+
+/** Options for {@link enumerateServiceTargets}. */
+export interface EnumerateTargetsOptions {
+  /** Cortex config dir to discover stack slugs under. Defaults to
+   *  {@link cortexConfigDir} (honours `$CORTEX_CONFIG_DIR`). */
+  configDir?: string;
+  /** launchd `~/Library/LaunchAgents` (or the tmp dir a test points it at) —
+   *  where each label's `<label>.plist` lives, used by restore's `bootstrap`. */
+  launchAgentsDir: string;
+  /** Slug discovery seam. Defaults to `discoverStacks(dir).map(slugLocator)`. */
+  discoverSlugs?: (configDir: string) => string[];
+  /** `$HOME` override (tests). */
+  home?: string;
+}
+
+/**
+ * Enumerate every service the gate must prove stopped: one per discovered stack
+ * slug (`ai.meta-factory.cortex.<slug>`), the relay ({@link RELAY_LABEL}), and
+ * the {@link LEGACY_LABELS}. Deduplicated by label (so a stack whose slug is
+ * literally `relay`/`bot` can't double-enumerate). Pure — the only I/O is the
+ * injected slug discovery.
+ */
+export function enumerateServiceTargets(opts: EnumerateTargetsOptions): ServiceTarget[] {
+  const configDir = opts.configDir ?? cortexConfigDir(opts.home);
+  const discover =
+    opts.discoverSlugs ?? ((dir: string) => discoverStacks(dir).map((s) => s.slugLocator));
+
+  const targets: ServiceTarget[] = [];
+  const seen = new Set<string>();
+  const push = (id: string, kind: ServiceTargetKind, label: string): void => {
+    if (seen.has(label)) return;
+    seen.add(label);
+    targets.push({
+      id,
+      kind,
+      label,
+      unit: `${label}.service`,
+      plistPath: join(opts.launchAgentsDir, `${label}.plist`),
+    });
+  };
+
+  for (const slug of discover(configDir)) push(slug, "stack", `${CORTEX_LABEL_PREFIX}${slug}`);
+  push("relay", "relay", RELAY_LABEL);
+  for (const legacy of LEGACY_LABELS) push(legacy, "legacy", legacy);
+
+  return targets;
+}
+
+// =============================================================================
+// The gate
+// =============================================================================
+
+/** Inputs to {@link runMigrationGate}. All side effects are injected. */
+export interface MigrationGateOptions {
+  platform: GatePlatform;
+  /** launchd `gui/<uid>` target uid (ignored on Linux). */
+  uid: number;
+  exec: GateExec;
+  /** Enumerated by {@link enumerateServiceTargets}. */
+  targets: ServiceTarget[];
+}
+
+/** Outcome of a `restore()` call — which targets came back, and which didn't. */
+export interface RestoreResult {
+  restored: string[];
+  failed: { id: string; reason: string }[];
+}
+
+/** The gate's verdict + the restore handle callers MUST use on any failure. */
+export interface MigrationGateResult {
+  /** `true` ONLY when every target was positively proven down. */
+  cleared: boolean;
+  /** Present when `cleared === false` — which targets refused to prove down. */
+  reason?: string;
+  /** Everything the gate reasoned about. */
+  targets: ServiceTarget[];
+  /** Targets UP at pre-check — the exact set `restore()` brings back (symmetry). */
+  running: ServiceTarget[];
+  /** Targets not proven down AFTER the stop — the fail-closed evidence. */
+  stillPresent: ServiceTarget[];
+  /** Re-`bootstrap`/`start` the `running` set and verify each returns. Callers
+   *  MUST invoke this on ANY failure path — `bootout` is persistent. */
+  restore: () => Promise<RestoreResult>;
+}
+
+/**
+ * Prove a single target is DOWN via the service manager. Returns `true` ONLY on
+ * positive proof of absence; a thrown exec (binary missing) or any up-signal
+ * returns `false` (fail-closed — the caller then treats it as still present).
+ */
+async function proveAbsent(opts: MigrationGateOptions, t: ServiceTarget): Promise<boolean> {
+  try {
+    if (opts.platform === "darwin") {
+      // `launchctl print` exits 0 while the job is in the domain, non-zero once
+      // booted out. Non-zero is the positive proof of absence.
+      const r = await opts.exec(["launchctl", "print", `gui/${opts.uid.toString()}/${t.label}`]);
+      return r.code !== 0;
+    }
+    // Linux: `is-active` prints the state word; a non-"up" state is proof-of-down.
+    const r = await opts.exec(["systemctl", "--user", "is-active", t.unit]);
+    return !SYSTEMD_UP_STATES.has(r.stdout.trim());
+  } catch {
+    // Exec threw (e.g. systemctl/launchctl ENOENT): we CANNOT prove absence, so
+    // the target is treated as present. This is the fail-closed spine.
+    return false;
+  }
+}
+
+/** Issue the authoritative stop for one target (defeats KeepAlive/Restart). Never
+ *  throws — a stop failure surfaces later as a failed absence proof. */
+async function stopTarget(opts: MigrationGateOptions, t: ServiceTarget): Promise<void> {
+  try {
+    if (opts.platform === "darwin") {
+      await opts.exec(["launchctl", "bootout", `gui/${opts.uid.toString()}/${t.label}`]);
+    } else {
+      await opts.exec(["systemctl", "--user", "stop", t.unit]);
+    }
+  } catch {
+    // Swallow — a stop that couldn't run leaves the target UP, which the verify
+    // pass below will catch as `stillPresent` (fail-closed), so nothing clears.
+  }
+}
+
+/**
+ * Run the migration gate over `targets`:
+ *   1. Pre-check which targets are UP (the restore set — symmetry anchor).
+ *   2. Stop EVERY target (idempotent; also catches a target that raced up after
+ *      the pre-check — it is booted out regardless).
+ *   3. Prove EVERY target is now down. `cleared` iff all are proven down.
+ *
+ * Always returns a `restore()` handle bound to the pre-check UP set — usable
+ * whether the gate cleared (caller migrates, then restores) or refused (caller
+ * restores immediately).
+ */
+export async function runMigrationGate(
+  opts: MigrationGateOptions,
+): Promise<MigrationGateResult> {
+  const { targets } = opts;
+
+  // 1. Pre-check: UP == "not proven absent". A target whose proof throws (binary
+  //    missing) counts as UP, so restore is attempted and the gate won't clear.
+  const running: ServiceTarget[] = [];
+  for (const t of targets) {
+    if (!(await proveAbsent(opts, t))) running.push(t);
+  }
+
+  // 2. Authoritatively stop every enumerated target (defeat KeepAlive/Restart).
+  for (const t of targets) await stopTarget(opts, t);
+
+  // 3. Positive-proof verification. Absence must be proven for ALL to clear.
+  const stillPresent: ServiceTarget[] = [];
+  for (const t of targets) {
+    if (!(await proveAbsent(opts, t))) stillPresent.push(t);
+  }
+
+  const cleared = stillPresent.length === 0;
+  const restore = makeRestore(opts, running);
+
+  return {
+    cleared,
+    ...(cleared ? {} : { reason: notClearedReason(opts.platform, stillPresent) }),
+    targets,
+    running,
+    stillPresent,
+    restore,
+  };
+}
+
+/** Build the `restore()` closure bound to the pre-check UP set. */
+function makeRestore(
+  opts: MigrationGateOptions,
+  running: readonly ServiceTarget[],
+): () => Promise<RestoreResult> {
+  return async (): Promise<RestoreResult> => {
+    const restored: string[] = [];
+    const failed: { id: string; reason: string }[] = [];
+    for (const t of running) {
+      try {
+        const back =
+          opts.platform === "darwin"
+            ? await restoreDarwin(opts, t)
+            : await restoreLinux(opts, t);
+        if (back.ok) restored.push(t.id);
+        else failed.push({ id: t.id, reason: back.reason });
+      } catch (err) {
+        failed.push({ id: t.id, reason: err instanceof Error ? err.message : String(err) });
+      }
+    }
+    return { restored, failed };
+  };
+}
+
+/** macOS restore: `bootstrap` the plist back into the domain, `kickstart` it,
+ *  then confirm with `print` that it is loaded again. */
+async function restoreDarwin(
+  opts: MigrationGateOptions,
+  t: ServiceTarget,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const gui = `gui/${opts.uid.toString()}`;
+  await opts.exec(["launchctl", "bootstrap", gui, t.plistPath]);
+  await opts.exec(["launchctl", "kickstart", "-k", `${gui}/${t.label}`]);
+  const check = await opts.exec(["launchctl", "print", `${gui}/${t.label}`]);
+  if (check.code === 0) return { ok: true };
+  return {
+    ok: false,
+    reason: `launchctl print ${t.label} still non-zero after bootstrap (${check.code.toString()}): ${check.stderr.trim()}`,
+  };
+}
+
+/** Linux restore: `systemctl --user start`, then confirm with `is-active`. */
+async function restoreLinux(
+  opts: MigrationGateOptions,
+  t: ServiceTarget,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  await opts.exec(["systemctl", "--user", "start", t.unit]);
+  const check = await opts.exec(["systemctl", "--user", "is-active", t.unit]);
+  if (SYSTEMD_UP_STATES.has(check.stdout.trim())) return { ok: true };
+  return {
+    ok: false,
+    reason: `systemctl --user is-active ${t.unit} = ${JSON.stringify(check.stdout.trim())} after start`,
+  };
+}
+
+/** Human-readable fail-closed reason naming the not-proven-down targets. */
+function notClearedReason(platform: GatePlatform, stillPresent: readonly ServiceTarget[]): string {
+  const how =
+    platform === "darwin"
+      ? "`launchctl print` still resolves them (or launchctl is unavailable)"
+      : "`systemctl --user is-active` reports an up-state (or systemctl is unavailable)";
+  const which = stillPresent
+    .map((t) => (platform === "darwin" ? t.label : t.unit))
+    .join(", ");
+  return `migration gate REFUSED to clear (fail-closed): ${stillPresent.length.toString()} target(s) not proven stopped — ${how}: ${which}`;
+}
+
+// =============================================================================
+// Production wiring
+// =============================================================================
+
+/** A real `Bun.spawn`-backed {@link GateExec}. Captures stdout (Linux `is-active`
+ *  needs it) + stderr + exit code. */
+export const bunGateExec: GateExec = async (argv) => {
+  const [cmd, ...rest] = argv;
+  const proc = Bun.spawn([cmd ?? "", ...rest], { stdout: "pipe", stderr: "pipe" });
+  const code = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { code, stdout, stderr };
+};
+
+/** Map `process.platform` onto the supported {@link GatePlatform} set. */
+export function currentGatePlatform(): GatePlatform {
+  return process.platform === "darwin" ? "darwin" : "linux";
+}
+
+/** Resolve the launchd `gui/<uid>` target: explicit override, else the process
+ *  uid, else the macOS default 501. */
+export function resolveGateUid(uid?: number): number {
+  return uid ?? process.getuid?.() ?? 501;
+}
+
+/** `~/Library/LaunchAgents` (or under a `home` override). */
+function defaultLaunchAgentsDir(home?: string): string {
+  return join(home ?? process.env.HOME ?? homedir(), "Library", "LaunchAgents");
+}
+
+/**
+ * The one-call production entry point X-07/X-11 use: enumerate the fleet + run
+ * the gate with real `Bun.spawn` exec and host-derived platform/uid/dirs. Every
+ * default is overridable for tests + non-standard installs.
+ */
+export async function clearFleetForMigration(opts?: {
+  platform?: GatePlatform;
+  uid?: number;
+  exec?: GateExec;
+  configDir?: string;
+  launchAgentsDir?: string;
+  home?: string;
+}): Promise<MigrationGateResult> {
+  const launchAgentsDir = opts?.launchAgentsDir ?? defaultLaunchAgentsDir(opts?.home);
+  const targets = enumerateServiceTargets({
+    ...(opts?.configDir !== undefined && { configDir: opts.configDir }),
+    launchAgentsDir,
+    ...(opts?.home !== undefined && { home: opts.home }),
+  });
+  return runMigrationGate({
+    platform: opts?.platform ?? currentGatePlatform(),
+    uid: resolveGateUid(opts?.uid),
+    exec: opts?.exec ?? bunGateExec,
+    targets,
+  });
+}

--- a/src/common/migration/migration-gate.ts
+++ b/src/common/migration/migration-gate.ts
@@ -44,8 +44,30 @@
  *
  * Any leg unproven → the target is PRESENT and the gate REFUSES to clear. There
  * is NO path that returns `cleared:true` without every target passing all three.
- * An empty target set is a FOOTGUN (discovery failure), not a vacuous clear — it
- * throws.
+ * An empty target set with no live pidfile is a FOOTGUN (discovery failure), not
+ * a vacuous clear — it throws.
+ *
+ * A note on leg 3 (KillMode): cortex ships NO systemd unit with a `KillMode`
+ * override, so systemd's default `KillMode=control-group` tears down the whole
+ * cgroup on `stop` — tracking `MainPID` for the death poll is sufficient. If a
+ * deployment hand-authors a unit with `KillMode=process`, a child forked outside
+ * `MainPID` is a documented residual (the config-tree belt below still catches it
+ * if it wrote a pidfile).
+ *
+ * ## The pidfile-liveness belt — making "DEAD" TRUE, not "service-discovered dead"
+ *
+ * The three legs only see daemons the SERVICE MANAGER knows about. A daemon
+ * hand-started as `cortex start --config …` (how the principal runs cortex on a
+ * dev checkout) has no launchd label / systemd unit — invisible to the legs, so
+ * clearing would be fail-open. The belt closes this out-of-model hole with
+ * INDEPENDENT positive proof of LIFE: for every EXPECTED stack (enumerated from
+ * the config tree), read the pidfile it would write — via the #1900
+ * {@link pidFileFor} verbatim, so the belt can't drift from the daemon — and if
+ * the pid is LIVE (`kill(pid,0)`), REFUSE. It is presence→refuse (no absence-
+ * TOCTOU) and catches BOTH out-of-model cases: hand-started daemons and
+ * system-scope units (both write pidfiles). A target clears only when it is
+ * service-down AND pid-dead AND has no live pidfile — which is what lets the
+ * top-line "proves the fleet is DEAD" claim actually hold.
  *
  * ## Restore-on-failure (G-36 / A-RESTORE)
  *
@@ -85,6 +107,7 @@ import {
 import { discoverStacks } from "../../cli/cortex/commands/stack-lib";
 import { cortexConfigDir } from "../config/config-path";
 import { expandTilde } from "../config/loader";
+import { pidFileFor } from "../pidfile";
 
 // =============================================================================
 // Public types + injected seams
@@ -194,8 +217,12 @@ function defaultLaunchAgentsDir(home?: string): string {
   return join(homeDir(home), "Library", "LaunchAgents");
 }
 
+/** `$XDG_CONFIG_HOME/systemd/user`, or `~/.config/systemd/user` when unset — the
+ *  XDG-honest systemd user-unit dir (this IS the XDG epic; #1867 G-38). */
 function defaultSystemdUserDir(home?: string): string {
-  return join(homeDir(home), ".config", "systemd", "user");
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  const base = xdg !== undefined && xdg.length > 0 ? xdg : join(homeDir(home), ".config");
+  return join(base, "systemd", "user");
 }
 
 /** Real-fs {@link DaemonLocatorIO} for production Linux discovery. */
@@ -338,6 +365,96 @@ function slugFromConfigPath(cfgPath: string): string {
 }
 
 // =============================================================================
+// Pidfile-liveness belt (out-of-model positive proof of LIFE)
+// =============================================================================
+//
+// Service discovery only sees daemons the service manager knows about. A daemon
+// hand-started as `cortex start --config …` (exactly how the principal runs
+// cortex on a dev checkout) has NO launchd label / systemd unit — so the 3-leg
+// service proof is blind to it, and clearing would be fail-open. This belt makes
+// the "fleet is DEAD" claim TRUE independently of service discovery: it reads the
+// pidfile every EXPECTED stack would write (via the #1900 `pidFileFor`) and, if
+// the pid is LIVE, REFUSES. It is presence→refuse (positive proof of life, no
+// absence-TOCTOU), so it catches both out-of-model cases: hand-started daemons
+// (which wrote a pidfile via checkSingleton) AND system-scope units (also write
+// pidfiles). Run AFTER the service stop, so a unit-managed daemon we just killed
+// (dead pid) is NOT a false refusal, while an un-managed live daemon still is.
+
+/** A stack whose pidfile currently holds a LIVE pid. Presence → refuse. */
+export interface LivePidfile {
+  /** The daemon `--config` path this pidfile belongs to (`"(default)"` for the
+   *  single-instance `cortex.pid`). */
+  configPath: string;
+  pidPath: string;
+  pid: number;
+}
+
+/** Belt configuration — every input is seam-injected for hermetic tests. */
+export interface PidfileBeltConfig {
+  configDir?: string;
+  home?: string;
+  /** Daemon `--config` paths of EXPECTED stacks. Default: derived from
+   *  discoverStacks (pointer path for split, monolith file for monolith). */
+  stackConfigPaths?: string[];
+  /** config path → pidfile path. Default: the #1900 {@link pidFileFor} VERBATIM,
+   *  so the belt's derivation can never drift from the daemon's own. */
+  pidFilePathFor?: (configPath: string | undefined) => string;
+  /** pidfile path → pid (or undefined when absent/unreadable/unparseable).
+   *  Default: real fs read + parse. */
+  readPidFile?: (path: string) => number | undefined;
+}
+
+/**
+ * The pidfile-liveness belt. Enumerate the expected stacks from the config tree,
+ * resolve each daemon's pidfile via {@link pidFileFor}, and report every one
+ * whose pid is LIVE (kill(pid,0) via the injected {@link GateEnv.procAlive},
+ * EPERM-as-alive). The default single-instance `cortex.pid` is checked too (a
+ * hand-started default daemon). No absence is ever inferred — a hit is a daemon
+ * that is *provably running right now*.
+ */
+export function pidfileLivenessBelt(env: GateEnv, cfg: PidfileBeltConfig = {}): LivePidfile[] {
+  const pidPathFor = cfg.pidFilePathFor ?? pidFileFor;
+  const readPid = cfg.readPidFile ?? defaultReadPidFile;
+  const stackConfigs =
+    cfg.stackConfigPaths ?? expectedDaemonConfigPaths(cfg.configDir ?? cortexConfigDir(cfg.home));
+
+  const live: LivePidfile[] = [];
+  const seenPidPath = new Set<string>();
+  // Every expected stack's daemon config, PLUS the default single-instance case.
+  const candidates: (string | undefined)[] = [...stackConfigs, undefined];
+  for (const configPath of candidates) {
+    const pidPath = pidPathFor(configPath);
+    if (seenPidPath.has(pidPath)) continue;
+    seenPidPath.add(pidPath);
+    const pid = readPid(pidPath);
+    if (pid !== undefined && env.procAlive(pid)) {
+      live.push({ configPath: configPath ?? "(default)", pidPath, pid });
+    }
+  }
+  return live;
+}
+
+/** Daemon `--config` paths for every discovered stack (pointer for split layout,
+ *  the monolith file for monolith — the path the daemon's `--config` carries). */
+function expectedDaemonConfigPaths(configDir: string): string[] {
+  return discoverStacks(configDir).map((s) =>
+    s.layout === "split" ? join(configDir, s.slugLocator, `${s.slugLocator}.yaml`) : s.configPath,
+  );
+}
+
+/** Read a pidfile → its pid, or undefined when absent/unreadable/unparseable. */
+function defaultReadPidFile(path: string): number | undefined {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf-8");
+  } catch {
+    return undefined;
+  }
+  const pid = parseInt(text.trim(), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+// =============================================================================
 // The gate
 // =============================================================================
 
@@ -350,6 +467,10 @@ export interface MigrationGateOptions {
   targets: ServiceTarget[];
   /** Death-wait policy. Defaults to {@link DEFAULT_DRAIN}. */
   drain?: DrainPolicy;
+  /** Config-tree pidfile-liveness belt. When provided, a LIVE pidfile for any
+   *  expected stack refuses the gate even with NO service unit discovered for it
+   *  (clearFleetForMigration / withMigrationGate always provide it). */
+  belt?: PidfileBeltConfig;
 }
 
 /** Outcome of a `restore()` call — which targets came back, and which didn't. */
@@ -367,8 +488,11 @@ export interface MigrationGateResult {
   targets: ServiceTarget[];
   /** Targets UP at pre-check — the exact set `restore()` brings back (symmetry). */
   running: ServiceTarget[];
-  /** Targets not proven dead — the fail-closed evidence. */
+  /** Targets not proven dead — the service-discovery fail-closed evidence. */
   stillPresent: ServiceTarget[];
+  /** Expected stacks with a LIVE pidfile — the out-of-model belt evidence (a
+   *  running daemon with no service unit). Cleared requires this empty too. */
+  livePidfiles: LivePidfile[];
   /** Re-`bootstrap`/`start` the pre-running set + verify each. Callers MUST call
    *  this on any failure path — `bootout`/`stop` are persistent. */
   restore: () => Promise<RestoreResult>;
@@ -396,14 +520,30 @@ export async function runMigrationGate(
   opts: MigrationGateOptions,
 ): Promise<MigrationGateResult> {
   const { targets } = opts;
-  if (targets.length === 0) {
-    throw new Error(
-      "migration gate: refusing to run with an EMPTY target set — enumeration returned " +
-        "nothing (unreadable systemd dir / no discovered units / no fleet). Clearing an empty " +
-        "set would be fail-open; this is a discovery failure, not a clear.",
-    );
-  }
   const drain = opts.drain ?? DEFAULT_DRAIN;
+
+  // Empty target set: NOT a vacuous clear. If the belt still finds a LIVE daemon
+  // (a hand-started stack with no unit), refuse and report it; otherwise throw —
+  // an empty set with no belt hit is a discovery failure, never a clear.
+  if (targets.length === 0) {
+    const livePidfiles = opts.belt ? pidfileLivenessBelt(opts.env, opts.belt) : [];
+    if (livePidfiles.length === 0) {
+      throw new Error(
+        "migration gate: refusing to run with an EMPTY target set and no live pidfile — " +
+          "enumeration returned nothing (unreadable systemd dir / no discovered units / no fleet). " +
+          "Clearing an empty set would be fail-open; this is a discovery failure, not a clear.",
+      );
+    }
+    return {
+      cleared: false,
+      reason: notClearedReason(opts.platform, [], livePidfiles),
+      targets,
+      running: [],
+      stillPresent: [],
+      livePidfiles,
+      restore: makeRestore(opts, []),
+    };
+  }
 
   // 1. Probe — capture up-state + PID while the daemon is still alive.
   const probes: TargetProbe[] = [];
@@ -412,22 +552,27 @@ export async function runMigrationGate(
   // 2. Authoritatively stop every target (defeat KeepAlive / Restart=always).
   for (const t of targets) await stopTarget(opts, t);
 
-  // 3. Positive death proof for every target.
+  // 3. Positive death proof for every service-discovered target.
   const stillPresent: ServiceTarget[] = [];
   for (const p of probes) {
     if (!(await proveDead(opts, p, drain))) stillPresent.push(p.target);
   }
 
+  // 4. Belt — AFTER the stop, so a unit-managed daemon we just killed (dead pid)
+  //    is not a false refusal, while a live daemon with no service unit still is.
+  const livePidfiles = opts.belt ? pidfileLivenessBelt(opts.env, opts.belt) : [];
+
   const running = probes.filter((p) => p.running).map((p) => p.target);
-  const cleared = stillPresent.length === 0;
+  const cleared = stillPresent.length === 0 && livePidfiles.length === 0;
   const restore = makeRestore(opts, running);
 
   return {
     cleared,
-    ...(cleared ? {} : { reason: notClearedReason(opts.platform, stillPresent) }),
+    ...(cleared ? {} : { reason: notClearedReason(opts.platform, stillPresent, livePidfiles) }),
     targets,
     running,
     stillPresent,
+    livePidfiles,
     restore,
   };
 }
@@ -597,14 +742,29 @@ async function restoreLinux(
   };
 }
 
-/** Human-readable fail-closed reason naming the not-proven-dead targets. */
-function notClearedReason(platform: GatePlatform, stillPresent: readonly ServiceTarget[]): string {
-  const how =
-    platform === "darwin"
-      ? "`launchctl print` still resolves them, or the PID is still draining, or launchctl is unavailable"
-      : "`systemctl --user is-active` is not a clean down word, or the PID is still draining, or systemctl is unavailable";
-  const which = stillPresent.map((t) => (platform === "darwin" ? t.label : t.unit)).join(", ");
-  return `migration gate REFUSED to clear (fail-closed): ${stillPresent.length.toString()} target(s) not proven dead — ${how}: ${which}`;
+/** Human-readable fail-closed reason naming the not-proven-dead targets + any
+ *  live-pidfile belt hits. */
+function notClearedReason(
+  platform: GatePlatform,
+  stillPresent: readonly ServiceTarget[],
+  livePidfiles: readonly LivePidfile[],
+): string {
+  const parts: string[] = [];
+  if (stillPresent.length > 0) {
+    const how =
+      platform === "darwin"
+        ? "`launchctl print` still resolves them, or the PID is still draining, or launchctl is unavailable"
+        : "`systemctl --user is-active` is not a clean down word, or the PID is still draining, or systemctl is unavailable";
+    const which = stillPresent.map((t) => (platform === "darwin" ? t.label : t.unit)).join(", ");
+    parts.push(`${stillPresent.length.toString()} service target(s) not proven dead (${how}): ${which}`);
+  }
+  if (livePidfiles.length > 0) {
+    const which = livePidfiles.map((l) => `${l.configPath} → pid ${l.pid.toString()}`).join(", ");
+    parts.push(
+      `${livePidfiles.length.toString()} stack(s) with a LIVE pidfile (running daemon, no service unit needed): ${which}`,
+    );
+  }
+  return `migration gate REFUSED to clear (fail-closed): ${parts.join("; ")}`;
 }
 
 // =============================================================================
@@ -661,9 +821,14 @@ export interface ClearFleetOptions {
   io?: DaemonLocatorIO;
   discoverSlugs?: (configDir: string) => string[];
   home?: string;
+  /** Belt seams (tests inject stackConfigPaths / pidFilePathFor / readPidFile).
+   *  `configDir` + `home` are folded in automatically. */
+  belt?: PidfileBeltConfig;
 }
 
-/** Enumerate the fleet + run the gate with host-derived defaults. */
+/** Enumerate the fleet + run the gate with host-derived defaults. The belt is
+ *  ALWAYS wired here, so the production path can never clear a hand-started
+ *  daemon that has no service unit. */
 export async function clearFleetForMigration(
   opts: ClearFleetOptions = {},
 ): Promise<MigrationGateResult> {
@@ -677,11 +842,17 @@ export async function clearFleetForMigration(
     ...(opts.discoverSlugs !== undefined && { discoverSlugs: opts.discoverSlugs }),
     ...(opts.home !== undefined && { home: opts.home }),
   });
+  const belt: PidfileBeltConfig = {
+    ...(opts.configDir !== undefined && { configDir: opts.configDir }),
+    ...(opts.home !== undefined && { home: opts.home }),
+    ...opts.belt,
+  };
   return runMigrationGate({
     platform,
     uid: resolveGateUid(opts.uid),
     env: opts.env ?? bunGateEnv,
     targets,
+    belt,
     ...(opts.drain !== undefined && { drain: opts.drain }),
   });
 }

--- a/src/common/migration/migration-gate.ts
+++ b/src/common/migration/migration-gate.ts
@@ -1,104 +1,144 @@
 /**
  * cortex#1901 (XDG epic #1867, phase P3c gate) — the migration gate that PROVES
- * a stack fleet is stopped before X-07 (config move) / X-11 (state move) relocate
- * a running daemon's directories. This issue delivers the REUSABLE gate; the
- * moves themselves are out of scope (they consume it).
+ * a stack fleet is DEAD before X-07 (config move) / X-11 (state move) relocate a
+ * running daemon's directories. This issue delivers the REUSABLE gate; the moves
+ * consume it. X-11 TRUSTS this verdict, so a gate that fail-OPENS is worse than
+ * no gate — every predicate here is built around POSITIVE proof of death.
  *
  * ## Why the oracle is the SERVICE MANAGER, never a pidfile
  *
- * A filesystem/pidfile oracle is wrong on two counts, and both are load-bearing:
+ * A filesystem/pidfile oracle is wrong on two counts:
  *   - Stack plists carry `RunAtLoad:true` AND `KeepAlive:true`, so a daemon is
  *     ALWAYS alive → an "abort if pidfile present" gate is a permanent no-op.
- *   - `cortex stop` and the singleton check UNLINK the pidfile (seven sites in
+ *   - `cortex stop` + the singleton check UNLINK the pidfile (seven sites in
  *     `cortex.ts` — grep `unlinkSync(pidFile)`) while KeepAlive respawns inside
  *     the throttle window, so "no pidfile" NEVER means "no daemon" (a TOCTOU).
  *
- * So the gate drives the service manager and proves absence THROUGH it:
- *   - **macOS:** `launchctl bootout gui/<uid>/<label>` — the only primitive that
- *     defeats KeepAlive — then prove absence with `launchctl print …` returning
- *     NON-ZERO. `bootout` removes the service from the domain, so the supervisor
- *     will NOT respawn until a matching `bootstrap`. The stop→verify window is
- *     race-free BY CONSTRUCTION — which is exactly why pidfile-absence is unsafe
- *     (supervisor races) but bootout-absence is safe (supervisor is out of it).
- *   - **Linux:** `systemctl --user stop <unit>` — an EXPLICIT stop, which
- *     `Restart=always` does NOT override (Restart fires on unexpected exit, not
- *     on a deliberate stop) — then prove absence with `systemctl --user is-active`
- *     returning a non-"up" state. REQUIRED + FAIL-CLOSED (G-08): the epic exists
- *     for a Linux user and CI is ubuntu, so the Linux path is a first-class
- *     implementation, not a stub.
+ * ## The three legs of a POSITIVE death proof (adversary root-cause, PR#1929)
  *
- * ## Fail-closed by construction
+ * "Absence inferred from a non-up / non-zero signal is ALSO produced by wrong-
+ * unit, manager-unreachable, wrong-domain, and process-still-draining — only one
+ * of which is safe." So a target is declared DEAD only when ALL THREE hold:
  *
- * A target is deemed absent ONLY on POSITIVE PROOF (`print` non-zero on macOS /
- * a definitive down-state from a clean `is-active` on Linux). If the service
- * manager binary is missing (the injected exec throws), or `print` still
- * resolves the job, or `is-active` reports an up-state, the target counts as
- * PRESENT and the gate REFUSES to clear. Absence is proven; it is never assumed.
- * There is no code path that returns `cleared:true` without every target having
- * been positively proven down.
+ *   1. **Right service.** macOS: launchd is name-by-convention, so the label
+ *      `ai.meta-factory.cortex.<slug>` IS the service (verified live by `print`).
+ *      Linux: the unit name is NOT conventional (real units are `cortex-bot.
+ *      service`, not `ai.meta-factory.cortex.bot.service` — see
+ *      daemon-locator.ts:126-127), so we DISCOVER the real unit id by scanning
+ *      `~/.config/systemd/user` for a `.service` whose `ExecStart` carries a
+ *      `--config` under the cortex config dir (or the relay entrypoint). A
+ *      derived name would query the WRONG unit → `is-active` "inactive" → a false
+ *      clear (A-UNIT).
+ *   2. **Manager-reached down verdict.** macOS: `launchctl print` returns
+ *      NON-ZERO (left the domain) from a call that did not throw. Linux:
+ *      `systemctl --user is-active` returns a CLEAN, definitive down word —
+ *      exactly `inactive` or `failed`. A `systemctl` that runs but cannot reach
+ *      its manager (no D-Bus / unset `XDG_RUNTIME_DIR`) yields non-zero + empty/
+ *      `unknown` stdout — that is NOT proof, it is PRESENT (A-ISACTIVE). We key
+ *      on the stdout WORD, never the exit code alone.
+ *   3. **Confirmed process death.** Deregistration ≠ death: cortex shutdown
+ *      drains up to ~15s (cortex.ts:443), so a booted-out daemon still holds the
+ *      state dir + locks after `print`/`is-active` report it gone. We capture the
+ *      job's PID BEFORE the stop, then poll `kill(pid,0)` until `ESRCH`, bounded
+ *      by a drain window ≥ 15s (A-TOCTOU).
  *
- * ## Restore-on-failure (G-36)
+ * Any leg unproven → the target is PRESENT and the gate REFUSES to clear. There
+ * is NO path that returns `cleared:true` without every target passing all three.
+ * An empty target set is a FOOTGUN (discovery failure), not a vacuous clear — it
+ * throws.
  *
- * `bootout` is PERSISTENT — an aborted migration would otherwise leave the fleet
- * down with KeepAlive defeated. {@link runMigrationGate} therefore returns a
- * `restore()` handle that `bootstrap`s (macOS) / `start`s (Linux) exactly the
- * targets that were UP when the gate ran, and verifies each came back. Callers
- * MUST invoke `restore()` on ANY failure path — the gate's own non-clear, or
- * their own migration throwing after a clear. Symmetry (the preupgrade/
- * postupgrade guarantee): nothing that was down is started; nothing that was up
- * is left down.
+ * ## Restore-on-failure (G-36 / A-RESTORE)
+ *
+ * `bootout`/`stop` leave the fleet DOWN, so a gate run that isn't paired with a
+ * restore strands the fleet. {@link withMigrationGate} is the BLESSED entry
+ * X-07/X-11 use: it runs the migration inside a `try/finally` that ALWAYS
+ * restores the exact pre-running set (nothing down is started; nothing up is left
+ * down). The raw {@link runMigrationGate} returns the same `restore()` handle for
+ * tests + advanced callers, but the wrapper makes the guarantee structural.
  *
  * ## Legacy labels (G-35)
  *
- * Enumeration covers not just live stack slugs + the relay, but the legacy label
- * set `scripts/preupgrade.sh` already boots out (`com.grove.bot`,
- * `com.grove.relay`, `ai.meta-factory.cortex.bot`) — a `com.grove.*` daemon left
- * from the grove-v2 era is exactly the KeepAlive process a state move must not
- * race.
+ * Enumeration covers stack slugs + relay + the legacy set `scripts/preupgrade.sh`
+ * boots out (`com.grove.bot`, `com.grove.relay`, `ai.meta-factory.cortex.bot`).
+ * On Linux the legacy set is unioned by-name but only when the `.service` file
+ * actually exists (a KeepAlive grove-v2 remnant a state move must not race).
  *
  * ## Seams
  *
- * Every side effect (the launchctl/systemctl exec), the `platform`, and the
- * `uid` are injected so the gate is unit-testable on a POSIX CI host with no
- * real launchd/systemd — mirroring the #763 `NatsServiceManager` ExecRunner seam.
+ * Exec, process-liveness (`kill(pid,0)`), sleep, and clock are all injected
+ * ({@link GateEnv}), plus platform + uid, so both the darwin and linux paths run
+ * on a POSIX CI host with no real launchd/systemd and no real subprocesses —
+ * mirroring the #763 `NatsServiceManager` ExecRunner seam. The Linux discovery
+ * reuses daemon-locator's `parseUnitExecStartArgs` + `configArgValue` (DRY — that
+ * IS the drift-proof matcher `network join`/`leave` already trust).
  */
 
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { join, resolve, sep } from "path";
 
+import {
+  configArgValue,
+  parseUnitExecStartArgs,
+  type DaemonLocatorIO,
+} from "../../cli/cortex/commands/daemon-locator";
 import { discoverStacks } from "../../cli/cortex/commands/stack-lib";
 import { cortexConfigDir } from "../config/config-path";
+import { expandTilde } from "../config/loader";
 
 // =============================================================================
-// Public types + the injected exec seam
+// Public types + injected seams
 // =============================================================================
 
 /** macOS (`darwin`) vs Linux — the only two platforms the fleet runs on. */
 export type GatePlatform = "darwin" | "linux";
 
 /** Result of one launchctl/systemctl subprocess. `stdout` is load-bearing on
- *  Linux (`is-active` prints the state word there). */
+ *  Linux (`is-active` prints the state WORD there) — we key on it, not the code. */
 export interface GateExecResult {
   code: number;
   stdout: string;
   stderr: string;
 }
 
-/** Injected process runner — captured in tests, real `Bun.spawn` in prod. May
- *  THROW synchronously on ENOENT (binary not on PATH); the gate treats a throw
- *  as "cannot prove absence" (fail-closed), never letting it escape. */
+/** Injected process runner. May THROW synchronously on ENOENT (binary not on
+ *  PATH); the gate treats a throw as "cannot prove" (fail-closed), never letting
+ *  it escape. */
 export type GateExec = (argv: string[]) => Promise<GateExecResult>;
+
+/**
+ * The full effect surface, injected so the gate is unit-testable with no real
+ * subprocesses/processes/wall-clock:
+ *   - `exec`      — launchctl/systemctl.
+ *   - `procAlive` — `kill(pid,0)` liveness probe (the confirmed-death leg).
+ *   - `sleep`     — the drain poll delay.
+ *   - `now`       — the drain deadline clock.
+ */
+export interface GateEnv {
+  exec: GateExec;
+  procAlive: (pid: number) => boolean;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+}
+
+/** How long to wait for a booted-out PID to actually exit (≥ the 15s cortex
+ *  shutdown drain) and how often to re-probe. */
+export interface DrainPolicy {
+  drainTimeoutMs: number;
+  pollIntervalMs: number;
+}
+
+/** Default drain: 20s ceiling (> the 15s cortex.ts:443 cap) polled every 250ms. */
+export const DEFAULT_DRAIN: DrainPolicy = { drainTimeoutMs: 20_000, pollIntervalMs: 250 };
 
 /** Which family a target belongs to — for logging + restore reasoning. */
 export type ServiceTargetKind = "stack" | "relay" | "legacy";
 
 /**
- * One service the gate must prove stopped, carrying BOTH platform identities so
- * a single enumerated target is usable on either OS:
- *   - `label` — the launchd label (`launchctl bootout/print gui/<uid>/<label>`).
- *   - `unit`  — the systemd unit id (`systemctl --user stop/is-active <unit>`),
- *      the `<label>.service` analogue of the launchd Label.
- *   - `plistPath` — where `launchctl bootstrap` reloads it from on restore.
+ * One service the gate must prove DEAD. Carries both platform identities:
+ *   - `label`    — launchd label (macOS authoritative; name-by-convention).
+ *   - `unit`     — systemd unit id (Linux authoritative; DISCOVERED, not derived).
+ *   - `plistPath`— where `launchctl bootstrap` reloads it from on restore (macOS).
  */
 export interface ServiceTarget {
   id: string;
@@ -112,17 +152,16 @@ export interface ServiceTarget {
 // Label / unit conventions (kept in lockstep with preupgrade.sh)
 // =============================================================================
 
-/** The launchd label prefix every cortex stack + the relay share. */
+/** The launchd label prefix every cortex stack + the relay share (macOS). */
 export const CORTEX_LABEL_PREFIX = "ai.meta-factory.cortex.";
 
-/** The relay's launchd label — enumerated alongside stack slugs (issue step 1). */
+/** The relay's launchd label (macOS). */
 export const RELAY_LABEL = `${CORTEX_LABEL_PREFIX}relay`;
 
 /**
  * The legacy label set `scripts/preupgrade.sh:80` already knows (G-35):
  *   - `com.grove.bot` / `com.grove.relay` — grove-v2 era plists that may linger.
  *   - `ai.meta-factory.cortex.bot` — the pre-cortex#251 dev-stack plist name.
- * A KeepAlive daemon under any of these is a process a state move must not race.
  */
 export const LEGACY_LABELS: readonly string[] = [
   "com.grove.bot",
@@ -130,8 +169,7 @@ export const LEGACY_LABELS: readonly string[] = [
   `${CORTEX_LABEL_PREFIX}bot`,
 ];
 
-/** systemd `is-active` states that mean the unit is (still) UP. Everything else
- *  a clean `is-active` can print (`inactive`/`failed`/`unknown`/`""`) is DOWN. */
+/** systemd `is-active` states that mean the unit is (still) UP. */
 const SYSTEMD_UP_STATES: ReadonlySet<string> = new Set([
   "active",
   "activating",
@@ -139,33 +177,78 @@ const SYSTEMD_UP_STATES: ReadonlySet<string> = new Set([
   "deactivating",
 ]);
 
+/** The ONLY `is-active` words that positively prove a reached-manager DOWN unit.
+ *  Note the deliberate exclusion of `""`/`unknown` — those are the
+ *  manager-unreachable signature (A-ISACTIVE), which must read as PRESENT. */
+const SYSTEMD_DOWN_WORDS: ReadonlySet<string> = new Set(["inactive", "failed"]);
+
+// =============================================================================
+// Filesystem defaults + helpers
+// =============================================================================
+
+function homeDir(home?: string): string {
+  return home ?? process.env.HOME ?? homedir();
+}
+
+function defaultLaunchAgentsDir(home?: string): string {
+  return join(homeDir(home), "Library", "LaunchAgents");
+}
+
+function defaultSystemdUserDir(home?: string): string {
+  return join(homeDir(home), ".config", "systemd", "user");
+}
+
+/** Real-fs {@link DaemonLocatorIO} for production Linux discovery. */
+const realIO: DaemonLocatorIO = {
+  listDir: (dir) => {
+    try {
+      return readdirSync(dir);
+    } catch {
+      return [];
+    }
+  },
+  readFile: (path) => readFileSync(path, "utf-8"),
+  exists: (path) => existsSync(path),
+};
+
 // =============================================================================
 // Enumeration
 // =============================================================================
 
 /** Options for {@link enumerateServiceTargets}. */
 export interface EnumerateTargetsOptions {
-  /** Cortex config dir to discover stack slugs under. Defaults to
-   *  {@link cortexConfigDir} (honours `$CORTEX_CONFIG_DIR`). */
+  platform: GatePlatform;
   configDir?: string;
-  /** launchd `~/Library/LaunchAgents` (or the tmp dir a test points it at) —
-   *  where each label's `<label>.plist` lives, used by restore's `bootstrap`. */
-  launchAgentsDir: string;
-  /** Slug discovery seam. Defaults to `discoverStacks(dir).map(slugLocator)`. */
+  /** launchd `~/Library/LaunchAgents` (macOS). */
+  launchAgentsDir?: string;
+  /** systemd `~/.config/systemd/user` (Linux). */
+  systemdUserDir?: string;
+  /** fs seam for Linux discovery + legacy existence checks. Default = real fs. */
+  io?: DaemonLocatorIO;
+  /** Stack-slug discovery seam (macOS label derivation). */
   discoverSlugs?: (configDir: string) => string[];
-  /** `$HOME` override (tests). */
   home?: string;
 }
 
 /**
- * Enumerate every service the gate must prove stopped: one per discovered stack
- * slug (`ai.meta-factory.cortex.<slug>`), the relay ({@link RELAY_LABEL}), and
- * the {@link LEGACY_LABELS}. Deduplicated by label (so a stack whose slug is
- * literally `relay`/`bot` can't double-enumerate). Pure — the only I/O is the
- * injected slug discovery.
+ * Enumerate every service the gate must prove dead.
+ *
+ * macOS — labels by convention (launchd IS name-by-convention, `print`-verified):
+ * one per discovered stack slug + relay + legacy set.
+ *
+ * Linux — REAL unit ids DISCOVERED from `~/.config/systemd/user` (a derived name
+ * would query the wrong unit; A-UNIT). A `.service` is a cortex daemon when its
+ * `ExecStart` carries a `--config` under the cortex config dir (a stack) or names
+ * the relay entrypoint (`relay.ts`). The legacy set is unioned by-name, but only
+ * when its `.service` file actually exists.
  */
 export function enumerateServiceTargets(opts: EnumerateTargetsOptions): ServiceTarget[] {
+  return opts.platform === "linux" ? enumerateLinux(opts) : enumerateDarwin(opts);
+}
+
+function enumerateDarwin(opts: EnumerateTargetsOptions): ServiceTarget[] {
   const configDir = opts.configDir ?? cortexConfigDir(opts.home);
+  const launchAgentsDir = opts.launchAgentsDir ?? defaultLaunchAgentsDir(opts.home);
   const discover =
     opts.discoverSlugs ?? ((dir: string) => discoverStacks(dir).map((s) => s.slugLocator));
 
@@ -178,8 +261,8 @@ export function enumerateServiceTargets(opts: EnumerateTargetsOptions): ServiceT
       id,
       kind,
       label,
-      unit: `${label}.service`,
-      plistPath: join(opts.launchAgentsDir, `${label}.plist`),
+      unit: `${label}.service`, // unused on darwin; kept for shape symmetry
+      plistPath: join(launchAgentsDir, `${label}.plist`),
     });
   };
 
@@ -190,18 +273,83 @@ export function enumerateServiceTargets(opts: EnumerateTargetsOptions): ServiceT
   return targets;
 }
 
+function enumerateLinux(opts: EnumerateTargetsOptions): ServiceTarget[] {
+  const configDir = opts.configDir ?? cortexConfigDir(opts.home);
+  const systemdUserDir = opts.systemdUserDir ?? defaultSystemdUserDir(opts.home);
+  const io = opts.io ?? realIO;
+  const cfgRoot = resolve(expandTilde(configDir));
+
+  const targets: ServiceTarget[] = [];
+  const seen = new Set<string>();
+  const push = (id: string, kind: ServiceTargetKind, unit: string): void => {
+    if (seen.has(unit)) return;
+    seen.add(unit);
+    targets.push({ id, kind, label: unit, unit, plistPath: join(systemdUserDir, unit) });
+  };
+
+  // 1. Discover real cortex units by ExecStart (name-agnostic — A-UNIT fix).
+  if (io.exists(systemdUserDir)) {
+    for (const name of io.listDir(systemdUserDir).sort()) {
+      if (!name.endsWith(".service")) continue;
+      let text: string;
+      try {
+        text = io.readFile(join(systemdUserDir, name));
+      } catch {
+        // Unreadable unit — cannot classify; skip. (A present-but-unreadable
+        // cortex unit is an install anomaly; documented residual.)
+        continue;
+      }
+      const argv = parseUnitExecStartArgs(text);
+      if (argv.length === 0) continue;
+      if (argv.some(isRelayEntrypoint)) {
+        push("relay", "relay", name);
+        continue;
+      }
+      const cfg = configArgValue(argv);
+      if (cfg === undefined) continue;
+      const resolved = resolve(expandTilde(cfg));
+      if (resolved === cfgRoot || resolved.startsWith(cfgRoot + sep)) {
+        push(slugFromConfigPath(resolved), "stack", name);
+      }
+    }
+  }
+
+  // 2. UNION the legacy set by-name, but only when the unit file EXISTS (G-35).
+  for (const legacy of LEGACY_LABELS) {
+    const unit = `${legacy}.service`;
+    if (io.exists(join(systemdUserDir, unit))) push(legacy, "legacy", unit);
+  }
+
+  return targets;
+}
+
+/** An ExecStart token that names the relay entrypoint (`…/relay.ts` / `cortex-relay`). */
+function isRelayEntrypoint(token: string): boolean {
+  return /(^|\/)relay\.ts$/.test(token) || /(^|\/)cortex-relay$/.test(token);
+}
+
+/** Derive a stack slug from a daemon `--config` path (for the target id only). */
+function slugFromConfigPath(cfgPath: string): string {
+  const base = cfgPath.split("/").pop() ?? cfgPath;
+  const noext = base.replace(/\.ya?ml$/i, "");
+  if (noext === "cortex") return "meta-factory";
+  const m = /^cortex\.(.+)$/.exec(noext);
+  return m?.[1] ?? noext;
+}
+
 // =============================================================================
 // The gate
 // =============================================================================
 
-/** Inputs to {@link runMigrationGate}. All side effects are injected. */
+/** Inputs to {@link runMigrationGate}. All effects are injected via {@link GateEnv}. */
 export interface MigrationGateOptions {
   platform: GatePlatform;
   /** launchd `gui/<uid>` target uid (ignored on Linux). */
   uid: number;
-  exec: GateExec;
-  /** Enumerated by {@link enumerateServiceTargets}. */
+  env: GateEnv;
   targets: ServiceTarget[];
+  /** Death-wait policy. Defaults to {@link DEFAULT_DRAIN}. */
+  drain?: DrainPolicy;
 }
 
 /** Outcome of a `restore()` call — which targets came back, and which didn't. */
@@ -212,91 +360,65 @@ export interface RestoreResult {
 
 /** The gate's verdict + the restore handle callers MUST use on any failure. */
 export interface MigrationGateResult {
-  /** `true` ONLY when every target was positively proven down. */
+  /** `true` ONLY when every target passed all three legs of the death proof. */
   cleared: boolean;
-  /** Present when `cleared === false` — which targets refused to prove down. */
+  /** Present when `cleared === false` — which targets refused to prove dead. */
   reason?: string;
-  /** Everything the gate reasoned about. */
   targets: ServiceTarget[];
   /** Targets UP at pre-check — the exact set `restore()` brings back (symmetry). */
   running: ServiceTarget[];
-  /** Targets not proven down AFTER the stop — the fail-closed evidence. */
+  /** Targets not proven dead — the fail-closed evidence. */
   stillPresent: ServiceTarget[];
-  /** Re-`bootstrap`/`start` the `running` set and verify each returns. Callers
-   *  MUST invoke this on ANY failure path — `bootout` is persistent. */
+  /** Re-`bootstrap`/`start` the pre-running set + verify each. Callers MUST call
+   *  this on any failure path — `bootout`/`stop` are persistent. */
   restore: () => Promise<RestoreResult>;
 }
 
-/**
- * Prove a single target is DOWN via the service manager. Returns `true` ONLY on
- * positive proof of absence; a thrown exec (binary missing) or any up-signal
- * returns `false` (fail-closed — the caller then treats it as still present).
- */
-async function proveAbsent(opts: MigrationGateOptions, t: ServiceTarget): Promise<boolean> {
-  try {
-    if (opts.platform === "darwin") {
-      // `launchctl print` exits 0 while the job is in the domain, non-zero once
-      // booted out. Non-zero is the positive proof of absence.
-      const r = await opts.exec(["launchctl", "print", `gui/${opts.uid.toString()}/${t.label}`]);
-      return r.code !== 0;
-    }
-    // Linux: `is-active` prints the state word; a non-"up" state is proof-of-down.
-    const r = await opts.exec(["systemctl", "--user", "is-active", t.unit]);
-    return !SYSTEMD_UP_STATES.has(r.stdout.trim());
-  } catch {
-    // Exec threw (e.g. systemctl/launchctl ENOENT): we CANNOT prove absence, so
-    // the target is treated as present. This is the fail-closed spine.
-    return false;
-  }
-}
-
-/** Issue the authoritative stop for one target (defeats KeepAlive/Restart). Never
- *  throws — a stop failure surfaces later as a failed absence proof. */
-async function stopTarget(opts: MigrationGateOptions, t: ServiceTarget): Promise<void> {
-  try {
-    if (opts.platform === "darwin") {
-      await opts.exec(["launchctl", "bootout", `gui/${opts.uid.toString()}/${t.label}`]);
-    } else {
-      await opts.exec(["systemctl", "--user", "stop", t.unit]);
-    }
-  } catch {
-    // Swallow — a stop that couldn't run leaves the target UP, which the verify
-    // pass below will catch as `stillPresent` (fail-closed), so nothing clears.
-  }
+/** Per-target probe captured BEFORE any stop (so we hold the live PID). */
+interface TargetProbe {
+  target: ServiceTarget;
+  running: boolean;
+  pid?: number;
 }
 
 /**
  * Run the migration gate over `targets`:
- *   1. Pre-check which targets are UP (the restore set — symmetry anchor).
- *   2. Stop EVERY target (idempotent; also catches a target that raced up after
- *      the pre-check — it is booted out regardless).
- *   3. Prove EVERY target is now down. `cleared` iff all are proven down.
+ *   1. PROBE every target — record up-state + the live PID (before any stop).
+ *   2. STOP every target authoritatively (bootout / systemctl stop).
+ *   3. PROVE-DEAD every target via all three legs. `cleared` iff every target
+ *      is positively proven dead.
  *
- * Always returns a `restore()` handle bound to the pre-check UP set — usable
- * whether the gate cleared (caller migrates, then restores) or refused (caller
- * restores immediately).
+ * Throws on an EMPTY target set (a footgun: discovery returned nothing, and a
+ * vacuous "clear" would be fail-open). Always returns a `restore()` handle bound
+ * to the pre-check UP set.
  */
 export async function runMigrationGate(
   opts: MigrationGateOptions,
 ): Promise<MigrationGateResult> {
   const { targets } = opts;
-
-  // 1. Pre-check: UP == "not proven absent". A target whose proof throws (binary
-  //    missing) counts as UP, so restore is attempted and the gate won't clear.
-  const running: ServiceTarget[] = [];
-  for (const t of targets) {
-    if (!(await proveAbsent(opts, t))) running.push(t);
+  if (targets.length === 0) {
+    throw new Error(
+      "migration gate: refusing to run with an EMPTY target set — enumeration returned " +
+        "nothing (unreadable systemd dir / no discovered units / no fleet). Clearing an empty " +
+        "set would be fail-open; this is a discovery failure, not a clear.",
+    );
   }
+  const drain = opts.drain ?? DEFAULT_DRAIN;
 
-  // 2. Authoritatively stop every enumerated target (defeat KeepAlive/Restart).
+  // 1. Probe — capture up-state + PID while the daemon is still alive.
+  const probes: TargetProbe[] = [];
+  for (const t of targets) probes.push(await probeTarget(opts, t));
+
+  // 2. Authoritatively stop every target (defeat KeepAlive / Restart=always).
   for (const t of targets) await stopTarget(opts, t);
 
-  // 3. Positive-proof verification. Absence must be proven for ALL to clear.
+  // 3. Positive death proof for every target.
   const stillPresent: ServiceTarget[] = [];
-  for (const t of targets) {
-    if (!(await proveAbsent(opts, t))) stillPresent.push(t);
+  for (const p of probes) {
+    if (!(await proveDead(opts, p, drain))) stillPresent.push(p.target);
   }
 
+  const running = probes.filter((p) => p.running).map((p) => p.target);
   const cleared = stillPresent.length === 0;
   const restore = makeRestore(opts, running);
 
@@ -308,6 +430,117 @@ export async function runMigrationGate(
     stillPresent,
     restore,
   };
+}
+
+/** Probe a target's up-state + live PID BEFORE any stop (leg-3 needs the PID). */
+async function probeTarget(opts: MigrationGateOptions, t: ServiceTarget): Promise<TargetProbe> {
+  if (opts.platform === "darwin") {
+    let r: GateExecResult;
+    try {
+      r = await opts.env.exec(["launchctl", "print", `gui/${opts.uid.toString()}/${t.label}`]);
+    } catch {
+      // launchctl unreachable — assume UP, no PID (fail-closed downstream).
+      return { target: t, running: true };
+    }
+    if (r.code !== 0) return { target: t, running: false };
+    const pid = parseLaunchctlPid(r.stdout);
+    return { target: t, running: true, ...(pid !== undefined && { pid }) };
+  }
+  // Linux: is-active for up-state, `show MainPID` for the PID.
+  let up: boolean;
+  try {
+    const r = await opts.env.exec(["systemctl", "--user", "is-active", t.unit]);
+    up = SYSTEMD_UP_STATES.has(r.stdout.trim());
+  } catch {
+    return { target: t, running: true }; // manager unreachable — assume UP, no PID
+  }
+  const pid = await linuxMainPid(opts, t);
+  const running = up || pid !== undefined;
+  return { target: t, running, ...(pid !== undefined && { pid }) };
+}
+
+/** Read a systemd unit's `MainPID` (0/absent → undefined). */
+async function linuxMainPid(opts: MigrationGateOptions, t: ServiceTarget): Promise<number | undefined> {
+  try {
+    const r = await opts.env.exec([
+      "systemctl",
+      "--user",
+      "show",
+      t.unit,
+      "--property=MainPID",
+      "--value",
+    ]);
+    const n = parseInt(r.stdout.trim(), 10);
+    return Number.isInteger(n) && n > 0 ? n : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse `pid = <n>` out of a `launchctl print` dump. */
+function parseLaunchctlPid(stdout: string): number | undefined {
+  const m = /^\s*pid = (\d+)/m.exec(stdout);
+  if (m?.[1] === undefined) return undefined;
+  const n = parseInt(m[1], 10);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+/** Issue the authoritative stop for one target. Never throws — a stop that
+ *  couldn't run surfaces as a failed death proof (fail-closed). */
+async function stopTarget(opts: MigrationGateOptions, t: ServiceTarget): Promise<void> {
+  try {
+    if (opts.platform === "darwin") {
+      await opts.env.exec(["launchctl", "bootout", `gui/${opts.uid.toString()}/${t.label}`]);
+    } else {
+      await opts.env.exec(["systemctl", "--user", "stop", t.unit]);
+    }
+  } catch {
+    // Swallow — a stop that couldn't run leaves the target UP, which the death
+    // proof below catches as stillPresent.
+  }
+}
+
+/**
+ * The three-leg death proof. Returns `true` ONLY when the manager reports the
+ * service down AND the pre-stop PID has exited. A target that was down at
+ * pre-check with no PID passes on the manager verdict alone (nothing to bury).
+ */
+async function proveDead(
+  opts: MigrationGateOptions,
+  p: TargetProbe,
+  drain: DrainPolicy,
+): Promise<boolean> {
+  if (!(await verifyManagerDown(opts, p.target))) return false; // leg 2
+  if (p.pid === undefined) {
+    // No PID to confirm. Safe ONLY if it was never up (else we can't prove death).
+    return !p.running;
+  }
+  return waitForDeath(opts.env, p.pid, drain); // leg 3
+}
+
+/** Leg 2: a manager-REACHED down verdict. A throw or a non-definitive word (the
+ *  manager-unreachable signature) is NOT proof → returns `false` (present). */
+async function verifyManagerDown(opts: MigrationGateOptions, t: ServiceTarget): Promise<boolean> {
+  try {
+    if (opts.platform === "darwin") {
+      const r = await opts.env.exec(["launchctl", "print", `gui/${opts.uid.toString()}/${t.label}`]);
+      return r.code !== 0; // left the domain (from a call that did not throw)
+    }
+    const r = await opts.env.exec(["systemctl", "--user", "is-active", t.unit]);
+    return SYSTEMD_DOWN_WORDS.has(r.stdout.trim()); // exactly inactive|failed
+  } catch {
+    return false; // manager unreachable → cannot prove → present
+  }
+}
+
+/** Leg 3: poll `kill(pid,0)` until `ESRCH`, bounded by the drain window. */
+async function waitForDeath(env: GateEnv, pid: number, drain: DrainPolicy): Promise<boolean> {
+  const deadline = env.now() + drain.drainTimeoutMs;
+  while (env.procAlive(pid)) {
+    if (env.now() >= deadline) return false; // still draining past the window → present
+    await env.sleep(drain.pollIntervalMs);
+  }
+  return true;
 }
 
 /** Build the `restore()` closure bound to the pre-check UP set. */
@@ -334,16 +567,15 @@ function makeRestore(
   };
 }
 
-/** macOS restore: `bootstrap` the plist back into the domain, `kickstart` it,
- *  then confirm with `print` that it is loaded again. */
+/** macOS restore: `bootstrap` the plist back, `kickstart`, confirm with `print`. */
 async function restoreDarwin(
   opts: MigrationGateOptions,
   t: ServiceTarget,
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
   const gui = `gui/${opts.uid.toString()}`;
-  await opts.exec(["launchctl", "bootstrap", gui, t.plistPath]);
-  await opts.exec(["launchctl", "kickstart", "-k", `${gui}/${t.label}`]);
-  const check = await opts.exec(["launchctl", "print", `${gui}/${t.label}`]);
+  await opts.env.exec(["launchctl", "bootstrap", gui, t.plistPath]);
+  await opts.env.exec(["launchctl", "kickstart", "-k", `${gui}/${t.label}`]);
+  const check = await opts.env.exec(["launchctl", "print", `${gui}/${t.label}`]);
   if (check.code === 0) return { ok: true };
   return {
     ok: false,
@@ -351,13 +583,13 @@ async function restoreDarwin(
   };
 }
 
-/** Linux restore: `systemctl --user start`, then confirm with `is-active`. */
+/** Linux restore: `systemctl --user start`, confirm with `is-active`. */
 async function restoreLinux(
   opts: MigrationGateOptions,
   t: ServiceTarget,
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
-  await opts.exec(["systemctl", "--user", "start", t.unit]);
-  const check = await opts.exec(["systemctl", "--user", "is-active", t.unit]);
+  await opts.env.exec(["systemctl", "--user", "start", t.unit]);
+  const check = await opts.env.exec(["systemctl", "--user", "is-active", t.unit]);
   if (SYSTEMD_UP_STATES.has(check.stdout.trim())) return { ok: true };
   return {
     ok: false,
@@ -365,24 +597,21 @@ async function restoreLinux(
   };
 }
 
-/** Human-readable fail-closed reason naming the not-proven-down targets. */
+/** Human-readable fail-closed reason naming the not-proven-dead targets. */
 function notClearedReason(platform: GatePlatform, stillPresent: readonly ServiceTarget[]): string {
   const how =
     platform === "darwin"
-      ? "`launchctl print` still resolves them (or launchctl is unavailable)"
-      : "`systemctl --user is-active` reports an up-state (or systemctl is unavailable)";
-  const which = stillPresent
-    .map((t) => (platform === "darwin" ? t.label : t.unit))
-    .join(", ");
-  return `migration gate REFUSED to clear (fail-closed): ${stillPresent.length.toString()} target(s) not proven stopped — ${how}: ${which}`;
+      ? "`launchctl print` still resolves them, or the PID is still draining, or launchctl is unavailable"
+      : "`systemctl --user is-active` is not a clean down word, or the PID is still draining, or systemctl is unavailable";
+  const which = stillPresent.map((t) => (platform === "darwin" ? t.label : t.unit)).join(", ");
+  return `migration gate REFUSED to clear (fail-closed): ${stillPresent.length.toString()} target(s) not proven dead — ${how}: ${which}`;
 }
 
 // =============================================================================
 // Production wiring
 // =============================================================================
 
-/** A real `Bun.spawn`-backed {@link GateExec}. Captures stdout (Linux `is-active`
- *  needs it) + stderr + exit code. */
+/** A real `Bun.spawn`-backed {@link GateExec}. */
 export const bunGateExec: GateExec = async (argv) => {
   const [cmd, ...rest] = argv;
   const proc = Bun.spawn([cmd ?? "", ...rest], { stdout: "pipe", stderr: "pipe" });
@@ -392,45 +621,107 @@ export const bunGateExec: GateExec = async (argv) => {
   return { code, stdout, stderr };
 };
 
+/** The default {@link GateEnv}: real subprocess, real `kill(pid,0)`, real clock. */
+export const bunGateEnv: GateEnv = {
+  exec: bunGateExec,
+  procAlive: (pid) => {
+    if (!Number.isInteger(pid) || pid <= 0) return false;
+    try {
+      process.kill(pid, 0); // signal 0 = liveness probe, delivers nothing
+      return true;
+    } catch (err) {
+      // ESRCH = no such process (dead). Anything else (EPERM/…) = exists but not
+      // ours → assume ALIVE (fail-closed).
+      return (err as { code?: string }).code !== "ESRCH";
+    }
+  },
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  now: () => Date.now(),
+};
+
 /** Map `process.platform` onto the supported {@link GatePlatform} set. */
 export function currentGatePlatform(): GatePlatform {
   return process.platform === "darwin" ? "darwin" : "linux";
 }
 
-/** Resolve the launchd `gui/<uid>` target: explicit override, else the process
- *  uid, else the macOS default 501. */
+/** Resolve the launchd `gui/<uid>` target uid. */
 export function resolveGateUid(uid?: number): number {
   return uid ?? process.getuid?.() ?? 501;
 }
 
-/** `~/Library/LaunchAgents` (or under a `home` override). */
-function defaultLaunchAgentsDir(home?: string): string {
-  return join(home ?? process.env.HOME ?? homedir(), "Library", "LaunchAgents");
+/** Shared options for the batteries-included entry points. */
+export interface ClearFleetOptions {
+  platform?: GatePlatform;
+  uid?: number;
+  env?: GateEnv;
+  drain?: DrainPolicy;
+  configDir?: string;
+  launchAgentsDir?: string;
+  systemdUserDir?: string;
+  io?: DaemonLocatorIO;
+  discoverSlugs?: (configDir: string) => string[];
+  home?: string;
+}
+
+/** Enumerate the fleet + run the gate with host-derived defaults. */
+export async function clearFleetForMigration(
+  opts: ClearFleetOptions = {},
+): Promise<MigrationGateResult> {
+  const platform = opts.platform ?? currentGatePlatform();
+  const targets = enumerateServiceTargets({
+    platform,
+    ...(opts.configDir !== undefined && { configDir: opts.configDir }),
+    ...(opts.launchAgentsDir !== undefined && { launchAgentsDir: opts.launchAgentsDir }),
+    ...(opts.systemdUserDir !== undefined && { systemdUserDir: opts.systemdUserDir }),
+    ...(opts.io !== undefined && { io: opts.io }),
+    ...(opts.discoverSlugs !== undefined && { discoverSlugs: opts.discoverSlugs }),
+    ...(opts.home !== undefined && { home: opts.home }),
+  });
+  return runMigrationGate({
+    platform,
+    uid: resolveGateUid(opts.uid),
+    env: opts.env ?? bunGateEnv,
+    targets,
+    ...(opts.drain !== undefined && { drain: opts.drain }),
+  });
+}
+
+/** The result of {@link withMigrationGate}. */
+export interface MigrationRunResult<T> {
+  /** Whether the gate cleared (and therefore the migration ran). */
+  cleared: boolean;
+  gate: MigrationGateResult;
+  /** The finally-guaranteed restore outcome (present whenever the fleet was
+   *  brought back — i.e. every path except a migration that itself threw, where
+   *  the restore still ran but the throw propagates to the caller). */
+  restore: RestoreResult;
+  /** The migration fn's return value (only on the cleared + no-throw path). */
+  result?: T;
 }
 
 /**
- * The one-call production entry point X-07/X-11 use: enumerate the fleet + run
- * the gate with real `Bun.spawn` exec and host-derived platform/uid/dirs. Every
- * default is overridable for tests + non-standard installs.
+ * The BLESSED entry X-07/X-11 use (A-RESTORE). Runs `migrate` ONLY after the gate
+ * clears, inside a `try/finally` that ALWAYS restores the pre-running fleet — so a
+ * migration that throws can never strand the fleet down (bootout/stop persist).
+ * When the gate REFUSES, `migrate` is not called and the fleet is restored
+ * immediately (the gate had already stopped everything to probe it).
  */
-export async function clearFleetForMigration(opts?: {
-  platform?: GatePlatform;
-  uid?: number;
-  exec?: GateExec;
-  configDir?: string;
-  launchAgentsDir?: string;
-  home?: string;
-}): Promise<MigrationGateResult> {
-  const launchAgentsDir = opts?.launchAgentsDir ?? defaultLaunchAgentsDir(opts?.home);
-  const targets = enumerateServiceTargets({
-    ...(opts?.configDir !== undefined && { configDir: opts.configDir }),
-    launchAgentsDir,
-    ...(opts?.home !== undefined && { home: opts.home }),
-  });
-  return runMigrationGate({
-    platform: opts?.platform ?? currentGatePlatform(),
-    uid: resolveGateUid(opts?.uid),
-    exec: opts?.exec ?? bunGateExec,
-    targets,
-  });
+export async function withMigrationGate<T>(
+  opts: ClearFleetOptions,
+  migrate: (gate: MigrationGateResult) => Promise<T>,
+): Promise<MigrationRunResult<T>> {
+  const gate = await clearFleetForMigration(opts);
+  if (!gate.cleared) {
+    const restore = await gate.restore();
+    return { cleared: false, gate, restore };
+  }
+  let result: T | undefined;
+  let restore!: RestoreResult;
+  try {
+    result = await migrate(gate);
+  } finally {
+    // GUARANTEE: whether migrate returned or threw, the fleet comes back.
+    restore = await gate.restore();
+  }
+  return { cleared: true, gate, restore, ...(result !== undefined && { result }) };
 }


### PR DESCRIPTION
Closes #1901. Part of epic #1867, wave 1 **TRUST LANE**. Delivers the reusable gate that X-07 (config move) and X-11 (state move) call before touching a live daemon's dirs — this issue is the GATE, not the moves.

## What
`runMigrationGate({platform, uid, exec, targets})` + pure `enumerateServiceTargets()` + batteries-included `clearFleetForMigration()`. Injected `GateExec` seam ⇒ unit-testable on a POSIX CI host with no real launchd/systemd.

- **Oracle = service manager, never pidfile** (traps T18/T1b): macOS `launchctl bootout gui/$UID/<label>` → prove absence via `launchctl print` non-zero; Linux `systemctl --user stop <unit>` → prove via `is-active` non-up-state.
- **Fail-closed by construction (G-08):** `proveAbsent` returns true ONLY on positive proof; a thrown exec, an up-state, or a still-resolving print ⇒ target counts PRESENT. No `cleared:true` path exists unless every target proved down. Linux is a real implementation (not a stub), tested via `platform:"linux"` on ubuntu CI.
- **Restore-on-failure (G-36):** `restore()` returned in both cleared and not-cleared results; callers MUST call it on any failure (bootout is persistent). Only the pre-running set is restarted (symmetry).
- **Legacy labels (G-35):** stack slugs + relay + `com.grove.{bot,relay}` + `ai.meta-factory.cortex.bot` (the preupgrade.sh:80 set).

## Verification
- 12/12 gate tests (bootout clears; KeepAlive/Restart=always `stubborn` job BLOCKS; Linux fail-closed when systemctl throws; restore symmetry) · tsc 0 · eslint 0 · vocab carve-out green

## KNOWN RESIDUAL for adversarial review (builder-flagged)
Linux unit id is derived by convention (`ai.meta-factory.cortex.<slug>.service`). If a deployment's real unit differs (daemon-locator shows real units are `cortex-<slug>.service`), `is-active <wrong-unit>` → "inactive" → treated as DOWN → **gate could clear while a live Linux daemon runs (fail-OPEN)**. Fix path scoped: discovery-based enumeration via daemon-locator's `parseUnitExecStartArgs`/`configArgValue`, unioned with the by-name legacy set. Flagged for the adversary to rule blocking-now vs X-11-hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)