### PR TITLE
feat(cli): runtime attach/detach + cortex plugin verbs + reverse renderers-static (#1793)

### DIFF
--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -262,7 +262,7 @@ one extracts (S9–S12).
 
 cortex#1793 (S8, ADR-0024 D3) adds `cortex plugin list|unload|reload|load` —
 activating/deactivating a plugin **without restarting the daemon**. Talks to
-a running daemon over the bus (`system.plugin.control_request`/`_response`,
+a running daemon over the bus (`system.plugin.control-request`/`-response`,
 `src/bus/system-events.ts`; the daemon-side handler is
 `src/gateway/plugin-control-server.ts`; the domain logic is
 `src/gateway/plugin-runtime.ts`). Every mutating verb is **dry-run by

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -1,12 +1,11 @@
 # Plugin SDK — authoring a surface plugin
 
-**Status:** describes the v1 (S5, cortex#1790) contract surface. Boot-time
-discovery/loading of OUT-OF-TREE bundles is a later slice (S6) — today every
-plugin registered against this SDK is still in-tree (`createDefaultSurfacePluginRegistry`,
-`src/adapters/registry.ts`), dogfooding the same contract an out-of-tree
-bundle will compile against. See [ADR-0024](adr/0024-pluggable-surface-adapters.md)
-for the full decision record and `CONTEXT.md` §Adapter/renderer SDK for the
-canonical vocabulary this doc uses.
+**Status:** describes the v1 (S5, cortex#1790) contract surface, boot-time
+out-of-tree bundle discovery/loading (S6, cortex#1792), and the runtime
+attach/detach/reload lifecycle (S8, cortex#1793 — see §Runtime lifecycle
+below). See [ADR-0024](adr/0024-pluggable-surface-adapters.md) for the full
+decision record and `CONTEXT.md` §Adapter/renderer SDK for the canonical
+vocabulary this doc uses.
 
 ## What a surface plugin is
 
@@ -259,10 +258,109 @@ to) forbid the other cross-boundary imports discussed above; those are
 tracked as ADR-0024's residual couplings, resolved plugin-by-plugin as each
 one extracts (S9–S12).
 
+## Runtime lifecycle (S8) — attach/detach/reload + state loss
+
+cortex#1793 (S8, ADR-0024 D3) adds `cortex plugin list|unload|reload|load` —
+activating/deactivating a plugin **without restarting the daemon**. Talks to
+a running daemon over the bus (`system.plugin.control_request`/`_response`,
+`src/bus/system-events.ts`; the daemon-side handler is
+`src/gateway/plugin-control-server.ts`; the domain logic is
+`src/gateway/plugin-runtime.ts`). Every mutating verb is **dry-run by
+default** — `--apply` is required to actually send the mutation (repo
+convention, mirrors `cortex network`/`cortex stack`).
+
+### Renderers are the cheap half; adapters are the hard half
+
+Per-instance detach for **renderers** already existed before S8:
+`SurfaceRouter.register()` returns an `{ unregister }` handle
+(`src/bus/surface-router.ts:262`) — the renderer boot loop in `cortex.ts`
+used to discard it; S8 retains it. A renderer has no inbound connection and
+no drain machinery is needed (the router already bounds every `render()`
+call with a timeout + `Promise.allSettled` isolation), so renderer
+`unload`/`reload`/`load` are all fully supported:
+
+- **`unload`** — `unregister()` (leaves the router's dispatch list) then
+  `stop()`. Always available.
+- **`reload`** — cache-bust re-`import()` of the SAME arc bundle, construct
+  a fresh instance from the ORIGINAL parsed config, **attach the new
+  instance before detaching the old one** (ADR-0024 D3: "duplicate delivery
+  is strictly safer than a blind window for a pager" — reloading `pagerduty`
+  must never leave a transient gap in `local.{principal}.system.>`
+  coverage). Only supported for a renderer that was constructed from an
+  **arc-installed bundle** — an in-tree renderer (`dashboard`, `pagerduty`)
+  has no bundle to re-import and refuses with a clear "restart required"
+  message.
+- **`load`** — activates a renderer whose `renderers[]` config entry existed
+  at boot but failed to construct because the plugin hadn't loaded yet
+  (`plugins.external` was off, or the bundle failed a transient gate). The
+  ORIGINAL raw config entry is reused verbatim, so `load` constructs exactly
+  what boot would have — never a runtime-improvised config.
+
+**Adapters** have no per-instance detach outside the (env-gated,
+off-by-default) shared `SurfaceGateway` — see
+`src/gateway/surface-gateway.ts`'s `attachAdapter`/`detachAdapter`. Every
+live stack today runs the classic per-stack boot path
+(`wireSurfaceAdapters`), which has no live detach at all (ADR-0024 blocker
+#13). So:
+
+- **`unload`** — works only when the daemon is running with
+  `CORTEX_GATEWAY=1`; otherwise refused with a clear reason (never a silent
+  no-op).
+- **`reload`** / **`load`** — out of scope for this slice for ADAPTERS.
+  Re-constructing an adapter instance needs the binding-seed + demux-key
+  inputs `GatewayAdapterFactory` owns today; that shim is tracked separately
+  at cortex#1896. `cortex plugin unload` + a config-driven restart is the v1
+  path for picking up an adapter code change.
+
+### The bun cache-bust finding
+
+`cortex#1793`'s scratch verification: bun 1.3.2's dynamic `import()` only
+honors a `?v=` cache-busting query string when the specifier is a **plain
+filesystem path**. The identical query string on a **`file://` URL** —
+which is what the S6 loader's boot-time import uses
+(`pathToFileURL(resolved.absPath).href`, `src/adapters/loader.ts`) —
+resolves to the SAME cached module every time, no matter how many distinct
+`?v=` values are tried. `reimportRendererPlugin` (`src/adapters/loader.ts`)
+therefore imports via the plain absolute path for a `bust: true` re-import;
+`loadOneBundle`'s boot-time import is unchanged (a bundle's first import for
+the process lifetime never needs busting). Re-verify this against any future
+bun upgrade before assuming reload still works — it is a bun implementation
+detail, not a documented guarantee.
+
+### State loss on detach/reload — by design, plugin authors must design for it
+
+Detaching (or reloading — detach is half of reload) a live instance
+discards ALL of its in-memory state. This is intentional (ADR-0024's
+renderer-delta consequence: "a renderer's resources are scoped to its
+lifetime… still true, and it's exactly what makes per-instance
+destroy-and-reconstruct safe"), but every plugin author must design for it:
+
+- **Renderers**: a ring buffer / dedup cache resets to empty on
+  detach/reload. Design any per-envelope derivation to be **reload-stable**
+  — e.g. `PagerDutyRenderer`'s `dedup_key` is derived per-envelope from
+  `${envelope.source}:${envelope.type}` (`src/renderers/pagerduty.ts`), not
+  from in-memory state, so a duplicate delivery across a reload is
+  correctly deduped by the PROVIDER (PagerDuty), not by cortex.
+- **Adapters** (when gateway-attached `unload`/future `reload` applies):
+  progress placeholders (`sendProgress`/`clearProgress` state), thread
+  caches, and the live platform websocket/HTTP connection are ALL lost on
+  detach. A re-attached adapter instance starts cold — it does NOT resume
+  mid-conversation state from before the detach. Adapter authors MUST
+  tolerate a cold re-attach: never assume `postResponse`/`sendProgress` will
+  land against a placeholder created by a PRIOR instance, and treat every
+  `start()` as a fresh connection with no memory of what came before.
+  Response routing itself is wire-level (`response_routing.adapter_instance`
+  + `channel_id`/`thread_id` echoed on the envelope), so a cold re-attach
+  does not break REPLIES — only best-effort UX affordances (a "typing…"
+  placeholder update, a cached thread lookup) are lost.
+
 ## Out of scope for this doc
 
-- Dynamic bundle loading / the compat-gate loader implementation (S6).
-- Runtime `cortex plugin list|load|unload|reload` verbs (S8).
+- Dynamic bundle loading / the compat-gate loader implementation (S6) — see
+  `src/adapters/loader.ts`.
 - Publishing an npm package for the SDK — a bundle resolves it via S6's
   loader import mechanism, not `npm install`.
-- Retiring `GatewayAdapterFactory` (tracked separately, cortex#1896).
+- Zero-downtime handover between old+new instance of the SAME platform
+  (v2 — the S8 issue's explicit out-of-scope line).
+- Retiring `GatewayAdapterFactory` and the adapter `reload`/`load` verbs that
+  depend on it (tracked separately, cortex#1896).

--- a/src/adapters/loader.ts
+++ b/src/adapters/loader.ts
@@ -842,3 +842,100 @@ async function loadOneBundle(bundle: DiscoveredBundle, sinks: LoadOneBundleSinks
     `cortex plugin-loader: loaded ${manifest.kind} "${manifest.id}" from bundle "${bundleName}"${firstParty ? " (first-party renderer exemption)" : ""}\n`,
   );
 }
+
+// =============================================================================
+// Runtime re-import — cortex#1793 (S8, ADR-0024 D3) reload support
+// =============================================================================
+
+/** Result of {@link reimportRendererPlugin}. */
+export type ReimportRendererResult =
+  | { ok: true; plugin: RendererPlugin }
+  | { ok: false; stage: string; reason: string };
+
+/**
+ * Re-`import()` a bundle's entry module and re-validate its default export
+ * as a {@link RendererPlugin} — the re-import half of `cortex plugin reload`
+ * (S8). Deliberately reuses the SAME entry-containment (stage e) and
+ * shape-validate/id-pin/freeze (stage f) logic `loadOneBundle` applies at
+ * boot, applied to the SAME bundle a second time, so a reload is held to the
+ * identical trust bar as a fresh boot-time load — no relaxed re-import path.
+ *
+ * Does NOT touch the {@link SurfacePluginRegistry} — the registry is a
+ * `(kind, id)`-keyed CLASS registry (ADR-0024 D5), and a reload replaces a
+ * live INSTANCE, not the class binding config-parsing resolves against. The
+ * caller (`src/gateway/plugin-runtime.ts`) uses the returned plugin's
+ * `createRenderer(config)` factory directly with the instance's ORIGINAL
+ * parsed config, then discards this frozen plugin object — never registers
+ * it.
+ *
+ * cortex#1793 (S8) scratch-verified finding: bun's dynamic `import()` only
+ * honors a `?v=` cache-busting query string when the specifier is a PLAIN
+ * filesystem path — the SAME query string on a `file://` URL (what
+ * `loadOneBundle`'s boot-time import uses, `pathToFileURL(...).href`)
+ * resolves to the SAME cached module every time (bun 1.3.2). `opts.bust`
+ * therefore imports via the plain `resolved.absPath`, not a `file://` URL,
+ * when re-importing for a reload; `loadOneBundle` is UNCHANGED (boot-time
+ * imports never need busting — they're each bundle's first and only import
+ * for that process lifetime).
+ *
+ * Renderer-only (adapters are out of scope for `cortex plugin reload` in
+ * this slice — see `docs/plugin-sdk.md` §Runtime lifecycle for the
+ * rationale: adapter re-construction needs binding-seed + demux-key inputs
+ * `GatewayAdapterFactory` owns today, tracked separately at cortex#1896).
+ */
+export async function reimportRendererPlugin(
+  bundle: DiscoveredBundle,
+  opts: { bust: boolean },
+): Promise<ReimportRendererResult> {
+  const { manifest, bundleName } = bundle;
+  const fail = (stage: string, reason: string): ReimportRendererResult => {
+    process.stderr.write(
+      `cortex plugin-loader: reload of ${bundleName} (renderer:${manifest.id}) refused at ${stage}: ${reason}\n`,
+    );
+    return { ok: false, stage, reason };
+  };
+
+  if (manifest.kind !== "renderer") {
+    return fail("kind_check", `reimportRendererPlugin only supports renderer bundles; "${bundleName}" is kind "${manifest.kind}"`);
+  }
+
+  const resolved = resolveEntryWithinBundle(bundle.installPath, manifest.entry);
+  if (!resolved.ok) {
+    return fail("entry_containment", resolved.reason);
+  }
+
+  let imported: unknown;
+  try {
+    // See doc comment: plain path + query-bust for reload; file:// URL never
+    // busts in bun 1.3.2 (scratch-verified cortex#1793).
+    const specifier = opts.bust ? `${resolved.absPath}?v=${Date.now()}` : pathToFileURL(resolved.absPath).href;
+    const mod: unknown = await import(specifier);
+    imported = isRecord(mod) ? mod.default : undefined;
+  } catch (err) {
+    return fail("import", `entry module threw at re-import: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!isRendererPluginShape(imported)) {
+    return fail("shape_validate", "default export does not satisfy the RendererPlugin shape");
+  }
+  const id = imported.id;
+  const rendererKind = imported.rendererKind;
+  if (id !== manifest.id) {
+    return fail("shape_validate", `default export's id ("${id}") does not match the manifest ("${manifest.id}")`);
+  }
+  if (rendererKind !== manifest.id) {
+    return fail(
+      "shape_validate",
+      `default export's rendererKind ("${rendererKind}") does not match its own id ("${manifest.id}")`,
+    );
+  }
+  // Same TOCTOU closure as `loadOneBundle`'s renderer branch — a frozen,
+  // decoupled copy pinned to the trusted `manifest` values.
+  const plugin: RendererPlugin = Object.freeze({
+    ...imported,
+    kind: manifest.kind,
+    id: manifest.id,
+    rendererKind: manifest.id,
+  });
+  return { ok: true, plugin };
+}

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -24,6 +24,8 @@ import {
   createSystemAdapterRecoveredEvent,
   createSystemDispatchStageEvent,
   createSystemInboundAbortedEvent,
+  createSystemPluginReloadFailedEvent,
+  createSystemPluginUnloadedEvent,
   type SystemEventSource,
 } from "../system-events";
 import { emitSystemAccessDenied } from "../emit-system-access-denied";
@@ -917,5 +919,108 @@ describe("emitSystemAccessDenied — drop-site emit helper (cortex#932)", () => 
       }),
     ).not.toThrow();
     expect(published.length).toBe(0);
+  });
+});
+
+describe("createSystemPluginUnloadedEvent (cortex#1793, S8)", () => {
+  const SOURCE: SystemEventSource = {
+    principal: "andreas",
+    agent: "cortex",
+    instance: "local",
+  };
+
+  test("required fields populated; envelope passes schema validation", () => {
+    const env = createSystemPluginUnloadedEvent({
+      source: SOURCE,
+      bundleName: "cli-tail-renderer",
+      kind: "renderer",
+      pluginId: "cli-tail",
+      instanceId: "cli-tail",
+    });
+    expect(env.type).toBe("system.plugin.unloaded");
+    expect(env.source).toBe("andreas.cortex.local");
+    expect(env.payload).toEqual({
+      bundle_name: "cli-tail-renderer",
+      kind: "renderer",
+      plugin_id: "cli-tail",
+      instance_id: "cli-tail",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("adapter kind — instance_id distinct from plugin_id", () => {
+    const env = createSystemPluginUnloadedEvent({
+      source: SOURCE,
+      bundleName: "acme-chat-adapter",
+      kind: "adapter",
+      pluginId: "acme-chat",
+      instanceId: "acme-chat:guild-123",
+    });
+    expect((env.payload as { plugin_id: string }).plugin_id).toBe("acme-chat");
+    expect((env.payload as { instance_id: string }).instance_id).toBe("acme-chat:guild-123");
+  });
+});
+
+describe("createSystemPluginReloadFailedEvent (cortex#1793, S8)", () => {
+  const SOURCE: SystemEventSource = {
+    principal: "andreas",
+    agent: "cortex",
+    instance: "local",
+  };
+
+  test("required fields only — optional fields omitted, not undefined-valued", () => {
+    const env = createSystemPluginReloadFailedEvent({
+      source: SOURCE,
+      bundleName: "cli-tail-renderer",
+      stage: "cache_bust_reimport",
+      reason: "import() threw: SyntaxError",
+    });
+    expect(env.type).toBe("system.plugin.reload_failed");
+    expect(env.payload).toEqual({
+      bundle_name: "cli-tail-renderer",
+      stage: "cache_bust_reimport",
+      reason: "import() threw: SyntaxError",
+    });
+    expect(env.payload).not.toHaveProperty("kind");
+    expect(env.payload).not.toHaveProperty("plugin_id");
+    expect(env.payload).not.toHaveProperty("instance_id");
+    // NOTE: NOT asserting `validateEnvelope(env).ok` here — deliberately.
+    // `envelope-validator.ts`'s `/type` pattern
+    // (`^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`) does not admit
+    // underscores within a segment, and `reload_failed` (like the
+    // already-shipped sibling `load_failed`, plus `system.bus.notify_discord`,
+    // `system.bus.reflex_activation_failed`, `system.gateway.routing_decision`,
+    // …) uses one. This is a PRE-EXISTING gap in the schema pattern vs. the
+    // established `snake_case` leaf-segment convention across MANY `system.*`
+    // event families already in production — not introduced by this event,
+    // and out of this slice's scope to fix (the pattern is only enforced on
+    // the SUBSCRIBER side, `myelin/subscriber.ts`, not at publish time, so it
+    // has never blocked these events from actually flowing). Flagged as a
+    // residual finding rather than silently renamed to dodge the regex.
+    expect(env.type).toBe("system.plugin.reload_failed");
+  });
+
+  test("all optional fields populated", () => {
+    const env = createSystemPluginReloadFailedEvent({
+      source: SOURCE,
+      bundleName: "cli-tail-renderer",
+      kind: "renderer",
+      pluginId: "cli-tail",
+      instanceId: "cli-tail",
+      stage: "construct",
+      reason: "createRenderer threw",
+    });
+    expect(env.payload).toEqual({
+      bundle_name: "cli-tail-renderer",
+      kind: "renderer",
+      plugin_id: "cli-tail",
+      instance_id: "cli-tail",
+      stage: "construct",
+      reason: "createRenderer threw",
+    });
+    // See the note above — `reload_failed` matches the established (if
+    // schema-pattern-noncompliant) `system.*` snake_case convention;
+    // `validateEnvelope` is not asserted here for the same pre-existing-gap
+    // reason.
   });
 });

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -24,6 +24,8 @@ import {
   createSystemAdapterRecoveredEvent,
   createSystemDispatchStageEvent,
   createSystemInboundAbortedEvent,
+  createSystemPluginControlRequestEvent,
+  createSystemPluginControlResponseEvent,
   createSystemPluginReloadFailedEvent,
   createSystemPluginUnloadedEvent,
   type SystemEventSource,
@@ -975,7 +977,7 @@ describe("createSystemPluginReloadFailedEvent (cortex#1793, S8)", () => {
       stage: "cache_bust_reimport",
       reason: "import() threw: SyntaxError",
     });
-    expect(env.type).toBe("system.plugin.reload_failed");
+    expect(env.type).toBe("system.plugin.reload-failed");
     expect(env.payload).toEqual({
       bundle_name: "cli-tail-renderer",
       stage: "cache_bust_reimport",
@@ -984,20 +986,19 @@ describe("createSystemPluginReloadFailedEvent (cortex#1793, S8)", () => {
     expect(env.payload).not.toHaveProperty("kind");
     expect(env.payload).not.toHaveProperty("plugin_id");
     expect(env.payload).not.toHaveProperty("instance_id");
-    // NOTE: NOT asserting `validateEnvelope(env).ok` here — deliberately.
-    // `envelope-validator.ts`'s `/type` pattern
-    // (`^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`) does not admit
-    // underscores within a segment, and `reload_failed` (like the
-    // already-shipped sibling `load_failed`, plus `system.bus.notify_discord`,
+    // `reload-failed` (hyphen) — NOT `reload_failed`. Confirmed via a live
+    // NATS round trip (S8 completion pass) that a type violating the
+    // vendored `/type` pattern (`^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`
+    // — no underscores) publishes without error but is SILENTLY DROPPED by
+    // every standard push-mode subscriber (`runtime.subscribe()` +
+    // `onEnvelope`, via `myelin/subscriber.ts`'s schema check). The
+    // already-shipped sibling `system.plugin.load_failed` (S6, on `main`)
+    // and several older `system.*` families (`system.bus.notify_discord`,
     // `system.bus.reflex_activation_failed`, `system.gateway.routing_decision`,
-    // …) uses one. This is a PRE-EXISTING gap in the schema pattern vs. the
-    // established `snake_case` leaf-segment convention across MANY `system.*`
-    // event families already in production — not introduced by this event,
-    // and out of this slice's scope to fix (the pattern is only enforced on
-    // the SUBSCRIBER side, `myelin/subscriber.ts`, not at publish time, so it
-    // has never blocked these events from actually flowing). Flagged as a
-    // residual finding rather than silently renamed to dodge the regex.
-    expect(env.type).toBe("system.plugin.reload_failed");
+    // …) still carry this bug — out of scope to mass-fix here (separate,
+    // coordinated change), but `reload-failed` is spelled correctly since
+    // it ships in THIS slice.
+    expect(validateEnvelope(env).ok).toBe(true);
   });
 
   test("all optional fields populated", () => {
@@ -1018,9 +1019,80 @@ describe("createSystemPluginReloadFailedEvent (cortex#1793, S8)", () => {
       stage: "construct",
       reason: "createRenderer threw",
     });
-    // See the note above — `reload_failed` matches the established (if
-    // schema-pattern-noncompliant) `system.*` snake_case convention;
-    // `validateEnvelope` is not asserted here for the same pre-existing-gap
-    // reason.
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+});
+
+describe("createSystemPluginControlRequestEvent / createSystemPluginControlResponseEvent (cortex#1793, S8)", () => {
+  const SOURCE: SystemEventSource = {
+    principal: "andreas",
+    agent: "cortex",
+    instance: "cli",
+  };
+
+  test("control-request: schema-valid, correlation_id echoes requestId", () => {
+    const requestId = "072670f4-6128-4781-b82b-17a36af6060a";
+    const env = createSystemPluginControlRequestEvent({
+      source: SOURCE,
+      requestId,
+      action: "unload",
+      instanceId: "discord:guild1",
+    });
+    expect(env.type).toBe("system.plugin.control-request");
+    expect(env.correlation_id).toBe(requestId);
+    expect(env.payload).toEqual({
+      request_id: requestId,
+      action: "unload",
+      instance_id: "discord:guild1",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("control-request: bundleName-only (load) omits instance_id", () => {
+    const env = createSystemPluginControlRequestEvent({
+      source: SOURCE,
+      requestId: "072670f4-6128-4781-b82b-17a36af6060a",
+      action: "load",
+      bundleName: "acme-bundle",
+    });
+    expect(env.payload).toEqual({
+      request_id: "072670f4-6128-4781-b82b-17a36af6060a",
+      action: "load",
+      bundle_name: "acme-bundle",
+    });
+    expect(env.payload).not.toHaveProperty("instance_id");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("control-response: success carries rows, schema-valid", () => {
+    const requestId = "072670f4-6128-4781-b82b-17a36af6060a";
+    const env = createSystemPluginControlResponseEvent({
+      source: SOURCE,
+      requestId,
+      ok: true,
+      rows: [{ kind: "renderer", platformOrKind: "pagerduty", instanceId: "pagerduty", bundleName: "in-tree", running: true }],
+    });
+    expect(env.type).toBe("system.plugin.control-response");
+    expect(env.correlation_id).toBe(requestId);
+    expect(env.payload.ok).toBe(true);
+    expect(env.payload.rows).toEqual([
+      { kind: "renderer", platformOrKind: "pagerduty", instanceId: "pagerduty", bundleName: "in-tree", running: true },
+    ]);
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("control-response: failure carries detail, no rows", () => {
+    const env = createSystemPluginControlResponseEvent({
+      source: SOURCE,
+      requestId: "072670f4-6128-4781-b82b-17a36af6060a",
+      ok: false,
+      detail: "no plugin instance \"ghost\" is currently live",
+    });
+    expect(env.payload).toEqual({
+      request_id: "072670f4-6128-4781-b82b-17a36af6060a",
+      ok: false,
+      detail: 'no plugin instance "ghost" is currently live',
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
   });
 });

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1808,3 +1808,102 @@ export function createSystemPluginLoadedEvent(
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// system.plugin.unloaded / system.plugin.reload_failed — cortex#1793 (S8,
+// ADR-0024 D3)
+// ---------------------------------------------------------------------------
+
+/**
+ * S8's runtime-lifecycle twins of the S6 boot-time `system.plugin.loaded` /
+ * `system.plugin.load_failed` pair, above. Same `system.plugin.*` family
+ * (never a separate `system.adapter.*`/`system.renderer.*` namespace — the
+ * SCOPE AMENDED comment on cortex#1793 is explicit that S8 stays consistent
+ * with S6's naming rather than forking one), same secret-free reason-string
+ * discipline, same per-plugin fail-isolation posture: one detach/reload
+ * outcome never blocks or masks another's.
+ *
+ * `createSystemPluginUnloadedEvent` fires on a SUCCESSFUL runtime detach
+ * (`cortex plugin unload`, or a reconcile-driven detach of a bundle removed
+ * from disk) — the adapter/renderer instance is gone, its resources released.
+ * `createSystemPluginReloadFailedEvent` fires when a `cortex plugin reload`
+ * (cache-bust re-`import()` + detach-old/attach-new) fails at any stage —
+ * the OLD instance is left running (D3: reload never tears down the live
+ * instance before the replacement is confirmed constructible).
+ */
+export interface SystemPluginUnloadedOpts {
+  source: SystemEventSource;
+  /** arc package name the bundle installed under, or the in-tree module name
+   *  for a never-extracted anchor (mock adapter / dashboard renderer). */
+  bundleName: string;
+  kind: "adapter" | "renderer";
+  pluginId: string;
+  /** The specific live instance detached (`PlatformAdapter.instanceId` /
+   *  `Renderer.id`) — distinct from `pluginId`, which names the plugin
+   *  CLASS a registry entry is keyed by (ADR-0024 D5 "registry keys plugin
+   *  CLASSES, not instances"). */
+  instanceId: string;
+  classification?: Classification;
+}
+
+/**
+ * Construct a `system.plugin.unloaded` envelope. Subject convention:
+ * `local.{principal}.system.plugin.unloaded`.
+ */
+export function createSystemPluginUnloadedEvent(
+  opts: SystemPluginUnloadedOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.plugin.unloaded",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    payload: {
+      bundle_name: opts.bundleName,
+      kind: opts.kind,
+      plugin_id: opts.pluginId,
+      instance_id: opts.instanceId,
+    },
+  });
+}
+
+export interface SystemPluginReloadFailedOpts {
+  source: SystemEventSource;
+  bundleName: string;
+  kind?: "adapter" | "renderer";
+  pluginId?: string;
+  /** The live instance a failed reload left running (unchanged) — present
+   *  whenever the old instance could be identified, absent only when the
+   *  failure occurred before an existing instance was resolved at all. */
+  instanceId?: string;
+  /** Which stage of cache-bust-reimport → construct → detach-old →
+   *  attach-new the failure occurred at. Open string, mirroring
+   *  `SystemPluginLoadFailedOpts.stage` — the reconcile module is the single
+   *  source of truth for the values it actually emits. */
+  stage: string;
+  /** Human-readable, secret-free failure detail. */
+  reason: string;
+  classification?: Classification;
+}
+
+/**
+ * Construct a `system.plugin.reload_failed` envelope. Subject convention:
+ * `local.{principal}.system.plugin.reload_failed`. The old instance is left
+ * running — this event reports a FAILED reload attempt, never a detach.
+ */
+export function createSystemPluginReloadFailedEvent(
+  opts: SystemPluginReloadFailedOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.plugin.reload_failed",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    payload: {
+      bundle_name: opts.bundleName,
+      ...(opts.kind !== undefined && { kind: opts.kind }),
+      ...(opts.pluginId !== undefined && { plugin_id: opts.pluginId }),
+      ...(opts.instanceId !== undefined && { instance_id: opts.instanceId }),
+      stage: opts.stage,
+      reason: opts.reason,
+    },
+  });
+}

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1907,3 +1907,129 @@ export function createSystemPluginReloadFailedEvent(
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// system.plugin.control_request / control_response — cortex#1793 (S8)
+// CLI-to-daemon runtime plugin control channel
+// ---------------------------------------------------------------------------
+
+/**
+ * `cortex plugin list|unload|reload|load` (S8) needs to read + mutate LIVE
+ * in-process daemon state (attached adapters, registered renderers) from a
+ * separate, short-lived CLI process. No admin/control channel for this
+ * existed before S8 — `cortex network status` (the precedent the S8 brief
+ * says to verify) reads config files + the nats-server's own `/leafz`
+ * monitor HTTP endpoint, NEITHER of which reaches into the cortex daemon
+ * process's memory. `SurfaceGateway`'s in-memory `adapters`/`attachedSeeds`
+ * and the renderer boot loop's `Renderer` instances exist ONLY inside the
+ * running daemon.
+ *
+ * Rather than open a second raw NATS connection with core request/reply
+ * (bypassing the myelin envelope/sovereignty pipeline `runtime.publish`/
+ * `runtime.subscribe`/`onEnvelope` already provide — and the pattern
+ * `cortex network ping` already establishes for a short-lived CLI process:
+ * `startMyelinRuntime(config, …)` against the SAME `cortex.yaml`), this pair
+ * of `system.plugin.*` events implements request/reply ON TOP of the
+ * existing publish/subscribe primitives:
+ *
+ *   1. The CLI opens its own `MyelinRuntime` against the principal's
+ *      `cortex.yaml`, subscribes to `local.{principal}.system.plugin.control_response`,
+ *      publishes a `control_request` envelope carrying a fresh UUID
+ *      `correlation_id`, and awaits a `control_response` bearing the SAME
+ *      `correlation_id` (bounded timeout).
+ *   2. The running daemon subscribes to `control_request` at boot
+ *      (`src/gateway/plugin-control-server.ts`), executes the requested
+ *      `list`/`unload`/`reload`/`load` action against its own live
+ *      `adapters[]` / renderer-handle map / `SurfaceGateway`
+ *      (`src/gateway/plugin-runtime.ts`), and replies with a
+ *      `control_response` carrying the same `correlation_id`.
+ *
+ * Local-only by construction: `local.{principal}.system.plugin.control_*`
+ * is never a `federated.*` subject, so it structurally cannot cross a leaf
+ * to a peer stack (leaf export/import lists only ever name `local.`/
+ * `federated.` prefixed patterns elsewhere in this codebase — a plugin
+ * control channel reaching across a federation boundary would let one
+ * principal unload another principal's adapters, which must never be
+ * possible). `classification: "local"` (the `system.*` default) matches.
+ *
+ * Payload is intentionally a thin, generic RPC envelope (`action` +
+ * loosely-typed `args`/`result`) rather than one dedicated event type per
+ * verb — this is administrative RPC, not a domain/audit event stream, and
+ * the four verbs share one request/response shape.
+ */
+export interface SystemPluginControlRequestOpts {
+  source: SystemEventSource;
+  /** Fresh UUID this request's response must echo back. */
+  requestId: string;
+  action: "list" | "unload" | "reload" | "load";
+  /** `unload`/`reload` target a live instance id; `load` targets a bundle name. */
+  instanceId?: string;
+  bundleName?: string;
+  classification?: Classification;
+}
+
+/**
+ * Construct a `system.plugin.control_request` envelope. Subject convention:
+ * `local.{principal}.system.plugin.control_request` — the daemon-side
+ * listener subscribes here; the CLI publishes here.
+ */
+export function createSystemPluginControlRequestEvent(
+  opts: SystemPluginControlRequestOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.plugin.control_request",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    correlationId: opts.requestId,
+    payload: {
+      request_id: opts.requestId,
+      action: opts.action,
+      ...(opts.instanceId !== undefined && { instance_id: opts.instanceId }),
+      ...(opts.bundleName !== undefined && { bundle_name: opts.bundleName }),
+    },
+  });
+}
+
+/** One row of `cortex plugin list` output — see `src/gateway/plugin-runtime.ts`. */
+export interface SystemPluginControlListRow {
+  kind: "adapter" | "renderer";
+  platformOrKind: string;
+  instanceId: string;
+  bundleName: string;
+  running: boolean;
+}
+
+export interface SystemPluginControlResponseOpts {
+  source: SystemEventSource;
+  /** Echoes the request's `requestId` — how the CLI matches reply to call. */
+  requestId: string;
+  ok: boolean;
+  /** Populated for a successful `list`; omitted otherwise. */
+  rows?: SystemPluginControlListRow[];
+  /** Human-readable outcome — populated for `unload`/`reload`/`load` (both
+   *  success and failure) and for a failed `list`. */
+  detail?: string;
+  classification?: Classification;
+}
+
+/**
+ * Construct a `system.plugin.control_response` envelope — the daemon's reply
+ * to a `control_request`. Subject convention:
+ * `local.{principal}.system.plugin.control_response`.
+ */
+export function createSystemPluginControlResponseEvent(
+  opts: SystemPluginControlResponseOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.plugin.control_response",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    correlationId: opts.requestId,
+    payload: {
+      request_id: opts.requestId,
+      ok: opts.ok,
+      ...(opts.rows !== undefined && { rows: opts.rows }),
+      ...(opts.detail !== undefined && { detail: opts.detail }),
+    },
+  });
+}

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1810,7 +1810,7 @@ export function createSystemPluginLoadedEvent(
 }
 
 // ---------------------------------------------------------------------------
-// system.plugin.unloaded / system.plugin.reload_failed — cortex#1793 (S8,
+// system.plugin.unloaded / system.plugin.reload-failed — cortex#1793 (S8,
 // ADR-0024 D3)
 // ---------------------------------------------------------------------------
 
@@ -1822,6 +1822,27 @@ export function createSystemPluginLoadedEvent(
  * with S6's naming rather than forking one), same secret-free reason-string
  * discipline, same per-plugin fail-isolation posture: one detach/reload
  * outcome never blocks or masks another's.
+ *
+ * **Leaf segment is `reload-failed` (hyphen), NOT `reload_failed`.** The
+ * vendored envelope schema's `/type` pattern
+ * (`^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`, `envelope.schema.json`)
+ * forbids underscores in a type segment. `system.plugin.load_failed` (S6,
+ * already on `main`) and several older `system.*` families
+ * (`system.bus.notify_discord`, `system.bus.reflex_activation_failed`,
+ * `system.gateway.routing_decision`, …) violate this pattern — the schema
+ * check only runs on the SUBSCRIBER side (`myelin/subscriber.ts`), so a
+ * violating envelope publishes without error and is then **silently
+ * dropped by every standard push-mode subscriber** (`runtime.subscribe()` +
+ * `onEnvelope`) — confirmed via a live NATS round-trip while building S8's
+ * `system.plugin.control-request`/`-response` pair (the exact bug this
+ * comment documents: the first draft used `control_request`/`control_response`
+ * and every response silently vanished). `unloaded` has no segment needing
+ * a separator fix; `reload-failed` is spelled correctly here rather than
+ * inheriting the sibling's already-broken convention. `load_failed` is left
+ * as-is — it already shipped on `main` via S6/#1927, and renaming a shipped
+ * wire type is a separate, coordinated fix (flagged, not bundled into this
+ * unrelated slice); every OTHER pre-existing underscore violation across
+ * `system.*` is the same systemic gap and is out of scope here too.
  *
  * `createSystemPluginUnloadedEvent` fires on a SUCCESSFUL runtime detach
  * (`cortex plugin unload`, or a reconcile-driven detach of a bundle removed
@@ -1886,15 +1907,15 @@ export interface SystemPluginReloadFailedOpts {
 }
 
 /**
- * Construct a `system.plugin.reload_failed` envelope. Subject convention:
- * `local.{principal}.system.plugin.reload_failed`. The old instance is left
+ * Construct a `system.plugin.reload-failed` envelope. Subject convention:
+ * `local.{principal}.system.plugin.reload-failed`. The old instance is left
  * running — this event reports a FAILED reload attempt, never a detach.
  */
 export function createSystemPluginReloadFailedEvent(
   opts: SystemPluginReloadFailedOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.plugin.reload_failed",
+    type: "system.plugin.reload-failed",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -1909,7 +1930,7 @@ export function createSystemPluginReloadFailedEvent(
 }
 
 // ---------------------------------------------------------------------------
-// system.plugin.control_request / control_response — cortex#1793 (S8)
+// system.plugin.control-request / control-response — cortex#1793 (S8)
 // CLI-to-daemon runtime plugin control channel
 // ---------------------------------------------------------------------------
 
@@ -1933,18 +1954,18 @@ export function createSystemPluginReloadFailedEvent(
  * existing publish/subscribe primitives:
  *
  *   1. The CLI opens its own `MyelinRuntime` against the principal's
- *      `cortex.yaml`, subscribes to `local.{principal}.system.plugin.control_response`,
- *      publishes a `control_request` envelope carrying a fresh UUID
- *      `correlation_id`, and awaits a `control_response` bearing the SAME
+ *      `cortex.yaml`, subscribes to `local.{principal}.system.plugin.control-response`,
+ *      publishes a `control-request` envelope carrying a fresh UUID
+ *      `correlation_id`, and awaits a `control-response` bearing the SAME
  *      `correlation_id` (bounded timeout).
- *   2. The running daemon subscribes to `control_request` at boot
+ *   2. The running daemon subscribes to `control-request` at boot
  *      (`src/gateway/plugin-control-server.ts`), executes the requested
  *      `list`/`unload`/`reload`/`load` action against its own live
  *      `adapters[]` / renderer-handle map / `SurfaceGateway`
  *      (`src/gateway/plugin-runtime.ts`), and replies with a
- *      `control_response` carrying the same `correlation_id`.
+ *      `control-response` carrying the same `correlation_id`.
  *
- * Local-only by construction: `local.{principal}.system.plugin.control_*`
+ * Local-only by construction: `local.{principal}.system.plugin.control-*`
  * is never a `federated.*` subject, so it structurally cannot cross a leaf
  * to a peer stack (leaf export/import lists only ever name `local.`/
  * `federated.` prefixed patterns elsewhere in this codebase — a plugin
@@ -1969,15 +1990,15 @@ export interface SystemPluginControlRequestOpts {
 }
 
 /**
- * Construct a `system.plugin.control_request` envelope. Subject convention:
- * `local.{principal}.system.plugin.control_request` — the daemon-side
+ * Construct a `system.plugin.control-request` envelope. Subject convention:
+ * `local.{principal}.system.plugin.control-request` — the daemon-side
  * listener subscribes here; the CLI publishes here.
  */
 export function createSystemPluginControlRequestEvent(
   opts: SystemPluginControlRequestOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.plugin.control_request",
+    type: "system.plugin.control-request",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     correlationId: opts.requestId,
@@ -2013,15 +2034,15 @@ export interface SystemPluginControlResponseOpts {
 }
 
 /**
- * Construct a `system.plugin.control_response` envelope — the daemon's reply
- * to a `control_request`. Subject convention:
- * `local.{principal}.system.plugin.control_response`.
+ * Construct a `system.plugin.control-response` envelope — the daemon's reply
+ * to a `control-request`. Subject convention:
+ * `local.{principal}.system.plugin.control-response`.
  */
 export function createSystemPluginControlResponseEvent(
   opts: SystemPluginControlResponseOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.plugin.control_response",
+    type: "system.plugin.control-response",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     correlationId: opts.requestId,

--- a/src/cli/cortex/commands/__tests__/plugin-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/plugin-cli.test.ts
@@ -1,0 +1,133 @@
+/**
+ * cortex#1793 (S8) — `cortex plugin` CLI dispatcher tests.
+ *
+ * Covers the parts of the surface that don't require a live daemon +
+ * NATS connection: help/usage/unknown-subcommand dispatch, and the pure
+ * rendering/parsing helpers in `plugin-lib.ts`. The live round-trip
+ * (`sendPluginControlRequest`) is exercised end-to-end by
+ * `src/gateway/__tests__/plugin-runtime.test.ts` at the domain-logic layer
+ * and by manual verification against a running dev stack (see the S8
+ * completion report) — a real NATS server is out of scope for a unit test
+ * here, matching this repo's existing `network ping`/`network status` test
+ * posture (those also unit-test the pure layer and fake the bus port).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { dispatchPlugin } from "../plugin";
+import {
+  renderPluginList,
+  renderMutationPreview,
+  renderLoadPreview,
+  resolvePrincipalIdForCli,
+} from "../plugin-lib";
+import type { SystemPluginControlListRow } from "../../../../bus/system-events";
+
+// =============================================================================
+// dispatch / usage / help
+// =============================================================================
+
+describe("dispatchPlugin — dispatch/usage/help", () => {
+  test("no subcommand: usage error, exit 2", async () => {
+    const result = await dispatchPlugin([]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("no subcommand specified");
+  });
+
+  test("unknown subcommand: usage error, exit 2", async () => {
+    const result = await dispatchPlugin(["frobnicate"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('unknown subcommand "frobnicate"');
+  });
+
+  test("--help: exit 0, prints usage", async () => {
+    const result = await dispatchPlugin(["--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("cortex plugin");
+    expect(result.stdout).toContain("list");
+    expect(result.stdout).toContain("unload");
+    expect(result.stdout).toContain("reload");
+    expect(result.stdout).toContain("load");
+  });
+
+  test("unload with no instance-id: missing-positional usage error", async () => {
+    const result = await dispatchPlugin(["unload"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("missing required positional argument");
+  });
+
+  test("load with no bundle-name: missing-positional usage error", async () => {
+    const result = await dispatchPlugin(["load"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("missing required positional argument");
+  });
+
+  test("unknown flag: usage error, exit 2", async () => {
+    const result = await dispatchPlugin(["list", "--bogus"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("unknown flag");
+  });
+});
+
+// =============================================================================
+// dry-run preview (no --apply, no network) — unload/reload/load never send a
+// mutating request without --apply; these paths DO reach sendPluginControlRequest
+// for a read-only "list" precheck, so they're exercised via the pure preview
+// renderers directly rather than dispatchPlugin (which would need a live daemon).
+// =============================================================================
+
+describe("dry-run preview renderers (plugin-lib.ts)", () => {
+  const rows: SystemPluginControlListRow[] = [
+    { kind: "renderer", platformOrKind: "pagerduty", instanceId: "pagerduty", bundleName: "acme-pagerduty", running: true },
+  ];
+
+  test("renderMutationPreview: names the real instance found in rows", () => {
+    const preview = renderMutationPreview("unload", "pagerduty", rows);
+    expect(preview).toContain("would unload renderer");
+    expect(preview).toContain("pagerduty");
+    expect(preview).toContain("acme-pagerduty");
+    expect(preview).toContain("--apply");
+  });
+
+  test("renderMutationPreview: absent instance is called out, not silently accepted", () => {
+    const preview = renderMutationPreview("reload", "ghost", rows);
+    expect(preview).toContain('no live instance "ghost" found');
+    expect(preview).toContain("would be refused");
+  });
+
+  test("renderLoadPreview: states intent without needing a live check", () => {
+    const preview = renderLoadPreview("acme-bundle");
+    expect(preview).toContain('load renderer bundle "acme-bundle"');
+    expect(preview).toContain("--apply");
+  });
+
+  test("renderPluginList: empty rows", () => {
+    expect(renderPluginList([])).toContain("no live adapter or renderer instances");
+  });
+
+  test("renderPluginList: aligned columns, all fields present", () => {
+    const out = renderPluginList([
+      { kind: "adapter", platformOrKind: "discord", instanceId: "discord:g1", bundleName: "in-tree", running: true },
+      { kind: "renderer", platformOrKind: "pagerduty", instanceId: "pagerduty", bundleName: "acme-pagerduty", running: true },
+    ]);
+    expect(out).toContain("KIND");
+    expect(out).toContain("discord");
+    expect(out).toContain("discord:g1");
+    expect(out).toContain("pagerduty");
+    expect(out).toContain("acme-pagerduty");
+  });
+});
+
+// =============================================================================
+// resolvePrincipalIdForCli
+// =============================================================================
+
+describe("resolvePrincipalIdForCli", () => {
+  test("returns the principal id when present", () => {
+    expect(resolvePrincipalIdForCli({ id: "meta-factory" })).toBe("meta-factory");
+  });
+
+  test("throws a clear error when principal.id is missing (mirrors the daemon's own resolvePrincipalId)", () => {
+    expect(() => resolvePrincipalIdForCli(undefined)).toThrow(/principal\.id/);
+    expect(() => resolvePrincipalIdForCli({ id: "" })).toThrow(/principal\.id/);
+  });
+});

--- a/src/cli/cortex/commands/plugin-lib.ts
+++ b/src/cli/cortex/commands/plugin-lib.ts
@@ -1,0 +1,199 @@
+/**
+ * `cortex plugin list|load|unload|reload` — cortex#1793 (S8, ADR-0024 D3).
+ *
+ * The CLI-side half of the runtime plugin control channel. Mirrors
+ * `cortex network ping`'s pattern for a short-lived CLI process talking to
+ * the live daemon over the bus (`network-ping-adapters.ts`:
+ * `startMyelinRuntime(config, …)` against the SAME `cortex.yaml` the daemon
+ * booted from) — see `src/bus/system-events.ts`'s
+ * `system.plugin.control_request`/`_response` doc comment for why this rides
+ * `runtime.publish`/`subscribe`/`onEnvelope` rather than a raw NATS
+ * request/reply connection.
+ *
+ * `list` is read-only and always safe. `unload`/`reload`/`load` are
+ * DRY-RUN BY DEFAULT (repo convention — `cortex network`/`cortex stack`):
+ * the CLI first runs `list` to describe what the mutation WOULD do without
+ * sending it; `--apply` is required to actually send the mutating request.
+ */
+
+import { loadConfigWithAgents } from "../../../common/config/loader";
+import { startMyelinRuntime, type MyelinRuntime } from "../../../bus/myelin/runtime";
+import {
+  createSystemPluginControlRequestEvent,
+  type SystemEventSource,
+  type SystemPluginControlListRow,
+} from "../../../bus/system-events";
+
+// =============================================================================
+// Live round trip
+// =============================================================================
+
+export type PluginControlAction = "list" | "unload" | "reload" | "load";
+
+export interface PluginControlRequest {
+  action: PluginControlAction;
+  instanceId?: string;
+  bundleName?: string;
+}
+
+export type PluginControlResult =
+  | { ok: true; rows?: SystemPluginControlListRow[]; detail?: string }
+  | { ok: false; reason: string };
+
+/** Resolve the principal id the SAME way the daemon does (`cortex.ts`'s
+ *  `resolvePrincipalId`) — the request/response subject's `{principal}`
+ *  segment must match exactly or the daemon never sees the request. */
+export function resolvePrincipalIdForCli(principal: { id?: string } | undefined): string {
+  const id = principal?.id;
+  if (id !== undefined && id !== "") return id;
+  throw new Error(
+    "cortex plugin: cannot resolve principal id — cortex.yaml must declare `principal.id`. " +
+      "Run `cortex migrate-config` if upgrading from a v2 config.",
+  );
+}
+
+/**
+ * Send one control request and await the matching response (by
+ * `correlation_id`), or time out. Opens its OWN short-lived `MyelinRuntime`
+ * against `configPath` — reused across a single CLI invocation only; always
+ * stopped before returning.
+ */
+export async function sendPluginControlRequest(
+  configPath: string,
+  request: PluginControlRequest,
+  opts?: { timeoutMs?: number },
+): Promise<PluginControlResult> {
+  const loaded = loadConfigWithAgents(configPath);
+  const principalId = resolvePrincipalIdForCli(loaded.principal);
+  const systemEventSource: SystemEventSource = {
+    principal: principalId,
+    agent: "cortex",
+    // Distinct instance name from the daemon's "local" — this is a
+    // short-lived CLI-side connection, not the daemon's own emission
+    // identity. Purely cosmetic (never read for routing).
+    instance: "cli",
+  };
+
+  const runtime: MyelinRuntime = await startMyelinRuntime(loaded.config);
+  try {
+    if (!runtime.enabled || !runtime.subscribe) {
+      return {
+        ok: false,
+        reason: "cortex plugin: NATS is not configured for this stack (runtime disabled) — nothing to talk to.",
+      };
+    }
+
+    const requestId = crypto.randomUUID();
+    const responseSubject = `local.${principalId}.system.plugin.control_response`;
+    const subscriber = await runtime.subscribe(responseSubject);
+    if (!subscriber) {
+      return { ok: false, reason: "cortex plugin: failed to subscribe for the daemon's response." };
+    }
+
+    const timeoutMs = opts?.timeoutMs ?? 5000;
+    const result = await new Promise<PluginControlResult>((resolve) => {
+      let settled = false;
+      const finish = (r: PluginControlResult): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        unregister();
+        resolve(r);
+      };
+      const timer = setTimeout(() => {
+        finish({
+          ok: false,
+          reason:
+            `cortex plugin: no response from the daemon within ${timeoutMs}ms — is a cortex daemon ` +
+            `running for this config (with a live NATS connection)?`,
+        });
+      }, timeoutMs);
+      const { unregister } = runtime.onEnvelope((envelope, matchedSubject) => {
+        if (matchedSubject !== responseSubject) return;
+        if (envelope.type !== "system.plugin.control_response") return;
+        const payload = envelope.payload as {
+          request_id?: unknown;
+          ok?: unknown;
+          rows?: unknown;
+          detail?: unknown;
+        };
+        if (payload.request_id !== requestId) return;
+        if (payload.ok === true) {
+          finish({
+            ok: true,
+            ...(Array.isArray(payload.rows) && { rows: payload.rows as SystemPluginControlListRow[] }),
+            ...(typeof payload.detail === "string" && { detail: payload.detail }),
+          });
+        } else {
+          finish({
+            ok: false,
+            reason: typeof payload.detail === "string" ? payload.detail : "cortex plugin: request refused (no reason given).",
+          });
+        }
+      });
+
+      runtime
+        .publish(
+          createSystemPluginControlRequestEvent({
+            source: systemEventSource,
+            requestId,
+            action: request.action,
+            ...(request.instanceId !== undefined && { instanceId: request.instanceId }),
+            ...(request.bundleName !== undefined && { bundleName: request.bundleName }),
+          }),
+        )
+        .catch((err: unknown) => {
+          finish({
+            ok: false,
+            reason: `cortex plugin: failed to publish the request: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        });
+    });
+
+    await subscriber.stop();
+    return result;
+  } finally {
+    await runtime.stop();
+  }
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+export function renderPluginList(rows: SystemPluginControlListRow[]): string {
+  if (rows.length === 0) return "(no live adapter or renderer instances)\n";
+  const header = ["KIND", "PLATFORM/KIND", "INSTANCE ID", "BUNDLE", "RUNNING"];
+  const lines = rows.map((r) => [r.kind, r.platformOrKind, r.instanceId, r.bundleName, r.running ? "yes" : "no"]);
+  const widths = header.map((h, i) => Math.max(h.length, ...lines.map((l) => (l[i] ?? "").length)));
+  const fmt = (cols: string[]): string => cols.map((c, i) => c.padEnd(widths[i] ?? 0)).join("  ");
+  return [fmt(header), ...lines.map(fmt)].join("\n") + "\n";
+}
+
+/** Dry-run preview text for `unload`/`reload` — describes the target instance
+ *  found in `rows` (or notes it's absent) without mutating anything. */
+export function renderMutationPreview(
+  verb: "unload" | "reload",
+  instanceId: string,
+  rows: SystemPluginControlListRow[],
+): string {
+  const target = rows.find((r) => r.instanceId === instanceId);
+  if (!target) {
+    return (
+      `(dry-run) no live instance "${instanceId}" found — "cortex plugin ${verb} ${instanceId} --apply" ` +
+      `would be refused by the daemon.\n`
+    );
+  }
+  return (
+    `(dry-run) would ${verb} ${target.kind} "${instanceId}" (${target.platformOrKind}, bundle "${target.bundleName}").\n` +
+    `Re-run with --apply to do it.\n`
+  );
+}
+
+/** Dry-run preview text for `load` — describes what a live daemon check would
+ *  need to confirm; `load` doesn't have a pre-check as cheap as `list`
+ *  (the bundle may not be live yet, which is the whole point), so the
+ *  preview is a plain statement of intent. */
+export function renderLoadPreview(bundleName: string): string {
+  return `(dry-run) would load renderer bundle "${bundleName}". Re-run with --apply to do it.\n`;
+}

--- a/src/cli/cortex/commands/plugin-lib.ts
+++ b/src/cli/cortex/commands/plugin-lib.ts
@@ -6,7 +6,7 @@
  * the live daemon over the bus (`network-ping-adapters.ts`:
  * `startMyelinRuntime(config, …)` against the SAME `cortex.yaml` the daemon
  * booted from) — see `src/bus/system-events.ts`'s
- * `system.plugin.control_request`/`_response` doc comment for why this rides
+ * `system.plugin.control-request`/`_response` doc comment for why this rides
  * `runtime.publish`/`subscribe`/`onEnvelope` rather than a raw NATS
  * request/reply connection.
  *
@@ -84,7 +84,7 @@ export async function sendPluginControlRequest(
     }
 
     const requestId = crypto.randomUUID();
-    const responseSubject = `local.${principalId}.system.plugin.control_response`;
+    const responseSubject = `local.${principalId}.system.plugin.control-response`;
     const subscriber = await runtime.subscribe(responseSubject);
     if (!subscriber) {
       return { ok: false, reason: "cortex plugin: failed to subscribe for the daemon's response." };
@@ -110,7 +110,7 @@ export async function sendPluginControlRequest(
       }, timeoutMs);
       const { unregister } = runtime.onEnvelope((envelope, matchedSubject) => {
         if (matchedSubject !== responseSubject) return;
-        if (envelope.type !== "system.plugin.control_response") return;
+        if (envelope.type !== "system.plugin.control-response") return;
         const payload = envelope.payload as {
           request_id?: unknown;
           ok?: unknown;

--- a/src/cli/cortex/commands/plugin.ts
+++ b/src/cli/cortex/commands/plugin.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env bun
+/**
+ * `cortex plugin <subcommand>` — cortex#1793 (S8, ADR-0024 D3).
+ *
+ * Runtime attach/detach/reload for adapters and renderers WITHOUT restarting
+ * the daemon. Talks to a running daemon over the bus
+ * (`src/cli/cortex/commands/plugin-lib.ts` + `src/gateway/plugin-control-server.ts`
+ * on the daemon side) — every subcommand requires a live daemon with NATS
+ * configured for the target `--config`.
+ *
+ * Subcommands:
+ *   list                     Live adapters + renderers: kind, platform/kind,
+ *                            instance id, bundle (or "in-tree"), running.
+ *   unload <instance-id>     Detach a live instance. DRY-RUN by default;
+ *                            `--apply` sends the mutation.
+ *   reload <instance-id>     Cache-bust re-import + attach-before-detach.
+ *                            RENDERER-ONLY in this slice — see
+ *                            `src/gateway/plugin-runtime.ts`'s module doc for
+ *                            why adapter reload is out of scope (cortex#1896).
+ *                            DRY-RUN by default; `--apply` sends the mutation.
+ *   load <bundle-name>       Activate a renderer bundle whose `renderers[]`
+ *                            config entry failed to construct at boot because
+ *                            the plugin hadn't loaded yet. DRY-RUN by default;
+ *                            `--apply` sends the mutation.
+ *
+ * SAFETY (mirrors `cortex network` / `cortex stack`): every mutating verb is
+ * dry-run unless `--apply`.
+ *
+ * Exit codes: 0 success · 1 operational failure (refused / timed out) · 2 usage.
+ */
+
+import { CliArgsError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { type ExitResult } from "./_shared/exit-result";
+import { parseSubcommandArgs, type FlagMap, type SubcommandSpec } from "./_shared/parser";
+import {
+  renderLoadPreview,
+  renderMutationPreview,
+  renderPluginList,
+  sendPluginControlRequest,
+  type PluginControlResult,
+} from "./plugin-lib";
+import { DEFAULT_CONFIG } from "../../../common/pidfile";
+
+export { type ExitResult } from "./_shared/exit-result";
+
+type PluginSubcommand = "list" | "unload" | "reload" | "load";
+
+const SPEC: SubcommandSpec<PluginSubcommand> = {
+  cliName: "plugin",
+  subcommands: {
+    list: { positionals: [], flags: { "--config": "value" } },
+    unload: { positionals: ["instance-id"], flags: { "--config": "value", "--apply": "bool" } },
+    reload: { positionals: ["instance-id"], flags: { "--config": "value", "--apply": "bool" } },
+    load: { positionals: ["bundle-name"], flags: { "--config": "value", "--apply": "bool" } },
+  },
+  universal: { "--json": "bool", "--help": "bool", "-h": "bool" },
+};
+
+export async function dispatchPlugin(argv: string[]): Promise<ExitResult> {
+  let parsed;
+  try {
+    parsed = parseSubcommandArgs(SPEC, argv);
+  } catch (err) {
+    if (err instanceof CliArgsError) {
+      return { exitCode: 2, stdout: "", stderr: `cortex plugin: ${err.message}\n${topLevelHelp()}` };
+    }
+    throw err;
+  }
+
+  const json = parsed.flags["--json"] === true;
+
+  if (parsed.subcommand === "help" || parsed.help) {
+    return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
+  }
+  if (parsed.subcommand === "unknown") {
+    const msg =
+      parsed.rawSubcommand === "" ? "usage error — no subcommand specified." : `unknown subcommand "${parsed.rawSubcommand}".`;
+    return { exitCode: 2, stdout: "", stderr: `cortex plugin: ${msg}\n${topLevelHelp()}` };
+  }
+
+  const configPath = optionalValueFlag(parsed.flags, "--config") ?? DEFAULT_CONFIG;
+
+  switch (parsed.subcommand) {
+    case "list":
+      return runList(configPath, json);
+    case "unload":
+      return runMutation("unload", configPath, parsed.positionals["instance-id"] ?? "", parsed.flags, json);
+    case "reload":
+      return runMutation("reload", configPath, parsed.positionals["instance-id"] ?? "", parsed.flags, json);
+    case "load":
+      return runLoad(configPath, parsed.positionals["bundle-name"] ?? "", parsed.flags, json);
+  }
+}
+
+// =============================================================================
+// Subcommand handlers
+// =============================================================================
+
+async function runList(configPath: string, json: boolean): Promise<ExitResult> {
+  let result: PluginControlResult;
+  try {
+    result = await sendPluginControlRequest(configPath, { action: "list" });
+  } catch (err) {
+    return operationalError(err, json);
+  }
+  if (!result.ok) {
+    return json
+      ? { exitCode: 1, stdout: renderJson(envelopeError(result.reason)), stderr: "" }
+      : { exitCode: 1, stdout: "", stderr: `cortex plugin: ${result.reason}\n` };
+  }
+  const rows = result.rows ?? [];
+  return json
+    ? { exitCode: 0, stdout: renderJson(envelopeOk(rows)), stderr: "" }
+    : { exitCode: 0, stdout: renderPluginList(rows), stderr: "" };
+}
+
+async function runMutation(
+  verb: "unload" | "reload",
+  configPath: string,
+  instanceId: string,
+  flags: FlagMap,
+  json: boolean,
+): Promise<ExitResult> {
+  const apply = flags["--apply"] === true;
+
+  if (!apply) {
+    // Dry-run: fetch the current list so the preview names a REAL instance
+    // (or clearly says there isn't one) rather than guessing.
+    let listResult: PluginControlResult;
+    try {
+      listResult = await sendPluginControlRequest(configPath, { action: "list" });
+    } catch (err) {
+      return operationalError(err, json);
+    }
+    if (!listResult.ok) {
+      return json
+        ? { exitCode: 1, stdout: renderJson(envelopeError(listResult.reason)), stderr: "" }
+        : { exitCode: 1, stdout: "", stderr: `cortex plugin: ${listResult.reason}\n` };
+    }
+    const preview = renderMutationPreview(verb, instanceId, listResult.rows ?? []);
+    return json
+      ? { exitCode: 0, stdout: renderJson(envelopeOk([{ dryRun: true, preview }])), stderr: "" }
+      : { exitCode: 0, stdout: preview, stderr: "" };
+  }
+
+  let result: PluginControlResult;
+  try {
+    result = await sendPluginControlRequest(configPath, { action: verb, instanceId });
+  } catch (err) {
+    return operationalError(err, json);
+  }
+  if (!result.ok) {
+    return json
+      ? { exitCode: 1, stdout: renderJson(envelopeError(result.reason)), stderr: "" }
+      : { exitCode: 1, stdout: "", stderr: `cortex plugin: ${result.reason}\n` };
+  }
+  const detail = result.detail ?? `${verb} ok`;
+  return json
+    ? { exitCode: 0, stdout: renderJson(envelopeOk([{ detail }])), stderr: "" }
+    : { exitCode: 0, stdout: `${detail}\n`, stderr: "" };
+}
+
+async function runLoad(configPath: string, bundleName: string, flags: FlagMap, json: boolean): Promise<ExitResult> {
+  const apply = flags["--apply"] === true;
+
+  if (!apply) {
+    const preview = renderLoadPreview(bundleName);
+    return json
+      ? { exitCode: 0, stdout: renderJson(envelopeOk([{ dryRun: true, preview }])), stderr: "" }
+      : { exitCode: 0, stdout: preview, stderr: "" };
+  }
+
+  let result: PluginControlResult;
+  try {
+    result = await sendPluginControlRequest(configPath, { action: "load", bundleName });
+  } catch (err) {
+    return operationalError(err, json);
+  }
+  if (!result.ok) {
+    return json
+      ? { exitCode: 1, stdout: renderJson(envelopeError(result.reason)), stderr: "" }
+      : { exitCode: 1, stdout: "", stderr: `cortex plugin: ${result.reason}\n` };
+  }
+  const detail = result.detail ?? "load ok";
+  return json
+    ? { exitCode: 0, stdout: renderJson(envelopeOk([{ detail }])), stderr: "" }
+    : { exitCode: 0, stdout: `${detail}\n`, stderr: "" };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function optionalValueFlag(flags: FlagMap, name: string): string | undefined {
+  const v = flags[name];
+  return typeof v === "string" ? v : undefined;
+}
+
+function operationalError(err: unknown, json: boolean): ExitResult {
+  const reason = err instanceof Error ? err.message : String(err);
+  return json
+    ? { exitCode: 1, stdout: renderJson(envelopeError(reason)), stderr: "" }
+    : { exitCode: 1, stdout: "", stderr: `cortex plugin: ${reason}\n` };
+}
+
+function topLevelHelp(): string {
+  return `cortex plugin — runtime attach/detach/reload for adapters + renderers (cortex#1793, S8)
+
+Usage:
+  cortex plugin list [--config <path>] [--json]
+  cortex plugin unload <instance-id> [--apply] [--config <path>] [--json]
+  cortex plugin reload <instance-id> [--apply] [--config <path>] [--json]
+  cortex plugin load <bundle-name> [--apply] [--config <path>] [--json]
+
+Every subcommand talks to a RUNNING daemon over the bus — it must be booted
+against the same --config with NATS configured, or every subcommand fails
+with a timeout.
+
+Subcommands:
+  list    Live adapters + renderers: kind, platform/kind, instance id, bundle
+          name ("in-tree" for statically-registered plugins), running state.
+  unload  Detach a live instance. Renderers: always supported. Adapters: only
+          when the daemon is running with CORTEX_GATEWAY=1 (per-stack
+          adapters built by the classic boot path have no live detach path —
+          ADR-0024 blocker #13).
+  reload  Cache-bust re-import (verified working for a plain filesystem path;
+          a file:// URL does NOT cache-bust in bun 1.3.2 — see
+          src/adapters/loader.ts's reimportRendererPlugin doc) + attach the
+          new instance before detaching the old one. RENDERER-ONLY in this
+          slice, and only for a renderer loaded from an arc bundle (an
+          in-tree renderer has no bundle to re-import — restart instead).
+          Adapter reload needs GatewayAdapterFactory reconstruction
+          (cortex#1896), out of scope here.
+  load    Activate a renderer whose "renderers[]" config entry exists but
+          failed to construct at boot (the plugin hadn't loaded yet).
+          Adapter load: same #1896 rationale as reload.
+
+Safety:
+  unload / reload / load default to DRY-RUN (describe what would happen,
+  touch nothing live). Pass --apply to send the mutating request.
+
+Flags:
+  --config <path>  cortex.yaml (or config-split pointer) the target daemon
+                    booted from. Default: ${DEFAULT_CONFIG}.
+  --apply           Send the mutating request (unload/reload/load only).
+  --json            Emit a { status, items, data, error } envelope.
+`;
+}
+
+if (import.meta.main) {
+  const result = await dispatchPlugin(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -131,10 +131,12 @@ import {
 } from "./bus/myelin/envelope-validator";
 
 import { attachLegacyOutboundLog } from "./adapters/discord";
-import { resolveRendererPluginAndConfig, type Renderer } from "./renderers";
+import { resolveRendererPluginAndConfig, UnimplementedRendererKindError, type Renderer } from "./renderers";
 import { createDefaultSurfacePluginRegistry, validateSurfacesAgainstRegistry } from "./adapters/registry";
 import { loadExternalPlugins } from "./adapters/loader";
 import { createSystemPluginLoadFailedEvent, createSystemPluginLoadedEvent } from "./bus/system-events";
+import { startPluginControlServer } from "./gateway/plugin-control-server";
+import type { PluginRuntimeDeps, RendererHandle } from "./gateway/plugin-runtime";
 import { deriveStackId, DEFAULT_STREAM_MAX_BYTES } from "./common/types/cortex-config";
 import type {
   Agent,
@@ -316,6 +318,7 @@ import { dispatchOffer } from "./cli/cortex/commands/offer";
 import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
 import { dispatchRelease } from "./cli/cortex/commands/release";
 import { dispatchStack } from "./cli/cortex/commands/stack";
+import { dispatchPlugin } from "./cli/cortex/commands/plugin";
 import { dispatchConfig } from "./cli/cortex/commands/config";
 import { dispatchCreds } from "./cli/cortex/commands/creds";
 import { dispatchStepUp } from "./cli/cortex/commands/stepup";
@@ -3331,6 +3334,28 @@ export async function startCortex(
   });
 
   const renderers: Renderer[] = [];
+  // cortex#1793 (S8, ADR-0024 D3) — the renderer instance-handle map runtime
+  // attach/detach/reload reads and mutates (`src/gateway/plugin-runtime.ts`).
+  // Retains what `SurfaceRouter.register()`'s `{ unregister }` return value
+  // used to be discarded here (ADR-0024's "the renderer boot loop simply
+  // discards it" finding) — S8 keeps it, so a live renderer can leave the
+  // router's dispatch list before teardown instead of only at full `stop()`.
+  const rendererHandles = new Map<string, RendererHandle>();
+  // `pluginLoadResult.loaded` (composed above, S6) tells us which renderer
+  // ids came from an arc-installed bundle vs an in-tree registration — the
+  // `bundleName` a `cortex plugin reload` needs to find the bundle again.
+  const loadedRendererBundleById = new Map<string, string>(
+    pluginLoadResult.loaded
+      .filter((p) => p.kind === "renderer")
+      .map((p) => [p.id, p.bundleName]),
+  );
+  // cortex#1793 (S8) — `renderers[]` entries whose `kind` wasn't registered
+  // at boot time (`UnimplementedRendererKindError` specifically — a plugin
+  // that hasn't loaded yet, NOT a malformed entry), keyed by the declared
+  // kind. `cortex plugin load <bundleName>` reuses the retained raw entry
+  // verbatim once its bundle becomes loadable, so `load` constructs EXACTLY
+  // what boot would have — never a runtime-improvised config.
+  const skippedRendererConfigs = new Map<string, unknown[]>();
   for (const raw of config.renderers ?? []) {
     // AgentConfig types renderers as z.unknown() so legacy bot.yaml loads
     // without breakage (the canonical shape lives on cortex-config's
@@ -3356,8 +3381,15 @@ export async function startCortex(
       };
       const renderer = plugin.createRenderer(rendererConfig);
       await renderer.start();
-      router.register(renderer.surfaceConfig);
+      const registration = router.register(renderer.surfaceConfig);
       renderers.push(renderer);
+      rendererHandles.set(renderer.id, {
+        renderer,
+        unregister: registration.unregister,
+        bundleName: loadedRendererBundleById.get(plugin.id) ?? "in-tree",
+        rendererKind: renderer.kind,
+        config: rendererConfig,
+      });
       console.log(`cortex: ${kindForLog} renderer started (id: ${renderer.id})`);
     } catch (err) {
       // Parse failure (structural or registry pass), construction failure,
@@ -3367,6 +3399,19 @@ export async function startCortex(
         `cortex: ${kindForLog} renderer failed to start:`,
         err instanceof Error ? err.message : err,
       );
+      // cortex#1793 (S8) — retain the raw entry ONLY for the "plugin hasn't
+      // loaded yet" case, keyed by its declared kind, so `cortex plugin
+      // load` can find it later. A structurally-invalid entry (caught by
+      // `RendererSchema.parse` before the kind is even resolved) is a config
+      // bug, not a load-order gap — never retained.
+      if (err instanceof UnimplementedRendererKindError) {
+        const declaredKind = (raw as { kind?: unknown }).kind;
+        if (typeof declaredKind === "string") {
+          const existing = skippedRendererConfigs.get(declaredKind) ?? [];
+          existing.push(raw);
+          skippedRendererConfigs.set(declaredKind, existing);
+        }
+      }
     }
   }
 
@@ -5600,6 +5645,23 @@ export async function startCortex(
   });
   const gw: SurfaceGateway | undefined = startedGateway?.gateway;
 
+  // cortex#1793 (S8, ADR-0024 D3) — the `cortex plugin list|unload|reload|load`
+  // control channel. `deps` is the SAME live `adapters`/`rendererHandles`/
+  // `skippedRendererConfigs` this boot populated above — every control
+  // request reads/mutates the running daemon's actual state, never a
+  // snapshot. `gw` may be `undefined` (CORTEX_GATEWAY unset, every live
+  // stack today) — `plugin-runtime.ts` degrades adapter `unload`/`reload` to
+  // a clear refusal in that case rather than silently no-opping.
+  const pluginRuntimeDeps: PluginRuntimeDeps = {
+    adapters,
+    rendererHandles,
+    router,
+    ...(gw !== undefined && { gateway: gw }),
+    skippedRendererConfigs,
+    registry: surfacePluginRegistry,
+  };
+  const pluginControlServer = await startPluginControlServer(runtime, pluginRuntimeDeps, systemEventSource);
+
   // a.3d (cortex#524) — gateway OUTBOUND reply round-trip. Reuse the per-stack
   // `createDispatchSink` (cortex#491) over the GATEWAY's own adapters instead
   // of building a second mux. The sink subscribes to every bound stack's
@@ -5703,6 +5765,11 @@ export async function startCortex(
       ...daemonBrainHosts.map((h, i) => `daemon-brain-host stop[${i}] (agent=${h.agentId})`),
       ...releaseConsumers.map((c, i) => `release-consumer stop[${i}] (agent=${c.agent.id})`),
       ...devConsumers.map((c, i) => `dev-consumer stop[${i}] (agent=${c.agent.id})`),
+      // cortex#1793 (S8) — the `cortex plugin` control-channel listener.
+      // No-op when the runtime never enabled (fake-runtime tests / a
+      // no-NATS stack) — `pluginControlServer.stop()` is always defined
+      // (a no-op handle in that case), so this slot always self-completes.
+      "plugin-control-server stop",
       "dispatch-listener stop",
       "dispatch-sink stop",
       "review-sink stop",
@@ -5919,6 +5986,11 @@ export async function startCortex(
       // signal#113 P-11 (#56) — drain the echo responder on the same boundary
       // as the dispatch listener. `stop()` is idempotent (no-op when dormant).
       await completeAsync("probe-responder stop", probeResponder.stop());
+      // cortex#1793 (S8) — stop accepting new `cortex plugin` control
+      // requests before the renderer/adapter state those requests mutate
+      // starts tearing down below. `stop()` is idempotent (no-op handle when
+      // the runtime never enabled).
+      await completeAsync("plugin-control-server stop", pluginControlServer.stop());
       // cortex#491 — drain the dispatch sink after the runner stops
       // publishing lifecycle envelopes but before the surface-router /
       // adapters stop, so no late `postResponse` lands after the
@@ -6513,6 +6585,24 @@ if (import.meta.main) {
     .helpOption(false)
     .action(async (args: string[]) => {
       const result = await dispatchStack(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  // cortex#1793 (S8) — runtime plugin attach/detach/reload. Same passthrough
+  // shape as `network` / `stack` / `provision-stack`: `dispatchPlugin` owns
+  // its own arg parsing, so commander hands it the raw remaining argv
+  // untouched. Talks to a RUNNING daemon over the bus — does not boot one.
+  program
+    .command("plugin")
+    .description("Runtime adapter/renderer attach/detach/reload (list / unload / reload / load)")
+    .argument("[args...]", "plugin subcommand + flags (see `cortex plugin --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchPlugin(args);
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
       process.exit(result.exitCode);

--- a/src/gateway/__tests__/plugin-runtime.test.ts
+++ b/src/gateway/__tests__/plugin-runtime.test.ts
@@ -1,0 +1,377 @@
+/**
+ * cortex#1793 (S8, ADR-0024 D3) — `src/gateway/plugin-runtime.ts` unit tests.
+ *
+ * Pure logic, no NATS, no real loader/arc calls — `discoverBundles`/
+ * `reimportRenderer` are injected fakes (`PluginRuntimeDeps`'s test seams).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  listLivePlugins,
+  loadLivePlugin,
+  reloadLivePlugin,
+  unloadLivePlugin,
+  type PluginRuntimeDeps,
+  type RendererHandle,
+} from "../plugin-runtime";
+import { SurfacePluginRegistry } from "../../adapters/registry";
+import type { PlatformAdapter, InboundMessage, AccessDecision, ResponseTarget, OutboundFile } from "../../adapters/types";
+import type { Renderer } from "../../renderers/types";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { RendererPlugin } from "../../adapters/registry";
+import type { DiscoveredBundle, DiscoverPluginBundlesResult, ReimportRendererResult } from "../../adapters/loader";
+import { SurfaceGateway, LoggingInboundSink } from "../surface-gateway";
+import type { GatewayBindingIndex } from "../binding-resolver";
+
+function emptyBindingIndex(): GatewayBindingIndex {
+  return { discord: new Map(), slack: new Map(), web: new Map(), mattermostSingle: null, mattermostMulti: false };
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+class FakeAdapter implements PlatformAdapter {
+  readonly platform: string;
+  readonly instanceId: string;
+  constructor(platform: string, instanceId: string) {
+    this.platform = platform;
+    this.instanceId = instanceId;
+  }
+  async start(_onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {}
+  async stop(): Promise<void> {}
+  async getPlatformUserId(): Promise<string> {
+    return "fake-bot-id";
+  }
+  async fetchContext() {
+    return [];
+  }
+  resolveAccess(_msg: InboundMessage): AccessDecision {
+    return { allowed: true, features: { chat: true, async: false, team: false } };
+  }
+  async postResponse(_t: ResponseTarget, _text: string, _files?: OutboundFile[]): Promise<void> {}
+  async sendTyping(): Promise<void> {}
+  async sendProgress(): Promise<void> {}
+  async clearProgress(): Promise<void> {}
+  async createThread(_msg: InboundMessage, _name: string): Promise<ResponseTarget> {
+    throw new Error("not supported");
+  }
+  async resolveLogicalTarget(): Promise<ResponseTarget | null> {
+    return null;
+  }
+  async notifyPrincipal(_text: string): Promise<void> {}
+}
+
+class FakeRenderer implements Renderer {
+  readonly kind: string;
+  readonly id: string;
+  readonly subjects: string[] = [];
+  startCalled = 0;
+  stopCalled = 0;
+  constructor(kind: string, id?: string) {
+    this.kind = kind;
+    this.id = id ?? kind;
+  }
+  async start(): Promise<void> {
+    this.startCalled++;
+  }
+  async stop(): Promise<void> {
+    this.stopCalled++;
+  }
+  async render(_envelope: Envelope): Promise<void> {}
+  get surfaceConfig() {
+    return { id: this.id, subjects: this.subjects, render: (e: Envelope) => this.render(e) };
+  }
+}
+
+function makeRouter() {
+  const registrations: { id: string; unregisterCalled: boolean }[] = [];
+  return {
+    registrations,
+    register(adapter: { id: string }) {
+      const entry = { id: adapter.id, unregisterCalled: false };
+      registrations.push(entry);
+      return { unregister: () => { entry.unregisterCalled = true; } };
+    },
+  };
+}
+
+function baseDeps(overrides: Partial<PluginRuntimeDeps> = {}): PluginRuntimeDeps {
+  return {
+    adapters: [],
+    rendererHandles: new Map(),
+    router: makeRouter(),
+    skippedRendererConfigs: new Map(),
+    registry: new SurfacePluginRegistry(),
+    ...overrides,
+  };
+}
+
+function rendererHandle(renderer: FakeRenderer, opts: Partial<RendererHandle> = {}): RendererHandle {
+  return {
+    renderer,
+    unregister: opts.unregister ?? (() => {}),
+    bundleName: opts.bundleName ?? "in-tree",
+    rendererKind: opts.rendererKind ?? renderer.kind,
+    config: opts.config ?? { subscribe: [] },
+  };
+}
+
+// ─── list ────────────────────────────────────────────────────────────────────
+
+describe("listLivePlugins", () => {
+  test("lists adapters and renderers together", () => {
+    const adapter = new FakeAdapter("discord", "discord:guild1");
+    const renderer = new FakeRenderer("dashboard");
+    const deps = baseDeps({
+      adapters: [adapter],
+      rendererHandles: new Map([["dashboard", rendererHandle(renderer)]]),
+    });
+
+    const rows = listLivePlugins(deps);
+
+    expect(rows).toHaveLength(2);
+    expect(rows).toContainEqual({
+      kind: "adapter",
+      platformOrKind: "discord",
+      instanceId: "discord:guild1",
+      bundleName: "in-tree",
+      running: true,
+    });
+    expect(rows).toContainEqual({
+      kind: "renderer",
+      platformOrKind: "dashboard",
+      instanceId: "dashboard",
+      bundleName: "in-tree",
+      running: true,
+    });
+  });
+
+  test("empty when nothing is live", () => {
+    expect(listLivePlugins(baseDeps())).toEqual([]);
+  });
+});
+
+// ─── unload ──────────────────────────────────────────────────────────────────
+
+describe("unloadLivePlugin", () => {
+  test("renderer: unregisters + stops + removes from the live map", async () => {
+    const renderer = new FakeRenderer("pagerduty");
+    let unregistered = false;
+    const handle = rendererHandle(renderer, { unregister: () => { unregistered = true; } });
+    const deps = baseDeps({ rendererHandles: new Map([["pagerduty", handle]]) });
+
+    const result = await unloadLivePlugin(deps, "pagerduty");
+
+    expect(result.ok).toBe(true);
+    expect(unregistered).toBe(true);
+    expect(renderer.stopCalled).toBe(1);
+    expect(deps.rendererHandles.has("pagerduty")).toBe(false);
+  });
+
+  test("adapter: refused when no gateway is present", async () => {
+    const adapter = new FakeAdapter("discord", "discord:guild1");
+    const deps = baseDeps({ adapters: [adapter] });
+
+    const result = await unloadLivePlugin(deps, "discord:guild1");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("CORTEX_GATEWAY");
+  });
+
+  test("adapter: detaches via the gateway when one is present", async () => {
+    const adapter = new FakeAdapter("discord", "discord:guild1");
+    const gateway = new SurfaceGateway([adapter], emptyBindingIndex(), new LoggingInboundSink());
+    const deps = baseDeps({ adapters: [adapter], gateway });
+
+    const result = await unloadLivePlugin(deps, "discord:guild1");
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("unknown instance id is refused, not a silent no-op", async () => {
+    const result = await unloadLivePlugin(baseDeps(), "nope");
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("no plugin instance");
+  });
+});
+
+// ─── reload ──────────────────────────────────────────────────────────────────
+
+describe("reloadLivePlugin", () => {
+  test("in-tree renderer refuses reload (restart-required)", async () => {
+    const renderer = new FakeRenderer("dashboard");
+    const deps = baseDeps({
+      rendererHandles: new Map([["dashboard", rendererHandle(renderer, { bundleName: "in-tree" })]]),
+    });
+
+    const result = await reloadLivePlugin(deps, "dashboard");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("in-tree");
+    expect(result.detail).toContain("restart");
+  });
+
+  test("adapter reload is refused, citing the #1896 follow-up", async () => {
+    const adapter = new FakeAdapter("discord", "discord:guild1");
+    const deps = baseDeps({ adapters: [adapter] });
+
+    const result = await reloadLivePlugin(deps, "discord:guild1");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("1896");
+  });
+
+  test("bundle no longer discoverable: refused, old instance untouched", async () => {
+    const renderer = new FakeRenderer("acme");
+    const handle = rendererHandle(renderer, { bundleName: "acme-bundle" });
+    const deps = baseDeps({
+      rendererHandles: new Map([["acme", handle]]),
+      discoverBundles: async (): Promise<DiscoverPluginBundlesResult> => ({ bundles: [], issues: [] }),
+    });
+
+    const result = await reloadLivePlugin(deps, "acme");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("no longer discoverable");
+    expect(renderer.stopCalled).toBe(0);
+  });
+
+  test("successful reload: attach-before-detach, old instance stopped after the new one is live", async () => {
+    const oldRenderer = new FakeRenderer("acme");
+    let oldUnregistered = false;
+    const handle = rendererHandle(oldRenderer, {
+      bundleName: "acme-bundle",
+      unregister: () => { oldUnregistered = true; },
+      config: { subscribe: ["local.>"] },
+    });
+
+    const fakeBundle = { bundleName: "acme-bundle" } as unknown as DiscoveredBundle;
+    let newRenderer: FakeRenderer | undefined;
+    const fakePlugin: RendererPlugin = {
+      kind: "renderer",
+      id: "acme",
+      rendererKind: "acme",
+      configSchema: { parse: (c: unknown) => c } as never,
+      createRenderer: (config: unknown) => {
+        newRenderer = new FakeRenderer("acme");
+        expect(config).toEqual({ subscribe: ["local.>"] });
+        return newRenderer;
+      },
+    };
+
+    const deps = baseDeps({
+      rendererHandles: new Map([["acme", handle]]),
+      discoverBundles: async (): Promise<DiscoverPluginBundlesResult> => ({ bundles: [fakeBundle], issues: [] }),
+      reimportRenderer: async (): Promise<ReimportRendererResult> => ({ ok: true, plugin: fakePlugin }),
+    });
+
+    const result = await reloadLivePlugin(deps, "acme");
+
+    expect(result.ok).toBe(true);
+    expect(newRenderer).toBeDefined();
+    expect(newRenderer?.startCalled).toBe(1);
+    // Attach-before-detach: the new instance is live BEFORE the old one is
+    // torn down — verified indirectly by both having run and the old
+    // instance's unregister/stop firing (order is enforced by the
+    // implementation; this asserts the net effect).
+    expect(oldUnregistered).toBe(true);
+    expect(oldRenderer.stopCalled).toBe(1);
+    expect(deps.rendererHandles.get("acme")?.renderer).toBe(newRenderer);
+  });
+
+  test("reimport failure leaves the old instance running", async () => {
+    const oldRenderer = new FakeRenderer("acme");
+    const handle = rendererHandle(oldRenderer, { bundleName: "acme-bundle" });
+    const fakeBundle = { bundleName: "acme-bundle" } as unknown as DiscoveredBundle;
+    const deps = baseDeps({
+      rendererHandles: new Map([["acme", handle]]),
+      discoverBundles: async (): Promise<DiscoverPluginBundlesResult> => ({ bundles: [fakeBundle], issues: [] }),
+      reimportRenderer: async (): Promise<ReimportRendererResult> => ({ ok: false, stage: "import", reason: "boom" }),
+    });
+
+    const result = await reloadLivePlugin(deps, "acme");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("boom");
+    expect(oldRenderer.stopCalled).toBe(0);
+    expect(deps.rendererHandles.get("acme")?.renderer).toBe(oldRenderer);
+  });
+});
+
+// ─── load ────────────────────────────────────────────────────────────────────
+
+describe("loadLivePlugin", () => {
+  test("refuses when the bundle is already live", async () => {
+    const renderer = new FakeRenderer("acme");
+    const deps = baseDeps({
+      rendererHandles: new Map([["acme", rendererHandle(renderer, { bundleName: "acme-bundle" })]]),
+    });
+
+    const result = await loadLivePlugin(deps, "acme-bundle");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("already has a live renderer instance");
+  });
+
+  test("refuses adapter-kind bundles, citing #1896", async () => {
+    const fakeBundle = {
+      bundleName: "acme-adapter-bundle",
+      manifest: { kind: "adapter", id: "acme" },
+    } as unknown as DiscoveredBundle;
+    const deps = baseDeps({
+      discoverBundles: async (): Promise<DiscoverPluginBundlesResult> => ({ bundles: [fakeBundle], issues: [] }),
+    });
+
+    const result = await loadLivePlugin(deps, "acme-adapter-bundle");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("1896");
+  });
+
+  test("refuses when there is no pending renderers[] entry to construct from", async () => {
+    const fakeBundle = {
+      bundleName: "acme-bundle",
+      manifest: { kind: "renderer", id: "acme" },
+    } as unknown as DiscoveredBundle;
+    const deps = baseDeps({
+      discoverBundles: async (): Promise<DiscoverPluginBundlesResult> => ({ bundles: [fakeBundle], issues: [] }),
+    });
+
+    const result = await loadLivePlugin(deps, "acme-bundle");
+
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("no pending");
+  });
+
+  test("successful load: constructs from the retained raw config, registers, and consumes the skipped entry", async () => {
+    const fakeBundle = {
+      bundleName: "acme-bundle",
+      manifest: { kind: "renderer", id: "acme" },
+    } as unknown as DiscoveredBundle;
+    let constructedWith: unknown;
+    let newRenderer: FakeRenderer | undefined;
+    const fakePlugin: RendererPlugin = {
+      kind: "renderer",
+      id: "acme",
+      rendererKind: "acme",
+      configSchema: { parse: (c: unknown) => c } as never,
+      createRenderer: (config: unknown) => {
+        constructedWith = config;
+        newRenderer = new FakeRenderer("acme");
+        return newRenderer;
+      },
+    };
+    const deps = baseDeps({
+      skippedRendererConfigs: new Map([["acme", [{ kind: "acme", subscribe: ["local.>"] }]]]),
+      discoverBundles: async (): Promise<DiscoverPluginBundlesResult> => ({ bundles: [fakeBundle], issues: [] }),
+      reimportRenderer: async (): Promise<ReimportRendererResult> => ({ ok: true, plugin: fakePlugin }),
+    });
+
+    const result = await loadLivePlugin(deps, "acme-bundle");
+
+    expect(result.ok).toBe(true);
+    expect(constructedWith).toEqual({ kind: "acme", subscribe: ["local.>"] });
+    expect(newRenderer?.startCalled).toBe(1);
+    expect(deps.rendererHandles.get("acme")?.renderer).toBe(newRenderer);
+    expect(deps.skippedRendererConfigs.has("acme")).toBe(false);
+  });
+});

--- a/src/gateway/__tests__/surface-gateway-attach-detach.test.ts
+++ b/src/gateway/__tests__/surface-gateway-attach-detach.test.ts
@@ -1,0 +1,294 @@
+/**
+ * cortex#1793 (S8, ADR-0024 D3) — SurfaceGateway runtime attach/detach tests.
+ *
+ * Covers the acceptance criterion from the issue: "Detach of one adapter
+ * leaves every other adapter delivering (test with two mock adapters through
+ * the real gateway)", plus:
+ *
+ *   1. attachAdapter folds discord/slack/web seeds into the live index and
+ *      inbound routes correctly afterward.
+ *   2. attachAdapter refuses a duplicate instanceId / a colliding demux key
+ *      (mirrors buildBindingIndex's loud boot-time throw).
+ *   3. detachAdapter removes exactly the detached instance's index entries —
+ *      a second, still-attached instance keeps delivering (the acceptance
+ *      criterion).
+ *   4. detachAdapter DRAINS: an in-flight handleInbound call started before
+ *      detach completes before adapter.stop() is invoked; new inbound
+ *      arriving DURING the drain window is dropped (not routed), not queued.
+ *   5. detachAdapter on an unknown instanceId is a no-op ({ detached: false }).
+ *   6. mattermost single/multi recompute across attach/detach.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  SurfaceGateway,
+  type GatewayInboundDecision,
+  type GatewayInboundSink,
+  type GatewayBindingSeed,
+} from "../surface-gateway";
+import { buildBindingIndex } from "../binding-resolver";
+import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+class MockAdapter implements PlatformAdapter {
+  readonly platform: string;
+  readonly instanceId: string;
+  startCalled = 0;
+  stopCalled = 0;
+  attachCalled = 0;
+
+  private _onMessage: ((msg: InboundMessage) => Promise<void>) | null = null;
+
+  constructor(platform: string, instanceId: string) {
+    this.platform = platform;
+    this.instanceId = instanceId;
+  }
+
+  async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    this.startCalled++;
+    this._onMessage = onMessage;
+  }
+
+  attachInboundDispatch(): void {
+    this.attachCalled++;
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalled++;
+    this._onMessage = null;
+  }
+
+  async trigger(inbound: InboundMessage): Promise<void> {
+    if (!this._onMessage) throw new Error("adapter not started");
+    await this._onMessage(inbound);
+  }
+
+  async getPlatformUserId(): Promise<string> {
+    return "bot-user-id";
+  }
+  async fetchContext() {
+    return [];
+  }
+  resolveAccess() {
+    return { allowed: true, features: { chat: true, async: false, team: false } };
+  }
+  async postResponse() {}
+  async sendTyping() {}
+  async sendProgress() {}
+  async clearProgress() {}
+  async createThread() {
+    return { instanceId: this.instanceId, channelId: "new-thread" };
+  }
+  async resolveLogicalTarget() {
+    return null;
+  }
+  async notifyPrincipal() {}
+}
+
+/** A sink whose publish() can be held open by the test (deferred resolve) —
+ *  used to simulate an in-flight handleInbound call during a detach. */
+class DeferredSink implements GatewayInboundSink {
+  readonly calls: { decision: GatewayInboundDecision; msg: InboundMessage }[] = [];
+  private gate: Promise<void> | null = null;
+  private release: (() => void) | null = null;
+
+  /** Hold every subsequent publish() open until `resolveGate()` is called. */
+  holdOpen(): void {
+    this.gate = new Promise((res) => {
+      this.release = res;
+    });
+  }
+
+  resolveGate(): void {
+    this.release?.();
+    this.gate = null;
+    this.release = null;
+  }
+
+  async publish(decision: GatewayInboundDecision, msg: InboundMessage): Promise<void> {
+    if (this.gate) await this.gate;
+    this.calls.push({ decision, msg });
+  }
+}
+
+function msg(overrides: Partial<InboundMessage>): InboundMessage {
+  return {
+    platform: "discord",
+    instanceId: "discord-a",
+    authorId: "u1",
+    authorName: "Test User",
+    content: "hello",
+    channelId: "ch-1",
+    attachments: [],
+    timestamp: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+const DISCORD_SEED_A: GatewayBindingSeed = {
+  platform: "discord",
+  agent: "luna",
+  stack: "andreas/meta-factory",
+  demuxKey: "guild-a",
+};
+
+const DISCORD_SEED_B: GatewayBindingSeed = {
+  platform: "discord",
+  agent: "echo",
+  stack: "andreas/work",
+  demuxKey: "guild-b",
+};
+
+// ─── 1 & 2 — attachAdapter ───────────────────────────────────────────────────
+
+describe("SurfaceGateway.attachAdapter()", () => {
+  test("folds seeds into the index and routes inbound afterward", async () => {
+    const index = buildBindingIndex({});
+    const sink = new DeferredSink();
+    const gw = new SurfaceGateway([], index, sink);
+    const adapter = new MockAdapter("discord", "disc-a");
+
+    await gw.attachAdapter(adapter, [DISCORD_SEED_A]);
+
+    expect(adapter.startCalled).toBe(1);
+    expect(adapter.attachCalled).toBe(1);
+
+    await adapter.trigger(msg({ instanceId: "disc-a", guildId: "guild-a" }));
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0]?.decision.match.agent).toBe("luna");
+  });
+
+  test("throws on a duplicate instanceId and does not mutate state", async () => {
+    const index = buildBindingIndex({});
+    const sink = new DeferredSink();
+    const gw = new SurfaceGateway([], index, sink);
+    const a1 = new MockAdapter("discord", "dup");
+    const a2 = new MockAdapter("discord", "dup");
+    await gw.attachAdapter(a1, [DISCORD_SEED_A]);
+
+    await expect(
+      gw.attachAdapter(a2, [{ ...DISCORD_SEED_A, demuxKey: "guild-c" }]),
+    ).rejects.toThrow(/already attached/);
+    expect(a2.startCalled).toBe(0);
+  });
+
+  test("throws on a colliding demux key across two distinct instances", async () => {
+    const index = buildBindingIndex({});
+    const sink = new DeferredSink();
+    const gw = new SurfaceGateway([], index, sink);
+    const a1 = new MockAdapter("discord", "disc-a");
+    const a2 = new MockAdapter("discord", "disc-b");
+    await gw.attachAdapter(a1, [DISCORD_SEED_A]);
+
+    await expect(gw.attachAdapter(a2, [DISCORD_SEED_A])).rejects.toThrow(/ambiguous discord config/);
+    expect(a2.startCalled).toBe(0);
+  });
+});
+
+// ─── 3 — detach isolation (the acceptance criterion) ────────────────────────
+
+describe("SurfaceGateway.detachAdapter() — isolation", () => {
+  test("detaching one instance leaves the other still delivering", async () => {
+    const index = buildBindingIndex({});
+    const sink = new DeferredSink();
+    const gw = new SurfaceGateway([], index, sink);
+    const a1 = new MockAdapter("discord", "disc-a");
+    const a2 = new MockAdapter("discord", "disc-b");
+    await gw.attachAdapter(a1, [DISCORD_SEED_A]);
+    await gw.attachAdapter(a2, [DISCORD_SEED_B]);
+
+    const result = await gw.detachAdapter("disc-a");
+    expect(result).toEqual({ detached: true });
+    // a1 was stopped (its own onMessage callback is torn down by MockAdapter's
+    // stop() — the platform connection is gone) — a2 was never touched.
+    expect(a1.stopCalled).toBe(1);
+    expect(a2.stopCalled).toBe(0);
+
+    // a2 still resolves + delivers.
+    await a2.trigger(msg({ instanceId: "disc-b", guildId: "guild-b" }));
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0]?.decision.match.agent).toBe("echo");
+  });
+
+  test("detaching an unknown instanceId is a no-op", async () => {
+    const index = buildBindingIndex({});
+    const sink = new DeferredSink();
+    const gw = new SurfaceGateway([], index, sink);
+    const result = await gw.detachAdapter("does-not-exist");
+    expect(result).toEqual({ detached: false });
+  });
+});
+
+// ─── 4 — drain ───────────────────────────────────────────────────────────────
+
+describe("SurfaceGateway.detachAdapter() — drain", () => {
+  test("awaits an in-flight handleInbound call before stop(), and drops inbound arriving during the drain", async () => {
+    const index = buildBindingIndex({});
+    const sink = new DeferredSink();
+    const gw = new SurfaceGateway([], index, sink);
+    const adapter = new MockAdapter("discord", "disc-a");
+    await gw.attachAdapter(adapter, [DISCORD_SEED_A]);
+
+    // Hold the sink open so the in-flight handleInbound call doesn't resolve
+    // until we release it.
+    sink.holdOpen();
+    const inFlight = adapter.trigger(msg({ instanceId: "disc-a", guildId: "guild-a" }));
+
+    // Give the in-flight call a tick to register itself before detaching.
+    await Promise.resolve();
+
+    const detachPromise = gw.detachAdapter("disc-a");
+
+    // Inbound arriving DURING the drain window (after the detach flag is
+    // set) must be dropped, not routed — even though the adapter object is
+    // still technically reachable in this test until stop() resolves.
+    await adapter.trigger(msg({ instanceId: "disc-a", guildId: "guild-a", content: "late" }));
+
+    // adapter.stop() must NOT have been called yet — the drain is still
+    // waiting on the held-open sink.
+    expect(adapter.stopCalled).toBe(0);
+
+    sink.resolveGate();
+    await inFlight;
+    const result = await detachPromise;
+
+    expect(result).toEqual({ detached: true });
+    expect(adapter.stopCalled).toBe(1);
+    // Exactly one publish — the original in-flight call. The late arrival
+    // was dropped, not queued.
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0]?.msg.content).toBe("hello");
+  });
+});
+
+// ─── 5 — mattermost single/multi recompute ──────────────────────────────────
+
+describe("SurfaceGateway attach/detach — mattermost single/multi recompute", () => {
+  test("single mattermost attach sets the fallback slot; a second attach flips to ambiguous; detaching one restores single", async () => {
+    const index = buildBindingIndex({});
+    const sink = new DeferredSink();
+    const gw = new SurfaceGateway([], index, sink);
+    const a1 = new MockAdapter("mattermost", "mm-1");
+    const a2 = new MockAdapter("mattermost", "mm-2");
+
+    await gw.attachAdapter(a1, [
+      { platform: "mattermost", agent: "luna", stack: "andreas/work", demuxKey: "https://mm1.example.com" },
+    ]);
+    await a1.trigger(msg({ platform: "mattermost", instanceId: "mm-1" }));
+    expect(sink.calls).toHaveLength(1);
+    expect(sink.calls[0]?.decision.match.agent).toBe("luna");
+
+    await gw.attachAdapter(a2, [
+      { platform: "mattermost", agent: "echo", stack: "andreas/meta-factory", demuxKey: "https://mm2.example.com" },
+    ]);
+    // Now ambiguous — a fresh inbound cannot be demuxed.
+    await a1.trigger(msg({ platform: "mattermost", instanceId: "mm-1", content: "ambiguous now" }));
+    expect(sink.calls).toHaveLength(1); // unchanged — dropped as unroutable
+
+    await gw.detachAdapter("mm-2");
+    await a1.trigger(msg({ platform: "mattermost", instanceId: "mm-1", content: "single again" }));
+    expect(sink.calls).toHaveLength(2);
+    expect(sink.calls[1]?.decision.match.agent).toBe("luna");
+  });
+});

--- a/src/gateway/binding-resolver.ts
+++ b/src/gateway/binding-resolver.ts
@@ -165,7 +165,14 @@ export interface GatewayBindingIndex {
  * - Returns `{ principal: undefined, stack: undefined }` when the input is
  *   absent (gap 4 — `stack` is optional on the binding).
  */
-function parseStack(raw: string | undefined): {
+/**
+ * cortex#1793 (S8) — exported (was module-private) so `SurfaceGateway`'s
+ * runtime `attachAdapter`/`detachAdapter` (`surface-gateway.ts`) can parse a
+ * seed's `stack` field with the EXACT same `{principal}/{stack}` splitting
+ * `buildBindingIndex` uses for the boot-time path — one parser, no drift
+ * between boot-built and runtime-attached index entries.
+ */
+export function parseStack(raw: string | undefined): {
   principal: string | undefined;
   stack: string | undefined;
 } {

--- a/src/gateway/plugin-control-server.ts
+++ b/src/gateway/plugin-control-server.ts
@@ -1,12 +1,12 @@
 /**
  * cortex#1793 (S8) — the daemon-side half of the `cortex plugin` control
- * channel. Subscribes to `local.{principal}.system.plugin.control_request`
+ * channel. Subscribes to `local.{principal}.system.plugin.control-request`
  * (via the running `MyelinRuntime` — see `src/bus/system-events.ts`'s
- * `system.plugin.control_request`/`_response` doc comment for the full
+ * `system.plugin.control-request`/`_response` doc comment for the full
  * rationale on why this rides `runtime.publish`/`subscribe`/`onEnvelope`
  * rather than a raw NATS request/reply connection), executes the requested
  * action against {@link PluginRuntimeDeps} (`src/gateway/plugin-runtime.ts`),
- * and replies with a `control_response` carrying the same `correlation_id`.
+ * and replies with a `control-response` carrying the same `correlation_id`.
  *
  * Wired into `src/cortex.ts` right after the renderer boot loop (once
  * `rendererHandles`/`skippedRendererConfigs` exist) and torn down in the
@@ -59,12 +59,12 @@ export async function startPluginControlServer(
     return noop;
   }
 
-  const subject = `local.${systemEventSource.principal}.system.plugin.control_request`;
+  const subject = `local.${systemEventSource.principal}.system.plugin.control-request`;
   const subscriber = await runtime.subscribe(subject);
   if (!subscriber) return noop;
 
   const { unregister } = runtime.onEnvelope((envelope, matchedSubject) => {
-    if (envelope.type !== "system.plugin.control_request") return;
+    if (envelope.type !== "system.plugin.control-request") return;
     if (matchedSubject !== subject) return;
     // Fire-and-forget: `onEnvelope` handlers are synchronous per the
     // `EnvelopeHandler` type, so the async body runs detached. Every
@@ -117,7 +117,7 @@ async function handleOneRequest(
     // rather than getting the underlying reason. Logged for the daemon
     // principal; never thrown (this runs detached from any caller).
     process.stderr.write(
-      `cortex plugin-control-server: failed to publish control_response for request "${requestId}": ${err instanceof Error ? err.message : String(err)}\n`,
+      `cortex plugin-control-server: failed to publish control-response for request "${requestId}": ${err instanceof Error ? err.message : String(err)}\n`,
     );
   }
 }

--- a/src/gateway/plugin-control-server.ts
+++ b/src/gateway/plugin-control-server.ts
@@ -1,0 +1,149 @@
+/**
+ * cortex#1793 (S8) — the daemon-side half of the `cortex plugin` control
+ * channel. Subscribes to `local.{principal}.system.plugin.control_request`
+ * (via the running `MyelinRuntime` — see `src/bus/system-events.ts`'s
+ * `system.plugin.control_request`/`_response` doc comment for the full
+ * rationale on why this rides `runtime.publish`/`subscribe`/`onEnvelope`
+ * rather than a raw NATS request/reply connection), executes the requested
+ * action against {@link PluginRuntimeDeps} (`src/gateway/plugin-runtime.ts`),
+ * and replies with a `control_response` carrying the same `correlation_id`.
+ *
+ * Wired into `src/cortex.ts` right after the renderer boot loop (once
+ * `rendererHandles`/`skippedRendererConfigs` exist) and torn down in the
+ * shutdown sequence alongside the other bus-side listeners.
+ */
+
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import {
+  createSystemPluginControlResponseEvent,
+  type SystemEventSource,
+  type SystemPluginControlListRow,
+} from "../bus/system-events";
+import {
+  listLivePlugins,
+  loadLivePlugin,
+  reloadLivePlugin,
+  unloadLivePlugin,
+  type PluginRuntimeDeps,
+} from "./plugin-runtime";
+
+export interface PluginControlServerHandle {
+  /** Detach the subscription + handler. Idempotent. */
+  stop(): Promise<void>;
+}
+
+interface ControlRequestPayload {
+  request_id?: unknown;
+  action?: unknown;
+  instance_id?: unknown;
+  bundle_name?: unknown;
+}
+
+/**
+ * Start the daemon-side control listener. No-op handle (does nothing on
+ * `stop()`) when `runtime.enabled` is false or `runtime.subscribe`/
+ * `onEnvelope` are unavailable (a fake-runtime test double, or a stack
+ * genuinely running with no NATS configured) — a plugin-control-less daemon
+ * is a degraded-but-safe state (`cortex plugin list` from the CLI simply
+ * times out with no responder), never a boot failure.
+ */
+export async function startPluginControlServer(
+  runtime: MyelinRuntime,
+  deps: PluginRuntimeDeps,
+  systemEventSource: SystemEventSource,
+): Promise<PluginControlServerHandle> {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function -- the interface is async (`Promise<void>`) so callers can await uniformly whether the handle is live or a no-op; this branch has nothing to do.
+  const noop: PluginControlServerHandle = { stop: async () => {} };
+  if (!runtime.enabled || !runtime.subscribe) {
+    return noop;
+  }
+
+  const subject = `local.${systemEventSource.principal}.system.plugin.control_request`;
+  const subscriber = await runtime.subscribe(subject);
+  if (!subscriber) return noop;
+
+  const { unregister } = runtime.onEnvelope((envelope, matchedSubject) => {
+    if (envelope.type !== "system.plugin.control_request") return;
+    if (matchedSubject !== subject) return;
+    // Fire-and-forget: `onEnvelope` handlers are synchronous per the
+    // `EnvelopeHandler` type, so the async body runs detached. Every
+    // failure path inside `handleOneRequest` is caught internally — nothing
+    // here can produce an unhandled rejection.
+    void handleOneRequest(runtime, deps, systemEventSource, envelope);
+  });
+
+  return {
+    stop: async () => {
+      unregister();
+      await subscriber.stop();
+    },
+  };
+}
+
+async function handleOneRequest(
+  runtime: MyelinRuntime,
+  deps: PluginRuntimeDeps,
+  systemEventSource: SystemEventSource,
+  envelope: Envelope,
+): Promise<void> {
+  const payload = envelope.payload as ControlRequestPayload;
+  const requestId = typeof payload.request_id === "string" ? payload.request_id : envelope.id;
+  const action = payload.action;
+
+  let response: { ok: boolean; rows?: SystemPluginControlListRow[]; detail?: string };
+  try {
+    response = await dispatchAction(deps, action, payload);
+  } catch (err) {
+    response = {
+      ok: false,
+      detail: `plugin-control-server: unhandled error executing "${String(action)}": ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  try {
+    await runtime.publish(
+      createSystemPluginControlResponseEvent({
+        source: systemEventSource,
+        requestId,
+        ok: response.ok,
+        ...(response.rows !== undefined && { rows: response.rows }),
+        ...(response.detail !== undefined && { detail: response.detail }),
+      }),
+    );
+  } catch (err) {
+    // The request came from a live CLI process waiting on this exact reply
+    // — a publish failure here just means that CLI invocation times out
+    // rather than getting the underlying reason. Logged for the daemon
+    // principal; never thrown (this runs detached from any caller).
+    process.stderr.write(
+      `cortex plugin-control-server: failed to publish control_response for request "${requestId}": ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+async function dispatchAction(
+  deps: PluginRuntimeDeps,
+  action: unknown,
+  payload: ControlRequestPayload,
+): Promise<{ ok: boolean; rows?: SystemPluginControlListRow[]; detail?: string }> {
+  if (action === "list") {
+    return { ok: true, rows: listLivePlugins(deps) };
+  }
+  if (action === "unload") {
+    const instanceId = typeof payload.instance_id === "string" ? payload.instance_id : undefined;
+    if (!instanceId) return { ok: false, detail: `"unload" requires instance_id` };
+    return unloadLivePlugin(deps, instanceId);
+  }
+  if (action === "reload") {
+    const instanceId = typeof payload.instance_id === "string" ? payload.instance_id : undefined;
+    if (!instanceId) return { ok: false, detail: `"reload" requires instance_id` };
+    return reloadLivePlugin(deps, instanceId);
+  }
+  if (action === "load") {
+    const bundleName = typeof payload.bundle_name === "string" ? payload.bundle_name : undefined;
+    if (!bundleName) return { ok: false, detail: `"load" requires bundle_name` };
+    return loadLivePlugin(deps, bundleName);
+  }
+  return { ok: false, detail: `unknown action "${String(action)}" — expected list | unload | reload | load` };
+}

--- a/src/gateway/plugin-runtime.ts
+++ b/src/gateway/plugin-runtime.ts
@@ -1,0 +1,410 @@
+/**
+ * cortex#1793 (S8, ADR-0024 D3) — the LIVE plugin registry `cortex plugin
+ * list|unload|reload|load` reads and mutates. Pure, injected-dependency
+ * logic: no NATS, no CLI parsing — `src/gateway/plugin-control-server.ts`
+ * wires this to the bus-side request/response envelopes
+ * (`system.plugin.control_request`/`_response`, `src/bus/system-events.ts`),
+ * and `src/cli/cortex/commands/plugin-lib.ts` is the CLI-side caller.
+ *
+ * ## Scope (deliberately asymmetric — "the renderer half is cheaper")
+ *
+ * Per ADR-0024's own D3 renderer delta and the S8 issue's scope amendment:
+ * per-instance detach for RENDERERS already existed (`SurfaceRouter.register()`
+ * returns `{ unregister }`) — the boot loop just discarded it (cortex.ts's
+ * renderer loop, fixed alongside this file). ADAPTERS have no per-instance
+ * detach outside the (env-gated, off-by-default) `SurfaceGateway` — see
+ * `src/gateway/surface-gateway.ts`'s `attachAdapter`/`detachAdapter`.
+ *
+ * This module reflects that asymmetry honestly rather than faking parity:
+ *
+ *   - `list` — full support, both kinds, always (read-only).
+ *   - `unload` — full support for renderers (always); for adapters, only
+ *     when a live {@link SurfaceGateway} is supplied (`CORTEX_GATEWAY=1`).
+ *     Without the gateway, a per-stack adapter has no live detach path at
+ *     all — refused with a clear reason, never a silent no-op.
+ *   - `reload` — full support for a renderer instance that was constructed
+ *     from an arc-installed BUNDLE (cache-bust re-`import()`, scratch-
+ *     verified working — see `reimportRendererPlugin`'s doc comment in
+ *     `src/adapters/loader.ts`). Refused for an IN-TREE renderer (no bundle
+ *     to re-import; restart is the only way to pick up code changes) and
+ *     for every adapter (adapter re-construction needs the binding-seed +
+ *     demux-key inputs `GatewayAdapterFactory` owns today — that shim is
+ *     cortex#1896, explicitly out of scope for this slice).
+ *   - `load` — full support for a renderer bundle that was DISCOVERED but
+ *     not constructed at boot (its `renderers[]` YAML entry's `kind` didn't
+ *     resolve because the plugin hadn't loaded yet — `plugins.external` was
+ *     off, or the bundle failed a transient gate) — the original raw config
+ *     entry cortex.ts retained is reused verbatim, so `load` constructs
+ *     EXACTLY what boot would have. Refused for adapters (same #1896
+ *     rationale as reload).
+ */
+
+import type { PlatformAdapter } from "../adapters/types";
+import {
+  discoverPluginBundles,
+  reimportRendererPlugin,
+  type DiscoveredBundle,
+} from "../adapters/loader";
+import type { RendererPlugin, SurfacePluginRegistry } from "../adapters/registry";
+import type { Renderer } from "../renderers/types";
+import type { SurfaceGateway } from "./surface-gateway";
+
+// =============================================================================
+// Live-state shapes
+// =============================================================================
+
+/**
+ * One live renderer instance, tracked from the moment it is registered
+ * (boot loop, `load`, or `reload`) until it is torn down (`unload` or the
+ * old side of a `reload`). Retains everything a later `reload` needs to
+ * reconstruct an equivalent instance: the ORIGINAL parsed config (so reload
+ * never re-derives config from scratch) and the bundle it came from
+ * (`"in-tree"` for the two permanent contract anchors — the mock adapter has
+ * no renderer twin, so in practice `dashboard`/`pagerduty` — per ADR-0024 D2).
+ */
+export interface RendererHandle {
+  renderer: Renderer;
+  unregister: () => void;
+  /** `"in-tree"` for statically-registered renderers; the arc bundle name
+   *  for one loaded via `loadExternalPlugins`/`cortex plugin load`. */
+  bundleName: string;
+  /** Same as `renderer.kind` — kept alongside so callers don't need the
+   *  live `Renderer` object just to build a list row. */
+  rendererKind: string;
+  /** The parsed config this instance was constructed with. `undefined` only
+   *  transiently during construction; every handle in the live map has one. */
+  config: unknown;
+}
+
+export interface LivePluginRow {
+  kind: "adapter" | "renderer";
+  /** adapter: `PlatformAdapter.platform`; renderer: `Renderer.kind`. */
+  platformOrKind: string;
+  instanceId: string;
+  bundleName: string;
+  running: boolean;
+}
+
+export interface MutationResult {
+  ok: boolean;
+  detail: string;
+}
+
+/**
+ * A renderer `renderers[]` YAML entry that FAILED to construct at boot
+ * (`resolveRendererPluginAndConfig` threw — usually `UnimplementedRendererKindError`
+ * because the plugin hadn't loaded into the registry yet). Retained verbatim
+ * so `load` can construct EXACTLY what boot would have, once the bundle is
+ * actually loadable. Keyed by the raw entry's `kind` in
+ * {@link PluginRuntimeDeps.skippedRendererConfigs}.
+ */
+export type SkippedRendererConfig = unknown;
+
+/**
+ * Injected live state + collaborators. Constructed once at boot
+ * (`src/cortex.ts`) and handed to every control-request handler — the SAME
+ * object every call reads/mutates, so a `list` right after an `unload` sees
+ * the change.
+ */
+export interface PluginRuntimeDeps {
+  /** Live reference to cortex.ts's boot-time `adapters` array — NOT a copy. */
+  adapters: PlatformAdapter[];
+  /** Live reference to the renderer-handle map cortex.ts's renderer boot
+   *  loop populates and `load`/`reload`/`unload` mutate in place. */
+  rendererHandles: Map<string, RendererHandle>;
+  /** `router.register` — used by `load`/`reload` to bind a NEW renderer
+   *  instance before the old one (if any) is torn down. */
+  router: { register(adapter: Renderer["surfaceConfig"]): { unregister: () => void } };
+  /** Present only when `CORTEX_GATEWAY=1` — gates adapter `unload`. */
+  gateway?: SurfaceGateway;
+  /** Raw `renderers[]` entries that failed to resolve at boot, keyed by the
+   *  entry's `kind` — the `load` verb's input. Live reference, mutated by
+   *  `load` (matched entries are removed once successfully loaded). */
+  skippedRendererConfigs: Map<string, SkippedRendererConfig[]>;
+  /** The SAME registry cortex.ts composed at boot — `load` needs it to
+   *  resolve a bundle's declared renderer plugin id against what's already
+   *  registered (refuses a `load` that would shadow an existing kind). */
+  registry: SurfacePluginRegistry;
+  /** Forwarded to `discoverPluginBundles`/tests; `undefined` = arc's real
+   *  install root. */
+  pkgRoot?: string;
+}
+
+// =============================================================================
+// list
+// =============================================================================
+
+export function listLivePlugins(deps: PluginRuntimeDeps): LivePluginRow[] {
+  const adapterRows: LivePluginRow[] = deps.adapters.map((a) => ({
+    kind: "adapter" as const,
+    platformOrKind: a.platform,
+    instanceId: a.instanceId,
+    // S6's loader doesn't thread per-adapter-instance bundle provenance
+    // through to `wireSurfaceAdapters`/`SurfaceGateway` yet — every adapter
+    // in `list` reports "in-tree" until that's wired (tracked with the same
+    // #1896 GatewayAdapterFactory follow-up `reload`/`load` cite for adapters).
+    bundleName: "in-tree",
+    running: true,
+  }));
+  const rendererRows: LivePluginRow[] = [...deps.rendererHandles.values()].map((h) => ({
+    kind: "renderer" as const,
+    platformOrKind: h.rendererKind,
+    instanceId: h.renderer.id,
+    bundleName: h.bundleName,
+    running: true,
+  }));
+  return [...adapterRows, ...rendererRows];
+}
+
+// =============================================================================
+// unload
+// =============================================================================
+
+export async function unloadLivePlugin(
+  deps: PluginRuntimeDeps,
+  instanceId: string,
+): Promise<MutationResult> {
+  const handle = deps.rendererHandles.get(instanceId);
+  if (handle) {
+    handle.unregister();
+    await handle.renderer.stop();
+    deps.rendererHandles.delete(instanceId);
+    return { ok: true, detail: `renderer "${instanceId}" detached` };
+  }
+
+  const adapter = deps.adapters.find((a) => a.instanceId === instanceId);
+  if (adapter) {
+    if (!deps.gateway) {
+      return {
+        ok: false,
+        detail:
+          `adapter "${instanceId}" cannot be unloaded — this daemon is not running with CORTEX_GATEWAY=1. ` +
+          `Per-stack adapters constructed by the classic boot path (wireSurfaceAdapters) have no live ` +
+          `detach mechanism (ADR-0024 blocker #13); only gateway-attached adapters support runtime unload.`,
+      };
+    }
+    const res = await deps.gateway.detachAdapter(instanceId);
+    if (!res.detached) {
+      return {
+        ok: false,
+        detail: `adapter "${instanceId}" was not attached via the gateway — nothing to detach.`,
+      };
+    }
+    return { ok: true, detail: `adapter "${instanceId}" detached` };
+  }
+
+  return { ok: false, detail: `no plugin instance "${instanceId}" is currently live` };
+}
+
+// =============================================================================
+// reload — renderer-only (see module doc)
+// =============================================================================
+
+export async function reloadLivePlugin(
+  deps: PluginRuntimeDeps,
+  instanceId: string,
+): Promise<MutationResult> {
+  const handle = deps.rendererHandles.get(instanceId);
+  if (!handle) {
+    const isAdapter = deps.adapters.some((a) => a.instanceId === instanceId);
+    if (isAdapter) {
+      return {
+        ok: false,
+        detail:
+          `adapter reload is out of scope for this slice — re-constructing an adapter needs the ` +
+          `binding-seed + demux-key inputs GatewayAdapterFactory owns today (tracked separately at ` +
+          `cortex#1896). Use "cortex plugin unload" + a config-driven restart instead.`,
+      };
+    }
+    return { ok: false, detail: `no plugin instance "${instanceId}" is currently live` };
+  }
+
+  if (handle.bundleName === "in-tree") {
+    return {
+      ok: false,
+      detail:
+        `renderer "${instanceId}" is in-tree (bundleName "in-tree") — it has no bundle to re-import; ` +
+        `a full daemon restart is the only way to pick up code changes to an in-tree renderer.`,
+    };
+  }
+
+  const { bundles, issues } = await discoverPluginBundles({ pkgRoot: deps.pkgRoot });
+  const bundle = bundles.find((b) => b.bundleName === handle.bundleName);
+  if (!bundle) {
+    const issueDetail = issues.find((i) => i.bundleName === handle.bundleName);
+    return {
+      ok: false,
+      detail:
+        `bundle "${handle.bundleName}" is no longer discoverable` +
+        (issueDetail ? ` (${issueDetail.reason})` : "") +
+        ` — reload refused, the old instance is left running.`,
+    };
+  }
+
+  const reimport = await reimportRendererPlugin(bundle, { bust: true });
+  if (!reimport.ok) {
+    return {
+      ok: false,
+      detail: `reload failed at ${reimport.stage}: ${reimport.reason} — the old instance is left running.`,
+    };
+  }
+
+  return attachFreshRendererReplacing(deps, handle, instanceId, reimport.plugin, handle.config, handle.bundleName);
+}
+
+// =============================================================================
+// load — renderer-only (see module doc)
+// =============================================================================
+
+export async function loadLivePlugin(
+  deps: PluginRuntimeDeps,
+  bundleName: string,
+): Promise<MutationResult> {
+  const alreadyLive = [...deps.rendererHandles.values()].some((h) => h.bundleName === bundleName);
+  if (alreadyLive) {
+    return {
+      ok: false,
+      detail: `bundle "${bundleName}" already has a live renderer instance — use "reload", not "load".`,
+    };
+  }
+
+  const { bundles, issues } = await discoverPluginBundles({ pkgRoot: deps.pkgRoot });
+  const bundle = bundles.find((b) => b.bundleName === bundleName);
+  if (!bundle) {
+    const issueDetail = issues.find((i) => i.bundleName === bundleName);
+    return {
+      ok: false,
+      detail: `bundle "${bundleName}" is not discoverable` + (issueDetail ? ` (${issueDetail.reason})` : "") + ".",
+    };
+  }
+  if (bundle.manifest.kind !== "renderer") {
+    return {
+      ok: false,
+      detail:
+        `"cortex plugin load" supports renderer bundles only in this slice — adapter load needs the ` +
+        `binding-seed + demux-key inputs GatewayAdapterFactory owns today (cortex#1896). ` +
+        `"${bundleName}" declares kind "${bundle.manifest.kind}".`,
+    };
+  }
+
+  const skippedEntries = deps.skippedRendererConfigs.get(bundle.manifest.id);
+  if (!skippedEntries || skippedEntries.length === 0) {
+    return {
+      ok: false,
+      detail:
+        `no pending "renderers[]" config entry for kind "${bundle.manifest.id}" — "cortex plugin load" ` +
+        `only activates a renderer this stack's cortex.yaml already declares (its boot-time construction ` +
+        `failed because the plugin hadn't loaded). Add a "renderers[]" entry of this kind first.`,
+    };
+  }
+
+  const reimport = await reimportRendererPlugin(bundle, { bust: false });
+  if (!reimport.ok) {
+    return { ok: false, detail: `load failed at ${reimport.stage}: ${reimport.reason}` };
+  }
+
+  let parsedConfig: unknown;
+  try {
+    parsedConfig = reimport.plugin.configSchema.parse(skippedEntries[0]);
+  } catch (err) {
+    return {
+      ok: false,
+      detail: `load failed — the retained config entry does not satisfy the bundle's schema: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const result = await attachFreshRendererReplacing(
+    deps,
+    undefined,
+    reimport.plugin.id,
+    reimport.plugin,
+    parsedConfig,
+    bundleName,
+  );
+  if (result.ok) {
+    const remaining = skippedEntries.slice(1);
+    if (remaining.length > 0) {
+      deps.skippedRendererConfigs.set(bundle.manifest.id, remaining);
+    } else {
+      deps.skippedRendererConfigs.delete(bundle.manifest.id);
+    }
+  }
+  return result;
+}
+
+// =============================================================================
+// Shared construct → start → attach-before-detach helper
+// =============================================================================
+
+/**
+ * Construct a NEW renderer from `plugin`/`config`, start it, and register it
+ * on the router BEFORE tearing down `oldHandle` (when one is supplied) —
+ * ADR-0024 D3's renderer-delta requirement: "attach-before-detach … the
+ * router tolerates two targets on the same subjects, and PagerDuty's
+ * `dedup_key` absorbs the duplicate. Duplicate delivery is strictly safer
+ * than a blind window for a pager." `load` has no old instance
+ * (`oldHandle === undefined`) — construct-and-attach only.
+ */
+async function attachFreshRendererReplacing(
+  deps: PluginRuntimeDeps,
+  oldHandle: RendererHandle | undefined,
+  oldInstanceId: string,
+  plugin: RendererPlugin,
+  config: unknown,
+  bundleName: string,
+): Promise<MutationResult> {
+  let fresh: Renderer;
+  try {
+    fresh = plugin.createRenderer(config);
+  } catch (err) {
+    return {
+      ok: false,
+      detail:
+        `construction of the new instance failed: ${err instanceof Error ? err.message : String(err)}` +
+        (oldHandle ? " — the old instance is left running." : ""),
+    };
+  }
+  try {
+    await fresh.start();
+  } catch (err) {
+    return {
+      ok: false,
+      detail:
+        `starting the new instance failed: ${err instanceof Error ? err.message : String(err)}` +
+        (oldHandle ? " — the old instance is left running." : ""),
+    };
+  }
+
+  const newReg = deps.router.register(fresh.surfaceConfig);
+  deps.rendererHandles.set(fresh.id, {
+    renderer: fresh,
+    unregister: newReg.unregister,
+    bundleName,
+    rendererKind: fresh.kind,
+    config,
+  });
+
+  if (oldHandle) {
+    // Old instance leaves the router's dispatch list BEFORE teardown — no
+    // render can observe a half-swapped renderer (ADR-0024 D3).
+    oldHandle.unregister();
+    try {
+      await oldHandle.renderer.stop();
+    } catch (err) {
+      process.stderr.write(
+        `cortex plugin-runtime: old renderer instance "${oldInstanceId}" failed to stop cleanly after reload: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    if (fresh.id !== oldInstanceId) {
+      deps.rendererHandles.delete(oldInstanceId);
+    }
+    return { ok: true, detail: `renderer "${oldInstanceId}" reloaded from bundle "${bundleName}"` };
+  }
+
+  return { ok: true, detail: `renderer "${fresh.id}" loaded from bundle "${bundleName}"` };
+}
+
+// Re-exported so `plugin-control-server.ts` can construct discovery-only
+// diagnostics without importing loader.ts directly (keeps the loader import
+// surface to this one file, mirroring cortex.ts's existing convention).
+export type { DiscoveredBundle };

--- a/src/gateway/plugin-runtime.ts
+++ b/src/gateway/plugin-runtime.ts
@@ -3,7 +3,7 @@
  * list|unload|reload|load` reads and mutates. Pure, injected-dependency
  * logic: no NATS, no CLI parsing — `src/gateway/plugin-control-server.ts`
  * wires this to the bus-side request/response envelopes
- * (`system.plugin.control_request`/`_response`, `src/bus/system-events.ts`),
+ * (`system.plugin.control-request`/`-response`, `src/bus/system-events.ts`),
  * and `src/cli/cortex/commands/plugin-lib.ts` is the CLI-side caller.
  *
  * ## Scope (deliberately asymmetric — "the renderer half is cheaper")

--- a/src/gateway/plugin-runtime.ts
+++ b/src/gateway/plugin-runtime.ts
@@ -44,6 +44,8 @@ import {
   discoverPluginBundles,
   reimportRendererPlugin,
   type DiscoveredBundle,
+  type DiscoverPluginBundlesResult,
+  type ReimportRendererResult,
 } from "../adapters/loader";
 import type { RendererPlugin, SurfacePluginRegistry } from "../adapters/registry";
 import type { Renderer } from "../renderers/types";
@@ -128,6 +130,17 @@ export interface PluginRuntimeDeps {
   /** Forwarded to `discoverPluginBundles`/tests; `undefined` = arc's real
    *  install root. */
   pkgRoot?: string;
+  /** Test seam — defaults to the real `discoverPluginBundles`. Production
+   *  callers never set this. */
+  discoverBundles?: (opts: {
+    pkgRoot?: string;
+  }) => Promise<DiscoverPluginBundlesResult>;
+  /** Test seam — defaults to the real `reimportRendererPlugin`. Production
+   *  callers never set this. */
+  reimportRenderer?: (
+    bundle: DiscoveredBundle,
+    opts: { bust: boolean },
+  ) => Promise<ReimportRendererResult>;
 }
 
 // =============================================================================
@@ -228,7 +241,8 @@ export async function reloadLivePlugin(
     };
   }
 
-  const { bundles, issues } = await discoverPluginBundles({ pkgRoot: deps.pkgRoot });
+  const discoverBundles = deps.discoverBundles ?? discoverPluginBundles;
+  const { bundles, issues } = await discoverBundles({ pkgRoot: deps.pkgRoot });
   const bundle = bundles.find((b) => b.bundleName === handle.bundleName);
   if (!bundle) {
     const issueDetail = issues.find((i) => i.bundleName === handle.bundleName);
@@ -241,7 +255,8 @@ export async function reloadLivePlugin(
     };
   }
 
-  const reimport = await reimportRendererPlugin(bundle, { bust: true });
+  const reimportRenderer = deps.reimportRenderer ?? reimportRendererPlugin;
+  const reimport = await reimportRenderer(bundle, { bust: true });
   if (!reimport.ok) {
     return {
       ok: false,
@@ -268,7 +283,8 @@ export async function loadLivePlugin(
     };
   }
 
-  const { bundles, issues } = await discoverPluginBundles({ pkgRoot: deps.pkgRoot });
+  const discoverBundles = deps.discoverBundles ?? discoverPluginBundles;
+  const { bundles, issues } = await discoverBundles({ pkgRoot: deps.pkgRoot });
   const bundle = bundles.find((b) => b.bundleName === bundleName);
   if (!bundle) {
     const issueDetail = issues.find((i) => i.bundleName === bundleName);
@@ -298,7 +314,8 @@ export async function loadLivePlugin(
     };
   }
 
-  const reimport = await reimportRendererPlugin(bundle, { bust: false });
+  const reimportRenderer = deps.reimportRenderer ?? reimportRendererPlugin;
+  const reimport = await reimportRenderer(bundle, { bust: false });
   if (!reimport.ok) {
     return { ok: false, detail: `load failed at ${reimport.stage}: ${reimport.reason}` };
   }

--- a/src/gateway/surface-gateway.ts
+++ b/src/gateway/surface-gateway.ts
@@ -47,6 +47,7 @@
 import type { PlatformAdapter, InboundMessage } from "../adapters/types";
 import {
   resolveBinding,
+  parseStack,
   type GatewayBindingIndex,
   type GatewayBindingMatch,
 } from "./binding-resolver";
@@ -97,6 +98,40 @@ export interface GatewayInboundSink {
 }
 
 // =============================================================================
+// Runtime attach/detach (cortex#1793, S8, ADR-0024 D3 renderer-delta note +
+// "the adapter side is the hard half" scope amendment)
+// =============================================================================
+
+/**
+ * One binding seed to fold into the gateway's live {@link GatewayBindingIndex}
+ * when {@link SurfaceGateway.attachAdapter} brings a new adapter instance up
+ * at RUNTIME (no boot, no restart) — the runtime twin of the per-platform
+ * loops `buildBindingIndex` runs once at boot. Uses the SAME demux-key
+ * conventions byte-for-byte (`binding-resolver.ts`'s "v1 decisions") so an
+ * adapter attached mid-life resolves inbound identically to one present at
+ * boot:
+ *
+ *   - discord / slack: `demuxKey` = `binding.guildId` / `binding.workspaceId`.
+ *   - mattermost: `demuxKey` = `binding.apiUrl` (only meaningful for the
+ *     single-vs-multi recompute — see {@link SurfaceGateway.attachAdapter}).
+ *   - web: `demuxKey` = the adapter's own `instanceId` (NOT pre-fixed with
+ *     `"web:"` — the gateway derives the `web:${demuxKey}` index key itself,
+ *     matching `buildBindingIndex`'s web loop).
+ */
+export interface GatewayBindingSeed {
+  platform: "discord" | "slack" | "mattermost" | "web";
+  agent: string;
+  stack?: string;
+  demuxKey: string;
+}
+
+/** Outcome of {@link SurfaceGateway.detachAdapter}. */
+export interface DetachAdapterResult {
+  /** `false` when no attached instance matched `instanceId` — a no-op, not an error. */
+  detached: boolean;
+}
+
+// =============================================================================
 // SurfaceGateway
 // =============================================================================
 
@@ -129,6 +164,35 @@ export class SurfaceGateway {
   private readonly index: GatewayBindingIndex;
   private readonly sink: GatewayInboundSink;
   private readonly onUnroutable: (msg: InboundMessage, reason: string) => void;
+
+  /**
+   * cortex#1793 (S8) — the seeds each ATTACHED (runtime, not boot) instance
+   * folded into {@link index}, keyed by `PlatformAdapter.instanceId`. Boot-time
+   * adapters (constructed via the constructor's initial `adapters` array) are
+   * NOT tracked here — their index entries live for the gateway's whole
+   * lifetime and are torn down only by a full {@link stop}. Only entries added
+   * via {@link attachAdapter} are tracked, so {@link detachAdapter} removes
+   * EXACTLY what its matching attach added — never a boot-time binding.
+   */
+  private readonly attachedSeeds = new Map<string, GatewayBindingSeed[]>();
+
+  /**
+   * cortex#1793 (S8) — instance ids currently mid-detach or fully detached.
+   * Checked FIRST (synchronously, before any await) at the top of
+   * {@link handleInbound} so inbound racing in during/after a detach is
+   * dropped + logged rather than routed through a binding index entry that
+   * `detachAdapter` may already have removed. Cleared once the matching
+   * `detachAdapter` call returns (never inhabited by a boot-time instance).
+   */
+  private readonly detachedInstanceIds = new Set<string>();
+
+  /**
+   * cortex#1793 (S8) — in-flight `handleInbound` work per instance id, so
+   * {@link detachAdapter} can DRAIN: wait for everything already admitted
+   * before the detach flag was set, without blocking on work that arrives
+   * (and is dropped) after.
+   */
+  private readonly inFlight = new Map<string, Set<Promise<void>>>();
 
   constructor(
     adapters: PlatformAdapter[],
@@ -193,6 +257,235 @@ export class SurfaceGateway {
   }
 
   /**
+   * cortex#1793 (S8, ADR-0024 D3) — bring ONE new adapter instance up at
+   * runtime, no restart. The per-instance counterpart to {@link start}
+   * (which brings every BOOT-time adapter up together): folds `seeds` into
+   * the live {@link GatewayBindingIndex} (same demux-key rules
+   * `buildBindingIndex` uses — see {@link GatewayBindingSeed}), then
+   * `start()`s the adapter and attaches its inbound listener exactly like the
+   * boot-time loop does.
+   *
+   * Throws (adapter NOT attached) when:
+   *   - `adapter.instanceId` is already attached (boot-time or a prior
+   *     runtime attach) — call {@link detachAdapter} first to replace it;
+   *   - any discord/slack/web seed's demux key collides with an
+   *     already-bound key — the SAME loud "ambiguous config" error
+   *     `buildBindingIndex` throws at boot, so a colliding runtime attach
+   *     fails exactly as loudly as a colliding boot config would.
+   *
+   * Mattermost has no per-entry demux map (boot-time `buildBindingIndex`
+   * tracks only a single-vs-multi flag) — attaching a mattermost seed
+   * recomputes that flag from every seed this gateway has EVER attached
+   * (tracked in {@link attachedSeeds}), mirroring the boot-time loop's
+   * "exactly one binding is the fallback; more than one is ambiguous" rule.
+   *
+   * Never partially applies: index entries are added BEFORE `adapters.push`,
+   * so a throw here leaves neither the index nor the adapter list mutated
+   * for this attach.
+   */
+  async attachAdapter(
+    adapter: PlatformAdapter,
+    seeds: readonly GatewayBindingSeed[],
+  ): Promise<void> {
+    if (this.adapters.some((a) => a.instanceId === adapter.instanceId)) {
+      throw new Error(
+        `SurfaceGateway.attachAdapter: instance "${adapter.instanceId}" is already attached — ` +
+          `detachAdapter it first to replace it.`,
+      );
+    }
+
+    // Fold every non-mattermost seed into the index FIRST (loud throw on
+    // collision, before touching adapters/attachedSeeds) — mattermost is
+    // handled separately below via recompute, since it has no per-entry map.
+    for (const seed of seeds) {
+      if (seed.platform === "mattermost") continue;
+      this.addNonMattermostSeed(seed);
+    }
+    this.attachedSeeds.set(adapter.instanceId, [...seeds]);
+    if (seeds.some((s) => s.platform === "mattermost")) {
+      this.recomputeMattermostSlot();
+    }
+
+    this.detachedInstanceIds.delete(adapter.instanceId);
+    this.adapters.push(adapter);
+    await adapter.start((msg) => this.handleInbound(adapter, msg));
+    adapter.attachInboundDispatch?.();
+    process.stdout.write(
+      `[surface-gateway] adapter attached at runtime + inbound listener attached — ` +
+        `platform=${adapter.platform} instanceId=${adapter.instanceId}\n`,
+    );
+  }
+
+  /**
+   * cortex#1793 (S8, ADR-0024 D3) — detach ONE adapter instance at runtime,
+   * no restart, WITHOUT disturbing any other attached instance (the
+   * acceptance criterion: "detach of one adapter leaves every other adapter
+   * delivering").
+   *
+   * Sequence:
+   *   1. Mark `instanceId` detached FIRST (synchronous, before any await) —
+   *      any `handleInbound` call whose entry check runs after this point
+   *      drops its message (logged) instead of routing it, even though the
+   *      adapter object and its index entries are torn down a few lines
+   *      later in this same call. JS's single-threaded execution means no
+   *      inbound can slip between this line and the index/adapters mutation
+   *      below (neither yields to the event loop).
+   *   2. Remove the instance from `adapters` and fold its seeds back out of
+   *      the index (mattermost: recompute the slot from the REMAINING
+   *      tracked seeds).
+   *   3. DRAIN — await every `handleInbound` call already admitted into
+   *      {@link inFlight} for this instance (work that started before step 1)
+   *      so `adapter.stop()` never races an in-flight render/publish.
+   *   4. `adapter.stop()`.
+   *
+   * Returns `{ detached: false }` (no-op, not an error) when `instanceId`
+   * names no currently-attached adapter — mirrors the idempotent-miss
+   * convention `PlatformAdapter.stop()` documents elsewhere in this codebase.
+   */
+  async detachAdapter(instanceId: string): Promise<DetachAdapterResult> {
+    const idx = this.adapters.findIndex((a) => a.instanceId === instanceId);
+    if (idx === -1) return { detached: false };
+    const adapter = this.adapters[idx];
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- idx came from findIndex on THIS array, one line above; TS narrows via noUncheckedIndexedAccess but the index is provably in-bounds.
+    const liveAdapter = adapter!;
+
+    // Step 1 — flag FIRST. No await between here and step 2's mutations, so
+    // no inbound can observe a half-torn-down state.
+    this.detachedInstanceIds.add(instanceId);
+
+    // Step 2 — remove from the live adapter list + fold seeds back out of
+    // the index.
+    this.adapters.splice(idx, 1);
+    const seeds = this.attachedSeeds.get(instanceId) ?? [];
+    this.attachedSeeds.delete(instanceId);
+    for (const seed of seeds) {
+      if (seed.platform === "mattermost") continue;
+      this.removeNonMattermostSeed(seed);
+    }
+    if (seeds.some((s) => s.platform === "mattermost")) {
+      this.recomputeMattermostSlot();
+    }
+
+    // Step 3 — drain in-flight handleInbound work for this instance.
+    const pending = this.inFlight.get(instanceId);
+    if (pending && pending.size > 0) {
+      await Promise.allSettled([...pending]);
+    }
+    this.inFlight.delete(instanceId);
+
+    // Step 4 — release the platform connection.
+    await liveAdapter.stop();
+
+    process.stdout.write(
+      `[surface-gateway] adapter detached at runtime — platform=${liveAdapter.platform} ` +
+        `instanceId=${instanceId}\n`,
+    );
+    return { detached: true };
+  }
+
+  /** Fold one discord/slack/web seed into the live index. Throws the same
+   *  loud ambiguous-binding error {@link binding-resolver.ts}'s
+   *  `buildBindingIndex` throws at boot on a duplicate demux key. */
+  private addNonMattermostSeed(seed: GatewayBindingSeed): void {
+    const { principal, stack } = parseStack(seed.stack);
+    if (seed.platform === "discord") {
+      if (this.index.discord.has(seed.demuxKey)) {
+        throw new Error(
+          `SurfaceGateway.attachAdapter: ambiguous discord config — guildId "${seed.demuxKey}" is already bound.`,
+        );
+      }
+      this.index.discord.set(seed.demuxKey, {
+        agent: seed.agent,
+        principal,
+        stack,
+        instance: `discord:${seed.demuxKey}`,
+      });
+      return;
+    }
+    if (seed.platform === "slack") {
+      if (this.index.slack.has(seed.demuxKey)) {
+        throw new Error(
+          `SurfaceGateway.attachAdapter: ambiguous slack config — workspaceId "${seed.demuxKey}" is already bound.`,
+        );
+      }
+      this.index.slack.set(seed.demuxKey, {
+        agent: seed.agent,
+        principal,
+        stack,
+        instance: `slack:${seed.demuxKey}`,
+      });
+      return;
+    }
+    // web
+    const key = `web:${seed.demuxKey}`;
+    if (this.index.web.has(key)) {
+      throw new Error(
+        `SurfaceGateway.attachAdapter: ambiguous web config — instanceId "${seed.demuxKey}" is already bound.`,
+      );
+    }
+    this.index.web.set(key, {
+      agent: seed.agent,
+      principal,
+      stack,
+      instance: key,
+    });
+  }
+
+  /** Reverse of {@link addNonMattermostSeed} — removes exactly the entry the
+   *  matching attach inserted. */
+  private removeNonMattermostSeed(seed: GatewayBindingSeed): void {
+    if (seed.platform === "discord") {
+      this.index.discord.delete(seed.demuxKey);
+      return;
+    }
+    if (seed.platform === "slack") {
+      this.index.slack.delete(seed.demuxKey);
+      return;
+    }
+    this.index.web.delete(`web:${seed.demuxKey}`);
+  }
+
+  /**
+   * Recompute the index's mattermost single/multi slot from every mattermost
+   * seed CURRENTLY attached at runtime (`attachedSeeds`), mirroring
+   * `buildBindingIndex`'s "exactly one binding → fallback; more than one →
+   * ambiguous" rule. Deliberately does NOT consider boot-time mattermost
+   * bindings separately — those are already folded into the SAME
+   * `mattermostSingle`/`mattermostMulti` slot this recompute overwrites, so a
+   * boot-time binding must also flow through `attachedSeeds` bookkeeping to
+   * survive a later runtime attach/detach. In v1 (S8), boot never populates
+   * `attachedSeeds` (only `attachAdapter` does), so this recompute is a
+   * runtime-only concern until a boot-time mattermost + a runtime-attached
+   * mattermost coexist — not a configuration this slice's scope produces.
+   */
+  private recomputeMattermostSlot(): void {
+    const mmSeeds = [...this.attachedSeeds.values()]
+      .flat()
+      .filter((s) => s.platform === "mattermost");
+    if (mmSeeds.length === 0) {
+      this.index.mattermostSingle = null;
+      this.index.mattermostMulti = false;
+      return;
+    }
+    if (mmSeeds.length === 1) {
+      const sole = mmSeeds[0];
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length check above guarantees index 0 exists.
+      const { agent, stack, demuxKey } = sole!;
+      const { principal, stack: parsedStack } = parseStack(stack);
+      this.index.mattermostSingle = {
+        agent,
+        principal,
+        stack: parsedStack,
+        instance: `mattermost:${demuxKey}`,
+      };
+      this.index.mattermostMulti = false;
+      return;
+    }
+    this.index.mattermostSingle = null;
+    this.index.mattermostMulti = true;
+  }
+
+  /**
    * Route one inbound message to the sink.
    *
    * Called from inside the adapter's `onMessage` callback — MUST NOT throw.
@@ -201,12 +494,40 @@ export class SurfaceGateway {
    * throwing `sink.publish`, or anything else is logged with full context and
    * swallowed so the adapter loop stays alive.
    *
-   * @param _adapter the adapter that received the message. Unused in the shadow
-   *   stage; reserved for GW.a.3, where the outbound mux needs the per-connection
-   *   context to render replies. Kept on the signature (design §5 references
-   *   `gateway.handleInbound(adapter, msg)`) rather than re-threaded later.
+   * cortex#1793 (S8) — checks {@link detachedInstanceIds} FIRST: inbound for
+   * an instance mid-detach or already detached is dropped + logged rather
+   * than routed. Otherwise the actual work is tracked in {@link inFlight} for
+   * the duration of the call so {@link detachAdapter} can drain it.
+   *
+   * @param adapter the adapter that received the message. Used to key the
+   *   detached-check and the in-flight tracking by `instanceId`.
    */
   async handleInbound(
+    adapter: PlatformAdapter,
+    msg: InboundMessage,
+  ): Promise<void> {
+    if (this.detachedInstanceIds.has(adapter.instanceId)) {
+      process.stderr.write(
+        `[surface-gateway] dropping inbound — instance "${adapter.instanceId}" is detached. ` +
+          `platform=${msg.platform} channelId=${msg.channelId}\n`,
+      );
+      return;
+    }
+    const work = this.doHandleInbound(adapter, msg);
+    let set = this.inFlight.get(adapter.instanceId);
+    if (!set) {
+      set = new Set();
+      this.inFlight.set(adapter.instanceId, set);
+    }
+    set.add(work);
+    try {
+      await work;
+    } finally {
+      set.delete(work);
+    }
+  }
+
+  private async doHandleInbound(
     _adapter: PlatformAdapter,
     msg: InboundMessage,
   ): Promise<void> {

--- a/src/renderers/types.ts
+++ b/src/renderers/types.ts
@@ -42,19 +42,39 @@ import type { RendererKind } from "../common/types/cortex-config";
  *      "approve" click) goes through the bus as a logical envelope
  *      from the principal, not from any agent (architecture §9.3).
  *
- * **Renderers are static across hot-reload.** Unlike platform adapters
- * (which carry an `updateConfig(AgentConfig)` hook that the
- * `ConfigWatcher` invokes on bot.yaml changes), renderers have no
- * config-update surface. A change to `renderers[]` — adding a
- * pagerduty integration, rotating a routing key, expanding the
- * dashboard subscription set — requires a cortex restart to take
- * effect. This is intentional for the v1 slice: a renderer's
- * resources (HTTP clients, ring buffers, subscriptions) are scoped to
- * its lifetime, and the failure modes of partial hot-reload (a
- * routing key swap mid-flight) are easier to reason about with a
- * full stop/start cycle. A future iteration MAY add an
- * `updateConfig(RendererConfig)` hook if the principal-visible cost of
- * the restart proves too high (Holly cycle 1 W3).
+ * **REVERSED — renderers are NOT static across hot-reload.** [ADR-0024](../../docs/adr/0024-pluggable-surface-adapters.md)
+ * (cortex#1793, S8) reverses the "Renderers are static across hot-reload"
+ * decision this comment used to make, on its own stated terms (ADR-0024
+ * §Consequences: "⚠ REVERSAL"). The original three premises and what
+ * changed:
+ *
+ *   1. *"A restart is cheap enough"* — no longer true once a renderer is a
+ *      separately-installable bundle (ADR-0024 D5): forcing a full daemon
+ *      restart to activate one new renderer drags every live adapter
+ *      connection and in-flight dispatch through it for an unrelated plugin.
+ *   2. *"Partial hot-reload is harder to reason about"* — honoured, not
+ *      contradicted. There is still no `updateConfig(RendererConfig)` hook
+ *      and no mid-flight routing-key swap. What changed is the GRANULARITY
+ *      of the stop/start cycle: **detach → destroy → construct → attach**
+ *      via the `{ unregister }` handle `SurfaceRouter.register()` already
+ *      returned (`src/bus/surface-router.ts`) — the renderer boot loop used
+ *      to discard that handle; S8 retains it. The target leaves the
+ *      router's dispatch list *before* teardown, so no render ever observes
+ *      a half-swapped renderer. Full stop/start remains the semantic; its
+ *      blast radius shrinks from *the daemon* to *one renderer*.
+ *   3. *"A renderer's resources are scoped to its lifetime"* — still true,
+ *      and it's exactly what makes per-instance destroy-and-reconstruct safe
+ *      here (a renderer owns nothing durable and never publishes) where it
+ *      would NOT be safe for a platform adapter (which drops a live
+ *      connection and orphans progress placeholders).
+ *
+ * State loss on detach/reload is intentional and, per the above, harmless:
+ * the dashboard ring buffer resets (nothing reads it — ADR-0024 D2/OQ8); a
+ * renderer with a stable per-envelope derivation (e.g. PagerDuty's
+ * `dedup_key`, `src/renderers/pagerduty.ts`) is reload-stable by
+ * construction. `cortex plugin reload` (cortex#1793) is the runtime verb;
+ * `docs/plugin-sdk.md` documents the state-loss contract a plugin author
+ * must design for.
  */
 export interface Renderer {
   /** Discriminator matching `RendererKind`. */


### PR DESCRIPTION
Closes #1793. Epic #1784, W4 (S8) — the last purely-internal slice. Builds on merged S3-S6.

## What landed
- **Gateway per-instance attach/detach** (`surface-gateway.ts`, +329) with **drain** (in-flight `handleInbound` completes; new inbound to a detached instance drops, logged), detached-instance tracking, boot-vs-runtime seed separation.
- **Retained the router `unregister` handle** — the renderer boot loop in `cortex.ts` was DISCARDING it; now tracked in a `rendererHandles` map so a render target can be detached at runtime.
- **`cortex plugin list|unload|reload|load` CLI** — dry-run by default, `--apply` to mutate (modeled on `cortex stack`). Reads live daemon state via a NEW `system.plugin.control-request`/`-response` RPC over `runtime.publish`/`subscribe`, scoped `local.{principal}.*` (structurally can't cross a federation leaf). `cortex network status` has no reusable admin channel — it only reads config + nats `/leafz` — so this is a purpose-built one.
- **OQ12**: `renderers/types.ts` "renderers are static across hot-reload" comment rewritten to cite ADR-0024's reversal (grepped: only ADR-0024 + design doc still mention the phrase, both as historical/reversed context).
- **`docs/plugin-sdk.md`**: new "Runtime lifecycle" section — renderer/adapter asymmetry, the cache-bust finding, the detach state-loss contract.

## Reload cache-bust — VERIFIED, not assumed
Scratch-tested bun 1.3.2's `import()`: a `file://` URL (what S6's boot loader uses) does NOT cache-bust via `?v=`, but a plain filesystem path DOES (incl. nested relative imports). `reimportRendererPlugin` uses the plain-path form for reload; boot import untouched. Documented in code + docs.

## Scope (asymmetric, matches ADR-0024)
Renderers get full unload/reload/load. Adapters get `unload` only under `CORTEX_GATEWAY=1` (refused with a clear message otherwise — never a silent no-op); adapter reload/load refused citing **#1896** (the GatewayAdapterFactory shim owns the binding-seed/demux inputs real reconstruction needs).

## 🐛 Real bug caught — and it's on `main` (filed #1935)
Testing against a **real ephemeral nats-server** (not fakes) exposed that the envelope `type` pattern (`envelope.schema.json:22`) is **hyphen-only — underscores are silently dropped on delivery**. S8's own events were `control_request`/`reload_failed` (underscore) → published fine, received by nobody. **Fixed to hyphens here.** But this means merged `system.*` families with underscores (`system.plugin.load_failed` from S6, `peer_dispatch_received`, `reflex_activation_*`, `routing_decision`, `self_check`, …) are **currently unreceivable** — filed as **#1935** (coordinated fix, out of scope here; S8 flagged rather than mass-renamed).

## Provenance
Salvage-and-finish: a prior agent built the attach/detach + events + OQ12 then hit its usage limit; salvaged, verified correct, and finished (CLI verbs + reload + unregister-handle + docs) by the next agent.

## Gates
tsc 0 · scoped suite green (only 20 pre-existing `network secret add/revoke-member` failures, confirmed identical on baseline via `git stash`) · eslint 0 · vocab-gate PASS · shippable-hygiene clean · +32 new tests (15 plugin-runtime, 13 CLI, 4 system-events). Rebased on main.

**Not-done (flagged follow-ups):** adapter reload/load (#1896); standalone broadcast of `unloaded`/`reload-failed` beyond the RPC response (constructors exist + wire-verified, nothing calls them yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)