### PR TITLE
feat(loader): extend first-party exemption to cortex-declared adapter bundles (#1794 S9a)

### DIFF
--- a/docs/config-layout/system/system.yaml
+++ b/docs/config-layout/system/system.yaml
@@ -82,15 +82,21 @@ paths:
 # EXCEPTION, extended (cortex#1794 S9a, epic #1784 "transparent repackaging"
 # decision, 2026-07-12): a first-party ADAPTER bundle — one whose repoUrl is
 # declared under CORTEX's OWN, PR-reviewed `arc-manifest.yaml` `dependencies:`
+# AND whose dependency name follows the compass#115
+# `metafactory-cortex-adapter-<name>` naming standard
 # (`src/adapters/loader.ts`'s `isFirstPartyBundle` / `readCortexDeclaredAdapterRepos`;
 # again never the bundle's own manifest, `tier`, or any other bundle-author-
-# controlled signal) — ALSO loads even when `external` is off. Rationale:
-# extracting an in-tree adapter (e.g. `web`) into its own arc bundle must be
-# a transparent, non-breaking repackage — `arc upgrade cortex` auto-installs
-# the declared bundle and the surface keeps working with ZERO config change,
-# not a silent surface outage behind a flag nobody flipped. `external` keeps
-# its real job of gating genuinely THIRD-party plugins — nothing cortex
-# itself declares as a dependency.
+# controlled signal) — ALSO loads even when `external` is off. The naming
+# check matters: cortex declares OTHER dependencies too (`arc`, the package
+# manager; `metafactory-discord`, ADR-0017 CLI/skill tooling) that must NOT
+# get an adapter's flag-off exemption just because they're declared for some
+# unrelated reason (PR #1942 code-review fix). Rationale: extracting an
+# in-tree adapter (e.g. `web`) into its own arc bundle must be a transparent,
+# non-breaking repackage — `arc upgrade cortex` auto-installs the declared
+# bundle and the surface keeps working with ZERO config change, not a silent
+# surface outage behind a flag nobody flipped. `external` keeps its real job
+# of gating genuinely THIRD-party plugins — nothing cortex itself declares as
+# a first-party adapter bundle by name.
 plugins:
   external: false
 

--- a/docs/config-layout/system/system.yaml
+++ b/docs/config-layout/system/system.yaml
@@ -78,6 +78,19 @@ paths:
 # `external` is off. Rationale: "don't load third-party code" is secure for
 # adapters, but fail-open for a paging sink — a stack with an uninstalled or
 # unloaded PagerDuty bundle must not silently stop paging.
+#
+# EXCEPTION, extended (cortex#1794 S9a, epic #1784 "transparent repackaging"
+# decision, 2026-07-12): a first-party ADAPTER bundle — one whose repoUrl is
+# declared under CORTEX's OWN, PR-reviewed `arc-manifest.yaml` `dependencies:`
+# (`src/adapters/loader.ts`'s `isFirstPartyBundle` / `readCortexDeclaredAdapterRepos`;
+# again never the bundle's own manifest, `tier`, or any other bundle-author-
+# controlled signal) — ALSO loads even when `external` is off. Rationale:
+# extracting an in-tree adapter (e.g. `web`) into its own arc bundle must be
+# a transparent, non-breaking repackage — `arc upgrade cortex` auto-installs
+# the declared bundle and the surface keeps working with ZERO config change,
+# not a silent surface outage behind a flag nobody flipped. `external` keeps
+# its real job of gating genuinely THIRD-party plugins — nothing cortex
+# itself declares as a dependency.
 plugins:
   external: false
 

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -258,6 +258,47 @@ to) forbid the other cross-boundary imports discussed above; those are
 tracked as ADR-0024's residual couplings, resolved plugin-by-plugin as each
 one extracts (S9–S12).
 
+## Loading & the first-party exemption
+
+`src/adapters/loader.ts` discovers installed bundles (`arc list --json`),
+then gates each one through, in order: an unconditional org-trust check (only
+`the-metafactory`-org repos ever load, ADR-0024 D4 mitigation #1), the
+`system.plugins.external` flag (default OFF — see
+`docs/config-layout/system/system.yaml`), the SDK compat range, a
+duplicate-id/namespace-shadow check, and finally structural shape validation
+of the imported default export. None of this is something a plugin author
+needs to implement — it's listed here so you know WHY an installed bundle
+might not load, and what "first-party" buys you.
+
+**The `external: false` default means a THIRD-party bundle needs an explicit
+principal opt-in to load at all.** Two exemptions let a bundle load anyway,
+both anchored on something only CORTEX's own reviewed source controls —
+never anything the bundle's own manifest, `id`, `kind`, or arc's `tier` field
+says about itself (both were empirically checked and rejected as spoofable —
+see `isFirstPartyRendererBundle`'s doc comment in `loader.ts`):
+
+- **Renderer** (ADR-0024 §OQ9): the bundle's `repoUrl` is on
+  `FIRST_PARTY_RENDERER_REPOS`, a hardcoded, PR-reviewed allowlist in
+  `loader.ts`. Empty today — no first-party renderer bundle ships yet.
+- **Adapter** (cortex#1794 S9a, epic #1784 "transparent repackaging"
+  decision, 2026-07-12): the bundle's `repoUrl` matches an entry under
+  cortex's OWN `arc-manifest.yaml` `dependencies:` block, read fresh at
+  every boot (`readCortexDeclaredAdapterRepos`) — NOT a hardcoded allowlist,
+  so declaring a new first-party adapter bundle is a plain `arc-manifest.yaml`
+  PR, no loader code change. This is what makes extracting an in-tree
+  adapter (e.g. `web`) into its own bundle a *transparent* repackage:
+  `arc upgrade cortex` auto-installs the declared bundle, this exemption
+  loads it, and the surface keeps working with zero config change on any
+  existing stack — `external` never has to be flipped for a repackage that
+  isn't adding new third-party capability, only relocating cortex's own code.
+
+Both exemptions compose with (never replace) the org-trust gate — an
+exempt-looking bundle from outside `the-metafactory` is still refused before
+either allowlist is even consulted. If your bundle isn't declared as a
+cortex dependency and isn't loading, that's `system.plugins.external: false`
+doing its job; a principal opts in per-stack, or cortex's maintainers add
+your repo to the appropriate anchor once it's reviewed as truly first-party.
+
 ## Runtime lifecycle (S8) — attach/detach/reload + state loss
 
 cortex#1793 (S8, ADR-0024 D3) adds `cortex plugin list|unload|reload|load` —

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -285,12 +285,22 @@ see `isFirstPartyRendererBundle`'s doc comment in `loader.ts`):
   cortex's OWN `arc-manifest.yaml` `dependencies:` block, read fresh at
   every boot (`readCortexDeclaredAdapterRepos`) — NOT a hardcoded allowlist,
   so declaring a new first-party adapter bundle is a plain `arc-manifest.yaml`
-  PR, no loader code change. This is what makes extracting an in-tree
-  adapter (e.g. `web`) into its own bundle a *transparent* repackage:
-  `arc upgrade cortex` auto-installs the declared bundle, this exemption
-  loads it, and the surface keeps working with zero config change on any
-  existing stack — `external` never has to be flipped for a repackage that
-  isn't adding new third-party capability, only relocating cortex's own code.
+  PR, no loader code change. **Narrowed** (PR #1942 code-review fix): a
+  dependency only counts if its `name` ALSO follows the compass#115
+  `metafactory-cortex-adapter-<name>` repo-naming standard — being declared
+  as a cortex dependency for some OTHER reason (`arc`, the package manager;
+  `metafactory-discord`, ADR-0017 CLI/skill tooling) never grants the
+  exemption, even though both are real, org-trusted, cortex-declared
+  dependencies. This is what makes extracting an in-tree adapter (e.g.
+  `web`) into its own bundle a *transparent* repackage: once cortex declares
+  `metafactory-cortex-adapter-web`, `arc upgrade cortex` auto-installs it,
+  this exemption loads it, and the surface keeps working with zero config
+  change on any existing stack — `external` never has to be flipped for a
+  repackage that isn't adding new third-party capability, only relocating
+  cortex's own code. **Today the narrowed set is genuinely empty** — no
+  declared cortex dependency currently has an adapter-shaped name — so the
+  exemption is a real no-op until the first such bundle is declared, not an
+  accident of the raw dependency list happening to be empty (it isn't).
 
 Both exemptions compose with (never replace) the org-trust gate — an
 exempt-looking bundle from outside `the-metafactory` is still refused before
@@ -298,6 +308,15 @@ either allowlist is even consulted. If your bundle isn't declared as a
 cortex dependency and isn't loading, that's `system.plugins.external: false`
 doing its job; a principal opts in per-stack, or cortex's maintainers add
 your repo to the appropriate anchor once it's reviewed as truly first-party.
+
+**Threat-model note:** both exemptions, and the unconditional org-trust
+gate underneath them, ultimately rest on arc recording `repoUrl` as a
+package's real git clone source (verified empirically against a live
+`arc list --json`, S6). If a future arc version decoupled `repoUrl` from the
+actual clone source (e.g. an unauthenticated `--repo-url` override), every
+trust gate in this file would fall together — that is an explicit, named
+cross-repo (arc) dependency of cortex's entire plugin trust model, not
+something `loader.ts` can independently verify or defend against on its own.
 
 ## Runtime lifecycle (S8) — attach/detach/reload + state loss
 

--- a/src/adapters/__tests__/fixtures/adapter-declared-bundle/cortex-plugin.yaml
+++ b/src/adapters/__tests__/fixtures/adapter-declared-bundle/cortex-plugin.yaml
@@ -1,0 +1,12 @@
+# cortex#1794 (S9a) — first-party ADAPTER exemption fixture. This bundle's
+# `arc list`-recorded repoUrl is set (by the test) to
+# https://github.com/the-metafactory/metafactory-fixture-declared-adapter,
+# which the fixture cortex-manifest at
+# ../cortex-manifests/declares-fixture-adapter.yaml declares under
+# `dependencies:`. Proves an adapter bundle loads with
+# `system.plugins.external` OFF when — and only when — cortex's OWN manifest
+# declares it, mirroring the renderer OQ9 exemption's fixture style.
+kind: adapter
+id: fixture-declared-adapter
+entry: ./index.ts
+sdkRange: "^1"

--- a/src/adapters/__tests__/fixtures/adapter-declared-bundle/index.ts
+++ b/src/adapters/__tests__/fixtures/adapter-declared-bundle/index.ts
@@ -1,0 +1,81 @@
+/**
+ * cortex#1794 (S9a) — first-party ADAPTER exemption happy-path fixture.
+ * ZERO cortex runtime code — mirrors `echo-adapter-bundle/index.ts`'s shape
+ * exactly (only cortex-adjacent import is `import type` from `surface-sdk`,
+ * erased at runtime) under a distinct id/platform so it cannot collide with
+ * any in-tree platform or the other adapter fixtures.
+ */
+
+import { z } from "zod/v4";
+import type {
+  AccessDecision,
+  AdapterPlugin,
+  ContextMessage,
+  InboundMessage,
+  OutboundFile,
+  PlatformAdapter,
+  ResponseTarget,
+} from "../../../../surface-sdk";
+
+const ALLOW_ALL: AccessDecision = {
+  allowed: true,
+  features: { chat: true, async: true, team: true },
+};
+
+class FixtureDeclaredAdapter implements PlatformAdapter {
+  readonly platform = "fixture-declared-adapter";
+  readonly instanceId: string;
+
+  constructor(instanceId = "fixture-declared-adapter-instance") {
+    this.instanceId = instanceId;
+  }
+
+  async start(_onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {}
+  async stop(): Promise<void> {}
+  async getPlatformUserId(): Promise<string> {
+    return "fixture-declared-adapter-bot";
+  }
+  async fetchContext(_msg: InboundMessage, _depth: number): Promise<ContextMessage[]> {
+    return [];
+  }
+  resolveAccess(_msg: InboundMessage): AccessDecision {
+    return ALLOW_ALL;
+  }
+  async postResponse(_target: ResponseTarget, _text: string, _files?: OutboundFile[]): Promise<void> {}
+  async sendTyping(_target: ResponseTarget): Promise<void> {}
+  async sendProgress(_target: ResponseTarget, _text: string): Promise<void> {}
+  async clearProgress(_target: ResponseTarget): Promise<void> {}
+  async createThread(_msg: InboundMessage, _name: string): Promise<ResponseTarget> {
+    return { instanceId: this.instanceId, channelId: "fixture-declared-channel" };
+  }
+  async resolveLogicalTarget(_addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null> {
+    return null;
+  }
+  async notifyPrincipal(_text: string): Promise<void> {}
+}
+
+const FixtureDeclaredBindingSchema = z.object({ token: z.string().min(1) }).catchall(z.unknown());
+
+const fixtureDeclaredAdapterPlugin: AdapterPlugin = {
+  kind: "adapter",
+  id: "fixture-declared-adapter",
+  platform: "fixture-declared-adapter",
+  bindingSchema: FixtureDeclaredBindingSchema,
+  foldsIntoPresence: false,
+  secretFields: ["token"],
+  demuxKey: (binding) => {
+    const token = (binding as { token?: unknown }).token;
+    return typeof token === "string" ? token : "default";
+  },
+  buildGatewayConstructArgs: (group, base) => ({
+    instanceId: base.instanceId,
+    binding: group.entries[0]?.binding,
+  }),
+  createAdapter: (args) => new FixtureDeclaredAdapter((args as { instanceId?: string }).instanceId),
+};
+
+export default fixtureDeclaredAdapterPlugin;

--- a/src/adapters/__tests__/fixtures/cortex-manifests/declares-fixture-adapter.yaml
+++ b/src/adapters/__tests__/fixtures/cortex-manifests/declares-fixture-adapter.yaml
@@ -1,0 +1,20 @@
+# cortex#1794 (S9a) — fixture stand-in for cortex's OWN arc-manifest.yaml,
+# used ONLY via the `cortexManifestPath` test seam
+# (`src/adapters/loader.ts`'s `LoadPluginsOptions.cortexManifestPath`) to
+# exercise `readCortexDeclaredAdapterRepos` end-to-end without touching the
+# real repo-root arc-manifest.yaml. Shape mirrors the real file's
+# `dependencies:` block exactly (only `name` is read).
+name: "cortex-fixture"
+version: "0.0.0-test"
+type: component
+tier: community
+description: "Fixture stand-in for cortex's own arc-manifest.yaml (test-only)"
+dependencies:
+  - name: "arc"
+    version: ">=0.25.0"
+  # This is the fixture ADAPTER bundle's repoUrl (see
+  # ../adapter-declared-bundle/) declared as a dependency, exactly the way
+  # a real first-party adapter bundle (e.g. metafactory-cortex-adapter-web)
+  # is expected to be declared under cortex's real arc-manifest.yaml.
+  - name: "metafactory-fixture-declared-adapter"
+    version: ">=0.1.0"

--- a/src/adapters/__tests__/fixtures/cortex-manifests/declares-fixture-adapter.yaml
+++ b/src/adapters/__tests__/fixtures/cortex-manifests/declares-fixture-adapter.yaml
@@ -3,18 +3,34 @@
 # (`src/adapters/loader.ts`'s `LoadPluginsOptions.cortexManifestPath`) to
 # exercise `readCortexDeclaredAdapterRepos` end-to-end without touching the
 # real repo-root arc-manifest.yaml. Shape mirrors the real file's
-# `dependencies:` block exactly (only `name` is read).
+# `dependencies:` block exactly (only `name` is read) AND deliberately
+# mirrors its MIX of dependency kinds (PR #1942 code-review MAJOR fix) — not
+# every declared dependency is an adapter bundle, so this fixture proves the
+# narrowing (`ADAPTER_BUNDLE_DEP_NAME_RE`), not just the happy path.
 name: "cortex-fixture"
 version: "0.0.0-test"
 type: component
 tier: community
 description: "Fixture stand-in for cortex's own arc-manifest.yaml (test-only)"
 dependencies:
+  # Non-adapter dependency #1 — the package manager itself. Declared for an
+  # unrelated reason; must NEVER grant the adapter exemption.
   - name: "arc"
     version: ">=0.25.0"
-  # This is the fixture ADAPTER bundle's repoUrl (see
-  # ../adapter-declared-bundle/) declared as a dependency, exactly the way
-  # a real first-party adapter bundle (e.g. metafactory-cortex-adapter-web)
+  # Non-adapter dependency #2 — mirrors the REAL manifest's
+  # `metafactory-discord` entry exactly: a legitimately cortex-declared,
+  # org-trusted dependency that is CLI/skill tooling (ADR-0017), not an
+  # adapter. This is the exact case PR #1942's MAJOR finding was about — a
+  # pre-narrowing version of this anchor would have granted this name the
+  # adapter exemption the moment it ever shipped a `kind: adapter` manifest.
+  # Post-narrowing it never matches `metafactory-cortex-adapter-*`, so it
+  # never can.
+  - name: "metafactory-discord"
+    version: ">=0.1.0"
+  # The ONE dependency that DOES self-identify as a cortex-owned adapter
+  # component by name (compass#115 naming standard) — this is the fixture
+  # ADAPTER bundle's repoUrl (see ../adapter-declared-bundle/), declared the
+  # way a real first-party adapter bundle (e.g. metafactory-cortex-adapter-web)
   # is expected to be declared under cortex's real arc-manifest.yaml.
-  - name: "metafactory-fixture-declared-adapter"
+  - name: "metafactory-cortex-adapter-fixture"
     version: ">=0.1.0"

--- a/src/adapters/__tests__/fixtures/cortex-manifests/dependencies-not-array.yaml
+++ b/src/adapters/__tests__/fixtures/cortex-manifests/dependencies-not-array.yaml
@@ -1,0 +1,8 @@
+# cortex#1794 (S9a) — valid YAML, valid object, `dependencies:` key present
+# but its VALUE is not an array (a plain string) — exercises
+# `readCortexDeclaredAdapterRepos`'s `if (!Array.isArray(deps)) return new
+# Set()` fail-closed branch specifically (distinct from "key entirely
+# absent", already covered by no-dependencies-key.yaml).
+name: "cortex-fixture"
+version: "0.0.0-test"
+dependencies: "not-a-list"

--- a/src/adapters/__tests__/fixtures/cortex-manifests/dependency-missing-name.yaml
+++ b/src/adapters/__tests__/fixtures/cortex-manifests/dependency-missing-name.yaml
@@ -1,0 +1,11 @@
+# cortex#1794 (S9a) — valid YAML, valid `dependencies:` array, but the ONLY
+# entry has no `name` field at all (just a `version`) — exercises
+# `readCortexDeclaredAdapterRepos`'s per-entry `typeof dep.name !== "string"`
+# skip. A malformed entry must be skipped, never thrown on, and must never
+# contribute a spurious "undefined" repo to the derived set.
+name: "cortex-fixture"
+version: "0.0.0-test"
+dependencies:
+  - version: ">=1.0.0"
+  - name: "metafactory-cortex-adapter-fixture"
+    version: ">=0.1.0"

--- a/src/adapters/__tests__/fixtures/cortex-manifests/malformed.yaml
+++ b/src/adapters/__tests__/fixtures/cortex-manifests/malformed.yaml
@@ -1,0 +1,4 @@
+# cortex#1794 (S9a) — deliberately invalid YAML (unterminated flow mapping)
+# to exercise `readCortexDeclaredAdapterRepos`'s fail-closed parse-error path.
+name: "cortex-fixture"
+dependencies: [ { name: "oops"

--- a/src/adapters/__tests__/fixtures/cortex-manifests/no-dependencies-key.yaml
+++ b/src/adapters/__tests__/fixtures/cortex-manifests/no-dependencies-key.yaml
@@ -1,0 +1,5 @@
+# cortex#1794 (S9a) — valid YAML, valid object, but no `dependencies:` key
+# at all — exercises `readCortexDeclaredAdapterRepos`'s "missing key returns
+# empty set" branch (distinct from "file unreadable" and "malformed YAML").
+name: "cortex-fixture"
+version: "0.0.0-test"

--- a/src/adapters/__tests__/loader.test.ts
+++ b/src/adapters/__tests__/loader.test.ts
@@ -256,7 +256,16 @@ describe("isTrustedOrgRepo / isFirstPartyRendererBundle (cortex#1792, ADR-0024 D
 // real repo-root file, except in the one test that deliberately reads it to
 // prove the real file doesn't accidentally widen trust.
 const CORTEX_MANIFESTS_ROOT = join(FIXTURES_ROOT, "cortex-manifests");
-const DECLARED_ADAPTER_REPO = "https://github.com/the-metafactory/metafactory-fixture-declared-adapter";
+// PR #1942 MAJOR fix — the repo name MUST follow the compass#115
+// `metafactory-cortex-adapter-<name>` naming standard, or
+// `readCortexDeclaredAdapterRepos`'s narrowing filter drops it even though
+// it's a legitimately declared cortex dependency (see
+// `ADAPTER_BUNDLE_DEP_NAME_RE` in loader.ts).
+const DECLARED_ADAPTER_REPO = "https://github.com/the-metafactory/metafactory-cortex-adapter-fixture";
+// Mirrors the REAL manifest's `metafactory-discord` entry: a genuinely
+// cortex-declared, org-trusted dependency that is NOT an adapter bundle by
+// name shape (tooling, ADR-0017) — must never grant the adapter exemption.
+const NON_ADAPTER_DECLARED_REPO = "https://github.com/the-metafactory/metafactory-discord";
 const CORTEX_MANIFEST_DECLARES_FIXTURE = join(CORTEX_MANIFESTS_ROOT, "declares-fixture-adapter.yaml");
 
 describe("isFirstPartyAdapterBundle / isFirstPartyBundle (cortex#1794 S9a, epic #1784 decision)", () => {
@@ -300,13 +309,23 @@ describe("isFirstPartyAdapterBundle / isFirstPartyBundle (cortex#1794 S9a, epic 
 });
 
 describe("readCortexDeclaredAdapterRepos (cortex#1794 S9a) — the un-spoofable anchor source", () => {
-  test("reads dependency names from a fixture arc-manifest.yaml and derives the-metafactory repo URLs", () => {
+  test("reads dependency names from a fixture arc-manifest.yaml and derives EXACTLY the adapter-shaped repo URL — nothing else", () => {
+    // PR #1942 MAJOR regression test: the fixture manifest declares THREE
+    // dependencies (arc, metafactory-discord, metafactory-cortex-adapter-fixture)
+    // — asserting the EXACT resulting set (not just "contains X") proves the
+    // narrowing filter, not merely the happy path.
     const repos = readCortexDeclaredAdapterRepos(CORTEX_MANIFEST_DECLARES_FIXTURE);
-    expect(repos.has(DECLARED_ADAPTER_REPO.toLowerCase())).toBe(true);
-    // "arc" is also declared (mirrors the real manifest's shape) but it has
-    // no cortex-plugin.yaml anywhere, so it can never become a discovered
-    // bundle — being IN this set is harmless; it just never matches anything.
-    expect(repos.has("https://github.com/the-metafactory/arc")).toBe(true);
+    expect([...repos]).toEqual([DECLARED_ADAPTER_REPO.toLowerCase()]);
+    // Spelled out explicitly too, so a future refactor that silently widens
+    // the set (e.g. reverting the filter) fails loudly on BOTH assertions.
+    expect(repos.has("https://github.com/the-metafactory/arc")).toBe(false);
+    expect(repos.has(NON_ADAPTER_DECLARED_REPO.toLowerCase())).toBe(false);
+  });
+
+  test("PR #1942 MAJOR: a legitimately-declared but non-adapter-named dependency (mirrors the real metafactory-discord entry) never grants the exemption", () => {
+    const repos = readCortexDeclaredAdapterRepos(CORTEX_MANIFEST_DECLARES_FIXTURE);
+    expect(repos.has(NON_ADAPTER_DECLARED_REPO.toLowerCase())).toBe(false);
+    expect(isFirstPartyAdapterBundle({ repoUrl: NON_ADAPTER_DECLARED_REPO }, "adapter", repos)).toBe(false);
   });
 
   test("fail-closed: a missing manifest file returns an empty set, never throws", () => {
@@ -326,10 +345,32 @@ describe("readCortexDeclaredAdapterRepos (cortex#1794 S9a) — the un-spoofable 
     expect(readCortexDeclaredAdapterRepos(noDeps).size).toBe(0);
   });
 
-  test("cortex's REAL arc-manifest.yaml is readable and does NOT declare the fixture repo — proves the mechanism doesn't accidentally widen trust", () => {
+  // PR #1942 nit/test-coverage — the two fail-closed branches below were
+  // promised in the doc comment but previously untested.
+  test("fail-closed: `dependencies:` present but NOT an array returns an empty set, never throws", () => {
+    const notArray = join(CORTEX_MANIFESTS_ROOT, "dependencies-not-array.yaml");
+    expect(() => readCortexDeclaredAdapterRepos(notArray)).not.toThrow();
+    expect(readCortexDeclaredAdapterRepos(notArray).size).toBe(0);
+  });
+
+  test("fail-closed: a dependency entry with no `name` field is skipped, not thrown on — the OTHER valid entry still resolves", () => {
+    const missingName = join(CORTEX_MANIFESTS_ROOT, "dependency-missing-name.yaml");
+    const repos = readCortexDeclaredAdapterRepos(missingName);
+    expect([...repos]).toEqual([DECLARED_ADAPTER_REPO.toLowerCase()]);
+  });
+
+  test("cortex's REAL arc-manifest.yaml is readable, and its NARROWED adapter-exemption set is genuinely EMPTY today — the no-op claim is exact, not accidental", () => {
+    // PR #1942 MAJOR: the real manifest's raw `dependencies:` is
+    // `{arc, metafactory-discord}` — NEITHER matches
+    // `metafactory-cortex-adapter-*`, so the CORRECT claim is "the narrowed
+    // set is empty because no dependency asserts itself as an adapter bundle
+    // by name", not "the raw dependency list happens to be empty" (it isn't).
     const repos = readCortexDeclaredAdapterRepos(defaultCortexManifestPath());
+    expect(repos.size).toBe(0);
     expect(repos.has(DECLARED_ADAPTER_REPO.toLowerCase())).toBe(false);
     expect(repos.has(TRUSTED_REPO.toLowerCase())).toBe(false);
+    expect(repos.has("https://github.com/the-metafactory/arc")).toBe(false);
+    expect(repos.has("https://github.com/the-metafactory/metafactory-discord")).toBe(false);
   });
 });
 
@@ -836,6 +877,29 @@ describe("loadExternalPlugins — first-party ADAPTER exemption (cortex#1794 S9a
     expect(registry.getAdapter("fixture-declared-adapter")).toBeDefined();
   });
 
+  // PR #1942 MAJOR regression, end-to-end: a dependency that mirrors the
+  // REAL `metafactory-discord` entry (genuinely declared by cortex,
+  // org-trusted, but NOT an adapter-shaped name) must not grant the
+  // exemption even if a `kind: adapter` bundle is later installed at that
+  // exact repo. Uses `echo-adapter-bundle`'s manifest/export (any valid
+  // adapter shape works) with its repoUrl overridden to the non-adapter
+  // declared repo.
+  test("PR #1942 MAJOR: an adapter bundle at a legitimately-declared but non-adapter-shaped repo (metafactory-discord) does NOT get the exemption", async () => {
+    const registry = new SurfacePluginRegistry();
+    const result = await loadExternalPlugins({
+      registry,
+      externalEnabled: false,
+      pkgRoot: FIXTURES_ROOT,
+      runner: runnerFor([fixturePkg("echo-adapter-bundle", { repoUrl: NON_ADAPTER_DECLARED_REPO })]),
+      cortexManifestPath: CORTEX_MANIFEST_DECLARES_FIXTURE,
+    });
+    expect(result.loaded).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.bundleName).toBe("echo-adapter-bundle");
+    expect(registry.getAdapter("fixture-echo")).toBeUndefined();
+  });
+
   test("an adapter bundle whose repoUrl is NOT declared does not load with the flag off, but WOULD with it on (org-trust already satisfied)", async () => {
     const registryOff = new SurfacePluginRegistry();
     const offResult = await loadExternalPlugins({
@@ -930,12 +994,12 @@ describe("loadExternalPlugins — first-party ADAPTER exemption (cortex#1794 S9a
       externalEnabled: false,
       pkgRoot: FIXTURES_ROOT,
       runner: runnerFor([
-        fixturePkg("adapter-declared-bundle", { repoUrl: "https://github.com/attacker/metafactory-fixture-declared-adapter" }),
+        fixturePkg("adapter-declared-bundle", { repoUrl: "https://github.com/attacker/metafactory-cortex-adapter-fixture" }),
       ]),
       // Allowlist derived from the ATTACKER url directly (simulating a bug
       // elsewhere) — org-trust must still refuse it BEFORE the first-party
       // gate is ever consulted (D4 mitigation #1 is unconditional).
-      firstPartyAdapterRepos: new Set(["https://github.com/attacker/metafactory-fixture-declared-adapter"]),
+      firstPartyAdapterRepos: new Set(["https://github.com/attacker/metafactory-cortex-adapter-fixture"]),
     });
     expect(result.loaded).toEqual([]);
     expect(result.failed).toHaveLength(1);

--- a/src/adapters/__tests__/loader.test.ts
+++ b/src/adapters/__tests__/loader.test.ts
@@ -15,10 +15,14 @@ import { tmpdir } from "os";
 import { join, resolve } from "path";
 
 import {
+  defaultCortexManifestPath,
   discoverPluginBundles,
+  isFirstPartyAdapterBundle,
+  isFirstPartyBundle,
   isFirstPartyRendererBundle,
   isTrustedOrgRepo,
   loadExternalPlugins,
+  readCortexDeclaredAdapterRepos,
   type ArcListRunResult,
 } from "../loader";
 import { createDefaultSurfacePluginRegistry, registryFromFactory, SurfacePluginRegistry } from "../registry";
@@ -242,6 +246,90 @@ describe("isTrustedOrgRepo / isFirstPartyRendererBundle (cortex#1792, ADR-0024 D
   test("the production allowlist default is empty (no first-party renderer bundle ships yet)", () => {
     // Calling with no allowlist argument uses the real in-tree constant.
     expect(isFirstPartyRendererBundle({ repoUrl: TRUSTED_REPO }, "renderer")).toBe(false);
+  });
+});
+
+// cortex#1794 (S9a) — the ADAPTER half of the OQ9 exemption, extended per
+// epic #1784's "Andreas decision 2026-07-12" (transparent repackaging).
+// `CORTEX_MANIFESTS_ROOT` fixtures stand in for cortex's OWN
+// `arc-manifest.yaml` via the `cortexManifestPath` test seam — never the
+// real repo-root file, except in the one test that deliberately reads it to
+// prove the real file doesn't accidentally widen trust.
+const CORTEX_MANIFESTS_ROOT = join(FIXTURES_ROOT, "cortex-manifests");
+const DECLARED_ADAPTER_REPO = "https://github.com/the-metafactory/metafactory-fixture-declared-adapter";
+const CORTEX_MANIFEST_DECLARES_FIXTURE = join(CORTEX_MANIFESTS_ROOT, "declares-fixture-adapter.yaml");
+
+describe("isFirstPartyAdapterBundle / isFirstPartyBundle (cortex#1794 S9a, epic #1784 decision)", () => {
+  test("adapter + on the declared-dependency allowlist -> exempt", () => {
+    const allowlist = new Set([DECLARED_ADAPTER_REPO.toLowerCase()]);
+    expect(isFirstPartyAdapterBundle({ repoUrl: DECLARED_ADAPTER_REPO }, "adapter", allowlist)).toBe(true);
+  });
+
+  test("renderer kind is NEVER exempt via the adapter allowlist path — the two exemptions are namespaced by kind", () => {
+    const allowlist = new Set([DECLARED_ADAPTER_REPO.toLowerCase()]);
+    expect(isFirstPartyAdapterBundle({ repoUrl: DECLARED_ADAPTER_REPO }, "renderer", allowlist)).toBe(false);
+  });
+
+  test("adapter NOT on the allowlist -> not exempt, no matter how trustworthy the repo looks", () => {
+    const allowlist = new Set([DECLARED_ADAPTER_REPO.toLowerCase()]);
+    expect(isFirstPartyAdapterBundle({ repoUrl: TRUSTED_REPO }, "adapter", allowlist)).toBe(false);
+  });
+
+  test("isFirstPartyBundle dispatches by kind: renderer path delegates verbatim, adapter path uses the adapter allowlist", () => {
+    const rendererAllowlist = new Set([TRUSTED_REPO.toLowerCase()]);
+    const adapterAllowlist = new Set([DECLARED_ADAPTER_REPO.toLowerCase()]);
+    expect(
+      isFirstPartyBundle({ repoUrl: TRUSTED_REPO }, "renderer", { rendererAllowlist, adapterAllowlist }),
+    ).toBe(true);
+    expect(
+      isFirstPartyBundle({ repoUrl: DECLARED_ADAPTER_REPO }, "adapter", { rendererAllowlist, adapterAllowlist }),
+    ).toBe(true);
+    // Cross-checks: a repo on the RENDERER list gets no adapter exemption,
+    // and vice versa — no accidental cross-pollination between the two.
+    expect(
+      isFirstPartyBundle({ repoUrl: DECLARED_ADAPTER_REPO }, "renderer", { rendererAllowlist, adapterAllowlist }),
+    ).toBe(false);
+    expect(
+      isFirstPartyBundle({ repoUrl: TRUSTED_REPO }, "adapter", { rendererAllowlist, adapterAllowlist }),
+    ).toBe(false);
+  });
+
+  test("isFirstPartyBundle with no allowlists supplied defaults closed for adapters (empty set, not open)", () => {
+    expect(isFirstPartyBundle({ repoUrl: DECLARED_ADAPTER_REPO }, "adapter")).toBe(false);
+  });
+});
+
+describe("readCortexDeclaredAdapterRepos (cortex#1794 S9a) — the un-spoofable anchor source", () => {
+  test("reads dependency names from a fixture arc-manifest.yaml and derives the-metafactory repo URLs", () => {
+    const repos = readCortexDeclaredAdapterRepos(CORTEX_MANIFEST_DECLARES_FIXTURE);
+    expect(repos.has(DECLARED_ADAPTER_REPO.toLowerCase())).toBe(true);
+    // "arc" is also declared (mirrors the real manifest's shape) but it has
+    // no cortex-plugin.yaml anywhere, so it can never become a discovered
+    // bundle — being IN this set is harmless; it just never matches anything.
+    expect(repos.has("https://github.com/the-metafactory/arc")).toBe(true);
+  });
+
+  test("fail-closed: a missing manifest file returns an empty set, never throws", () => {
+    const missing = join(CORTEX_MANIFESTS_ROOT, "does-not-exist.yaml");
+    expect(() => readCortexDeclaredAdapterRepos(missing)).not.toThrow();
+    expect(readCortexDeclaredAdapterRepos(missing).size).toBe(0);
+  });
+
+  test("fail-closed: malformed YAML returns an empty set, never throws", () => {
+    const malformed = join(CORTEX_MANIFESTS_ROOT, "malformed.yaml");
+    expect(() => readCortexDeclaredAdapterRepos(malformed)).not.toThrow();
+    expect(readCortexDeclaredAdapterRepos(malformed).size).toBe(0);
+  });
+
+  test("a valid manifest with no `dependencies:` key at all returns an empty set", () => {
+    const noDeps = join(CORTEX_MANIFESTS_ROOT, "no-dependencies-key.yaml");
+    expect(readCortexDeclaredAdapterRepos(noDeps).size).toBe(0);
+  });
+
+  test("cortex's REAL arc-manifest.yaml is readable and does NOT declare the fixture repo — proves the mechanism doesn't accidentally widen trust", () => {
+    const repos = readCortexDeclaredAdapterRepos(defaultCortexManifestPath());
+    expect(repos.has(DECLARED_ADAPTER_REPO.toLowerCase())).toBe(false);
+    expect(repos.has(TRUSTED_REPO.toLowerCase())).toBe(false);
   });
 });
 
@@ -717,5 +805,140 @@ describe("loadExternalPlugins (cortex#1792) — the full discover-gate-import-re
       runner: runnerFor([fixturePkg("echo-adapter-bundle"), fixturePkg("cli-tail-bundle")]),
     });
     expect(result.loaded.map((l) => l.bundleName)).toEqual(["cli-tail-bundle", "echo-adapter-bundle"]);
+  });
+});
+
+// cortex#1794 (S9a, epic #1784 "TRANSPARENT REPACKAGING" decision) — the
+// end-to-end fixture proof: a first-party ADAPTER bundle loads with
+// `system.plugins.external` OFF exactly like a first-party renderer already
+// does, but gated on cortex's OWN declared `arc-manifest.yaml` dependencies
+// instead of a hardcoded allowlist; an undeclared adapter bundle does not.
+describe("loadExternalPlugins — first-party ADAPTER exemption (cortex#1794 S9a)", () => {
+  test("a first-party ADAPTER bundle (repoUrl declared in cortex's arc-manifest dependencies) loads with system.plugins.external OFF", async () => {
+    const registry = new SurfacePluginRegistry();
+    const result = await loadExternalPlugins({
+      registry,
+      externalEnabled: false,
+      pkgRoot: FIXTURES_ROOT,
+      runner: runnerFor([fixturePkg("adapter-declared-bundle", { repoUrl: DECLARED_ADAPTER_REPO })]),
+      cortexManifestPath: CORTEX_MANIFEST_DECLARES_FIXTURE,
+    });
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(result.loaded).toEqual([
+      {
+        bundleName: "adapter-declared-bundle",
+        kind: "adapter",
+        id: "fixture-declared-adapter",
+        firstParty: true,
+      },
+    ]);
+    expect(registry.getAdapter("fixture-declared-adapter")).toBeDefined();
+  });
+
+  test("an adapter bundle whose repoUrl is NOT declared does not load with the flag off, but WOULD with it on (org-trust already satisfied)", async () => {
+    const registryOff = new SurfacePluginRegistry();
+    const offResult = await loadExternalPlugins({
+      registry: registryOff,
+      externalEnabled: false,
+      pkgRoot: FIXTURES_ROOT,
+      // echo-adapter-bundle's repoUrl defaults to TRUSTED_REPO, which is NOT
+      // declared in declares-fixture-adapter.yaml's dependencies.
+      runner: runnerFor([fixturePkg("echo-adapter-bundle")]),
+      cortexManifestPath: CORTEX_MANIFEST_DECLARES_FIXTURE,
+    });
+    expect(offResult.loaded).toEqual([]);
+    expect(offResult.skipped).toHaveLength(1);
+    expect(offResult.skipped[0]?.bundleName).toBe("echo-adapter-bundle");
+    expect(registryOff.getAdapter("fixture-echo")).toBeUndefined();
+
+    // Same bundle, same (irrelevant) cortexManifestPath, flag ON — loads.
+    // Proves the skip above was SPECIFICALLY the first-party-adapter gate
+    // (org-trust and every other gate already pass for this fixture).
+    const registryOn = new SurfacePluginRegistry();
+    const onResult = await loadExternalPlugins({
+      registry: registryOn,
+      externalEnabled: true,
+      pkgRoot: FIXTURES_ROOT,
+      runner: runnerFor([fixturePkg("echo-adapter-bundle")]),
+      cortexManifestPath: CORTEX_MANIFEST_DECLARES_FIXTURE,
+    });
+    expect(onResult.loaded).toEqual([
+      { bundleName: "echo-adapter-bundle", kind: "adapter", id: "fixture-echo", firstParty: false },
+    ]);
+  });
+
+  test("fail-closed: an unreadable cortexManifestPath grants NO adapter exemption — a genuinely declared-looking bundle still skips with the flag off", async () => {
+    const registry = new SurfacePluginRegistry();
+    const result = await loadExternalPlugins({
+      registry,
+      externalEnabled: false,
+      pkgRoot: FIXTURES_ROOT,
+      runner: runnerFor([fixturePkg("adapter-declared-bundle", { repoUrl: DECLARED_ADAPTER_REPO })]),
+      cortexManifestPath: join(CORTEX_MANIFESTS_ROOT, "does-not-exist.yaml"),
+    });
+    expect(result.loaded).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(registry.getAdapter("fixture-declared-adapter")).toBeUndefined();
+  });
+
+  test("firstPartyAdapterRepos (explicit test seam) wins over cortexManifestPath when both are set", async () => {
+    const registry = new SurfacePluginRegistry();
+    const result = await loadExternalPlugins({
+      registry,
+      externalEnabled: false,
+      pkgRoot: FIXTURES_ROOT,
+      runner: runnerFor([fixturePkg("adapter-declared-bundle", { repoUrl: DECLARED_ADAPTER_REPO })]),
+      // Points at a manifest that does NOT declare the bundle...
+      cortexManifestPath: join(CORTEX_MANIFESTS_ROOT, "no-dependencies-key.yaml"),
+      // ...but the explicit allowlist DOES include it, and must win.
+      firstPartyAdapterRepos: new Set([DECLARED_ADAPTER_REPO.toLowerCase()]),
+    });
+    expect(result.loaded).toEqual([
+      {
+        bundleName: "adapter-declared-bundle",
+        kind: "adapter",
+        id: "fixture-declared-adapter",
+        firstParty: true,
+      },
+    ]);
+  });
+
+  test("renderer path regression: a first-party RENDERER bundle still loads via firstPartyRendererRepos exactly as before, unaffected by the new adapter mechanism", async () => {
+    const registry = new SurfacePluginRegistry();
+    const result = await loadExternalPlugins({
+      registry,
+      externalEnabled: false,
+      pkgRoot: FIXTURES_ROOT,
+      runner: runnerFor([fixturePkg("cli-tail-bundle")]),
+      firstPartyRendererRepos: new Set([TRUSTED_REPO.toLowerCase()]),
+      // A cortex manifest is present and even declares a DIFFERENT adapter
+      // repo — must have zero bearing on the renderer exemption path.
+      cortexManifestPath: CORTEX_MANIFEST_DECLARES_FIXTURE,
+    });
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(result.loaded).toEqual([
+      { bundleName: "cli-tail-bundle", kind: "renderer", id: "cli-tail", firstParty: true },
+    ]);
+  });
+
+  test("org-trust gate still refuses a non-the-metafactory adapter bundle even if it magically matched the adapter allowlist", async () => {
+    const registry = new SurfacePluginRegistry();
+    const result = await loadExternalPlugins({
+      registry,
+      externalEnabled: false,
+      pkgRoot: FIXTURES_ROOT,
+      runner: runnerFor([
+        fixturePkg("adapter-declared-bundle", { repoUrl: "https://github.com/attacker/metafactory-fixture-declared-adapter" }),
+      ]),
+      // Allowlist derived from the ATTACKER url directly (simulating a bug
+      // elsewhere) — org-trust must still refuse it BEFORE the first-party
+      // gate is ever consulted (D4 mitigation #1 is unconditional).
+      firstPartyAdapterRepos: new Set(["https://github.com/attacker/metafactory-fixture-declared-adapter"]),
+    });
+    expect(result.loaded).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.stage).toBe("org_trust");
   });
 });

--- a/src/adapters/loader.ts
+++ b/src/adapters/loader.ts
@@ -469,13 +469,57 @@ export function isFirstPartyBundle(
 }
 
 /**
+ * cortex#1794 (S9a) — a dependency `name` in cortex's OWN `arc-manifest.yaml`
+ * grants the adapter exemption ONLY if it also asserts, by its OWN name
+ * shape, that it IS a cortex-owned adapter-type component — never merely
+ * "cortex depends on it for some reason". This is the fix for a code-review
+ * MAJOR (PR #1942): an earlier version of this anchor treated cortex's
+ * ENTIRE `dependencies:` list as adapter-exempt, so `arc` (the package
+ * manager) and `metafactory-discord` (ADR-0017 CLI/skill *tooling* —
+ * explicitly NOT the adapter, per ADR-0024's own migration provenance
+ * section) would BOTH have granted the exemption to any `kind: adapter`
+ * plugin they ever happened to ship, despite neither being declared FOR
+ * adapter-trust reasons. That is exactly the failure ADR-0024 §OQ9 names:
+ * *"'First-party' must be a checkable property of a bundle, not a naming
+ * convention… an unchecked 'first-party' exemption is a trust hole wearing
+ * a friendly name."* — the naming convention there is about a BUNDLE
+ * claiming its own trust; here the risk was the REVERSE mistake, reading
+ * "listed as a dependency" as "trusted as an adapter" when a dependency can
+ * be declared for any number of unrelated reasons.
+ *
+ * The fix narrows to the **ecosystem-wide, structurally-checkable**
+ * repo-naming standard (compass `standards/component-repo-naming.md`, PR
+ * the-metafactory/compass#115, adopted the same day as the epic #1784
+ * decision this anchor implements): a cortex-owned adapter bundle's repo
+ * name is ALWAYS `metafactory-cortex-adapter-<name>` (`<owner>` = `cortex`,
+ * `<type>` = `adapter`) — locked BEFORE the first such repo is created
+ * specifically so this epic's extractions have a stable name to check
+ * against ("Requested by Andreas 2026-07-12", same standard doc). This is
+ * still un-spoofable for the same reason as before — the NAME is read out
+ * of cortex's own PR-reviewed manifest, never anything the bundle
+ * self-declares — the narrowing only adds a SECOND, independently-checkable
+ * requirement on TOP of "declared by cortex": the declared name must also
+ * self-identify, in a fixed and enforced shape, as a cortex-adapter
+ * component. `arc` and `metafactory-discord` (or its scheduled rename,
+ * `metafactory-bundle-discord` — compass#116) never match this shape, by
+ * construction: neither is a `metafactory-cortex-adapter-*` name, so
+ * neither is EVER treated as first-party for the adapter exemption, no
+ * matter what kind of `cortex-plugin.yaml` a bundle at that name might one
+ * day ship. See {@link ADAPTER_BUNDLE_DEP_NAME_RE}.
+ */
+const ADAPTER_BUNDLE_DEP_NAME_RE = /^metafactory-cortex-adapter-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
  * cortex#1794 (S9a, epic #1784 "Andreas decision 2026-07-12") — the
  * un-spoofable first-party ADAPTER anchor: cortex's OWN, PR-reviewed
- * `arc-manifest.yaml` `dependencies:` block. This is deliberately NOT a
- * hardcoded allowlist like {@link FIRST_PARTY_RENDERER_REPOS} — it is read
- * fresh at every load, so declaring a new first-party adapter bundle (e.g.
- * the planned `metafactory-cortex-adapter-web`) is a plain `arc-manifest.yaml`
- * PR, never a `loader.ts` code change.
+ * `arc-manifest.yaml` `dependencies:` block, NARROWED to only the entries
+ * whose `name` matches {@link ADAPTER_BUNDLE_DEP_NAME_RE} (see that
+ * constant's doc comment for why the narrowing is required — PR #1942
+ * code-review MAJOR). This is deliberately NOT a hardcoded allowlist like
+ * {@link FIRST_PARTY_RENDERER_REPOS} — it is read fresh at every load, so
+ * declaring a new first-party adapter bundle (e.g. the planned
+ * `metafactory-cortex-adapter-web`) is a plain `arc-manifest.yaml` PR, never
+ * a `loader.ts` code change.
  *
  * Why this is un-spoofable: a bundle's OWN manifest (`cortex-plugin.yaml`)
  * and arc's `tier` field were already rejected as trust anchors for the
@@ -485,22 +529,52 @@ export function isFirstPartyBundle(
  * un-spoofability: it is CORTEX's manifest, shipped in CORTEX's repo, only
  * ever changed by a PR against CORTEX — a bundle author publishing
  * `metafactory-evil-adapter` cannot make cortex's own dependency list
- * declare their repo. The declaration is the review event (mirrors D4
- * mitigation #3 — "a bundle upgrade is a code-review event, not a passive
- * fetch" — applied one level up, to the act of TRUSTING the bundle at all).
+ * declare their repo, AND (post-narrowing) could not even self-select into
+ * the exemption by picking a matching name for their OWN repo — membership
+ * requires appearing, under that exact name, in CORTEX's manifest, which
+ * only a cortex-repo PR controls either way.
  *
  * Deriving a repo URL from a dependency `name`: `arc-manifest.yaml`
  * dependency names in this ecosystem ARE the GitHub repo name under the
  * trusted `the-metafactory` org, by the repo-first install convention
  * (ADR-0017 — see cortex's own `arc-manifest.yaml`, the `metafactory-discord`
  * entry: "the bundle is `arc install`-able from the
- * the-metafactory/metafactory-discord repo"). So `name: "metafactory-foo"`
- * derives `https://github.com/the-metafactory/metafactory-foo`, normalized
- * the same way {@link normalizeRepoUrl} normalizes an installed bundle's
- * `arc list`-recorded `repoUrl`, making membership a plain set-lookup. Every
- * derived URL is by construction inside `the-metafactory` — this composes
- * with (never replaces) the unconditional {@link isTrustedOrgRepo} gate,
- * which still runs first and independently for every bundle.
+ * the-metafactory/metafactory-discord repo"). So `name:
+ * "metafactory-cortex-adapter-web"` derives
+ * `https://github.com/the-metafactory/metafactory-cortex-adapter-web`,
+ * normalized the same way {@link normalizeRepoUrl} normalizes an installed
+ * bundle's `arc list`-recorded `repoUrl`, making membership a plain
+ * set-lookup. Every derived URL is by construction inside `the-metafactory`
+ * — this composes with (never replaces) the unconditional
+ * {@link isTrustedOrgRepo} gate, which still runs first and independently
+ * for every bundle.
+ *
+ * **Threat-model note (both this anchor AND {@link isTrustedOrgRepo}):**
+ * un-spoofability here ultimately rests on arc recording `repoUrl` as the
+ * package's actual git clone source (confirmed empirically against a live
+ * `arc list --json` — S6). If a future arc version ever added a `--repo-url`
+ * override decoupled from the real clone source, BOTH gates would fall
+ * together — this is an explicit cross-repo (arc) dependency of cortex's
+ * entire plugin trust model, not something this module can independently
+ * verify or defend against; it is recorded here so a future arc change is
+ * evaluated against it.
+ *
+ * **Persistence-via-self-rewrite (author-flagged, PR #1942 nit):** an
+ * already-loaded bundle — which, under D4's accepted full-daemon-authority
+ * model, already has filesystem access equivalent to the daemon — could
+ * rewrite cortex's OWN `arc-manifest.yaml` on disk to grant a FUTURE bundle
+ * this exemption on the next boot. This is NOT symmetric with the renderer
+ * allowlist's equivalent risk, only equivalent UNDER D4's full-compromise
+ * assumption: {@link FIRST_PARTY_RENDERER_REPOS} is a compiled-in TS
+ * constant, so self-granting via it means editing `loader.ts` source AND
+ * getting a rebuild to pick it up; this anchor is a plain YAML data file,
+ * read fresh every boot, no rebuild required — a strictly CHEAPER edit for
+ * an attacker who already has arbitrary file write. Under D4 (arbitrary
+ * code exec inside an already-loaded plugin = full compromise) neither
+ * barrier stops the attacker; the difference is defense-in-depth cost, not
+ * whether the barrier holds — recorded here, not fixed here, because D4
+ * already accepts this class of risk for v1 (named future escalation:
+ * registry signing / separate-process-over-IPC, ADR-0024 D4).
  *
  * Fail-closed by design: ANY read/parse failure — missing file, invalid
  * YAML, no `dependencies:` key, non-array `dependencies:`, a dependency
@@ -518,9 +592,15 @@ export function readCortexDeclaredAdapterRepos(manifestPath: string): ReadonlySe
     if (!Array.isArray(deps)) return new Set();
     const repos = new Set<string>();
     for (const dep of deps) {
-      if (isRecord(dep) && typeof dep.name === "string" && dep.name.trim().length > 0) {
-        repos.add(normalizeRepoUrl(`https://github.com/the-metafactory/${dep.name.trim()}`));
-      }
+      if (!isRecord(dep) || typeof dep.name !== "string") continue;
+      const name = dep.name.trim();
+      // PR #1942 MAJOR fix — only a dependency name that self-identifies as
+      // a cortex-owned ADAPTER component (the compass#115 naming standard)
+      // grants the exemption. `arc`, `metafactory-discord`, and any other
+      // legitimately-declared-but-unrelated dependency never match, no
+      // matter what they ship.
+      if (!ADAPTER_BUNDLE_DEP_NAME_RE.test(name)) continue;
+      repos.add(normalizeRepoUrl(`https://github.com/the-metafactory/${name}`));
     }
     return repos;
   } catch {

--- a/src/adapters/loader.ts
+++ b/src/adapters/loader.ts
@@ -24,7 +24,11 @@
  *      deterministic (bundle-name-sorted) order:
  *        a. org-trust gate (ADR-0024 D4 mitigation #1 — org-trusted repos
  *           only, unconditionally, regardless of the external flag);
- *        b. external-flag / first-party-renderer gate (OQ6/OQ9);
+ *        b. external-flag / first-party gate (OQ6/OQ9, extended cortex#1794
+ *           S9a) — a first-party RENDERER (in-tree allowlist) or a
+ *           first-party ADAPTER (repoUrl declared under cortex's OWN
+ *           `arc-manifest.yaml` `dependencies:`, read fresh each load —
+ *           {@link isFirstPartyBundle}) loads even with the flag off;
  *        c. compat gate — `Bun.semver.satisfies(SURFACE_SDK_VERSION,
  *           manifest.sdkRange)` (D1, loader-authoritative);
  *        d. duplicate-id gate — an in-tree plugin (or an earlier-loaded
@@ -66,7 +70,7 @@
  * has something to check coverage against.
  */
 
-import { existsSync, realpathSync } from "fs";
+import { existsSync, readFileSync, realpathSync } from "fs";
 import { homedir } from "os";
 import { join, resolve as resolvePath, sep } from "path";
 import { pathToFileURL } from "url";
@@ -403,6 +407,11 @@ const FIRST_PARTY_RENDERER_REPOS: ReadonlySet<string> = new Set([
   // never this production constant.
 ]);
 
+/** Shared empty-set default for {@link isFirstPartyBundle}'s adapter branch
+ *  — never populated in place; a genuinely empty allowlist just means "no
+ *  adapter exemption this call" (the fail-closed posture). */
+const EMPTY_REPO_SET: ReadonlySet<string> = new Set();
+
 function normalizeRepoUrl(url: string): string {
   return url.trim().replace(/\.git$/i, "").replace(/\/$/, "").toLowerCase();
 }
@@ -414,6 +423,124 @@ export function isFirstPartyRendererBundle(
 ): boolean {
   if (kind !== "renderer") return false;
   return allowlist.has(normalizeRepoUrl(arcPackage.repoUrl));
+}
+
+/**
+ * cortex#1794 (S9a) — the ADAPTER analogue of {@link isFirstPartyRendererBundle}.
+ * `kind`-gated the same way (an adapter bundle is NEVER exempt through the
+ * renderer allowlist, and vice versa — the two exemptions are namespaced by
+ * kind, never merged), but the allowlist source is different in kind, not
+ * just in content: the renderer allowlist ({@link FIRST_PARTY_RENDERER_REPOS})
+ * is a hardcoded in-tree constant; the adapter allowlist is COMPUTED fresh
+ * at every load from {@link readCortexDeclaredAdapterRepos} and handed in
+ * explicitly by the caller — this function stays a pure predicate over
+ * whatever set it's given, with no I/O and no default of its own, so a
+ * caller can never forget which allowlist it's checking against.
+ */
+export function isFirstPartyAdapterBundle(
+  arcPackage: Pick<ArcPackage, "repoUrl">,
+  kind: PluginKind,
+  allowlist: ReadonlySet<string>,
+): boolean {
+  if (kind !== "adapter") return false;
+  return allowlist.has(normalizeRepoUrl(arcPackage.repoUrl));
+}
+
+/**
+ * cortex#1794 (S9a) — kind-aware dispatch composing both first-party
+ * exemptions into one call so `loadOneBundle` (and any future caller) never
+ * has to branch on `kind` itself to decide which allowlist applies. Renderer
+ * behavior is delegated VERBATIM to {@link isFirstPartyRendererBundle}
+ * (same function, same default, zero behavior change — the regression
+ * guarantee for OQ9) and only the adapter branch is new.
+ */
+export function isFirstPartyBundle(
+  arcPackage: Pick<ArcPackage, "repoUrl">,
+  kind: PluginKind,
+  allowlists: {
+    rendererAllowlist?: ReadonlySet<string>;
+    adapterAllowlist?: ReadonlySet<string>;
+  } = {},
+): boolean {
+  if (kind === "renderer") {
+    return isFirstPartyRendererBundle(arcPackage, kind, allowlists.rendererAllowlist);
+  }
+  return isFirstPartyAdapterBundle(arcPackage, kind, allowlists.adapterAllowlist ?? EMPTY_REPO_SET);
+}
+
+/**
+ * cortex#1794 (S9a, epic #1784 "Andreas decision 2026-07-12") — the
+ * un-spoofable first-party ADAPTER anchor: cortex's OWN, PR-reviewed
+ * `arc-manifest.yaml` `dependencies:` block. This is deliberately NOT a
+ * hardcoded allowlist like {@link FIRST_PARTY_RENDERER_REPOS} — it is read
+ * fresh at every load, so declaring a new first-party adapter bundle (e.g.
+ * the planned `metafactory-cortex-adapter-web`) is a plain `arc-manifest.yaml`
+ * PR, never a `loader.ts` code change.
+ *
+ * Why this is un-spoofable: a bundle's OWN manifest (`cortex-plugin.yaml`)
+ * and arc's `tier` field were already rejected as trust anchors for the
+ * renderer exemption above (both fully controlled by the bundle author —
+ * see {@link isFirstPartyRendererBundle}'s doc comment for the empirical
+ * evidence). `arc-manifest.yaml` `dependencies:` has the SAME shape of
+ * un-spoofability: it is CORTEX's manifest, shipped in CORTEX's repo, only
+ * ever changed by a PR against CORTEX — a bundle author publishing
+ * `metafactory-evil-adapter` cannot make cortex's own dependency list
+ * declare their repo. The declaration is the review event (mirrors D4
+ * mitigation #3 — "a bundle upgrade is a code-review event, not a passive
+ * fetch" — applied one level up, to the act of TRUSTING the bundle at all).
+ *
+ * Deriving a repo URL from a dependency `name`: `arc-manifest.yaml`
+ * dependency names in this ecosystem ARE the GitHub repo name under the
+ * trusted `the-metafactory` org, by the repo-first install convention
+ * (ADR-0017 — see cortex's own `arc-manifest.yaml`, the `metafactory-discord`
+ * entry: "the bundle is `arc install`-able from the
+ * the-metafactory/metafactory-discord repo"). So `name: "metafactory-foo"`
+ * derives `https://github.com/the-metafactory/metafactory-foo`, normalized
+ * the same way {@link normalizeRepoUrl} normalizes an installed bundle's
+ * `arc list`-recorded `repoUrl`, making membership a plain set-lookup. Every
+ * derived URL is by construction inside `the-metafactory` — this composes
+ * with (never replaces) the unconditional {@link isTrustedOrgRepo} gate,
+ * which still runs first and independently for every bundle.
+ *
+ * Fail-closed by design: ANY read/parse failure — missing file, invalid
+ * YAML, no `dependencies:` key, non-array `dependencies:`, a dependency
+ * entry with no string `name` — is caught and returns an EMPTY set, never
+ * throws and never crashes boot. An unreadable manifest can only NARROW
+ * trust (no adapter bundle gets the exemption that boot); it must never be
+ * able to WIDEN it.
+ */
+export function readCortexDeclaredAdapterRepos(manifestPath: string): ReadonlySet<string> {
+  try {
+    const raw = readFileSync(manifestPath, "utf-8");
+    const parsed: unknown = parseYaml(raw);
+    if (!isRecord(parsed)) return new Set();
+    const deps: unknown = parsed.dependencies;
+    if (!Array.isArray(deps)) return new Set();
+    const repos = new Set<string>();
+    for (const dep of deps) {
+      if (isRecord(dep) && typeof dep.name === "string" && dep.name.trim().length > 0) {
+        repos.add(normalizeRepoUrl(`https://github.com/the-metafactory/${dep.name.trim()}`));
+      }
+    }
+    return repos;
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Default location of cortex's OWN `arc-manifest.yaml`, resolved relative to
+ * THIS module's location on disk — mirrors the established
+ * `getCortexVersion`/`getVersion`/`readIntendedVersion` pattern
+ * (`src/bus/dispatch-handler.ts`, `src/cortex.ts`,
+ * `src/cli/cortex/commands/release.ts`) that already reads cortex's own
+ * `arc-manifest.yaml` this same way. Deliberately NOT `defaultPkgRoot()` —
+ * that trusted root holds OTHER installed packages' bundles, never cortex's
+ * own checkout.
+ */
+export function defaultCortexManifestPath(): string {
+  // src/adapters/loader.ts -> repo root is two levels up.
+  return resolvePath(import.meta.dir, "..", "..", "arc-manifest.yaml");
 }
 
 // =============================================================================
@@ -506,8 +633,10 @@ export interface LoadedPluginInfo {
   bundleName: string;
   kind: PluginKind;
   id: string;
-  /** True when this bundle loaded under the OQ9 first-party-renderer
-   *  exemption rather than because `system.plugins.external` was on. */
+  /** True when this bundle loaded under a first-party exemption — the OQ9
+   *  renderer allowlist, or the cortex#1794 S9a adapter exemption (repoUrl
+   *  declared under cortex's own `arc-manifest.yaml` `dependencies:`) —
+   *  rather than because `system.plugins.external` was on. */
   firstParty: boolean;
 }
 
@@ -535,6 +664,26 @@ export interface LoadPluginsOptions {
   /** Test seam — see {@link isFirstPartyRendererBundle}. Production callers
    *  never set this (defaults to the real in-tree allowlist). */
   firstPartyRendererRepos?: ReadonlySet<string>;
+  /**
+   * cortex#1794 (S9a) test seam — pre-resolved first-party ADAPTER allowlist.
+   * Production callers never set this: it is computed automatically, once
+   * per {@link loadExternalPlugins} call, from cortex's own
+   * `arc-manifest.yaml` via {@link readCortexDeclaredAdapterRepos}. Set this
+   * ONLY in tests that want to inject the allowlist directly instead of
+   * pointing {@link cortexManifestPath} at a fixture file; if both are set,
+   * this one wins (`cortexManifestPath` is never read).
+   */
+  firstPartyAdapterRepos?: ReadonlySet<string>;
+  /**
+   * cortex#1794 (S9a) test seam — where to read cortex's OWN
+   * `arc-manifest.yaml` from when deriving the first-party adapter allowlist
+   * (ignored if {@link firstPartyAdapterRepos} is set explicitly). Defaults
+   * to {@link defaultCortexManifestPath} — cortex's REAL manifest at its
+   * real repo-relative location. Tests point this at a fixture manifest so
+   * the "declared dependency" mechanism is exercised end-to-end without
+   * depending on (or mutating) the real file.
+   */
+  cortexManifestPath?: string;
 }
 
 export interface LoadPluginsResult {
@@ -558,6 +707,17 @@ export async function loadExternalPlugins(
   const skipped: SkippedPluginInfo[] = [];
   const failed: FailedPluginInfo[] = [];
 
+  // cortex#1794 (S9a) — resolve the first-party ADAPTER allowlist ONCE per
+  // load, not per bundle: `readCortexDeclaredAdapterRepos` is a file read +
+  // YAML parse, and every bundle in this load is gated against the SAME
+  // snapshot of cortex's own manifest (a manifest edit mid-loop, however
+  // implausible, must not gate different bundles inconsistently within one
+  // boot). Explicit `firstPartyAdapterRepos` (test seam) always wins over
+  // reading a manifest at all.
+  const firstPartyAdapterRepos =
+    options.firstPartyAdapterRepos ??
+    readCortexDeclaredAdapterRepos(options.cortexManifestPath ?? defaultCortexManifestPath());
+
   const { bundles, issues: discoveryIssues } = await discoverPluginBundles({
     pkgRoot: options.pkgRoot,
     runner: options.runner,
@@ -575,6 +735,7 @@ export async function loadExternalPlugins(
         registry,
         externalEnabled,
         firstPartyRendererRepos: options.firstPartyRendererRepos,
+        firstPartyAdapterRepos,
         loaded,
         skipped,
         failed,
@@ -603,6 +764,9 @@ interface LoadOneBundleSinks {
   registry: SurfacePluginRegistry;
   externalEnabled: boolean;
   firstPartyRendererRepos: ReadonlySet<string> | undefined;
+  /** cortex#1794 (S9a) — pre-resolved once in {@link loadExternalPlugins},
+   *  never re-read per bundle. */
+  firstPartyAdapterRepos: ReadonlySet<string>;
   loaded: LoadedPluginInfo[];
   skipped: SkippedPluginInfo[];
   failed: FailedPluginInfo[];
@@ -628,18 +792,22 @@ async function loadOneBundle(bundle: DiscoveredBundle, sinks: LoadOneBundleSinks
     return;
   }
 
-  // (b) External-flag / first-party-renderer gate (OQ6/OQ9).
-  const firstParty = isFirstPartyRendererBundle(
-    arcPackage,
-    manifest.kind,
-    sinks.firstPartyRendererRepos,
-  );
+  // (b) External-flag / first-party gate (OQ6/OQ9, extended cortex#1794
+  // S9a). `isFirstPartyBundle` dispatches by `manifest.kind`: a renderer is
+  // checked against the in-tree allowlist EXACTLY as before (regression);
+  // an adapter is checked against the allowlist derived from cortex's own
+  // `arc-manifest.yaml` `dependencies:`, resolved once in
+  // `loadExternalPlugins` and threaded through unchanged for every bundle.
+  const firstParty = isFirstPartyBundle(arcPackage, manifest.kind, {
+    rendererAllowlist: sinks.firstPartyRendererRepos,
+    adapterAllowlist: sinks.firstPartyAdapterRepos,
+  });
   if (!sinks.externalEnabled && !firstParty) {
     sinks.skipped.push({
       bundleName,
       kind: manifest.kind,
       id: manifest.id,
-      reason: "system.plugins.external is off and this bundle is not an exempt first-party renderer",
+      reason: `system.plugins.external is off and this ${manifest.kind} bundle is not an exempt first-party bundle`,
     });
     return;
   }
@@ -839,7 +1007,7 @@ async function loadOneBundle(bundle: DiscoveredBundle, sinks: LoadOneBundleSinks
 
   sinks.loaded.push({ bundleName, kind: manifest.kind, id: manifest.id, firstParty });
   process.stderr.write(
-    `cortex plugin-loader: loaded ${manifest.kind} "${manifest.id}" from bundle "${bundleName}"${firstParty ? " (first-party renderer exemption)" : ""}\n`,
+    `cortex plugin-loader: loaded ${manifest.kind} "${manifest.id}" from bundle "${bundleName}"${firstParty ? ` (first-party ${manifest.kind} exemption)` : ""}\n`,
   );
 }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3127,13 +3127,17 @@ export async function startCortex(
   // behind an opt-in flag nobody flipped), or, since cortex#1794 (S9a, epic
   // #1784 "transparent repackaging" decision), a first-party ADAPTER whose
   // repoUrl is declared under THIS repo's own `arc-manifest.yaml`
-  // `dependencies:` — read fresh each boot via `defaultCortexManifestPath()`
-  // (the default here; no options passed), so an extracted in-tree adapter
-  // (e.g. `web`) keeps loading with zero config change on any existing
-  // stack once its bundle is declared as a dependency. The runtime-hard-fail
-  // half of OQ9 (does `system.>` coverage still hold two classes after
-  // this?) is cortex#1893, a separate issue; this loop only SURFACES what
-  // loaded so that check has something to read.
+  // `dependencies:` AND whose declared name follows the compass#115
+  // `metafactory-cortex-adapter-<name>` naming standard (PR #1942 fix — a
+  // dependency declared for an unrelated reason, e.g. `arc` or
+  // `metafactory-discord`, must NOT get the exemption) — read fresh each
+  // boot via `defaultCortexManifestPath()` (the default here; no options
+  // passed), so an extracted in-tree adapter (e.g. `web`) keeps loading with
+  // zero config change on any existing stack once its bundle is declared as
+  // a `metafactory-cortex-adapter-web`-named dependency. The
+  // runtime-hard-fail half of OQ9 (does `system.>` coverage still hold two
+  // classes after this?) is cortex#1893, a separate issue; this loop only
+  // SURFACES what loaded so that check has something to read.
   const pluginLoadResult = await loadExternalPlugins({
     registry: surfacePluginRegistry,
     externalEnabled: config.plugins.external,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3122,12 +3122,18 @@ export async function startCortex(
   // throwing import, a duplicate-platform shadow attempt, …) is skipped,
   // logged, and returned in `.failed` — every other in-tree AND bundle
   // plugin still loads. `config.plugins.external` (default off) gates every
-  // bundle except an OQ9-exempt first-party renderer, which loads
-  // regardless — a stack's paging sink must not silently vanish behind an
-  // opt-in flag nobody flipped. The runtime-hard-fail half of OQ9 (does
-  // `system.>` coverage still hold two classes after this?) is cortex#1893,
-  // a separate issue; this loop only SURFACES what loaded so that check has
-  // something to read.
+  // bundle except a first-party bundle: an OQ9-exempt first-party renderer
+  // (in-tree allowlist — a stack's paging sink must not silently vanish
+  // behind an opt-in flag nobody flipped), or, since cortex#1794 (S9a, epic
+  // #1784 "transparent repackaging" decision), a first-party ADAPTER whose
+  // repoUrl is declared under THIS repo's own `arc-manifest.yaml`
+  // `dependencies:` — read fresh each boot via `defaultCortexManifestPath()`
+  // (the default here; no options passed), so an extracted in-tree adapter
+  // (e.g. `web`) keeps loading with zero config change on any existing
+  // stack once its bundle is declared as a dependency. The runtime-hard-fail
+  // half of OQ9 (does `system.>` coverage still hold two classes after
+  // this?) is cortex#1893, a separate issue; this loop only SURFACES what
+  // loaded so that check has something to read.
   const pluginLoadResult = await loadExternalPlugins({
     registry: surfacePluginRegistry,
     externalEnabled: config.plugins.external,


### PR DESCRIPTION
Part of #1794 (S9) — the TRUST-PATH mechanism half. Makes surface-adapter extraction **transparent** (non-breaking, no forced v7, per the epic decision): a cortex-declared adapter bundle loads with `system.plugins.external` OFF, so `arc upgrade cortex` + auto-installed bundle = surface keeps working, zero config change. **Mechanism only — no repo created, no in-tree adapter moved** (that's the follow-on).

## The un-spoofable anchor (the #1 adversarial target)
"First-party" for an adapter bundle = its `arc list`-recorded `repoUrl` matches a repo derived from **cortex's OWN `arc-manifest.yaml` `dependencies:`**, NARROWED to only entries whose declared `name` follows the compass#115 `metafactory-cortex-adapter-<name>` naming standard (`ADAPTER_BUNDLE_DEP_NAME_RE`) — read fresh each load (`readCortexDeclaredAdapterRepos`). Un-spoofable because it's cortex's PR-reviewed manifest in cortex's repo; a bundle author publishing `metafactory-evil-adapter` cannot make cortex's dependency list name their repo, and cannot self-select into the exemption by picking a matching name for their OWN repo either. Explicitly did NOT reuse arc's `tier` or the bundle's `cortex-plugin.yaml` fields (both bundle-author-controlled — rejected in the S6 review). Composes with, never replaces, the unconditional `isTrustedOrgRepo` gate (test: org-trust refuses an attacker URL even if it's in the adapter allowlist).

**Narrowing fix (post code-review, PR #1942 MAJOR):** an earlier version of this anchor treated cortex's ENTIRE `dependencies:` list as adapter-exempt — so `arc` (package manager) and `metafactory-discord` (ADR-0017 CLI/skill *tooling*, explicitly not an adapter) would both have granted the exemption to any `kind: adapter` plugin they ever happened to ship, despite being declared for unrelated reasons. Exactly ADR-0024 §OQ9's named failure mode ("an unchecked first-party exemption is a trust hole wearing a friendly name"). Fixed by requiring the declared dependency `name` to ALSO self-identify as a cortex-owned adapter component via the compass#115 naming standard — `arc` and `metafactory-discord` never match, by construction, no matter what they ship.

## Shape
- `isFirstPartyRendererBundle` **byte-unchanged** (renderer regression = its original tests pass verbatim). New `isFirstPartyAdapterBundle` mirrors it (pure, mandatory-allowlist). `isFirstPartyBundle(pkg, kind, {rendererAllowlist, adapterAllowlist})` dispatches by kind; the loader never branches on kind for this decision.
- Production `cortex.ts` boot call is unchanged code — auto-resolves the real `arc-manifest.yaml` via `defaultCortexManifestPath()` (same import.meta.dir pattern as `getCortexVersion`).
- **Fail-closed:** unreadable/malformed manifest, non-array `dependencies:`, a dependency entry with no `name` → empty Set, never throws, never widens trust (unit tests for every branch, including the two previously-untested fail-closed shapes flagged in review).

## No-op in production TODAY — corrected claim
No real adapter bundle is declared as a cortex dependency yet, so the **narrowed** adapter allowlist derived from the real manifest is genuinely **empty** (verified: `repos.size === 0`) — but NOT because the raw dependency list is empty (it isn't: `{arc, metafactory-discord}`). It's empty because neither declared dependency has an adapter-shaped name. This exemption is a real no-op until the follow-on declares `metafactory-cortex-adapter-web`, not an accident of an empty list.

## For the adversarial reviewer (author self-flagged)
1. **Persistence-via-self-rewrite:** an already-loaded bundle (D4 full authority) could rewrite cortex's `arc-manifest.yaml` on disk to grant a future bundle the exemption on next boot. **Corrected framing** (per code-review nit): this is NOT symmetric with the renderer mechanism, only equivalent UNDER D4's full-compromise assumption — `FIRST_PARTY_RENDERER_REPOS` is compiled-in (self-granting needs a source edit + rebuild); this anchor is a YAML data file read fresh every boot (no rebuild needed) — a strictly cheaper edit for an attacker who already has arbitrary file write. Neither barrier stops a D4-compromised attacker; the difference is defense-in-depth cost, not whether the barrier holds. Recorded as a doc comment near the anchor + in docs/plugin-sdk.md, not fixed (D4 already accepts this risk class for v1).
2. **dependency-name==repo-name** derivation is convention (true per `metafactory-discord`), not structurally enforced; a non-repo-named dep silently never matches (inert/safe). Confirm it's inert, not a hole.
3. **New threat-model note:** both this anchor and the unconditional org-trust gate ultimately depend on arc recording `repoUrl` as the real git clone source. If arc ever decoupled that (e.g. an unauthenticated `--repo-url` override), both gates fall together — an explicit cross-repo (arc) dependency of the whole plugin trust model, recorded not fixed.
4. TOCTOU on the fresh-per-load read; `normalizeRepoUrl` bypass (case/slash/`.git`/unicode/prefix); can an attacker collide their repo name with a declared dep name?

## Gates
tsc 0 · eslint 0 · `bun test src/adapters src/renderers src/common src/gateway` → 2549 pass / 0 fail (+4 vs prior revision) · vocab PASS · shippable-hygiene clean. Rebased on main.

**Trust-path: code-review + independent adversarial pass before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)