### PR TITLE
docs: README-AGENTS Path B + getting-started omit postinstall.sh — fix manual-install parity (#1940)

### DIFF
--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -88,17 +88,30 @@ the managed path for normal operation):
 git clone https://github.com/the-metafactory/cortex
 cd cortex
 bun install
-bun link          # puts `cortex` on PATH via ~/.bun/bin
-cortex --version  # confirm it resolves
+bun link                  # puts `cortex` on PATH via ~/.bun/bin
+cortex --version          # confirm it resolves
+./scripts/postinstall.sh  # scaffold runtime dirs, relay policy, launchd plists
 ```
+
+**Do not skip `./scripts/postinstall.sh`.** Path A runs it automatically via the
+manifest lifecycle (`scripts.postinstall`); a manual clone does not, so without
+this step the daemon starts against missing scaffolding. It creates the runtime
+directories (`~/.claude/events/{raw,published}`, `~/.claude/{logs,relay}`,
+`~/.config/cortex/{logs,state}`), installs the default relay policy (never
+clobbering an existing `~/.claude/relay/relay-policy.yaml`), marks the entry-point
+scripts executable, and on macOS renders the launchd plists.
 
 Run the daemon with `cortex start --config <pointer>` (or directly with
 `bun src/cortex.ts start --config <pointer>`). Verify with `bun test` and
 `bun run lint`.
 
 **Updating a from-source clone:** `cd cortex && git pull && bun install` — a clean
-fast-forward if you haven't modified anything. For an arc-managed install, update
-with `arc upgrade cortex` instead (Path A).
+fast-forward if you haven't modified anything. Note this skips the manifest's
+`preupgrade`/`postupgrade` lifecycle that Path A gets from `arc upgrade cortex`
+(stop the running daemon → refresh symlinks → re-render plists → restart the
+previously-running stacks). After a manual pull, restart the daemon yourself, and
+re-run `./scripts/postinstall.sh` if the plist templates or runtime dirs changed.
+For an arc-managed install, update with `arc upgrade cortex` instead (Path A).
 
 ## 3. Configure a stack
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,6 +29,13 @@ and [§4](../README-AGENTS.md#4-stand-up-the-bus) are the authoritative
 reference for the full prerequisite list and the isolated per-stack bus
 config; this page only orders the steps.
 
+**Manual `git clone` installs — run `./scripts/postinstall.sh` first.** `arc
+install cortex` runs it for you via the manifest lifecycle; a raw clone does not,
+so run it once from the repo root before the steps below. It creates the runtime
+dirs (`~/.claude/events/{raw,published}`, `~/.config/cortex/{logs,state}`),
+installs the default relay policy, and on macOS renders the launchd plists. See
+[`README-AGENTS.md` §2 Path B](../README-AGENTS.md#2-install).
+
 The fresh-install happy path, in order:
 
 0. **Stand up the bus** — run an isolated NATS server for this stack (one


### PR DESCRIPTION
Closes #1940. Reported by Vincent (fresh-install, 2026-07-12).

## What
Following README-AGENTS.md **Path B** (manual clone) verbatim skipped ALL postinstall scaffolding — Path A (arc install) gets it from the manifest lifecycle (`scripts.postinstall`), Path B never told the reader to run `./scripts/postinstall.sh`.

- **README-AGENTS Path B**: added the `./scripts/postinstall.sh` step after `cortex --version` + a "do not skip" note (accurate scaffold list: runtime dirs, relay policy, macOS launchd plists).
- **README-AGENTS "updating a from-source clone"**: note that manual `git pull && bun install` skips the preupgrade/postupgrade lifecycle (stop → refresh symlinks → re-render plists → restart) — restart + re-run postinstall deliberately.
- **docs/getting-started.md**: same manual-install gap fixed.

Scaffold description verified against `scripts/postinstall.sh` (events dirs 700/755, relay policy, `~/.config/cortex/{logs,state}`, exec bits, macOS plist render).

## Verification
`grep -n postinstall README-AGENTS.md docs/getting-started.md` → 7 matches (was skipping the manual path). Docs-only, no code. Vocab clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)