### PR TITLE
refactor(gateway): drive inbound demux via plugin.demuxKey() instead of hardcoded per-platform fields (#1951)

### DIFF
--- a/src/adapters/__tests__/loader.web-bundle.test.ts
+++ b/src/adapters/__tests__/loader.web-bundle.test.ts
@@ -314,10 +314,13 @@ describe("config-path E2E — a REAL surfaces.web[] config survives validate →
   });
 
   test("buildBindingIndex + resolveBinding demux a real web binding to the right agent (proves the B1 fix: instanceId reads correctly post-extraction)", async () => {
-    await loadWebRegistry(); // not consumed by the resolver, but mirrors real boot order
+    // cortex#1951 — now genuinely consumed: buildBindingIndex derives the web
+    // demux key via this registry's registered `web` plugin `demuxKey`, not a
+    // hardcoded `binding.instanceId` read.
+    const registry = await loadWebRegistry();
     const surfaces = webSurfacesConfig("acme");
 
-    const index = buildBindingIndex(surfaces);
+    const index = buildBindingIndex(surfaces, registry);
     expect(index.web.size).toBe(1);
     expect(index.web.get("web:acme")?.agent).toBe("ivy");
 
@@ -366,7 +369,7 @@ describe("config-path E2E — a REAL surfaces.web[] config survives validate →
     };
     expect(() => validateSurfacesAgainstRegistry(surfaces, registry)).not.toThrow();
 
-    const index = buildBindingIndex(surfaces);
+    const index = buildBindingIndex(surfaces, registry);
     expect([...index.web.keys()].sort()).toEqual(["web:tenant-a", "web:tenant-b"]);
 
     const adapters = buildGatewayAdapters(surfaces, {

--- a/src/common/types/object-guards.ts
+++ b/src/common/types/object-guards.ts
@@ -14,42 +14,11 @@ export function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-/**
- * cortex#1794 (S9 MOVE) — safely narrow a required string field off an
- * `unknown`-valued binding record. Added when `web` extracted out of
- * `SurfacesSchema`'s hardcoded platform keys: `surfaces.web[].binding` is now
- * validated only structurally as `Record<string, unknown>` at the STRUCTURAL
- * pass (the per-field REAL validation moved to the REGISTRY pass — the
- * loaded plugin's own `bindingSchema` — see `surfaces.ts`'s module doc), so
- * `entry.binding.instanceId` and similar fields are `unknown`, not `string`,
- * to any cortex-core code reading them directly (gateway binding-resolver /
- * ownership-plan demux logic, which pre-dates the plugin registry and reads
- * concrete per-platform fields by design — see those modules' docs).
- *
- * Interpolating an `unknown` into a template literal (`${value}`) passes
- * `tsc` but fails `@typescript-eslint/restrict-template-expressions`; a bare
- * `String(value)` coercion would silently pass, but risks turning a
- * malformed/missing field into a nonsensical demux key (`"web:undefined"`,
- * `"web:[object Object]"`) instead of failing loudly — the exact silent-
- * misgroup risk `adapters/plugin-support.ts`'s `stringBindingField` guards
- * against for the OPTIONAL-with-fallback case. This helper is for the
- * REQUIRED case: by the time gateway code reads a binding, it is presumed
- * already validated (`validateSurfacesAgainstRegistry` ran at boot/config-
- * load), so a genuinely non-string value here means that validation was
- * skipped or a plugin's `bindingSchema` doesn't require a field cortex-core
- * code assumes it does — worth a loud failure, not a silently-wrong key.
- */
-export function requireStringBindingField(
-  binding: Record<string, unknown>,
-  field: string,
-  context: string,
-): string {
-  const value = binding[field];
-  if (typeof value !== "string" || value.length === 0) {
-    throw new Error(
-      `${context}: expected binding.${field} to be a non-empty string, got ${typeof value} — ` +
-        "the config should have been rejected at the registry-validation pass before reaching here.",
-    );
-  }
-  return value;
-}
+// cortex#1794 (S9 MOVE) added `requireStringBindingField` here as a band-aid
+// for `gateway/binding-resolver.ts` + `gateway/surface-ownership-plan.ts`
+// reading `surfaces.web[].binding` fields directly off an `unknown`-narrowed
+// record. cortex#1951 replaced BOTH call sites with the registered plugin's
+// own `demuxKey(binding)` (`AdapterPlugin`, `adapters/registry.ts`) — the
+// binding shape now lives ONLY in each platform's plugin, never in gateway
+// code — which made this helper unused. Removed rather than kept as
+// speculative API surface; re-add if a genuine new caller needs it.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3231,6 +3231,11 @@ export async function startCortex(
     surfaces: options.surfaces,
     gatewayEnabled: isGatewayEnabled(process.env),
     principal: principalId,
+    // cortex#1951 — thread the SAME boot-composed registry `buildGatewayAdapters`
+    // consumes below, so the ownership plan's Gateway adapter instance ids are
+    // derived via each platform's real registered `demuxKey`, not a hardcoded
+    // per-platform field read.
+    registry: surfacePluginRegistry,
   });
   const gatewayOwned = surfaceOwnershipPlan.ownedSurfaceKeys;
 

--- a/src/gateway/__tests__/binding-resolver.test.ts
+++ b/src/gateway/__tests__/binding-resolver.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../binding-resolver";
 import type { Surfaces } from "../../common/types/surfaces";
 import type { InboundMessage } from "../../adapters/types";
+import { testRegistryWithWeb } from "./test-registry-support";
 
 // ─── Shared fixtures ─────────────────────────────────────────────────────────
 
@@ -813,13 +814,13 @@ const WEB_SURFACES: Surfaces = {
 
 describe("buildBindingIndex — web happy path", () => {
   test("web: indexes by instanceId prefixed with 'web:'", () => {
-    const index = buildBindingIndex(WEB_SURFACES);
+    const index = buildBindingIndex(WEB_SURFACES, testRegistryWithWeb());
     expect(index.web.size).toBe(1);
     expect(index.web.has("web:acme")).toBe(true);
   });
 
   test("web entry carries agent, principal, stack, and instance from fixture", () => {
-    const index = buildBindingIndex(WEB_SURFACES);
+    const index = buildBindingIndex(WEB_SURFACES, testRegistryWithWeb());
     const entry = index.web.get("web:acme");
     expect(entry).toBeDefined();
     expect(entry!.agent).toBe("pylon");
@@ -864,13 +865,13 @@ describe("buildBindingIndex — web collision throws", () => {
         },
       ],
     };
-    expect(() => buildBindingIndex(ambiguous)).toThrow(/web.*acme/i);
+    expect(() => buildBindingIndex(ambiguous, testRegistryWithWeb())).toThrow(/web.*acme/i);
   });
 });
 
 describe("resolveBinding — web happy path", () => {
   test("web: resolves by instanceId (full 'web:<id>' key stamped by the WebAdapter)", () => {
-    const index = buildBindingIndex(WEB_SURFACES);
+    const index = buildBindingIndex(WEB_SURFACES, testRegistryWithWeb());
     // The WebAdapter stamps instanceId="web:acme" on every inbound message
     const inbound = msg({ platform: "web", instanceId: "web:acme" });
     const match = resolveBinding(index, inbound);
@@ -883,7 +884,7 @@ describe("resolveBinding — web happy path", () => {
   });
 
   test("web: instanceId not in index → null", () => {
-    const index = buildBindingIndex(WEB_SURFACES);
+    const index = buildBindingIndex(WEB_SURFACES, testRegistryWithWeb());
     const inbound = msg({ platform: "web", instanceId: "web:unknown" });
     expect(resolveBinding(index, inbound)).toBeNull();
   });

--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -33,6 +33,7 @@ import {
 } from "../surface-gateway";
 import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
 import type { Surfaces } from "../../common/types/surfaces";
+import { testRegistryWithWeb } from "./test-registry-support";
 
 // =============================================================================
 // Minimal fake PlatformAdapter (no real platform connection needed)
@@ -536,6 +537,7 @@ describe("maybeCreateSurfaceGateway — web surfaces", () => {
       enabled: true,
       surfaces: WEB_SURFACES,
       adapters: [makeFakeAdapter("fake-web-1")],
+      registry: testRegistryWithWeb(),
     });
     expect(result).toBeInstanceOf(SurfaceGateway);
   });
@@ -551,6 +553,7 @@ describe("maybeCreateSurfaceGateway — web surfaces", () => {
         enabled: true,
         surfaces: WEB_SURFACES,
         adapters: [makeFakeAdapter("fake-web-2")],
+        registry: testRegistryWithWeb(),
       });
       // Must have created the gateway, not hit the "no bindings" early-exit
       expect(result).toBeInstanceOf(SurfaceGateway);

--- a/src/gateway/__tests__/start-gateway-test-helper.ts
+++ b/src/gateway/__tests__/start-gateway-test-helper.ts
@@ -14,6 +14,13 @@ export function startGatewayWithPlan(
       surfaces: opts.surfaces,
       gatewayEnabled: isGatewayEnabled(opts.env),
       principal: opts.principal,
+      // cortex#1951 — same registry `startGatewayIfEnabled` itself resolves
+      // (opts.registry, or its own factory-derived fallback) so the
+      // ownership plan's Gateway adapter instance ids never drift from what
+      // gets constructed. `undefined` here is fine — `planSurfaceOwnership`
+      // falls back to the in-tree default registry same as
+      // `startGatewayIfEnabled` does.
+      registry: opts.registry,
     }),
   });
 }

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -4,6 +4,7 @@ import {
   planSurfaceOwnership,
 } from "../surface-ownership-plan";
 import type { Surfaces } from "../../common/types/surfaces";
+import { testRegistryWithWeb } from "./test-registry-support";
 
 const SURFACES: Surfaces = {
   discord: [
@@ -260,6 +261,7 @@ describe("planSurfaceOwnership — web surfaces", () => {
       surfaces: WEB_SURFACES,
       gatewayEnabled: true,
       principal: "andreas",
+      registry: testRegistryWithWeb(),
     });
     expect(plan.hasSurfaceBindings).toBe(true);
     expect(plan.gatewayStartEligible).toBe(true);
@@ -270,6 +272,7 @@ describe("planSurfaceOwnership — web surfaces", () => {
       surfaces: WEB_SURFACES,
       gatewayEnabled: true,
       principal: "andreas",
+      registry: testRegistryWithWeb(),
     });
     expect([...plan.ownedSurfaceKeys]).toContain("web:pylon");
   });
@@ -279,6 +282,7 @@ describe("planSurfaceOwnership — web surfaces", () => {
       surfaces: WEB_SURFACES,
       gatewayEnabled: true,
       principal: "andreas",
+      registry: testRegistryWithWeb(),
     });
     expect(plan.gatewayAdapterInstanceIds).toContain("web:acme");
   });
@@ -288,6 +292,7 @@ describe("planSurfaceOwnership — web surfaces", () => {
       surfaces: WEB_SURFACES,
       gatewayEnabled: true,
       principal: "andreas",
+      registry: testRegistryWithWeb(),
     });
     expect(plan.outboundStacks).toContain("acme");
   });

--- a/src/gateway/__tests__/test-registry-support.ts
+++ b/src/gateway/__tests__/test-registry-support.ts
@@ -1,0 +1,56 @@
+/**
+ * cortex#1951 — shared test registry helpers for gateway inbound-routing
+ * tests.
+ *
+ * `buildBindingIndex`/`planSurfaceOwnership`/`maybeCreateSurfaceGateway` now
+ * derive each platform's demux key via the registered plugin's
+ * `demuxKey(binding)` instead of a hardcoded field read — they default to
+ * {@link createDefaultSurfacePluginRegistry} (in-tree discord/slack/
+ * mattermost) when the caller omits a registry, so most existing gateway
+ * tests need zero changes. `web` extracted out-of-tree (cortex#1794 S9) and
+ * is normally loaded at boot via `loadExternalPlugins` against the REAL
+ * `metafactory-cortex-adapter-web` bundle — gateway-layer tests that
+ * exercise `surfaces.web[]` don't need that bundle machinery, just a plugin
+ * whose `demuxKey` reproduces the real bundle's contract
+ * (`stringBindingField(binding, "instanceId")`, see that bundle's
+ * `src/plugin.ts` / the fixture copy at
+ * `src/adapters/__tests__/fixtures/metafactory-cortex-adapter-web/src/plugin.ts`).
+ */
+
+import { z } from "zod/v4";
+import {
+  createDefaultSurfacePluginRegistry,
+  type AdapterPlugin,
+  type SurfacePluginRegistry,
+} from "../../adapters/registry";
+import { stringBindingField } from "../../adapters/plugin-support";
+
+/**
+ * The web platform's `demuxKey` contract, reproduced from the real
+ * `metafactory-cortex-adapter-web` bundle (out-of-tree — see module doc).
+ * `createAdapter` throws — gateway-layer routing/ownership-plan tests never
+ * construct a live `WebAdapter` through this stub, only derive demux keys.
+ */
+const webAdapterPluginStub: AdapterPlugin = {
+  kind: "adapter",
+  id: "web",
+  platform: "web",
+  bindingSchema: z.unknown(),
+  foldsIntoPresence: false,
+  secretFields: [],
+  demuxKey: (binding) => stringBindingField(binding, "instanceId"),
+  buildGatewayConstructArgs: (_group, base) => ({ instanceId: base.instanceId }),
+  createAdapter: () => {
+    throw new Error("webAdapterPluginStub — never constructed in gateway-layer tests");
+  },
+};
+
+/**
+ * The in-tree default (discord/slack/mattermost) plus a `web` stub —
+ * for tests that exercise `surfaces.web[]` demux/ownership-plan derivation.
+ */
+export function testRegistryWithWeb(): SurfacePluginRegistry {
+  const registry = createDefaultSurfacePluginRegistry();
+  registry.registerAdapter(webAdapterPluginStub);
+  return registry;
+}

--- a/src/gateway/binding-resolver.ts
+++ b/src/gateway/binding-resolver.ts
@@ -57,11 +57,47 @@
  *   fallback and is used unconditionally; if more than one binding exists the
  *   inbound cannot be demuxed, and `resolveBinding` returns `null` with the
  *   ambiguity recorded in the index.
+ *
+ * ## cortex#1951 — demux keys are registry-driven, not hardcoded
+ *
+ * `buildBindingIndex` used to read each platform's demux field by name
+ * (`entry.binding.guildId` / `.workspaceId` / `.apiUrl`) directly off the
+ * binding. That hardcoded every platform's binding shape into gateway code —
+ * fine while adapters were all in-tree, but it broke lint the moment `web`
+ * extracted out-of-tree (cortex#1794 S9) and its binding collapsed to
+ * `Record<string, unknown>` (patched with the `requireStringBindingField`
+ * band-aid, cortex#1948 B1). ADR-0024 already made adapter CONSTRUCTION
+ * registry-driven (`buildGatewayAdapters` calls `plugin.demuxKey(binding)`);
+ * this file now does the same for INBOUND routing — every per-binding demux
+ * key here is `registry.getAdapter(platform).demuxKey(binding)`, so no
+ * gateway code knows any platform's binding shape and a future extraction
+ * (slack/mattermost/discord, cortex#1896) touches nothing here.
+ *
+ * **Discord is the one deliberate divergence from the construction path.**
+ * `discordAdapterPlugin.demuxKey` (per-binding `guildId`) is a
+ * spec-completeness fallback for construction — `buildGatewayAdapters` always
+ * groups discord bindings by bot TOKEN (`groupBindings`, one gateway session
+ * per token) because that's how Discord actually delivers events. But
+ * `InboundMessage` for a live Discord event carries `guildId`, not the bot
+ * token, so the INBOUND demux index below keys per-binding on `guildId` via
+ * `demuxKey` — the same field, just not grouped. This is intentional, not a
+ * missed generalisation: routing an inbound message requires the key that's
+ * actually present on the message.
+ *
+ * `registry` defaults to {@link createDefaultSurfacePluginRegistry} (in-tree
+ * discord/slack/mattermost) when the caller omits it — a back-compat/test
+ * convenience. Production boot (`gateway-bootstrap.ts` /
+ * `startGatewayIfEnabled`) always threads its own composed registry
+ * explicitly, so the default is dead code on the real boot path.
  */
 
 import type { Surfaces } from "../common/types/surfaces";
 import type { InboundMessage } from "../adapters/types";
-import { requireStringBindingField } from "../common/types/object-guards";
+import {
+  createDefaultSurfacePluginRegistry,
+  resolveAdapterPluginOrThrow,
+  type SurfacePluginRegistry,
+} from "../adapters/registry";
 
 // =============================================================================
 // Public types
@@ -387,9 +423,19 @@ export function crossPrincipalBindings(
  * as `foldSurfaceBindings` in `surfaces.ts`.  `resolveBinding` (the per-message
  * hot path) never throws; index build is where we fail fast at startup.
  *
- * @throws `Error` when two bindings collide on the same `(platform, demuxKey)`.
+ * @param registry cortex#1951 — the `(kind, id)`-keyed plugin registry each
+ *   platform's demux key is now derived from (`plugin.demuxKey(binding)`).
+ *   Defaults to {@link createDefaultSurfacePluginRegistry} (in-tree
+ *   discord/slack/mattermost only) when omitted — see the module doc's
+ *   "demux keys are registry-driven" section.
+ * @throws `Error` when two bindings collide on the same `(platform, demuxKey)`,
+ *   or when a platform has bindings but no matching plugin is registered
+ *   ({@link resolveAdapterPluginOrThrow}).
  */
-export function buildBindingIndex(surfaces: Surfaces): GatewayBindingIndex {
+export function buildBindingIndex(
+  surfaces: Surfaces,
+  registry: SurfacePluginRegistry = createDefaultSurfacePluginRegistry(),
+): GatewayBindingIndex {
   const discord = new Map<string, IndexEntry>();
   const slack = new Map<string, IndexEntry>();
   const web = new Map<string, IndexEntry>();
@@ -397,41 +443,52 @@ export function buildBindingIndex(surfaces: Surfaces): GatewayBindingIndex {
   let mattermostMulti = false;
 
   // ── Discord ─────────────────────────────────────────────────────────────
-  for (const entry of surfaces.discord ?? []) {
-    const demuxKey = entry.binding.guildId;
-    if (discord.has(demuxKey)) {
-      throw new Error(
-        `gateway binding-resolver: ambiguous discord config — two bindings share guildId "${demuxKey}". ` +
-          `Each (platform, guildId) pair must map to exactly one binding. ` +
-          `Fix the surfaces.yaml discord bindings to remove the duplicate.`,
-      );
+  // Per-binding guildId demux — see the module doc's "Discord is the one
+  // deliberate divergence" note for why this does NOT use the token-grouped
+  // instance ids `buildGatewayAdapters`/`gatewayInstanceIds` compute.
+  const discordEntries = surfaces.discord ?? [];
+  if (discordEntries.length > 0) {
+    const discordPlugin = resolveAdapterPluginOrThrow("discord", registry);
+    for (const entry of discordEntries) {
+      const demuxKey = discordPlugin.demuxKey(entry.binding);
+      if (discord.has(demuxKey)) {
+        throw new Error(
+          `gateway binding-resolver: ambiguous discord config — two bindings share guildId "${demuxKey}". ` +
+            `Each (platform, guildId) pair must map to exactly one binding. ` +
+            `Fix the surfaces.yaml discord bindings to remove the duplicate.`,
+        );
+      }
+      const { principal, stack } = parseStack(entry.stack);
+      discord.set(demuxKey, {
+        agent: entry.agent,
+        principal,
+        stack,
+        instance: `discord:${demuxKey}`,
+      });
     }
-    const { principal, stack } = parseStack(entry.stack);
-    discord.set(demuxKey, {
-      agent: entry.agent,
-      principal,
-      stack,
-      instance: `discord:${demuxKey}`,
-    });
   }
 
   // ── Slack ────────────────────────────────────────────────────────────────
-  for (const entry of surfaces.slack ?? []) {
-    const demuxKey = entry.binding.workspaceId;
-    if (slack.has(demuxKey)) {
-      throw new Error(
-        `gateway binding-resolver: ambiguous slack config — two bindings share workspaceId "${demuxKey}". ` +
-          `Each (platform, workspaceId) pair must map to exactly one binding. ` +
-          `Fix the surfaces.yaml slack bindings to remove the duplicate.`,
-      );
+  const slackEntries = surfaces.slack ?? [];
+  if (slackEntries.length > 0) {
+    const slackPlugin = resolveAdapterPluginOrThrow("slack", registry);
+    for (const entry of slackEntries) {
+      const demuxKey = slackPlugin.demuxKey(entry.binding);
+      if (slack.has(demuxKey)) {
+        throw new Error(
+          `gateway binding-resolver: ambiguous slack config — two bindings share workspaceId "${demuxKey}". ` +
+            `Each (platform, workspaceId) pair must map to exactly one binding. ` +
+            `Fix the surfaces.yaml slack bindings to remove the duplicate.`,
+        );
+      }
+      const { principal, stack } = parseStack(entry.stack);
+      slack.set(demuxKey, {
+        agent: entry.agent,
+        principal,
+        stack,
+        instance: `slack:${demuxKey}`,
+      });
     }
-    const { principal, stack } = parseStack(entry.stack);
-    slack.set(demuxKey, {
-      agent: entry.agent,
-      principal,
-      stack,
-      instance: `slack:${demuxKey}`,
-    });
   }
 
   // ── Mattermost ───────────────────────────────────────────────────────────
@@ -454,14 +511,16 @@ export function buildBindingIndex(surfaces: Surfaces): GatewayBindingIndex {
   // non-null assertion under noUncheckedIndexedAccess).
   const soleMm = mmEntries.length === 1 ? mmEntries[0] : undefined;
   if (soleMm) {
+    const mattermostPlugin = resolveAdapterPluginOrThrow("mattermost", registry);
+    const demuxKey = mattermostPlugin.demuxKey(soleMm.binding);
     const { principal, stack } = parseStack(soleMm.stack);
-    // Use apiUrl as the demux key for the interim instance id (the only stable
-    // per-binding identifier Mattermost surfaces carry).
+    // demuxKey (apiUrl) is the interim instance id — the only stable
+    // per-binding identifier Mattermost surfaces carry.
     mattermostSingle = {
       agent: soleMm.agent,
       principal,
       stack,
-      instance: `mattermost:${soleMm.binding.apiUrl}`,
+      instance: `mattermost:${demuxKey}`,
     };
   } else if (mmEntries.length > 1) {
     mattermostMulti = true;
@@ -473,30 +532,27 @@ export function buildBindingIndex(surfaces: Surfaces): GatewayBindingIndex {
   // Demux key = the adapter instanceId the WebAdapter stamps on every
   // InboundMessage (`web:${binding.instanceId}`), matched verbatim in
   // resolveBinding. Web carries no platform-native guild/server id.
-  for (const entry of surfaces.web ?? []) {
-    // cortex#1794 (S9 MOVE) — `entry.binding` is `Record<string, unknown>`
-    // now that `web` validates via the generic catchall (see
-    // `object-guards.ts`'s `requireStringBindingField` doc).
-    const instanceId = requireStringBindingField(
-      entry.binding,
-      "instanceId",
-      "gateway binding-resolver: surfaces.web[].binding",
-    );
-    const demuxKey = `web:${instanceId}`;
-    if (web.has(demuxKey)) {
-      throw new Error(
-        `gateway binding-resolver: ambiguous web config — two bindings share instanceId "${instanceId}". ` +
-          `Each (platform, instanceId) pair must map to exactly one binding. ` +
-          `Fix the surfaces.yaml web bindings to remove the duplicate.`,
-      );
+  const webEntries = surfaces.web ?? [];
+  if (webEntries.length > 0) {
+    const webPlugin = resolveAdapterPluginOrThrow("web", registry);
+    for (const entry of webEntries) {
+      const instanceId = webPlugin.demuxKey(entry.binding);
+      const demuxKey = `web:${instanceId}`;
+      if (web.has(demuxKey)) {
+        throw new Error(
+          `gateway binding-resolver: ambiguous web config — two bindings share instanceId "${instanceId}". ` +
+            `Each (platform, instanceId) pair must map to exactly one binding. ` +
+            `Fix the surfaces.yaml web bindings to remove the duplicate.`,
+        );
+      }
+      const { principal, stack } = parseStack(entry.stack);
+      web.set(demuxKey, {
+        agent: entry.agent,
+        principal,
+        stack,
+        instance: demuxKey,
+      });
     }
-    const { principal, stack } = parseStack(entry.stack);
-    web.set(demuxKey, {
-      agent: entry.agent,
-      principal,
-      stack,
-      instance: demuxKey,
-    });
   }
 
   return { discord, slack, web, mattermostSingle, mattermostMulti };

--- a/src/gateway/gateway-bootstrap.ts
+++ b/src/gateway/gateway-bootstrap.ts
@@ -60,6 +60,10 @@ import type { PlatformAdapter, InboundMessage } from "../adapters/types";
 import type { Surfaces } from "../common/types/surfaces";
 import { buildBindingIndex } from "./binding-resolver";
 import {
+  createDefaultSurfacePluginRegistry,
+  type SurfacePluginRegistry,
+} from "../adapters/registry";
+import {
   SurfaceGateway,
   LoggingInboundSink,
   type GatewayInboundSink,
@@ -106,6 +110,15 @@ export interface GatewayBootstrapOpts {
    * When absent the gateway's default `console.warn` fires.
    */
   onUnroutable?: (msg: InboundMessage, reason: string) => void;
+  /**
+   * cortex#1951 — the `(kind, id)`-keyed plugin registry `buildBindingIndex`
+   * derives each platform's demux key from. Defaults to
+   * {@link createDefaultSurfacePluginRegistry} (in-tree discord/slack/
+   * mattermost only) when omitted — a back-compat/test convenience.
+   * `startGatewayIfEnabled` always threads its own composed registry (the
+   * SAME one it hands `buildGatewayAdapters`) explicitly.
+   */
+  registry?: SurfacePluginRegistry;
 }
 
 // =============================================================================
@@ -225,7 +238,10 @@ export function maybeCreateSurfaceGateway(
   //
   // buildBindingIndex throws on duplicate demux keys — that is intentional
   // (loud startup failure on bad config). The throw propagates to the caller.
-  const index = buildBindingIndex(surfaces);
+  const index = buildBindingIndex(
+    surfaces,
+    opts.registry ?? createDefaultSurfacePluginRegistry(),
+  );
 
   // Sink selection: defaults to LoggingInboundSink (SHADOW — no bus publish)
   // when the caller omits `sink`, so every existing caller and the default

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -183,6 +183,13 @@ export async function startGatewayIfEnabled(
     return undefined;
   }
 
+  // cortex#1951 — resolve ONCE, thread the SAME registry to both
+  // `maybeCreateSurfaceGateway` calls below (inbound demux) AND
+  // `buildGatewayAdapters` (construction) — one registry, no drift between
+  // how a binding's demux key and its live adapter are derived.
+  const registry =
+    opts.registry ?? registryFromFactory(opts.factory ?? defaultGatewayAdapterFactory);
+
   // ── Path 2: flag on but no bindings → degrade gracefully. ─────────────────
   // Short-circuit BEFORE buildGatewayAdapters so the factory is never called
   // when there is nothing to demux (keeps the no-binding invariant crisp).
@@ -196,6 +203,7 @@ export async function startGatewayIfEnabled(
       enabled: true,
       surfaces,
       adapters: [],
+      registry,
       ...(opts.onUnroutable !== undefined && { onUnroutable: opts.onUnroutable }),
     });
     return undefined;
@@ -236,7 +244,7 @@ export async function startGatewayIfEnabled(
   const adapters = buildGatewayAdapters(surfaces, {
     principal: opts.principal,
     runtime: opts.runtime,
-    registry: opts.registry ?? registryFromFactory(opts.factory ?? defaultGatewayAdapterFactory),
+    registry,
   });
 
   // Sink selection — the SECOND opt-in gate.
@@ -296,6 +304,7 @@ export async function startGatewayIfEnabled(
     enabled: true,
     surfaces,
     adapters,
+    registry,
     ...(sink !== undefined && { sink }),
     ...(onUnroutable !== undefined && { onUnroutable }),
   });

--- a/src/gateway/surface-ownership-plan.ts
+++ b/src/gateway/surface-ownership-plan.ts
@@ -11,14 +11,17 @@
 
 import type { PlatformAdapter } from "../adapters/types";
 import type { Surfaces } from "../common/types/surfaces";
-import { requireStringBindingField } from "../common/types/object-guards";
+import {
+  createDefaultSurfacePluginRegistry,
+  resolveAdapterPluginOrThrow,
+  type SurfacePluginRegistry,
+} from "../adapters/registry";
 import {
   crossPrincipalBindings,
   distinctBoundPrincipalStacks,
   distinctBoundStacks,
   type BoundPrincipalStack,
 } from "./binding-resolver";
-import { groupDiscordBindingsByToken } from "./discord-token-groups";
 
 export interface SurfaceOwnershipPlan {
   /** True when `CORTEX_GATEWAY` selected the Gateway path. */
@@ -46,6 +49,15 @@ export interface SurfaceOwnershipPlanOpts {
   surfaces: Surfaces | undefined;
   gatewayEnabled: boolean;
   principal: string;
+  /**
+   * cortex#1951 — the `(kind, id)`-keyed plugin registry `gatewayInstanceIds`
+   * derives each platform's demux key from (`plugin.demuxKey(binding)`)
+   * instead of a hardcoded field read. Defaults to
+   * {@link createDefaultSurfacePluginRegistry} (in-tree discord/slack/
+   * mattermost only) when omitted — a back-compat/test convenience;
+   * production boot always threads its own composed registry explicitly.
+   */
+  registry?: SurfacePluginRegistry;
 }
 
 function countSurfaceBindings(surfaces: Surfaces | undefined): number {
@@ -68,24 +80,65 @@ function ownedKeys(surfaces: Surfaces | undefined): Set<string> {
   return keys;
 }
 
-function gatewayInstanceIds(surfaces: Surfaces | undefined): string[] {
+/**
+ * cortex#1951 — registry-driven Gateway adapter instance ids. Each platform's
+ * id is derived via `registry.getAdapter(platform)` instead of a hardcoded
+ * field read, so no gateway code knows any platform's binding shape.
+ *
+ * Discord is the one platform with non-default grouping: bindings are
+ * token-keyed (one gateway session per bot token — Discord delivers every
+ * guild event for a token over ONE gateway connection), so its ids come from
+ * `discordPlugin.groupBindings` — the SAME token-grouping rule
+ * `buildGatewayAdapters` uses to construct the live adapters, byte-identical
+ * to calling `groupDiscordBindingsByToken` directly (that's exactly what the
+ * plugin's `groupBindings` does under the hood). Slack/Mattermost/Web have no
+ * grouping — one instance id per binding, `${platform}:${demuxKey}`.
+ */
+function gatewayInstanceIds(
+  surfaces: Surfaces | undefined,
+  registry: SurfacePluginRegistry,
+): string[] {
   const ids: string[] = [];
   if (surfaces === undefined) return ids;
-  for (const group of groupDiscordBindingsByToken(surfaces.discord ?? [])) {
-    ids.push(group.instanceId);
+
+  const discordEntries = surfaces.discord ?? [];
+  if (discordEntries.length > 0) {
+    const discordPlugin = resolveAdapterPluginOrThrow("discord", registry);
+    const groups = discordPlugin.groupBindings
+      ? discordPlugin.groupBindings(discordEntries)
+      : discordEntries.map((entry) => ({
+          entries: [entry],
+          instanceId: `discord:${discordPlugin.demuxKey(entry.binding)}`,
+        }));
+    for (const group of groups) {
+      ids.push(group.instanceId);
+    }
   }
-  for (const entry of surfaces.slack ?? []) {
-    ids.push(`slack:${entry.binding.workspaceId}`);
+
+  const slackEntries = surfaces.slack ?? [];
+  if (slackEntries.length > 0) {
+    const slackPlugin = resolveAdapterPluginOrThrow("slack", registry);
+    for (const entry of slackEntries) {
+      ids.push(`slack:${slackPlugin.demuxKey(entry.binding)}`);
+    }
   }
-  for (const entry of surfaces.mattermost ?? []) {
-    ids.push(`mattermost:${entry.binding.apiUrl}`);
+
+  const mattermostEntries = surfaces.mattermost ?? [];
+  if (mattermostEntries.length > 0) {
+    const mattermostPlugin = resolveAdapterPluginOrThrow("mattermost", registry);
+    for (const entry of mattermostEntries) {
+      ids.push(`mattermost:${mattermostPlugin.demuxKey(entry.binding)}`);
+    }
   }
-  for (const entry of surfaces.web ?? []) {
-    // cortex#1794 (S9 MOVE) — see `object-guards.ts`'s
-    // `requireStringBindingField` doc: `entry.binding` is now
-    // `Record<string, unknown>` for the generically-validated `web` platform.
-    ids.push(`web:${requireStringBindingField(entry.binding, "instanceId", "gateway surface-ownership-plan: surfaces.web[].binding")}`);
+
+  const webEntries = surfaces.web ?? [];
+  if (webEntries.length > 0) {
+    const webPlugin = resolveAdapterPluginOrThrow("web", registry);
+    for (const entry of webEntries) {
+      ids.push(`web:${webPlugin.demuxKey(entry.binding)}`);
+    }
   }
+
   return ids;
 }
 
@@ -120,12 +173,14 @@ export function planSurfaceOwnership(
     return emptyPlan(opts, hasSurfaceBindings);
   }
 
+  const registry = opts.registry ?? createDefaultSurfacePluginRegistry();
+
   return {
     gatewayEnabled: true,
     hasSurfaceBindings,
     gatewayStartEligible: true,
     ownedSurfaceKeys: ownedKeys(opts.surfaces),
-    gatewayAdapterInstanceIds: gatewayInstanceIds(opts.surfaces),
+    gatewayAdapterInstanceIds: gatewayInstanceIds(opts.surfaces, registry),
     outboundStacks: distinctBoundStacks(opts.surfaces),
     outboundPrincipalStacks: distinctBoundPrincipalStacks(
       opts.surfaces,


### PR DESCRIPTION
Closes #1951 (epic #1784 pattern-hardening, before slack/mattermost/discord extract). Makes the shared gateway's INBOUND-routing half registry-driven, matching the CONSTRUCTION half. **Behaviour-preserving.**

## Problem
`binding-resolver.ts` (demux index) and `surface-ownership-plan.ts` (instance-id planning) hardcoded each platform's demux field — `binding.guildId`/`.workspaceId`/`.apiUrl`/`.instanceId`. When web extracted (#1948) its field went `unknown` and these reads broke Lint — patched with a `requireStringBindingField` band-aid. Each future extraction (#1896) would re-hit it.

## Fix
Both functions now derive the demux key via `registry.getAdapter(platform).demuxKey(binding)` — no gateway code knows any platform's binding shape. Both take an optional `SurfacePluginRegistry` (default in-tree-only); production boot threads its own composed registry, so the default is dead code on the real path. The **#1948 `requireStringBindingField` band-aid is deleted** (now unused).

## Byte-identical (behaviour-preserving)
Verified each plugin's `demuxKey` == the old hardcoded read: discord `guildId`, slack `workspaceId`, mattermost `apiUrl`, web `instanceId` (real bundle). **Existing binding-resolver + surface-ownership-plan tests — which pin the exact keys — pass unchanged.**

## Discord subtlety (deliberate, documented)
Inbound demux stays per-binding `guildId` (via `demuxKey`), NOT the construction path's token-grouping — `InboundMessage` carries `guildId`, not the bot token, so that's the only routable key. `gatewayInstanceIds`' discord instance-id now goes through `discordPlugin.groupBindings()` (registry-driven) instead of a direct `groupDiscordBindingsByToken` import — byte-identical output, one less binding-shape import.

## For the reviewer
- Confirm the demux keys are truly byte-identical for all 4 platforms (the key-pinning tests are the proof — spot-check discord's guildId-vs-token-grouping distinction).
- `surface-ownership-plan` still has per-platform branches (each now calling `demuxKey`) — the FIELD coupling is gone; is the residual per-platform iteration acceptable, or should it fully genericize? (I'd argue acceptable for this slice — the extraction-breaking coupling is the field read, now gone.)

## Gates
tsc 0 · lint 0 · `bun test src/gateway src/adapters src/common` 2473/0 · vocab PASS. Rebased on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)