### PR TITLE
test(surface-sdk): reusable extraction-boundary helper catching one-level imports (#1949)

### DIFF
--- a/src/surface-sdk/__tests__/boundary-guard.test.ts
+++ b/src/surface-sdk/__tests__/boundary-guard.test.ts
@@ -221,4 +221,8 @@ describe("plugin SDK boundary guard (cortex#1790, ADR-0024 D5)", () => {
 // `buildAdapterPolicyPort` from `adapters/plugin-support.ts`, fixed during
 // the move — see the bundle's `src/plugin.ts` module doc). A future adapter
 // extraction that revives this style of test should check ANY cross-
-// directory `../` specifier outside `surface-sdk`, not just `../../`.
+// directory `../` specifier outside `surface-sdk`, not just `../../` —
+// use `crossBoundaryImports()` from `./extraction-boundary.ts` (cortex#1949),
+// which catches exactly that class and is self-tested in
+// `./extraction-boundary.test.ts`. cortex#1896 calls it per-adapter as each
+// is inverted, asserting `[]` before that adapter extracts.

--- a/src/surface-sdk/__tests__/extraction-boundary.test.ts
+++ b/src/surface-sdk/__tests__/extraction-boundary.test.ts
@@ -67,6 +67,16 @@ describe("crossBoundaryImports (cortex#1949)", () => {
     expect(crossBoundaryImports(pluginDir, sdkDir)).toEqual([]);
   });
 
+  test("catches a DYNAMIC `import(\"../x\")` crossing the boundary (#1953 review blocker)", () => {
+    const { pluginDir, sdkDir } = scaffold({
+      "src/adapters/acme/index.ts":
+        `export async function load() { const m = await import("../plugin-support"); return m; }\n`,
+      "src/adapters/plugin-support.ts": `export const helper = 1;\n`,
+    });
+    const v = crossBoundaryImports(pluginDir, sdkDir);
+    expect(v.map((x) => x.specifier)).toContain("../plugin-support");
+  });
+
   test("ignores bare/package imports (e.g. zod)", () => {
     const { pluginDir, sdkDir } = scaffold({
       "src/adapters/acme/index.ts": `import { z } from "zod";\nexport const s = z;\n`,

--- a/src/surface-sdk/__tests__/extraction-boundary.test.ts
+++ b/src/surface-sdk/__tests__/extraction-boundary.test.ts
@@ -1,0 +1,84 @@
+/**
+ * cortex#1949 — self-test for the extraction boundary helper.
+ *
+ * Proves {@link crossBoundaryImports} catches the class of import that the S9b
+ * (web) dependency-inversion's own `../../`-only guard MISSED — a ONE-level
+ * `../plugin-support` cross-boundary import — as well as two-level, while
+ * allowing same-dir and `surface-sdk` imports. cortex#1896 uses this helper to
+ * assert each adapter is boundary-clean as it's inverted, before extraction.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import { crossBoundaryImports } from "./extraction-boundary";
+
+const roots: string[] = [];
+
+/** Build a throwaway {plugin dir, sibling dirs, sdk dir} layout under tmp. */
+function scaffold(files: Record<string, string>): { pluginDir: string; sdkDir: string } {
+  const root = mkdtempSync(join(tmpdir(), "extraction-boundary-"));
+  roots.push(root);
+  const pluginDir = join(root, "src", "adapters", "acme");
+  const sdkDir = join(root, "src", "surface-sdk");
+  mkdirSync(pluginDir, { recursive: true });
+  mkdirSync(sdkDir, { recursive: true });
+  mkdirSync(join(root, "src", "adapters"), { recursive: true });
+  writeFileSync(join(sdkDir, "index.ts"), "export type Marker = 1;\n");
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = resolve(root, rel);
+    mkdirSync(resolve(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  return { pluginDir, sdkDir };
+}
+
+afterAll(() => {
+  for (const r of roots) rmSync(r, { recursive: true, force: true });
+});
+
+describe("crossBoundaryImports (cortex#1949)", () => {
+  test("catches a ONE-level `../` cross-boundary import (the web-move gap)", () => {
+    const { pluginDir, sdkDir } = scaffold({
+      "src/adapters/acme/index.ts": `import { helper } from "../plugin-support";\nexport const x = helper;\n`,
+      "src/adapters/plugin-support.ts": `export const helper = 1;\n`,
+    });
+    const v = crossBoundaryImports(pluginDir, sdkDir);
+    expect(v).toHaveLength(1);
+    expect(v[0]!.specifier).toBe("../plugin-support");
+  });
+
+  test("catches a two-level `../../` cross-boundary import", () => {
+    const { pluginDir, sdkDir } = scaffold({
+      "src/adapters/acme/index.ts": `import type { E } from "../../common/policy";\nexport type T = E;\n`,
+      "src/common/policy.ts": `export type E = 1;\n`,
+    });
+    const v = crossBoundaryImports(pluginDir, sdkDir);
+    expect(v.map((x) => x.specifier)).toContain("../../common/policy");
+  });
+
+  test("allows same-directory and surface-sdk imports (clean, ready-to-extract)", () => {
+    const { pluginDir, sdkDir } = scaffold({
+      "src/adapters/acme/index.ts":
+        `import type { Marker } from "../../surface-sdk";\nimport { local } from "./schema";\nexport const y: Marker = local;\n`,
+      "src/adapters/acme/schema.ts": `export const local = 1 as const;\n`,
+    });
+    expect(crossBoundaryImports(pluginDir, sdkDir)).toEqual([]);
+  });
+
+  test("ignores bare/package imports (e.g. zod)", () => {
+    const { pluginDir, sdkDir } = scaffold({
+      "src/adapters/acme/index.ts": `import { z } from "zod";\nexport const s = z;\n`,
+    });
+    expect(crossBoundaryImports(pluginDir, sdkDir)).toEqual([]);
+  });
+
+  test("catches a bare side-effect `import \"...\"` that crosses the boundary", () => {
+    const { pluginDir, sdkDir } = scaffold({
+      "src/adapters/acme/index.ts": `import "../side-effect";\nexport const z = 1;\n`,
+      "src/adapters/side-effect.ts": `globalThis;\n`,
+    });
+    expect(crossBoundaryImports(pluginDir, sdkDir).map((x) => x.specifier)).toContain("../side-effect");
+  });
+});

--- a/src/surface-sdk/__tests__/extraction-boundary.ts
+++ b/src/surface-sdk/__tests__/extraction-boundary.ts
@@ -1,0 +1,85 @@
+/**
+ * cortex#1949 — extraction boundary check (reusable helper).
+ *
+ * The S5 boundary-guard test (`boundary-guard.test.ts`) is SYMBOL-scoped: it
+ * only forbids importing a plugin-CONTRACT symbol from its pre-SDK location. It
+ * deliberately permits an in-tree plugin's OTHER cross-boundary imports (into
+ * `common/policy`, `MyelinRuntime`, …) because those are the residual couplings
+ * the per-adapter dependency-inversions (cortex#1896) resolve one at a time.
+ *
+ * THIS helper is the check an ALREADY-INVERTED plugin (one about to extract to
+ * its own bundle) must pass: it may import ONLY from its own directory and the
+ * `surface-sdk` barrel — ANY other relative import that resolves OUTSIDE the
+ * plugin directory is a cross-boundary coupling that would break the bundle
+ * out-of-tree.
+ *
+ * It exists because the S9b (web) dependency-inversion's own boundary test had
+ * a real gap — it flagged only `../../` (two-level) specifiers, so a ONE-level
+ * `../plugin-support` runtime import slipped through undetected and only
+ * surfaced at the MOVE. This helper catches ANY cross-directory `../`
+ * specifier, one level or more.
+ *
+ * Enforcement is per-plugin and gated on that plugin being inverted: cortex#1896
+ * calls {@link crossBoundaryImports} for discord/slack/mattermost as each is
+ * inverted, asserting `[]`. It is NOT run against the un-inverted in-tree
+ * adapters (they would legitimately fail — that's what #1896 fixes).
+ */
+
+import { readdirSync, readFileSync } from "fs";
+import { dirname, relative, resolve } from "path";
+
+export interface CrossBoundaryImport {
+  /** Absolute path of the file containing the offending import. */
+  file: string;
+  /** The raw import specifier (e.g. `"../plugin-support"`). */
+  specifier: string;
+  /** Absolute path the specifier resolves to (sans extension). */
+  resolved: string;
+}
+
+const IMPORT_RE = /(?:import|export)[\s\S]*?from\s*["']([^"']+)["']/g;
+const BARE_IMPORT_RE = /import\s*["']([^"']+)["']/g;
+
+/** Recursively list `*.ts` files under `dir`, skipping `__tests__` + `.d.ts`. */
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFiles(full));
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Return every relative import in `pluginDir` that resolves OUTSIDE `pluginDir`
+ * and is not the `surface-sdk` barrel. An inverted, ready-to-extract plugin
+ * must return `[]`.
+ *
+ * @param pluginDir absolute path of the plugin's directory (e.g. an adapter dir)
+ * @param sdkDir    absolute path of `src/surface-sdk` (the one allowed cross-dir target)
+ */
+export function crossBoundaryImports(pluginDir: string, sdkDir: string): CrossBoundaryImport[] {
+  const pluginRoot = resolve(pluginDir);
+  const sdkRoot = resolve(sdkDir);
+  const violations: CrossBoundaryImport[] = [];
+
+  for (const file of tsFiles(pluginRoot)) {
+    const src = readFileSync(file, "utf-8");
+    const specifiers = new Set<string>();
+    for (const m of src.matchAll(IMPORT_RE)) specifiers.add(m[1]!);
+    for (const m of src.matchAll(BARE_IMPORT_RE)) specifiers.add(m[1]!);
+
+    for (const spec of specifiers) {
+      if (!spec.startsWith(".")) continue; // package/bare import — not a boundary concern
+      const resolved = resolve(dirname(file), spec);
+      // Inside the plugin's own directory → fine.
+      if (resolved === pluginRoot || resolved.startsWith(pluginRoot + "/")) continue;
+      // The surface-sdk barrel → the one allowed cross-dir target.
+      if (resolved === sdkRoot || resolved.startsWith(sdkRoot + "/")) continue;
+      violations.push({ file: relative(pluginRoot, file), specifier: spec, resolved });
+    }
+  }
+  return violations;
+}

--- a/src/surface-sdk/__tests__/extraction-boundary.ts
+++ b/src/surface-sdk/__tests__/extraction-boundary.ts
@@ -39,6 +39,11 @@ export interface CrossBoundaryImport {
 
 const IMPORT_RE = /(?:import|export)[\s\S]*?from\s*["']([^"']+)["']/g;
 const BARE_IMPORT_RE = /import\s*["']([^"']+)["']/g;
+// Dynamic `import("../x")` / `await import("../x")` — a lazy-loaded boundary
+// import is exactly the class this guard exists to catch (#1953 review): a
+// lazy `import("../plugin-support")` would extract broken just like a static
+// one, so a guard blind to it is false confidence.
+const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*["']([^"']+)["']/g;
 
 /** Recursively list `*.ts` files under `dir`, skipping `__tests__` + `.d.ts`. */
 function tsFiles(dir: string): string[] {
@@ -70,6 +75,7 @@ export function crossBoundaryImports(pluginDir: string, sdkDir: string): CrossBo
     const specifiers = new Set<string>();
     for (const m of src.matchAll(IMPORT_RE)) specifiers.add(m[1]!);
     for (const m of src.matchAll(BARE_IMPORT_RE)) specifiers.add(m[1]!);
+    for (const m of src.matchAll(DYNAMIC_IMPORT_RE)) specifiers.add(m[1]!);
 
     for (const spec of specifiers) {
       if (!spec.startsWith(".")) continue; // package/bare import — not a boundary concern


### PR DESCRIPTION
Closes #1949 (epic #1784 pattern-hardening). The S9b web-move exposed that the dependency-inversion boundary guard only flagged **two-level** `../../` imports — a **one-level** `../plugin-support` runtime import slipped through undetected and only surfaced at the MOVE.

## What this adds
- **`src/surface-sdk/__tests__/extraction-boundary.ts`** — `crossBoundaryImports(pluginDir, sdkDir)`: returns every relative import in a plugin dir that resolves OUTSIDE the dir and isn't the surface-sdk barrel. Catches ANY cross-directory `../` specifier (one level or more), incl. bare side-effect `import "..."`. An inverted, ready-to-extract plugin returns `[]`.
- **`extraction-boundary.test.ts`** — 5 self-tests: one-level caught (the web gap), two-level caught, same-dir + surface-sdk allowed, bare/package ignored, side-effect import caught.

## Why a helper, not an enforced test now
The existing S5 boundary guard is deliberately permissive (un-inverted in-tree adapters still import `common/policy` etc. — the residual couplings #1896 resolves per-adapter). This stricter check can only be ENFORCED on an already-inverted plugin, and web (the only inverted one) is now extracted/gone. So this ships the tested TOOLING; **#1896 calls it per-adapter as each inverts, asserting `[]` before that adapter extracts** — closing the class the web move exposed, for slack/mattermost/discord. The existing prose note now points at it.

## Gates
tsc 0 · eslint 0 · 5/5 self-tests · vocab PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)