### PR TITLE
test(xdg): P5 migration E2E guard — 5 invariants + xdg-audit doctor (#1870)

### DIFF
--- a/src/__tests__/xdg-migration-guard.e2e.test.ts
+++ b/src/__tests__/xdg-migration-guard.e2e.test.ts
@@ -1,0 +1,514 @@
+/**
+ * XDG P5 — migration + backward-compat E2E guard (cortex#1870, EPIC #1867).
+ *
+ * ## What this is
+ *
+ * The epic's PROGRESS METER. It runs FIRST (gated only by the `{home,env}`
+ * seam — arc#292 / cortex#1908) and precedes every path move. Per the v3
+ * rescope + the 2026-07-12 gap-review amendment it pins INVARIANTS, not paths:
+ * a test that pinned today's *paths* would be a change-detector every later
+ * wave is required to break. These five invariants must stay GREEN through
+ * every migration wave:
+ *
+ *   (i)   exactly one live process per stack PID — distinct config trees get
+ *         distinct pidfiles (no cross-tree SIGTERM) and a LIVE legacy pidfile
+ *         is never adopted (no two daemons under one identity).
+ *   (ii)  hook-writer / relay-reader / MC-cursor resolve to a BYTE-IDENTICAL
+ *         events dir (the whole hook→relay→MC pipeline shares one seam).
+ *   (iii) every installed plist's ProgramArguments paths + WorkingDirectory +
+ *         Std*Path parents + `--config` name EXTANT files, and (Linux) every
+ *         `.service` ExecStart path is extant (G-03 widened — the relay.plist
+ *         that execs `…/src/taps/cc-events/relay.ts` with KeepAlive is the
+ *         fleet-crash class `--config`-only checking is blind to).
+ *   (iv)  daemon-env resolution ≡ shell-env resolution (G-37): the HOME a
+ *         rendered plist stamps into EnvironmentVariables agrees with the HOME
+ *         the paths baked into its argv resolve under, so a daemon and the CLI
+ *         never split into different trees.
+ *   (v)   FRESH-ENV STRICT (Fallback Contract): a scratch $HOME with NO legacy
+ *         trees + CORTEX_XDG_STRICT=1 completes config/events/pidfile
+ *         resolution emitting ZERO `xdg-fallback:` lines. The fresh-install
+ *         failure-class killer — an upgraded machine silently exercises the
+ *         fallback net, so only a fresh strict env proves new-path resolution.
+ *
+ * ## CI-runnable vs real-machine
+ *
+ * Everything here is HERMETIC (scratch $HOME, injected dirs — never the real
+ * `~/.config` / `~/.claude` / `~/Library`) so it runs on the `bun test` CI job
+ * (ubuntu). But scratch-HOME tests are, by the amendment's own words,
+ * "vacuously green" against a box that has live stacks the tests never see. So
+ * this guard ALSO EXPOSES the real-machine doctor preflight (G-23):
+ * `bun scripts/xdg-audit.ts --machine`. That command is the launchctl/plist/db
+ * oracle over the ACTUAL machine; the final test shells out to it as the
+ * preflight surface (informational in CI, the gate on a real fleet box).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+
+import {
+  configArgValue,
+  parsePlistProgramArguments,
+  parseUnitExecStartArgs,
+} from "../cli/cortex/commands/daemon-locator";
+import { migrateLegacyPidFile, pidFileForIn } from "../common/pidfile";
+import { eventsDir, publishedEventsDir, rawEventsDir } from "../common/events-path";
+import { resolveConfigFile } from "../common/config/config-path";
+import { XDG_FALLBACK_PREFIX } from "../common/xdg";
+
+// bun accepts `todo("name")` at runtime but the bundled types want a body fn;
+// this cast keeps the single-arg form type-clean (same as the C-1355 guard).
+const todo = test.todo as unknown as (name: string) => void;
+
+// ── env isolation ──────────────────────────────────────────────────────────
+// The whole suite runs under `bun test` (shared process). Save/restore every
+// var these invariants touch so no test leaks into another (or into the real
+// suite's home-injected assertions).
+const MANAGED = [
+  "HOME",
+  "CORTEX_CONFIG_DIR",
+  "CORTEX_EVENTS_DIR",
+  "CORTEX_STATE_DIR",
+  "CORTEX_XDG_STRICT",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+const scratches: string[] = [];
+
+function scratch(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), `x1870-${prefix}-`));
+  scratches.push(d);
+  return d;
+}
+
+beforeEach(() => {
+  for (const v of MANAGED) savedEnv[v] = process.env[v];
+});
+afterEach(() => {
+  for (const v of MANAGED) {
+    if (savedEnv[v] === undefined) Reflect.deleteProperty(process.env, v);
+    else process.env[v] = savedEnv[v];
+  }
+  while (scratches.length) rmSync(scratches.pop()!, { recursive: true, force: true });
+});
+
+// ── plist / unit rendering + verification helpers ───────────────────────────
+
+const SERVICES_DIR = join(import.meta.dir, "..", "services");
+const STACK_TEMPLATE = join(SERVICES_DIR, "ai.meta-factory.cortex.stack.plist");
+const RELAY_TEMPLATE = join(SERVICES_DIR, "ai.meta-factory.cortex.relay.plist");
+
+/** Substitute the shell renderer's `__TOKEN__` placeholders (plist-render.sh). */
+function renderTemplate(
+  templatePath: string,
+  tokens: Record<string, string>,
+): string {
+  let xml = readFileSync(templatePath, "utf-8");
+  for (const [k, v] of Object.entries(tokens)) {
+    xml = xml.split(`__${k}__`).join(v);
+  }
+  return xml;
+}
+
+function firstString(xml: string, key: string): string | undefined {
+  const m = new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`).exec(xml);
+  return m?.[1];
+}
+
+interface PathVerdict {
+  path: string;
+  kind: "exec" | "config" | "workdir" | "stdio";
+  extant: boolean;
+}
+
+/**
+ * The invariant-(iii) verifier over a launchd plist: collect every filesystem
+ * path the plist names and classify extant-ness.
+ *   - ProgramArguments absolute paths (minus the `--config` value) → the exec /
+ *     script FILE must exist (this is the relay.ts / cortex-bin class G-03).
+ *   - the `--config` value → the config FILE must exist.
+ *   - WorkingDirectory → the DIR must exist.
+ *   - Standard{Out,Error}Path → the PARENT dir must exist (launchd creates the
+ *     log file itself, but fails to spawn if its parent is absent).
+ */
+function verifyPlistPaths(xml: string): PathVerdict[] {
+  const args = parsePlistProgramArguments(xml);
+  const config = configArgValue(args);
+  const out: PathVerdict[] = [];
+
+  for (const a of args) {
+    if (!a.startsWith("/")) continue; // "start", "--config" etc.
+    if (a === config) continue; // handled as config below
+    out.push({ path: a, kind: "exec", extant: existsSync(a) });
+  }
+  if (config !== undefined) {
+    out.push({ path: config, kind: "config", extant: existsSync(config) });
+  }
+  const workdir = firstString(xml, "WorkingDirectory");
+  if (workdir !== undefined) {
+    out.push({ path: workdir, kind: "workdir", extant: existsSync(workdir) });
+  }
+  for (const key of ["StandardOutPath", "StandardErrorPath"]) {
+    const p = firstString(xml, key);
+    if (p !== undefined) out.push({ path: p, kind: "stdio", extant: existsSync(dirname(p)) });
+  }
+  return out;
+}
+
+/** Build a fully-populated scratch fleet layout + the two rendered plists. */
+function renderFleet(): {
+  home: string;
+  cortexDir: string;
+  configPath: string;
+  stackPlist: string;
+  relayPlist: string;
+} {
+  const home = scratch("home");
+  const cortexDir = join(home, ".local", "share", "metafactory", "cortex");
+  const slug = "work";
+
+  // Materialize every path the templates reference so a correctly-installed
+  // fleet verifies fully extant.
+  mkdirSync(join(home, "bin"), { recursive: true });
+  writeFileSync(join(home, "bin", "cortex"), "#!/bin/sh\n", { mode: 0o755 });
+  const bunPath = join(home, "bin", "bun");
+  writeFileSync(bunPath, "#!/bin/sh\n", { mode: 0o755 });
+  mkdirSync(join(cortexDir, "src", "taps", "cc-events"), { recursive: true });
+  writeFileSync(join(cortexDir, "src", "taps", "cc-events", "relay.ts"), "// relay\n");
+  const configDir = join(home, ".config", "cortex", slug);
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, `${slug}.yaml`);
+  writeFileSync(configPath, "principal: {}\n");
+  mkdirSync(join(home, ".config", "cortex", "logs"), { recursive: true });
+  mkdirSync(join(home, ".claude", "logs"), { recursive: true });
+
+  const tokens = {
+    HOME: home,
+    CORTEX_DIR: cortexDir,
+    CONFIG_PATH: configPath,
+    STACK_SLUG: slug,
+    BUN_PATH: bunPath,
+  };
+  return {
+    home,
+    cortexDir,
+    configPath,
+    stackPlist: renderTemplate(STACK_TEMPLATE, tokens),
+    relayPlist: renderTemplate(RELAY_TEMPLATE, tokens),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Invariant (i) — exactly one live process per stack PID.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("(i) exactly one live process per stack PID", () => {
+  test("distinct config TREES sharing a basename get DISTINCT pidfiles (no cross-tree SIGTERM)", () => {
+    const stateDir = scratch("state");
+    const dirA = scratch("treeA");
+    const dirB = scratch("treeB");
+    const cfgA = join(dirA, "stack.yaml");
+    const cfgB = join(dirB, "stack.yaml");
+    writeFileSync(cfgA, "principal: {}\n");
+    writeFileSync(cfgB, "principal: {}\n");
+
+    const pidA = pidFileForIn(stateDir, cfgA);
+    const pidB = pidFileForIn(stateDir, cfgB);
+    // Same basename ("stack") but different full paths ⇒ different hash8 ⇒
+    // different pidfile. Under the old basename-only scheme both were
+    // `cortex-stack.pid`: start/stop on one hit the other's daemon (#1900).
+    expect(pidA).not.toBe(pidB);
+    // Stable identity: the same config path always resolves the same pidfile,
+    // so start/stop/status/reload converge on ONE process.
+    expect(pidFileForIn(stateDir, cfgA)).toBe(pidA);
+  });
+
+  test("a LIVE legacy pidfile is NEVER adopted (never two daemons under one identity)", () => {
+    const stateDir = scratch("state");
+    const cfgDir = scratch("cfg");
+    const configPath = join(cfgDir, "bot.yaml");
+    writeFileSync(configPath, "principal: {}\n");
+
+    // Plant an OLD-format (no-hash) pidfile naming a LIVE process (ourselves).
+    const legacy = join(stateDir, "cortex-bot.pid");
+    writeFileSync(legacy, String(process.pid));
+
+    const adopted = migrateLegacyPidFile(configPath, stateDir);
+    // Liveness gate refuses: the live daemon keeps its pidfile; nothing renamed.
+    expect(adopted).toBeUndefined();
+    expect(existsSync(legacy)).toBe(true);
+    expect(existsSync(pidFileForIn(stateDir, configPath))).toBe(false);
+  });
+
+  test("a DEAD legacy pidfile IS adopted (live fleet not orphaned mid-upgrade)", () => {
+    const stateDir = scratch("state");
+    const cfgDir = scratch("cfg");
+    const configPath = join(cfgDir, "bot.yaml");
+    writeFileSync(configPath, "principal: {}\n");
+
+    const legacy = join(stateDir, "cortex-bot.pid");
+    // A PID that is (almost certainly) dead → safe to adopt.
+    writeFileSync(legacy, "999999");
+
+    const adopted = migrateLegacyPidFile(configPath, stateDir);
+    expect(adopted).toBe(legacy);
+    expect(existsSync(legacy)).toBe(false);
+    expect(existsSync(pidFileForIn(stateDir, configPath))).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Invariant (ii) — byte-identical events dir across hook / relay / MC.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("(ii) hook-writer / relay-reader / MC-cursor resolve to a byte-identical events dir", () => {
+  test("override wins over home ⇒ all three sites resolve the SAME dir regardless of home spelling", () => {
+    const ev = scratch("events");
+    process.env.CORTEX_EVENTS_DIR = ev;
+
+    // The three consumers derive home DIFFERENTLY: the hook calls eventsDir()
+    // (no arg → process.env.HOME), MC calls with os.homedir(), the relay with
+    // its own. With the override set, home is IGNORED — so all spellings agree.
+    const hookRaw = rawEventsDir(); // event-logger.hook.ts spelling
+    const mcRaw = rawEventsDir("/some/other/home"); // mc/config.ts spelling
+    const relayPub = publishedEventsDir("/yet/another/home"); // relay.ts spelling
+
+    expect(hookRaw).toBe(mcRaw);
+    expect(hookRaw).toBe(join(ev, "raw"));
+    expect(relayPub).toBe(join(ev, "published"));
+    // hook (raw) and relay (published) share ONE root — byte-identical.
+    expect(dirname(hookRaw)).toBe(dirname(relayPub));
+    expect(eventsDir("/ignored")).toBe(ev);
+  });
+
+  test("unset ⇒ still byte-identical across sites (default ~/.claude/events)", () => {
+    delete process.env.CORTEX_EVENTS_DIR;
+    const home = "/fake/home";
+    expect(rawEventsDir(home)).toBe(join(home, ".claude", "events", "raw"));
+    expect(publishedEventsDir(home)).toBe(join(home, ".claude", "events", "published"));
+    expect(dirname(rawEventsDir(home))).toBe(dirname(publishedEventsDir(home)));
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Invariant (iii) — every installed plist / unit path is extant.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("(iii) installed plist ProgramArguments + WorkingDirectory + Std*Path + --config are extant", () => {
+  test("a correctly-installed stack plist has EVERY path extant", () => {
+    const { stackPlist } = renderFleet();
+    const verdicts = verifyPlistPaths(stackPlist);
+    // sanity: we actually exercised exec + config + workdir + stdio kinds.
+    expect(new Set(verdicts.map((v) => v.kind))).toEqual(
+      new Set(["exec", "config", "workdir", "stdio"]),
+    );
+    const missing = verdicts.filter((v) => !v.extant);
+    expect(missing).toEqual([]);
+  });
+
+  test("a correctly-installed relay plist has EVERY path extant (incl. the relay.ts exec — the G-03 fleet-crash class)", () => {
+    const { relayPlist, cortexDir } = renderFleet();
+    const verdicts = verifyPlistPaths(relayPlist);
+    // The relay carries NO --config and execs `…/src/taps/cc-events/relay.ts`
+    // (pkg/repos on a real box) — the exact path `--config`-only checking is
+    // blind to. It MUST be verified extant.
+    const relayExec = verdicts.find((v) => v.path.endsWith("relay.ts"));
+    expect(relayExec).toBeDefined();
+    expect(relayExec!.kind).toBe("exec");
+    expect(relayExec!.extant).toBe(true);
+    expect(relayExec!.path.startsWith(cortexDir)).toBe(true);
+    expect(verdicts.filter((v) => !v.extant)).toEqual([]);
+  });
+
+  test("NEGATIVE: a relay whose exec moved out from under it is FLAGGED (the crash this pins against)", () => {
+    const { relayPlist } = renderFleet();
+    // Simulate a wave that moved the repos tree without re-rendering the plist.
+    const stale = relayPlist.replace(
+      /<string>[^<]*relay\.ts<\/string>/,
+      "<string>/nonexistent/pkg/repos/cortex/src/taps/cc-events/relay.ts</string>",
+    );
+    const verdicts = verifyPlistPaths(stale);
+    const missing = verdicts.filter((v) => !v.extant);
+    expect(missing.length).toBeGreaterThan(0);
+    expect(missing.some((v) => v.path.endsWith("relay.ts"))).toBe(true);
+  });
+
+  test("(Linux) a .service ExecStart path is verified extant (G-09)", () => {
+    const { cortexDir } = renderFleet();
+    const relayTs = join(cortexDir, "src", "taps", "cc-events", "relay.ts");
+    const unit = [
+      "[Service]",
+      `ExecStart=/usr/bin/bun ${relayTs} start`,
+      "WorkingDirectory=" + cortexDir,
+      "[Install]",
+      "WantedBy=default.target",
+    ].join("\n");
+    const args = parseUnitExecStartArgs(unit);
+    const execPaths = args.filter((a) => a.startsWith("/"));
+    expect(execPaths).toContain(relayTs);
+    for (const p of execPaths) {
+      // /usr/bin/bun may be absent on CI; assert the CORTEX-owned exec is extant
+      // (the migration-relevant path). The system interpreter is out of scope.
+      if (p.startsWith(cortexDir)) expect(existsSync(p)).toBe(true);
+    }
+
+    const staleUnit = unit.replace(relayTs, "/nonexistent/pkg/repos/relay.ts");
+    const staleArgs = parseUnitExecStartArgs(staleUnit);
+    const staleCortexExec = staleArgs.find((a) => a.includes("/pkg/repos/"));
+    expect(staleCortexExec).toBeDefined();
+    expect(existsSync(staleCortexExec!)).toBe(false); // FLAGGED
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Invariant (iv) — daemon-env ≡ shell-env (G-37).
+// ═══════════════════════════════════════════════════════════════════════════
+describe("(iv) daemon-env resolution ≡ shell-env resolution", () => {
+  test("the plist's stamped HOME agrees with the HOME its argv paths resolve under (no split trees)", () => {
+    const { stackPlist, home, configPath } = renderFleet();
+
+    const stampedHome = firstString(stackPlist.split("<key>EnvironmentVariables</key>")[1] ?? "", "HOME");
+    expect(stampedHome).toBe(home);
+
+    // The daemon resolves $HOME-derived state under `stampedHome`; the CLI
+    // resolves under the same real HOME. They must be the SAME root, else a
+    // `cortex stop` from the shell targets a different tree than the daemon.
+    const argvConfig = configArgValue(parsePlistProgramArguments(stackPlist));
+    expect(argvConfig).toBe(configPath);
+    expect(argvConfig!.startsWith(stampedHome!)).toBe(true);
+    expect(firstString(stackPlist, "WorkingDirectory")).toBeDefined();
+  });
+
+  test("resolution is a pure function of env ⇒ a daemon and a CLI sharing env cannot diverge", () => {
+    // Single seam: given the same override env, both sides get the same dir.
+    const ev = scratch("events");
+    process.env.CORTEX_EVENTS_DIR = ev;
+    const asDaemon = rawEventsDir("/daemon/home");
+    const asCli = rawEventsDir("/cli/home");
+    expect(asDaemon).toBe(asCli); // override collapses any HOME divergence
+  });
+
+  // Forward invariant (flips live with the daemon-env stamping wave, G-37 full):
+  // once the renderer stamps the resolved CORTEX_CONFIG_DIR / CORTEX_STATE_DIR /
+  // CORTEX_EVENTS_DIR (and any honored $XDG_* roots) into the plist
+  // EnvironmentVariables / systemd Environment=, this guard must assert each
+  // stamped dir byte-equals the shell-seam resolution. Today the template stamps
+  // only HOME/PATH/CORTEX_CHANNEL (asserted above); the trio is not yet stamped.
+  todo(
+    "(iv) G-37 full: rendered EnvironmentVariables/Environment= stamp resolved CONFIG/STATE/EVENTS dirs == shell-seam resolution",
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Invariant (v) — fresh-env strict, ZERO xdg-fallback lines (Fallback Contract).
+// ═══════════════════════════════════════════════════════════════════════════
+describe("(v) fresh-env strict discrimination — the fresh-install failure-class killer", () => {
+  let written: string[];
+  let restore: () => void;
+
+  beforeEach(() => {
+    written = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      written.push(String(chunk));
+      return true;
+    };
+    restore = () => {
+      process.stderr.write = orig;
+    };
+  });
+  afterEach(() => restore());
+
+  function fallbackLines(): string[] {
+    return written.filter((l) => l.includes(XDG_FALLBACK_PREFIX));
+  }
+
+  test("scratch $HOME, NO legacy trees, CORTEX_XDG_STRICT=1 ⇒ full resolution flow emits ZERO xdg-fallback lines", () => {
+    const home = scratch("fresh-home"); // pristine — no ~/.config/{cortex,grove}
+    const cfg = scratch("cfg");
+    const ev = scratch("events");
+    const st = scratch("state");
+    process.env.HOME = home;
+    process.env.CORTEX_CONFIG_DIR = cfg;
+    process.env.CORTEX_EVENTS_DIR = ev;
+    process.env.CORTEX_STATE_DIR = st;
+    process.env.CORTEX_XDG_STRICT = "1";
+
+    // The resolution surface a full install→start→hook→stop drives through the
+    // seams (config files, events round-trip, pidfile identity). NONE should
+    // touch a legacy tree on a fresh strict env.
+    for (const f of ["cli.yaml", "bot.yaml", "mission-control.yaml"]) {
+      const r = resolveConfigFile(f, home);
+      expect(r.source).not.toBe("grove"); // never the legacy fallback
+      expect(r.path.startsWith(cfg)).toBe(true);
+    }
+    // Events round-trip through the seam.
+    mkdirSync(rawEventsDir(home), { recursive: true });
+    writeFileSync(join(rawEventsDir(home), "e.jsonl"), "{}\n");
+    expect(existsSync(publishedEventsDir(home).replace(/published$/, "raw"))).toBe(true);
+    // Pidfile identity under the scratch state dir.
+    expect(pidFileForIn(st, join(cfg, "bot.yaml")).startsWith(st)).toBe(true);
+
+    expect(fallbackLines()).toEqual([]);
+  });
+
+  test("NEGATIVE control: strict + a legacy grove file + NO override ⇒ a fallback line IS emitted (proves strict discriminates)", () => {
+    const home = scratch("legacy-home");
+    // Legacy tree present, override ABSENT ⇒ the grove read-fallback fires.
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(join(home, ".config", "grove", "cli.yaml"), "legacy: true\n");
+    process.env.HOME = home;
+    delete process.env.CORTEX_CONFIG_DIR; // no override → grove fallback reachable
+    process.env.CORTEX_XDG_STRICT = "1";
+
+    const r = resolveConfigFile("cli.yaml", home);
+    expect(r.source).toBe("grove"); // legacy fallback in effect
+    const lines = fallbackLines();
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(lines[0]).toContain("config");
+  });
+
+  test("the SAME legacy fallback is SILENT when NOT strict (no production noise)", () => {
+    const home = scratch("legacy-home-2");
+    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+    writeFileSync(join(home, ".config", "grove", "cli.yaml"), "legacy: true\n");
+    process.env.HOME = home;
+    delete process.env.CORTEX_CONFIG_DIR;
+    delete process.env.CORTEX_XDG_STRICT; // NOT strict
+
+    const r = resolveConfigFile("cli.yaml", home);
+    expect(r.source).toBe("grove"); // same fallback path…
+    expect(fallbackLines()).toEqual([]); // …but byte-identical/silent
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// G-23 — real-machine doctor preflight the guard EXPOSES.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("G-23 — xdg-audit --machine doctor preflight", () => {
+  test("`bun scripts/xdg-audit.ts --machine --json` runs and yields a parseable finding inventory", () => {
+    const script = join(import.meta.dir, "..", "..", "scripts", "xdg-audit.ts");
+    expect(existsSync(script)).toBe(true);
+
+    // READ-ONLY on the ACTUAL machine (the amendment's launchctl/plist/db
+    // oracle). In CI the runner's $HOME has no cortex fleet ⇒ ~0 findings; on a
+    // real fleet box it inventories live plists/pidfiles/dangling symlinks.
+    // This test is the PREFLIGHT SURFACE, not a CI gate on the count: it asserts
+    // the doctor executes and returns a structured inventory, so the machine
+    // guard is wired and runnable. A human/CI-on-a-real-box reads the count.
+    const proc = Bun.spawnSync(["bun", script, "--machine", "--json"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const out = proc.stdout.toString();
+    const parsed = JSON.parse(out) as { findings: unknown[]; total: number };
+    expect(Array.isArray(parsed.findings)).toBe(true);
+    expect(typeof parsed.total).toBe("number");
+    // exit code = min(total, 99) by construction — a usable gate value.
+    expect(proc.exitCode).toBe(Math.min(parsed.total, 99));
+  });
+});

--- a/src/common/__tests__/xdg.test.ts
+++ b/src/common/__tests__/xdg.test.ts
@@ -1,0 +1,98 @@
+/**
+ * XDG wave-2 (cortex#1870) — shared env plumbing unit tests.
+ *
+ * Pins the three primitives the seams share:
+ *   - readDirEnv: trim + empty/whitespace ⇒ unset (PR#1920 nit a+b).
+ *   - xdgStrict: truthy-value parse of CORTEX_XDG_STRICT.
+ *   - noteXdgFallback: emits the ONE structured line ONLY under strict.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  XDG_FALLBACK_PREFIX,
+  noteXdgFallback,
+  readDirEnv,
+  xdgStrict,
+} from "../xdg";
+
+const VARS = ["CORTEX_CONFIG_DIR", "CORTEX_EVENTS_DIR", "CORTEX_XDG_STRICT", "X_DIR_TEST"] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const v of VARS) {
+    saved[v] = process.env[v];
+    Reflect.deleteProperty(process.env, v);
+  }
+});
+afterEach(() => {
+  for (const v of VARS) {
+    if (saved[v] === undefined) Reflect.deleteProperty(process.env, v);
+    else process.env[v] = saved[v];
+  }
+});
+
+describe("readDirEnv — trimmed dir-override read", () => {
+  test("unset ⇒ undefined", () => {
+    expect(readDirEnv("X_DIR_TEST")).toBeUndefined();
+  });
+  test("empty ⇒ undefined (not '/')", () => {
+    process.env.X_DIR_TEST = "";
+    expect(readDirEnv("X_DIR_TEST")).toBeUndefined();
+  });
+  test("whitespace-only ⇒ undefined (PR#1920 nit a — never a literal relative dir)", () => {
+    process.env.X_DIR_TEST = "   ";
+    expect(readDirEnv("X_DIR_TEST")).toBeUndefined();
+  });
+  test("real value ⇒ trimmed value", () => {
+    process.env.X_DIR_TEST = "  /tmp/scratch  ";
+    expect(readDirEnv("X_DIR_TEST")).toBe("/tmp/scratch");
+  });
+});
+
+describe("xdgStrict — CORTEX_XDG_STRICT parse", () => {
+  test("unset ⇒ false", () => {
+    expect(xdgStrict()).toBe(false);
+  });
+  test.each(["1", "true", "TRUE", "yes", " Yes "])("%p ⇒ true", (v) => {
+    process.env.CORTEX_XDG_STRICT = v;
+    expect(xdgStrict()).toBe(true);
+  });
+  test.each(["0", "false", "no", ""])("%p ⇒ false", (v) => {
+    process.env.CORTEX_XDG_STRICT = v;
+    expect(xdgStrict()).toBe(false);
+  });
+});
+
+describe("noteXdgFallback — strict-gated structured line", () => {
+  let written: string[];
+  let restore: () => void;
+
+  beforeEach(() => {
+    written = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      written.push(String(chunk));
+      return true;
+    };
+    restore = () => {
+      process.stderr.write = orig;
+    };
+  });
+  afterEach(() => restore());
+
+  test("non-strict ⇒ SILENT (byte-identical production behavior)", () => {
+    noteXdgFallback("config", "cli.yaml from grove");
+    expect(written).toEqual([]);
+  });
+
+  test("strict ⇒ emits exactly one xdg-fallback: line with site + detail", () => {
+    process.env.CORTEX_XDG_STRICT = "1";
+    noteXdgFallback("config", "cli.yaml from grove");
+    expect(written.length).toBe(1);
+    expect(written[0]).toStartWith(XDG_FALLBACK_PREFIX);
+    expect(written[0]).toContain("config");
+    expect(written[0]).toContain("cli.yaml from grove");
+    expect(written[0]!.endsWith("\n")).toBe(true);
+  });
+});

--- a/src/common/config/config-path.ts
+++ b/src/common/config/config-path.ts
@@ -38,6 +38,8 @@
 import { copyFileSync, existsSync, mkdirSync, statSync, chmodSync } from "fs";
 import { dirname, join } from "path";
 
+import { noteXdgFallback, readDirEnv } from "../xdg";
+
 /** The canonical config directory name. */
 export const CORTEX_CONFIG_DIRNAME = "cortex";
 /** The legacy config directory name (read-fallback only during transition). */
@@ -71,8 +73,11 @@ function homeDir(home?: string): string {
  * that exports `CORTEX_CONFIG_DIR=` (blank) gets today's behavior, not `/`.
  */
 export function cortexConfigDirOverride(): string | undefined {
-  const v = process.env.CORTEX_CONFIG_DIR;
-  return v !== undefined && v.length > 0 ? v : undefined;
+  // Shared with `eventsDirOverride` via `readDirEnv` (PR#1920 nit b): trims,
+  // and a blank/whitespace-only value reads as unset (not a literal relative
+  // dir), so `CORTEX_CONFIG_DIR=` and `CORTEX_CONFIG_DIR="  "` keep today's
+  // `~/.config/cortex` default.
+  return readDirEnv("CORTEX_CONFIG_DIR");
 }
 
 /**
@@ -114,7 +119,14 @@ export function resolveConfigFile(filename: string, home?: string): ResolvedConf
   // and be meaningless (grove has no counterpart under an explicit root).
   if (cortexConfigDirOverride() === undefined) {
     const grove = groveConfigPath(filename, home);
-    if (existsSync(grove)) return { path: grove, source: "grove" };
+    if (existsSync(grove)) {
+      // Legacy-fallback site (#1908 kept this ~/.config/grove read-fallback).
+      // Under CORTEX_XDG_STRICT this emits the one grep-able `xdg-fallback:`
+      // line the #1870 guard asserts ZERO of on a fresh install; non-strict
+      // stays silent/byte-identical.
+      noteXdgFallback("config", `${filename} resolved from legacy ~/.config/grove`);
+      return { path: grove, source: "grove" };
+    }
   }
 
   return { path: cortex, source: "default" };
@@ -157,6 +169,8 @@ export function migrateGroveConfigFile(filename: string, home?: string): boolean
   const grove = groveConfigPath(filename, home);
   if (!existsSync(grove)) return false; // nothing to migrate
 
+  // A migration copy IS a legacy-tree read — surface it under strict mode too.
+  noteXdgFallback("config", `${filename} migrated from legacy ~/.config/grove`);
   const mode = statSync(grove).mode & 0o777;
   mkdirSync(dirname(cortex), { recursive: true });
   copyFileSync(grove, cortex);

--- a/src/common/events-path.ts
+++ b/src/common/events-path.ts
@@ -24,18 +24,21 @@
 
 import { join } from "path";
 
+import { readDirEnv } from "./xdg";
+
 function homeDir(home?: string): string {
   return home ?? process.env.HOME ?? "~";
 }
 
 /**
- * The `CORTEX_EVENTS_DIR` override, or `undefined` when unset/empty. An empty
- * string is treated as unset so `CORTEX_EVENTS_DIR=` (blank) keeps today's
- * behavior rather than resolving to `/`.
+ * The `CORTEX_EVENTS_DIR` override, or `undefined` when unset/empty. A blank OR
+ * whitespace-only value is treated as unset (via {@link readDirEnv}) so
+ * `CORTEX_EVENTS_DIR=` and `CORTEX_EVENTS_DIR="  "` both keep today's behavior
+ * rather than resolving to `/` or a literal relative `"  "` directory
+ * (PR#1920 nit a).
  */
 export function eventsDirOverride(): string | undefined {
-  const v = process.env.CORTEX_EVENTS_DIR;
-  return v !== undefined && v.length > 0 ? v : undefined;
+  return readDirEnv("CORTEX_EVENTS_DIR");
 }
 
 /**

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -90,7 +90,7 @@ function customPidComponents(
  * derivation in a temp dir (test-isolation rule: never write into the real
  * `~/.config/grove/state`); production always uses {@link STATE_DIR}.
  */
-function pidFileForIn(stateDir: string, configPath: string | undefined): string {
+export function pidFileForIn(stateDir: string, configPath: string | undefined): string {
   const c = customPidComponents(configPath);
   if (c === undefined) return join(stateDir, "cortex.pid");
   const hash = createHash("sha256").update(c.canonical).digest("hex").slice(0, 8);

--- a/src/common/xdg.ts
+++ b/src/common/xdg.ts
@@ -1,0 +1,72 @@
+/**
+ * XDG wave-2 (cortex#1870, EPIC cortex#1867) — shared env plumbing for the
+ * `{home,env}` path seams (`CORTEX_CONFIG_DIR` / `CORTEX_EVENTS_DIR` /
+ * `CORTEX_STATE_DIR`) and the Fallback Contract.
+ *
+ * Three tiny, dependency-free primitives, extracted so the seam modules don't
+ * drift:
+ *
+ *   1. {@link readDirEnv} — the single dir-override env read. `cortexConfigDir`
+ *      and `eventsDir` each inlined "read env, empty ⇒ unset" and diverged: the
+ *      config seam left a whitespace-only value as a literal relative dir, the
+ *      events seam the same (PR#1920 nit a+b). One helper: trim, and treat a
+ *      value that is empty *after trimming* as unset — so `CORTEX_EVENTS_DIR="  "`
+ *      is unset, not a relative `"  "` directory.
+ *
+ *   2. {@link xdgStrict} — the `CORTEX_XDG_STRICT` read. Strict mode is the
+ *      fresh-install failure-class killer (#1870 invariant (v)): a scratch
+ *      `$HOME` with NO legacy trees, `CORTEX_XDG_STRICT=1`, must complete the
+ *      full flow emitting ZERO `xdg-fallback:` lines. This is the env read half.
+ *
+ *   3. {@link noteXdgFallback} — the ONE structured fallback log line, emitted
+ *      at each legacy-fallback site (today: the `~/.config/grove` config
+ *      read-fallback the #1908 seam kept). It fires ONLY under strict mode, so
+ *      production on an upgraded machine stays byte-identical/silent while a
+ *      fresh strict run makes any silent reliance on the legacy net LOUD and
+ *      grep-able. This is the MINIMAL hook to make invariant (v) real+green on
+ *      origin/main today; the full Fallback Contract (refuse-vs-warn policy,
+ *      every classified site) is later-wave work.
+ */
+
+/** Structured prefix every fallback diagnostic carries (the guard greps this). */
+export const XDG_FALLBACK_PREFIX = "xdg-fallback:";
+
+/**
+ * Read a directory-override env var, normalized: returns the TRIMMED value, or
+ * `undefined` when the var is unset OR empty/whitespace-only. Trimming means a
+ * stray `CORTEX_CONFIG_DIR="  "` (or a value with accidental surrounding
+ * whitespace) never resolves as a literal relative directory — it reads as
+ * unset, preserving today's default-path behavior.
+ */
+export function readDirEnv(name: string): string | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+  const v = raw.trim();
+  return v.length > 0 ? v : undefined;
+}
+
+/**
+ * Whether XDG strict mode is on (`CORTEX_XDG_STRICT` set to a truthy value:
+ * `1` / `true` / `yes`, case-insensitive, trimmed). In strict mode any reliance
+ * on the legacy path net is surfaced via {@link noteXdgFallback}.
+ */
+export function xdgStrict(): boolean {
+  const v = process.env.CORTEX_XDG_STRICT?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+/**
+ * Emit the ONE structured `xdg-fallback:` diagnostic for a legacy-path
+ * fallback that just fired — but ONLY under {@link xdgStrict}. Non-strict
+ * (i.e. every upgraded machine that legitimately leans on the fallback net)
+ * stays silent and byte-identical to before, so this adds no production noise;
+ * a fresh strict run turns every fallback into a grep-able line so the #1870
+ * guard can assert ZERO of them.
+ *
+ * @param site  Short stable site tag, e.g. `"config"`.
+ * @param detail Human context, e.g. `"cli.yaml resolved from ~/.config/grove"`.
+ */
+export function noteXdgFallback(site: string, detail: string): void {
+  if (!xdgStrict()) return;
+  process.stderr.write(`${XDG_FALLBACK_PREFIX} ${site} — ${detail}\n`);
+}


### PR DESCRIPTION
Closes #1870. Part of epic #1867, wave 2 — the **progress meter** every later wave stays green against.

## What
A hermetic E2E guard pinning 5 invariants, plus minimal strict/fallback prod hooks the Fallback Contract needs:
- (i) one live process per stack PID (uses #1900's hash8 identity — two same-basename trees → distinct pidfiles; live-legacy-pidfile refused, dead adopted)
- (ii) hook/relay/MC spellings collapse to ONE events dir under CORTEX_EVENTS_DIR (override wins over HOME, so all 3 real consumers agree)
- (iii) renders the real `src/services/*.plist` templates and stats every ProgramArguments exec + `--config` + WorkingDirectory + Std*Path — incl. the relay KeepAlive exec that has NO `--config` (G-03 class); NEGATIVE control flags a moved exec; Linux .service ExecStart via daemon-locator
- (iv) daemon-env ≡ shell-env (partial: asserts plist HOME-agreement + pure-fn resolution now; full CONFIG/STATE/EVENTS stamping is a NAMED `test.todo` that flips live with the env-stamping wave, G-37)
- (v) FRESH-ENV STRICT: scratch $HOME, no legacy trees, `CORTEX_XDG_STRICT=1` → full resolve+round-trip emits ZERO `xdg-fallback:` lines; two controls discriminate (strict+legacy→≥1 line; non-strict→silent)

## New prod hooks (minimal — NOT the full contract)
- `src/common/xdg.ts`: `xdgStrict()` reads CORTEX_XDG_STRICT; `noteXdgFallback()` emits ONE structured line **only under strict** (byte-identical/silent otherwise — verified). Wired at config-path.ts's two legacy grove sites. Plus the shared `readDirEnv()` helper (folds PR#1920 nits: whitespace-trim + dedup).
- G-23: `bun scripts/xdg-audit.ts --machine` wired as the doctor-preflight test — the real-machine oracle so the CI-hermetic tests aren't vacuously green.

## Verification
- `bun test` (scoped, 6 files incl. daemon-locator/nats-plist-loader regressions): 86 pass / 1 todo / 0 fail
- tsc 0 · eslint clean · vocab carve-out PASS

Residual (documented): CI-hermetic (iii)/(v) prove the verifier logic + seam contracts, not a live fleet — real-machine coverage rides on `xdg-audit --machine`; (iv) full stamping pinned by the todo until its wave lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)