### PR TITLE
feat(surface-sdk): resolvable SDK for out-of-tree bundles — stop per-bundle vendoring (#1950)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,31 @@ jobs:
         run: bun test
 
   # ──────────────────────────────────────────────────────────────────
+  # Surface-SDK .d.ts drift guard (cortex#1950). The shippable, self-contained
+  # plugin-SDK type artifact (src/surface-sdk/generated/surface-sdk.d.ts) is
+  # GENERATED from the barrel (src/surface-sdk/index.ts) by `bun run sdk:dts`.
+  # Out-of-tree bundles resolve it via package.json exports["./surface-sdk"];
+  # if it drifts from the barrel, a bundle compiles against stale types. This
+  # job regenerates it and fails on any diff — so a merged artifact is always
+  # byte-identical to what the current barrel produces, and it can never go
+  # stale the way the old per-bundle hand-vendored copies did.
+  # ──────────────────────────────────────────────────────────────────
+  surface-sdk-dts-sync:
+    name: Surface-SDK .d.ts sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: regenerate + diff (bun run sdk:dts:check)
+        run: bun run sdk:dts:check
+
+  # ──────────────────────────────────────────────────────────────────
   # Shippable-config hygiene gate — L2 of the confidentiality program
   # (design doc §4 L2, compass#81/#87). A DETERMINISTIC whole-tree check
   # that FAILS if deployment-specific content lands in a shippable path:

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,9 @@
         "@types/libsodium-wrappers": "^0.8.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "dts-bundle-generator": "^9",
         "eslint": "^10.3.0",
+        "typescript": "^5",
         "typescript-eslint": "^8.59.3",
       },
       "peerDependencies": {
@@ -196,6 +198,10 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
@@ -211,6 +217,12 @@
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
@@ -248,9 +260,13 @@
 
     "discord.js": ["discord.js@14.25.1", "", { "dependencies": { "@discordjs/builders": "^1.13.0", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.0", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.33", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g=="],
 
+    "dts-bundle-generator": ["dts-bundle-generator@9.5.1", "", { "dependencies": { "typescript": ">=5.0.2", "yargs": "^17.6.0" }, "bin": { "dts-bundle-generator": "dist/bin/dts-bundle-generator.js" } }, "sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -259,6 +275,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -304,6 +322,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -329,6 +349,8 @@
     "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
@@ -406,6 +428,8 @@
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
@@ -417,6 +441,10 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
@@ -446,9 +474,17 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -35,13 +35,13 @@ import type {
   SurfaceBindingEntry, BindingGroup, GatewayConstructBase,
   // Host-injected policy port (cortex#1794 S9b)
   AdapterPolicyPort,
-} from "@cortex/surface-sdk"; // in-tree: "../../surface-sdk" (adapters) / "../surface-sdk" (renderers)
-import { SURFACE_SDK_VERSION } from "@cortex/surface-sdk";
+} from "@the-metafactory/cortex/surface-sdk"; // in-tree: "../../surface-sdk" (adapters) / "../surface-sdk" (renderers)
+import type { SURFACE_SDK_VERSION } from "@the-metafactory/cortex/surface-sdk";
 ```
 
-*(The `@cortex/surface-sdk` specifier is illustrative of how an out-of-tree
-bundle resolves the SDK once S6's loader ships it; in-tree code today uses
-the plain relative path shown above and in the skeletons below.)*
+*(In-tree code uses the plain relative path shown above and in the skeletons
+below. An out-of-tree bundle resolves the `@the-metafactory/cortex/surface-sdk`
+specifier per §Resolving the SDK in an out-of-tree bundle, below.)*
 
 `AdapterPolicyPort` (cortex#1794 S9b) is a dependency-inversion PORT, not a
 data type: it describes `resolveAccess(msg)` / `isOperatorPrincipal(platform,
@@ -443,12 +443,68 @@ destroy-and-reconstruct safe"), but every plugin author must design for it:
   does not break REPLIES — only best-effort UX affordances (a "typing…"
   placeholder update, a cached thread lookup) are lost.
 
+## Resolving the SDK in an out-of-tree bundle (cortex#1950)
+
+An out-of-tree bundle imports the contract as `import type` — so at RUNTIME the
+loader's dynamic `import()` never resolves the SDK (the types are erased). The
+bundle only needs the SDK types RESOLVABLE at TYPE-CHECK time, so its standalone
+`bunx tsc --noEmit` passes. cortex makes that resolvable **without publishing a
+package and without a bundle vendoring a hand-copied subset** (which drifts on
+every `SURFACE_SDK_VERSION` bump and does not scale past one bundle):
+
+**cortex ships a self-contained, generated `.d.ts`.** `bun run sdk:dts`
+(`scripts/gen-surface-sdk-dts.ts`) rolls the barrel up into ONE flat file,
+`src/surface-sdk/generated/surface-sdk.d.ts`, with every transitive contract
+type inlined and the *only* external import being `zod/v4` (which every plugin
+already depends on — the binding/config schemas are zod). `package.json`
+exposes it:
+
+```jsonc
+"exports": {
+  "./surface-sdk": {
+    "types": "./src/surface-sdk/generated/surface-sdk.d.ts", // ← the flat artifact
+    "default": "./src/surface-sdk/index.ts"
+  }
+}
+```
+
+Pointing a consumer at the raw `src/surface-sdk/index.ts` does **not** work — it
+transitively drags cortex's whole source tree + dev-deps into the bundle's `tsc`.
+The flat `.d.ts` pulls none of it.
+
+**The artifact cannot drift.** It is generated from the barrel, never
+hand-edited, and CI (`.github/workflows/ci.yml` → `surface-sdk-dts-sync`)
+regenerates it and fails on any diff. Because `SURFACE_SDK_VERSION` is inlined
+into the artifact, the shipped types always track the contract version.
+
+**A bundle resolves the artifact via a pinned single-file sync** (the reference
+implementation is `metafactory-cortex-adapter-web`):
+
+- a `postinstall` step fetches just `surface-sdk.d.ts` from cortex at a **pinned
+  ref** into a gitignored `sdk/` dir (no cortex dependency tree, no clone — one
+  file);
+- `tsconfig.json` `paths` maps `@the-metafactory/cortex/surface-sdk` → that
+  local file. Since the file lands in the bundle's own tree, its `zod/v4` import
+  resolves the bundle's OWN single zod — no cross-instance zod-type skew.
+
+*(A bundle that would rather take a real package dependency can instead
+`bun add github:the-metafactory/cortex#<ref>` and import the same specifier via
+the `exports` map above — but that pulls cortex's entire runtime dep tree
+(react, discord.js, …) into the bundle for types alone, so the single-file sync
+is preferred for a lean adapter/renderer bundle.)*
+
+**Versioning — staleness is never silent.** The bundle pins a cortex ref, so a
+`SURFACE_SDK_VERSION` major bump in cortex does not silently re-type the bundle
+— it stays on the pinned types until its maintainer bumps the ref (an explicit,
+reviewable change). If a bundle is left on types too old for the running daemon,
+the **S6 loader's `satisfies(SURFACE_SDK_VERSION, sdkRange)` gate refuses it at
+`import()` with a `system.error`** — staleness fails loud at load, never silently
+mis-compiles against a contract the daemon no longer honours.
+
 ## Out of scope for this doc
 
 - Dynamic bundle loading / the compat-gate loader implementation (S6) — see
   `src/adapters/loader.ts`.
-- Publishing an npm package for the SDK — a bundle resolves it via S6's
-  loader import mechanism, not `npm install`.
 - Zero-downtime handover between old+new instance of the SAME platform
   (v2 — the S8 issue's explicit out-of-scope line).
 - Retiring `GatewayAdapterFactory` and the adapter `reload`/`load` verbs that

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -125,6 +125,10 @@ export default tseslint.config(
       "dist/",
       "node_modules/",
       "docs/mockups/",
+      // cortex#1950 — GENERATED, self-contained plugin-SDK .d.ts shipped for
+      // out-of-tree bundles (bun run sdk:dts). Excluded from tsconfig too;
+      // not part of the typed project.
+      "src/surface-sdk/generated/",
       "src/bus/myelin/vendor/",
       "src/worker/",
       "src/webhook-proxy/",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "license": "AGPL-3.0-only",
   "private": true,
   "exports": {
+    "./surface-sdk": {
+      "types": "./src/surface-sdk/generated/surface-sdk.d.ts",
+      "default": "./src/surface-sdk/index.ts"
+    },
     "./bus": {
       "types": "./src/bus/index.ts",
       "default": "./src/bus/index.ts"
@@ -25,7 +29,9 @@
     "db:migrate:safe": "bun scripts/scan-deploy-surface.ts d1 --advisory && bun --cwd src/surface/mc/worker run db:migrate",
     "lint": "eslint .",
     "lint:errors": "eslint --quiet .",
-    "lint:fix": "eslint --fix ."
+    "lint:fix": "eslint --fix .",
+    "sdk:dts": "bun scripts/gen-surface-sdk-dts.ts",
+    "sdk:dts:check": "bun scripts/gen-surface-sdk-dts.ts --check"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -33,7 +39,9 @@
     "@types/libsodium-wrappers": "^0.8.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "dts-bundle-generator": "^9",
     "eslint": "^10.3.0",
+    "typescript": "^5",
     "typescript-eslint": "^8.59.3"
   },
   "peerDependencies": {

--- a/scripts/gen-surface-sdk-dts.ts
+++ b/scripts/gen-surface-sdk-dts.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+/**
+ * gen-surface-sdk-dts.ts — regenerate the shippable, self-contained plugin-SDK
+ * type artifact (cortex#1950).
+ *
+ * ## Why this exists
+ *
+ * Out-of-tree surface-plugin bundles (`metafactory-cortex-adapter-web`, and the
+ * slack/mattermost/discord bundles that follow) compile against the plugin SDK
+ * contract with `import type { PlatformAdapter, … } from
+ * "@the-metafactory/cortex/surface-sdk"`. Those imports are erased at runtime
+ * (the loader's dynamic `import()` never resolves them — see docs/plugin-sdk.md),
+ * but a bundle's standalone `bunx tsc --noEmit` needs the types RESOLVABLE.
+ *
+ * The barrel (`src/surface-sdk/index.ts`) re-exports types rooted transitively
+ * across cortex + myelin, so pointing a consumer's `tsc` at the raw `.ts` source
+ * drags the whole cortex source tree + its dev-deps into the bundle's compile
+ * (verified: hundreds of errors in `adapters/discord/*`, missing `discord.js`).
+ * The fix is to ship a single FLAT `.d.ts` with every transitive type INLINED
+ * and nothing external except `zod/v4` (which every bundle already depends on).
+ * `package.json`'s `exports["./surface-sdk"].types` points at that artifact.
+ *
+ * ## Drift-proofing
+ *
+ * This artifact is GENERATED from the real barrel — it is never hand-edited, so
+ * it cannot drift the way the old per-bundle vendored copies did. A `SURFACE_SDK_VERSION`
+ * bump (or any contract change) is picked up automatically because the artifact
+ * is regenerated from source. CI runs this script with `--check` and fails on any
+ * uncommitted diff (`.github/workflows/ci.yml` → `surface-sdk-dts-sync`), so a
+ * merged artifact is always byte-identical to what the current barrel produces.
+ *
+ * ## Usage
+ *
+ *   bun run sdk:dts          # regenerate + write the artifact (commit the result)
+ *   bun run sdk:dts:check    # regenerate to a temp file + diff; non-zero on drift
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const ENTRY = "src/surface-sdk/index.ts";
+export const ARTIFACT = join(repoRoot, "src/surface-sdk/generated/surface-sdk.d.ts");
+
+const HEADER = `// ============================================================================
+// GENERATED FILE — DO NOT EDIT BY HAND.
+//
+// Self-contained type artifact for the cortex plugin SDK (cortex#1950). This is
+// the file out-of-tree surface-plugin bundles resolve when they
+//   import type { PlatformAdapter, … } from "@the-metafactory/cortex/surface-sdk";
+// (package.json exports["./surface-sdk"].types points here).
+//
+// Regenerate after ANY change to src/surface-sdk/index.ts or the contract types
+// it re-exports:
+//   bun run sdk:dts
+//
+// CI (.github/workflows/ci.yml → surface-sdk-dts-sync) fails on any drift between
+// this committed file and a fresh regeneration, so it can never go stale.
+// ============================================================================
+`;
+
+/** Roll the barrel up into one flat .d.ts (all transitive types inlined; only
+ *  zod kept as an external import — every bundle already depends on zod). */
+function generate(): string {
+  const bin = join(repoRoot, "node_modules/.bin/dts-bundle-generator");
+  const outTmp = join(repoRoot, "src/surface-sdk/generated/.surface-sdk.gen.tmp.d.ts");
+  mkdirSync(dirname(outTmp), { recursive: true });
+  // dts-bundle-generator is a node/CJS tool that needs `typescript` resolvable
+  // from repoRoot (devDependency). Run it under node explicitly.
+  const res = spawnSync(
+    "node",
+    [bin, "--no-check", "--no-banner", "--silent", "-o", outTmp, "--", ENTRY],
+    { cwd: repoRoot, stdio: ["ignore", "inherit", "inherit"] },
+  );
+  if (res.status !== 0) {
+    process.stderr.write(`dts-bundle-generator failed (exit ${res.status})\n`);
+    process.exit(res.status ?? 1);
+  }
+  const body = readFileSync(outTmp, "utf8").trimStart();
+  // clean up the temp file
+  spawnSync("rm", ["-f", outTmp]);
+  return HEADER + "\n" + body;
+}
+
+const check = process.argv.includes("--check");
+const generated = generate();
+
+if (check) {
+  let current = "";
+  try {
+    current = readFileSync(ARTIFACT, "utf8");
+  } catch {
+    current = "";
+  }
+  if (current !== generated) {
+    process.stderr.write(
+      `\n❌ ${ARTIFACT} is out of sync with ${ENTRY}.\n` +
+        `   Run \`bun run sdk:dts\` and commit the result.\n\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(`✅ surface-sdk .d.ts artifact is in sync.\n`);
+} else {
+  mkdirSync(dirname(ARTIFACT), { recursive: true });
+  writeFileSync(ARTIFACT, generated);
+  process.stdout.write(`✅ wrote ${ARTIFACT}\n`);
+}

--- a/scripts/gen-vocab-ratchet.ts
+++ b/scripts/gen-vocab-ratchet.ts
@@ -136,6 +136,12 @@ const CARVEOUT_PATHS: string[] = [
   // The gate's own source + CI definition necessarily NAME the deprecated terms
   "scripts/check-carveouts.sh",
   ".github/workflows/",
+  // cortex#1950 — GENERATED plugin-SDK .d.ts (bun run sdk:dts). Rolls up JSDoc
+  // verbatim from already-allowlisted sources (e.g. src/bus/payload-filter.ts's
+  // "EventBridge-style operators"), so it inherits their carve-out status; it
+  // is never hand-edited and its drift guard is surface-sdk-dts-sync, not this
+  // gate.
+  "src/surface-sdk/generated/",
   // Policy authorization-role cluster — `operator` = reserved authz ROLE/capability literal
   "src/common/policy/",
   "docs/design-policy-cutover.md",

--- a/scripts/vocab-ratchet.json
+++ b/scripts/vocab-ratchet.json
@@ -86,6 +86,7 @@
       "CONTEXT.md",
       "scripts/check-carveouts.sh",
       ".github/workflows/",
+      "src/surface-sdk/generated/",
       "src/common/policy/",
       "docs/design-policy-cutover.md",
       "cortex.yaml.example",

--- a/src/surface-sdk/__tests__/dts-artifact.test.ts
+++ b/src/surface-sdk/__tests__/dts-artifact.test.ts
@@ -1,0 +1,77 @@
+/**
+ * dts-artifact.test.ts — fast sanity checks on the shippable, self-contained
+ * plugin-SDK type artifact (cortex#1950).
+ *
+ * The artifact (`src/surface-sdk/generated/surface-sdk.d.ts`) is what out-of-tree
+ * surface-plugin bundles resolve when they `import type { … } from
+ * "@the-metafactory/cortex/surface-sdk"` (package.json exports["./surface-sdk"]).
+ * It is GENERATED from the barrel by `bun run sdk:dts` and must never be
+ * hand-edited.
+ *
+ * This test is deliberately FAST — it does not regenerate (that takes ~30s and
+ * needs the dts-bundle-generator toolchain). It catches the cheap, common drift
+ * modes (a `SURFACE_SDK_VERSION` bump, a contract symbol added/removed) so
+ * `bun test src/surface-sdk` flags them locally. The exhaustive byte-for-byte
+ * drift guard is the CI job `surface-sdk-dts-sync` (.github/workflows/ci.yml),
+ * which runs `bun run sdk:dts:check` (regenerate + `git diff --exit-code`).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { SURFACE_SDK_VERSION } from "../index";
+
+const ARTIFACT = join(import.meta.dir, "..", "generated", "surface-sdk.d.ts");
+const artifact = readFileSync(ARTIFACT, "utf8");
+
+describe("surface-sdk generated .d.ts artifact", () => {
+  test("carries a GENERATED-do-not-edit banner", () => {
+    expect(artifact).toContain("GENERATED FILE — DO NOT EDIT BY HAND");
+    expect(artifact).toContain("bun run sdk:dts");
+  });
+
+  test("inlines the SAME SURFACE_SDK_VERSION as the barrel (tracks the contract)", () => {
+    // If the barrel bumps the version but the artifact is stale, this fails —
+    // the version must be re-generated into the shipped types, not left behind.
+    expect(artifact).toContain(`export declare const SURFACE_SDK_VERSION = "${SURFACE_SDK_VERSION}"`);
+  });
+
+  test("is self-contained — the only external import is zod (which every bundle already has)", () => {
+    const importLines = artifact
+      .split("\n")
+      .filter((l) => /^\s*import\b/.test(l) || /^\s*export\s+.*\bfrom\s+['"]/.test(l));
+    for (const line of importLines) {
+      const m = /from\s+['"]([^'"]+)['"]/.exec(line);
+      if (!m) continue;
+      const spec = m[1]!;
+      // Only bare zod (and its subpaths) may remain external; anything else
+      // means a cortex-internal module leaked in and the artifact is no longer
+      // resolvable standalone.
+      expect(spec === "zod" || spec.startsWith("zod/")).toBe(true);
+    }
+  });
+
+  test("re-exports the full plugin CONTRACT surface a bundle compiles against", () => {
+    // The load-bearing contract symbols. If S5 renames/removes one, the barrel
+    // changes and this list must be regenerated with it — the failure points a
+    // bundle author at the breaking change.
+    for (const sym of [
+      "PlatformAdapter",
+      "InboundMessage",
+      "AccessDecision",
+      "ResponseTarget",
+      "OutboundFile",
+      "ContextMessage",
+      "Renderer",
+      "RenderTarget",
+      "Envelope",
+      "SurfacePlugin",
+      "AdapterPlugin",
+      "RendererPlugin",
+      "AdapterPolicyPort",
+    ]) {
+      expect(artifact).toContain(sym);
+    }
+  });
+});

--- a/src/surface-sdk/generated/surface-sdk.d.ts
+++ b/src/surface-sdk/generated/surface-sdk.d.ts
@@ -1,0 +1,971 @@
+// ============================================================================
+// GENERATED FILE — DO NOT EDIT BY HAND.
+//
+// Self-contained type artifact for the cortex plugin SDK (cortex#1950). This is
+// the file out-of-tree surface-plugin bundles resolve when they
+//   import type { PlatformAdapter, … } from "@the-metafactory/cortex/surface-sdk";
+// (package.json exports["./surface-sdk"].types points here).
+//
+// Regenerate after ANY change to src/surface-sdk/index.ts or the contract types
+// it re-exports:
+//   bun run sdk:dts
+//
+// CI (.github/workflows/ci.yml → surface-sdk-dts-sync) fails on any drift between
+// this committed file and a fresh regeneration, so it can never go stale.
+// ============================================================================
+
+import { z } from 'zod/v4';
+
+export interface ContextAttachment {
+	name: string;
+	url: string;
+	contentType: string;
+	size: number;
+}
+export interface ContextMessage {
+	role: "human" | "assistant";
+	author: string;
+	content: string;
+	timestamp: string;
+	attachments?: ContextAttachment[];
+}
+/** Platform-agnostic inbound message */
+export interface InboundMessage {
+	/** Platform identifier: "discord", "mattermost", "slack", etc. */
+	platform: string;
+	/** Unique adapter instance ID (e.g. "discord-pai-collab") */
+	instanceId: string;
+	/** Platform-native user ID */
+	authorId: string;
+	/** Display name for prompt context */
+	authorName: string;
+	/** Raw message text (with mention/trigger word stripped) */
+	content: string;
+	/** Platform-native channel ID */
+	channelId: string;
+	/** Thread/reply-chain ID (if in a thread) */
+	threadId?: string;
+	/** G-204c: Human-readable channel name (e.g. "grove") for context routing */
+	channelName?: string;
+	/** G-204c: Human-readable thread name (e.g. "grove/issue/43") for entity routing */
+	threadName?: string;
+	/** Platform guild/server/team ID (e.g., Discord guild ID) for network resolution */
+	guildId?: string;
+	/** Whether this message is from a DM channel */
+	isDM?: boolean;
+	/** DM classification: principal (full access) or user (standard guards) */
+	dmType?: "principal" | "user";
+	/**
+	 * cortex#729: True when the authenticated sender is the home principal,
+	 * computed for EVERY inbound message (DM and channel @mention) via the
+	 * PolicyEngine principal-role check. Unlike `dmType` (DM-only), this signal
+	 * is set in channels too, so the dispatch-handler's prompt-filter
+	 * trust-scope can bypass the hard-block for the home principal's channel
+	 * @mentions — not just their DMs. Non-spoofable (keyed on the
+	 * authenticated platform author id). Defaults to false/undefined.
+	 */
+	authorIsPrincipal?: boolean;
+	/** Inbound file attachments */
+	attachments: InboundAttachment[];
+	/** Message timestamp */
+	timestamp: Date;
+	/** Escape hatch for platform-specific data (discord.js Message, MM post, etc.) */
+	_native?: unknown;
+}
+/** Inbound file attachment metadata */
+export interface InboundAttachment {
+	url: string;
+	filename: string;
+	contentType?: string;
+	size?: number;
+	/** Base64 file bytes, INLINED by the adapter when the surface needs auth to
+	 *  download (Mattermost) — lets the brain consume the file without the bot
+	 *  token or a host-allowlisted public URL. Absent for public-CDN surfaces
+	 *  (Discord), which travel by URL. */
+	content?: string;
+}
+/** Result of access control check */
+export interface AccessDecision {
+	allowed: boolean;
+	features: {
+		chat: boolean;
+		async: boolean;
+		team: boolean;
+	};
+	/** Disallowed MCP tools for this user */
+	toolRestrictions?: string[];
+	/**
+	 * cortex#1167 — EXPLICIT tool ALLOWLIST. When present and non-empty, the CC
+	 * session is confined to exactly these tools (anything else, including every
+	 * `mcp__*`, is denied — allowlist semantics, NOT the allow-by-default of an
+	 * absent/empty list). Set ONLY by the open-onboarding anon path so a
+	 * zero-authority stranger never gets allow-by-default tool access. Real
+	 * principal decisions leave it undefined and keep the existing deny-list
+	 * (`toolRestrictions`) behaviour unchanged.
+	 */
+	allowedTools?: string[];
+	/** Allowed working directories for this user */
+	dirRestrictions?: string[];
+	/** G-121: Skills this role may invoke. undefined → all; [] → none; [...] → only listed. */
+	allowedSkills?: string[];
+	/** Whether bash guard should be active. Default: true. Principal DM may set false. */
+	bashGuard?: boolean;
+	/** Override bash allowlist (DM role may specify its own) */
+	bashAllowlist?: {
+		rules: {
+			pattern: string;
+			repos?: string[];
+		}[];
+		repos: string[];
+	};
+	/** Whether this is a DM conversation */
+	isDM?: boolean;
+	/**
+	 * cortex#741 — whether this sender is TRUSTED for the inbound prompt-injection
+	 * filter. True only for the stack's home principal (the principal that
+	 * `resolvePolicyAccess` resolves as holding the reserved policy-role
+	 * short-circuit). The dispatch-handler consults this at the `scanPrompt` gate:
+	 * a trusted sender's *direct* chat message is NOT hard-blocked on an
+	 * injection-pattern match (the match is still logged / audited — never
+	 * silently bypassed). Untrusted/indirect content paths (ContentFilter.hook,
+	 * payload-filter, file-read scanning) ignore this flag and stay fully active.
+	 * See the PR for the exemption-boundary rationale.
+	 */
+	trusted?: boolean;
+	/** Human-readable denial reason */
+	denyReason?: string;
+	/**
+	 * cortex#1165 — stable machine code for WHY a deny happened, so callers can
+	 * branch on the *category* without brittle `denyReason` string matching.
+	 * Only present when `allowed === false`.
+	 *
+	 *   - `no_policy`       — no policy block / engine wiring (migrate-config).
+	 *   - `unmapped_sender` — the (platform, authorId) tuple maps to NO
+	 *                         principal. This is the one category the Pier
+	 *                         open-onboarding gate (AgentSchema.openOnboarding)
+	 *                         may convert into a zero-authority anon ALLOW.
+	 *   - `registry_drift`  — index resolved an id the registry lacks.
+	 *   - `lockout`         — recognized principal with zero keyword caps.
+	 */
+	denyCode?: "no_policy" | "unmapped_sender" | "registry_drift" | "lockout";
+	/**
+	 * cortex#1165 — set `true` ONLY on the synthetic zero-authority anonymous
+	 * principal minted by the Pier open-onboarding gate. It carries NO roles and
+	 * unlocks NO privileged path; the marker exists so downstream/audit code can
+	 * see "this session is an unauthenticated stranger" at a glance. Never set on
+	 * a real, principal-resolved decision.
+	 */
+	anonPrincipal?: boolean;
+	/**
+	 * cortex#1165 — the synthetic principal id assigned to an open-onboarding
+	 * anonymous sender (e.g. `anon:discord:<authorId>`). Present iff
+	 * `anonPrincipal === true`. Used for log/audit correlation only — it is NOT
+	 * a registry id and resolves to no capabilities.
+	 */
+	anonPrincipalId?: string;
+}
+/** Where to send a response */
+export interface ResponseTarget {
+	/** Which adapter instance to respond on */
+	instanceId: string;
+	/** Platform-native channel ID */
+	channelId: string;
+	/** Thread to reply in (if applicable) */
+	threadId?: string;
+	/**
+	 * cortex#708 — session/correlation id for the dispatch that produced this
+	 * target. Threaded from the inbound message's native id (`msg._native.id`,
+	 * the same correlation `dispatch-handler` derives `inboundMessageId` from)
+	 * so that per-session adapter state (e.g. the Discord progress placeholder)
+	 * is keyed on the session rather than the channel/thread.
+	 *
+	 * Without it, two concurrent sessions landing in the same channel/DM share
+	 * one channel-scoped key and collapse onto a single "working…" placeholder
+	 * — the second session edits the first's message. Optional: undefined for
+	 * targets that don't originate from an inbound dispatch (e.g. the
+	 * surface-router's envelope render path), where channel-scoped keying is
+	 * correct.
+	 */
+	sessionId?: string;
+	/** Escape hatch for platform-specific channel objects */
+	_native?: unknown;
+}
+/** Outbound file attachment */
+export interface OutboundFile {
+	content: Buffer;
+	filename: string;
+	contentType?: string;
+}
+/**
+ * The core adapter interface. Each platform implements this.
+ * Adapters are thin I/O wrappers — all pipeline logic lives in MessageRouter.
+ */
+export interface PlatformAdapter {
+	/** Platform identifier: "discord", "mattermost", "slack", etc. */
+	readonly platform: string;
+	/** Unique instance ID across all adapters */
+	readonly instanceId: string;
+	/** Connect to the platform and start listening for messages */
+	start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void>;
+	/** Disconnect and clean up resources */
+	stop(): Promise<void>;
+	/**
+	 * MIG-7.2c-binding: Return the platform user id of the bot account this
+	 * adapter is connected as. Required for `PresenceBinding` to register the
+	 * adapter with the process-wide `TrustResolver` so inbound messages from
+	 * peer agents are resolvable by their platform id (§9.3).
+	 *
+	 * Contract: callable only after `start()` has completed. Adapters that
+	 * learn their bot id at connect-time (e.g. Discord via `client.user`)
+	 * MUST throw if called pre-start; adapters that fetch on demand (e.g.
+	 * Mattermost via `/api/v4/users/me`) MAY cache the result.
+	 */
+	getPlatformUserId(): Promise<string>;
+	/** Fetch conversation history for context */
+	fetchContext(msg: InboundMessage, depth: number): Promise<ContextMessage[]>;
+	/** Check if the message author has access */
+	resolveAccess(msg: InboundMessage): AccessDecision;
+	/** Post a response (handles platform-specific splitting/formatting) */
+	postResponse(target: ResponseTarget, text: string, files?: OutboundFile[]): Promise<void>;
+	/** Show typing indicator */
+	sendTyping(target: ResponseTarget): Promise<void>;
+	/** Post or update a progress message (edit-in-place, one message per target) */
+	sendProgress(target: ResponseTarget, text: string): Promise<void>;
+	/** Delete the progress message for a target */
+	clearProgress(target: ResponseTarget): Promise<void>;
+	/** Create a thread from a message */
+	createThread(msg: InboundMessage, name: string): Promise<ResponseTarget>;
+	/**
+	 * cortex#502 — resolve a LOGICAL surface address (the review-path
+	 * `response_routing` shape) to a native {@link ResponseTarget}.
+	 *
+	 * The review wire stays platform-NEUTRAL (`{ surface, channel, thread? }`
+	 * — repo short name + `{repo}/{entity-type}/{number}` logical key per the
+	 * channel-routing SOP) so the same `review.verdict.*` / `dispatch.task.*`
+	 * envelope routes on Discord/Mattermost/Slack unchanged. Each adapter
+	 * implements this seam to map logical→native:
+	 *
+	 *   - Returns `null` when `addr.surface` is NOT this adapter's platform
+	 *     (the review sink then skips this adapter — no cross-surface posting).
+	 *   - Otherwise resolves `addr.channel` (repo short name) to the platform
+	 *     channel and, when `addr.thread` is present, the platform thread
+	 *     primitive (Discord reuses `findOrCreateThreadByName`).
+	 *   - Returns `null` when the channel/thread can't be resolved (caller
+	 *     falls back to ignoring the envelope rather than mis-posting).
+	 *
+	 * Mattermost/Slack implement the same method later with their own
+	 * name→primitive mapping; the wire never changes.
+	 */
+	resolveLogicalTarget(addr: {
+		surface: string;
+		channel: string;
+		thread?: string;
+	}): Promise<ResponseTarget | null>;
+	/** Send a notification to the principal */
+	notifyPrincipal(text: string): Promise<void>;
+	/** F-092: Hot-reload adapter config (optional, for adapters that support it) */
+	updateConfig?(config: unknown): void;
+	/**
+	 * Two-phase inbound registration (optional). `start()` connects + stores the
+	 * `onMessage` callback; this SECOND call registers the platform's message
+	 * listener so inbound events actually dispatch. Discord + Slack split start
+	 * from listen (the per-stack boot defers this until after Pass-2 trust merge);
+	 * single-phase adapters (Mattermost) register inside `start()` and omit it.
+	 *
+	 * Callers that drive an adapter directly (the shared surface gateway,
+	 * cortex#524) MUST call this after `start()` or no inbound is ever delivered.
+	 * Idempotent — adapters latch on first attach so re-calls are no-ops.
+	 */
+	attachInboundDispatch?(): void;
+}
+/**
+ * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather
+ * than codegen because (a) the schema is small and stable, (b) the manual
+ * type doubles as documentation for callers, (c) avoiding a build step keeps
+ * the import-safe / zero-side-effect property of this module.
+ */
+export interface Envelope {
+	/** UUID v4 — unique per envelope. */
+	id: string;
+	/** `{principal}.{stack}.{assistant}` — exactly 3 dotted segments (myelin#185 breaking cut). */
+	source: string;
+	/** `domain.entity.action` — what kind of signal this is. */
+	type: string;
+	/** ISO-8601 timestamp. */
+	timestamp: string;
+	/** UUID v4 — links related envelopes across a workflow. Optional. */
+	correlation_id?: string;
+	/** The message's passport. Sovereignty travels with the envelope. */
+	sovereignty: {
+		classification: "local" | "federated" | "public";
+		/** ISO 3166-1 alpha-2 country code (e.g. "NZ", "DE"). */
+		data_residency: string;
+		/** Maximum number of hops the envelope may traverse. ≥ 0. */
+		max_hop: number;
+		/** Whether the envelope's payload may be processed by frontier models. */
+		frontier_ok: boolean;
+		/** Constraint on which model class may process the payload. */
+		model_class: "local-only" | "frontier" | "any";
+	};
+	/**
+	 * F-15 economics block — token budget, actual usage, billing attribution.
+	 * Mutable annotation field; intermediaries may aggregate. Per myelin
+	 * `architecture.md` §5.2 this field MUST NOT inform security or trust
+	 * decisions — surface it for observability and cost accounting only.
+	 */
+	economics?: Economics;
+	/** Forward-compatible metadata. Optional. */
+	extensions?: Record<string, unknown>;
+	/** Arbitrary signal content. */
+	payload: Record<string, unknown>;
+	/**
+	 * Identity attestation — proves who sent this envelope. Optional in the
+	 * schema (envelopes predate MY-400 identity layer).
+	 *
+	 * **Wire shapes accepted (myelin#31 chain-of-stamps):**
+	 *   - Single stamp object (legacy back-compat shim, single signer).
+	 *   - Array of stamps (canonical post-#31 chain form). Each stamp signs
+	 *     the canonical bytes of the envelope *including the prior chain* —
+	 *     tampering with any earlier stamp invalidates every subsequent
+	 *     stamp's signature.
+	 *
+	 * Cortex callers that want a uniform view should use
+	 * {@link getSignedByChain} to normalise both shapes to `SignedBy[]`.
+	 *
+	 * IAW Phase A.2: `signed_by` is **surfaced but not yet consumed for
+	 * trust decisions** — that wiring lands in IAW Phase B (cortex#102).
+	 */
+	signed_by?: SignedBy | SignedBy[];
+	/**
+	 * F-021 — capability tags the task needs. Matched against AGENT_CAPABILITIES
+	 * (myelin#11). Empty array = no filter. Pattern parallels DID_RE: no
+	 * trailing or consecutive hyphens.
+	 */
+	requirements?: string[];
+	/**
+	 * F-021 — minimum agent sovereignty mode required to ack the task.
+	 *
+	 * | mode | semantics |
+	 * |---|---|
+	 * | `open` | ack all |
+	 * | `selective` | evaluate-and-may-nak |
+	 * | `strict` | explicit capability + sovereignty match |
+	 * | `bidding` | F-10 broadcast bid-request, collect signed responses, select winner |
+	 */
+	sovereignty_required?: SovereigntyRequirement;
+	/** F-021 — ISO-8601 absolute soft deadline. Informs nak `not-now` decisions. */
+	deadline?: string;
+	/**
+	 * F-021 — principal-facing routing semantics. Vocabulary migration
+	 * 2026-05 R11 renamed `broadcast` → `offer` on the wire; the transition
+	 * schema accepts both. New publishers emit `offer`.
+	 *
+	 * | mode | semantics |
+	 * |---|---|
+	 * | `offer` | competing consumers — first ack wins (R11 canonical) |
+	 * | `broadcast` | deprecated alias of `offer` (accepted on read) |
+	 * | `direct` | named recipient — requires `target_assistant` |
+	 * | `delegate` | outcome handoff (multi-step orchestration) — requires `target_assistant` |
+	 */
+	distribution_mode?: DistributionMode;
+	/**
+	 * F-021 — required when `distribution_mode` is `direct` or `delegate`.
+	 * DID of the receiving assistant (`did:mf:<name>`). Vocabulary migration
+	 * 2026-05 R13 (breaking cut myelin#184) renamed from `target_principal`;
+	 * the deprecated key was dropped from the wire — envelopes carrying it
+	 * are rejected by the schema. Resolve via {@link getTargetAssistant}.
+	 */
+	target_assistant?: string;
+	/**
+	 * myelin#161 — policy-level actor identity, separate from the
+	 * cryptographic `signed_by[]` chain. The chain proves WHO signed; the
+	 * originator names WHO the signer claims to be acting on behalf of.
+	 *
+	 * `originator` IS covered by the envelope signature (a signable field —
+	 * see myelin canonicalize SIGNABLE_FIELDS). Tampering with `originator`
+	 * invalidates every subsequent stamp.
+	 *
+	 * Cortex callers should resolve the policy actor via the upstream
+	 * `getActorPrincipal(envelope)` helper rather than reading this field
+	 * directly — that helper falls back to `signed_by[0].identity` for
+	 * legacy envelopes that pre-date myelin#161.
+	 */
+	originator?: Originator;
+}
+/**
+ * myelin#161 — policy-attribution claim that travels next to the
+ * `signed_by[]` chain. The signer commits to the attribution claim by
+ * including the field in the canonical signature input.
+ */
+export interface Originator {
+	/**
+	 * DID of the actor whose capabilities this envelope asserts.
+	 * Vocabulary migration 2026-05 R2 — canonical key is `identity`;
+	 * the transition schema accepts `principal` too. Readers should use
+	 * {@link getActorPrincipal} which dual-reads.
+	 */
+	identity?: string;
+	/**
+	 * @deprecated Renamed to `identity` (vocabulary migration 2026-05, R2).
+	 * Pre-migration envelopes carry this key; accepted on read through the
+	 * transition window. Removed in the breaking major.
+	 */
+	principal?: string;
+	/**
+	 * How the signer learned the originator identity:
+	 *   - `adapter-resolved` — adapter (Discord/Slack/Mattermost/HTTP/cc-events)
+	 *     mapped a non-myelin identifier (platform id, OS user) to a myelin
+	 *     principal at sign time.
+	 *   - `federated` — the originator claim was relayed from another
+	 *     principal; the chain proves the cross-principal hop.
+	 *   - `delegated` — the signer holds delegation credentials for the
+	 *     originator (service principal acting on behalf of a principal).
+	 */
+	attribution: AttributionMode;
+}
+/** myelin#161 — see {@link Originator}. */
+export type AttributionMode = "adapter-resolved" | "federated" | "delegated";
+/**
+ * Discriminated stamp shape — one entry in an envelope's `signed_by` chain.
+ * `method` selects which fields are present:
+ *   - `"ed25519"` — bare per-bot signature; intra-org trust.
+ *   - `"hub-stamp"` — federation hub re-signature for cross-org trust.
+ *
+ * Optional `role` (myelin#31) is the semantic position of the stamp in the
+ * chain (`origin` / `transit` / `accountability` / `sovereignty` / `notary`).
+ * Consumers that need role-aware predicates MUST handle the undefined case
+ * — pre-#31 stamps and the legacy shim do not carry a role.
+ */
+export type SignedBy = SignedByEd25519 | SignedByHubStamp;
+/**
+ * Bare ed25519 signature — the principal signs the envelope directly.
+ * Used for intra-org traffic where every bot's `did:mf:*` principal is
+ * trusted and key material is held locally.
+ */
+export interface SignedByEd25519 {
+	method: "ed25519";
+	/**
+	 * Stamp DID — `did:mf:<name>` per myelin convention. Vocabulary
+	 * migration 2026-05 R2 (breaking cut myelin#182): canonical key is
+	 * `identity`; the deprecated `principal` key was dropped from the wire
+	 * — stamps carrying it are rejected by the schema.
+	 */
+	identity?: string;
+	/** Base64-encoded ed25519 signature (88+ chars). */
+	signature: string;
+	/** ISO-8601 timestamp the signature was produced. */
+	at: string;
+	/** Optional semantic role of this stamp in the chain (myelin#31). */
+	role?: StampRole;
+}
+/**
+ * Hub-stamped signature — a federation hub re-signs after verifying the
+ * principal's bare signature. Used for cross-org traffic where the
+ * receiver trusts the hub but not necessarily the originating bot.
+ */
+export interface SignedByHubStamp {
+	method: "hub-stamp";
+	/**
+	 * Originating identity — `did:mf:<name>`. Vocabulary migration 2026-05
+	 * R2 (breaking cut myelin#182): canonical key is `identity`; the
+	 * deprecated `principal` key was dropped from the wire — stamps
+	 * carrying it are rejected by the schema.
+	 */
+	identity?: string;
+	/** Hub identity that re-signed — `did:mf:<hub-name>`. */
+	stamped_by: string;
+	/** Base64-encoded ed25519 signature from the hub. */
+	signature: string;
+	/** ISO-8601 timestamp the hub signed. */
+	at: string;
+	/** Optional semantic role of this stamp in the chain (myelin#31). */
+	role?: StampRole;
+}
+/**
+ * Semantic position of a stamp inside a chain (myelin#31). Roles describe
+ * what the stamp ATTESTS, not what the principal IS. Optional for
+ * back-compat — pre-#31 stamps do not carry a role.
+ */
+export type StampRole = "origin" | "transit" | "accountability" | "sovereignty" | "notary";
+/**
+ * F-021 — `sovereignty_required` enum. Determines how aggressively
+ * candidates may decline a task before nakking.
+ */
+export type SovereigntyRequirement = "open" | "selective" | "strict" | "bidding";
+/**
+ * F-021 — `distribution_mode` enum. Vocabulary migration 2026-05 R11
+ * renamed `broadcast` → `offer` on the wire; the transition schema
+ * accepts both. Emitters publish `offer`; readers tolerate `broadcast`
+ * for JetStream replay of pre-migration envelopes.
+ */
+export type DistributionMode = "broadcast" | "offer" | "direct" | "delegate";
+/**
+ * F-15 economics — token budget, actual usage, billing attribution.
+ *
+ * Per myelin `architecture.md` §5.2, this is a **mutable annotation field**
+ * sitting intentionally outside the L4 signature so intermediaries can
+ * accumulate cost without invalidating attestations. It MUST NOT inform
+ * security or trust decisions — surface it for observability only.
+ */
+export interface Economics {
+	/** Publisher-set constraints on resource usage. */
+	budget?: EconomicsBudget;
+	/** Actual usage populated by executor; aggregated by hubs in delegate chains. */
+	actual?: EconomicsActual;
+	/** DID of principal receiving/paying for this work. */
+	wallet?: string;
+	/** External invoice or tracking reference. */
+	billing_ref?: string;
+	/** ISO 4217 currency code when not USD. */
+	currency?: string;
+	/** Forward-compatible — schema allows additional properties. */
+	[key: string]: unknown;
+}
+export interface EconomicsBudget {
+	/** Maximum total tokens (input + output) permitted. */
+	max_tokens?: number;
+	/** Maximum cost in USD. */
+	max_cost_usd?: number;
+	[key: string]: unknown;
+}
+export interface EconomicsActual {
+	/** LLM input tokens consumed. */
+	input_tokens?: number;
+	/** LLM output tokens generated. */
+	output_tokens?: number;
+	/** Convenience total — may equal input + output, may not (delegate aggregation). */
+	total_tokens?: number;
+	/** Lowercase model identifier (e.g. `claude-sonnet-4`, `gpt-4o`). */
+	model?: string;
+	/** Execution duration in milliseconds. */
+	duration_ms?: number;
+	/** Computed cost in USD. */
+	cost_usd?: number;
+	[key: string]: unknown;
+}
+declare const RendererKindSchema: z.ZodString;
+export type RendererKind = z.infer<typeof RendererKindSchema>;
+declare const RendererVisibilitySchema: z.ZodObject<{
+	hide_residency_outside: z.ZodOptional<z.ZodArray<z.ZodString>>;
+	require_model_class: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+		"local-only": "local-only";
+		frontier: "frontier";
+		any: "any";
+	}>>>;
+	max_classification: z.ZodOptional<z.ZodEnum<{
+		local: "local";
+		federated: "federated";
+		public: "public";
+	}>>;
+}, z.core.$strip>;
+export type RendererVisibility = z.infer<typeof RendererVisibilitySchema>;
+/**
+ * One acceptable form for a leaf in a payload-filter pattern. Strings,
+ * numbers, and booleans are exact-match literals; the object forms are
+ * the EventBridge-style operators.
+ */
+export type FilterValue = string | number | boolean | {
+	"anything-but": string | number | boolean | (string | number | boolean)[];
+} | {
+	prefix: string;
+} | {
+	exists: boolean;
+} | {
+	"equals-ignore-case": string;
+};
+/**
+ * A pattern matches a JSON object. Nesting follows the JSON structure of
+ * the value being matched: a key whose value is an array of FilterValue
+ * is a leaf; a key whose value is another PayloadFilterPattern descends
+ * into that subtree.
+ */
+export interface PayloadFilterPattern {
+	[key: string]: FilterValue[] | PayloadFilterPattern;
+}
+/**
+ * A surface-adapter's full filter. The `envelope` pattern matches the
+ * outer envelope context (type, source, correlation_id, etc.); the
+ * `payload` pattern matches the envelope's payload object. Both are
+ * optional — a filter with neither key matches everything (degenerate but
+ * legal).
+ */
+export interface PayloadFilter {
+	envelope?: PayloadFilterPattern;
+	payload?: PayloadFilterPattern;
+}
+/**
+ * One surface adapter. Adapters are dumb-by-design — they declare their
+ * NATS subject patterns + an optional payload filter and a `render()`
+ * function. The router does the matching + isolation; the adapter just
+ * renders.
+ */
+interface SurfaceAdapter {
+	/** Stable identifier — used in error reporting and metrics. */
+	id: string;
+	/** One or more NATS subject patterns (union — match ANY). */
+	subjects: string[];
+	/** Optional client-side filter applied AFTER subject match. */
+	filter?: PayloadFilter;
+	/**
+	 * IAW Phase A.4 — optional visibility constraints. When set, the router
+	 * evaluates the envelope's `sovereignty` against each active rule
+	 * (residency / model_class / max_classification) BEFORE invoking
+	 * `render()`. Drops emit a `system.access.filtered` envelope so principals
+	 * can observe access decisions.
+	 *
+	 * Unset (the v1 default) means "no visibility filter" — the adapter
+	 * receives every envelope that passes subject + payload filters, matching
+	 * pre-A.4 behaviour exactly. See {@link RendererVisibility} for rule
+	 * semantics.
+	 */
+	visibility?: RendererVisibility;
+	/**
+	 * Adapter-specific rendering. Bounded by router's renderTimeoutMs.
+	 *
+	 * `signal` is an opt-in `AbortSignal` that fires when the router's per-render
+	 * timeout elapses. Adapters that issue I/O (HTTP, NATS, sub-process) SHOULD
+	 * forward the signal to those calls so the loser of `Promise.race` is
+	 * actually cancelled — without it, the timed-out work keeps running in the
+	 * background, holding sockets and spending quota. Adapters that do nothing
+	 * but synchronous CPU (mocks, formatters) MAY accept the parameter and
+	 * ignore it; the contract is opt-in for backwards compatibility with
+	 * existing render functions.
+	 *
+	 * **IAW Phase D.3 (cortex#116) — `subject`.** Optional third argument
+	 * carrying the matched NATS subject. Adapters that need to derive
+	 * federation context from the wire path (e.g. the dispatch-listener
+	 * deriving `source_network` from `federated.{network_id}.>`) read
+	 * this directly rather than re-parsing the envelope. Existing
+	 * adapters that match `(envelope, signal)` continue to work — the
+	 * parameter is additive and ignored by adapters that don't accept
+	 * it.
+	 */
+	render(envelope: Envelope, signal?: AbortSignal, subject?: string): Promise<void>;
+	/** Optional liveness probe. Currently unused by the router; reserved
+	 *  for the dashboard's adapter-health panel (G-1111.E follow-on). */
+	health?(): Promise<{
+		ok: boolean;
+		lag?: number;
+	}>;
+}
+/**
+ * A non-agent-bound surface that subscribes to bus subjects and projects
+ * envelopes into a sink (UI, external API, log stream). Implementations
+ * MUST satisfy three contracts:
+ *
+ *   1. `start()` is idempotent and synchronous-or-fast. Heavy I/O at
+ *      construction is fine; lifecycle hooks should not block cortex
+ *      startup for more than a few hundred ms.
+ *   2. `render()` MUST NOT throw. Failed delivery logs + drops; the
+ *      surface-router wraps every `render()` in a per-call timeout +
+ *      `Promise.allSettled` regardless, but renderers carry the moral
+ *      obligation to not poison the dispatch path.
+ *   3. `render()` MUST NOT publish on the bus as a side effect.
+ *      Principal-input emitted from a renderer (e.g., a dashboard
+ *      "approve" click) goes through the bus as a logical envelope
+ *      from the principal, not from any agent (architecture §9.3).
+ *
+ * **REVERSED — renderers are NOT static across hot-reload.** [ADR-0024](../../docs/adr/0024-pluggable-surface-adapters.md)
+ * (cortex#1793, S8) reverses the "Renderers are static across hot-reload"
+ * decision this comment used to make, on its own stated terms (ADR-0024
+ * §Consequences: "⚠ REVERSAL"). The original three premises and what
+ * changed:
+ *
+ *   1. *"A restart is cheap enough"* — no longer true once a renderer is a
+ *      separately-installable bundle (ADR-0024 D5): forcing a full daemon
+ *      restart to activate one new renderer drags every live adapter
+ *      connection and in-flight dispatch through it for an unrelated plugin.
+ *   2. *"Partial hot-reload is harder to reason about"* — honoured, not
+ *      contradicted. There is still no `updateConfig(RendererConfig)` hook
+ *      and no mid-flight routing-key swap. What changed is the GRANULARITY
+ *      of the stop/start cycle: **detach → destroy → construct → attach**
+ *      via the `{ unregister }` handle `SurfaceRouter.register()` already
+ *      returned (`src/bus/surface-router.ts`) — the renderer boot loop used
+ *      to discard that handle; S8 retains it. The target leaves the
+ *      router's dispatch list *before* teardown, so no render ever observes
+ *      a half-swapped renderer. Full stop/start remains the semantic; its
+ *      blast radius shrinks from *the daemon* to *one renderer*.
+ *   3. *"A renderer's resources are scoped to its lifetime"* — still true,
+ *      and it's exactly what makes per-instance destroy-and-reconstruct safe
+ *      here (a renderer owns nothing durable and never publishes) where it
+ *      would NOT be safe for a platform adapter (which drops a live
+ *      connection and orphans progress placeholders).
+ *
+ * State loss on detach/reload is intentional and, per the above, harmless:
+ * the dashboard ring buffer resets (nothing reads it — ADR-0024 D2/OQ8); a
+ * renderer with a stable per-envelope derivation (e.g. PagerDuty's
+ * `dedup_key`, `src/renderers/pagerduty.ts`) is reload-stable by
+ * construction. `cortex plugin reload` (cortex#1793) is the runtime verb;
+ * `docs/plugin-sdk.md` documents the state-loss contract a plugin author
+ * must design for.
+ */
+export interface Renderer {
+	/** Discriminator matching `RendererKind`. */
+	readonly kind: RendererKind;
+	/** Stable identifier, used in surface-router metrics + error reporting. */
+	readonly id: string;
+	/** NATS subject patterns this renderer wants to receive. Empty means
+	 *  the surface-router never invokes `render()`. */
+	readonly subjects: string[];
+	/** Bring the renderer to a state where `render()` calls can succeed.
+	 *  May open HTTP clients, allocate buffers, register internal handlers.
+	 *  Idempotent. */
+	start(): Promise<void>;
+	/** Tear down resources. After `stop()`, `render()` calls SHOULD be no-ops
+	 *  rather than throw — adapter-lifecycle race conditions are common at
+	 *  shutdown and an error here would pollute the shutdown log. */
+	stop(): Promise<void>;
+	/** Project a single envelope onto the renderer's sink. The surface-router
+	 *  wraps this call with a timeout + isolation; implementations focus on
+	 *  the projection, not the dispatch plumbing. */
+	render(envelope: Envelope, signal?: AbortSignal): Promise<void>;
+	/** Return the `SurfaceAdapter` face the surface-router consumes. Wired
+	 *  exactly once at startup via `router.register(renderer.surfaceConfig)`. */
+	readonly surfaceConfig: SurfaceAdapter;
+}
+export type PluginKind = "adapter" | "renderer";
+/**
+ * A `surfaces.{platform}[]` entry — `{ agent, stack?, binding }`. Structurally
+ * matches every platform's array element in `Surfaces`
+ * (`src/common/types/surfaces.ts`); kept loosely typed here (`binding` as a
+ * plain record) so the registry has no compile-time dependency on any one
+ * platform's Zod-inferred binding shape.
+ */
+export interface SurfaceBindingEntry {
+	readonly agent: string;
+	readonly stack?: string;
+	readonly binding: Record<string, unknown>;
+}
+/**
+ * One construction group — the binding entries that share ONE live
+ * connection, plus the instance id that connection registers under. Mirrors
+ * `DiscordTokenGroup` (`src/gateway/discord-token-groups.ts`), generalised:
+ * every platform's default (ungrouped) case is a one-entry group whose
+ * `instanceId` is `{platform}:{demuxKey(binding)}`; Discord's `groupBindings`
+ * returns the token-keyed groups computed today.
+ */
+export interface BindingGroup {
+	readonly entries: readonly SurfaceBindingEntry[];
+	readonly instanceId: string;
+}
+/** The fields `buildGatewayAdapters`' generic loop threads into
+ *  {@link AdapterPlugin.buildGatewayConstructArgs} for every platform. */
+export interface GatewayConstructBase {
+	readonly instanceId: string;
+	readonly source: unknown;
+	readonly runtime: unknown;
+	/**
+	 * cortex#1794 (S9b) — a host-bound `AdapterPolicyPort` (`surface-sdk`),
+	 * typed `unknown` here for the SAME reason `source`/`runtime` are: this
+	 * registry module has no compile-time dependency on `surface-sdk` or
+	 * `common/policy`, so each plugin's `buildGatewayConstructArgs` casts
+	 * internally (the convention `AdapterPlugin`'s docstring already
+	 * establishes for `createAdapter`'s args). Currently only the web plugin
+	 * forwards it — see `metafactory-cortex-adapter-web`'s `src/plugin.ts`
+	 * (relocated out-of-tree, cortex#1794 S9 MOVE; was `adapters/web/plugin.ts`).
+	 */
+	readonly policy?: unknown;
+}
+/**
+ * Per-platform adapter plugin descriptor. `createAdapter`'s args type is
+ * intentionally loose (`Record<string, unknown>`, cast internally to the
+ * platform's own Factory-args shape) — the registry stores plugins for every
+ * platform in one map, and each platform's construction args genuinely
+ * diverge (Discord needs `allowedGuildIds` + `presenceByGuildId`; Slack/
+ * Mattermost/Web don't). Each plugin module owns the single internal cast,
+ * the same convention `wireSurfaceAdapters` already uses for its concrete-
+ * adapter casts (`as DiscordAdapter` etc.) — never unsafe in practice because
+ * a plugin is only ever invoked with the args its own call sites build for it.
+ */
+export interface AdapterPlugin {
+	readonly kind: "adapter";
+	/** Registry key. Equals `platform`. */
+	readonly id: string;
+	/** `surfaces.{platform}` key (e.g. "discord"). */
+	readonly platform: string;
+	/**
+	 * cortex#1789 (S4) — the schema this platform's `surfaces.{platform}[].binding`
+	 * must satisfy. Consumed by {@link resolveAdapterPluginOrThrow} /
+	 * {@link validateSurfacesAgainstRegistry} (the REGISTRY pass) — the
+	 * structural pass (`SurfacesSchema`) only checks the generic
+	 * `{agent, stack?, binding}` shape; this schema is where the real
+	 * per-platform field validation (required tokens, regex-checked ids, …)
+	 * happens. For the four in-tree platforms this is the EXACT schema
+	 * `SurfacesSchema`'s old `.strict()` object used pre-S4
+	 * (`DiscordBindingSchema`/`SlackBindingSchema`/`MattermostBindingSchema`/
+	 * `WebBindingSchema`, `src/common/types/surfaces.ts`) — byte-identical
+	 * validation, only the call site moved.
+	 */
+	readonly bindingSchema: z.ZodType;
+	/**
+	 * cortex#1789 (S4, ADR-0024 D5 scope item 3) — does this platform's
+	 * `surfaces.{platform}[]` fold into `agents[*].presence.{platform}` at
+	 * config-compose time (`foldSurfaceBindings`)? `true` for discord/slack/
+	 * mattermost (a legacy inline-presence shape exists to fold into); `false`
+	 * for web (there is no legacy web presence shape — the gateway factory
+	 * consumes `surfaces.web[]` directly). Replaces the hardcoded `PLATFORMS`
+	 * fold-list constant in `surfaces.ts` — `loader.ts` derives the fold list
+	 * from `registry.listAdapters().filter(p => p.foldsIntoPresence)` instead
+	 * of a second list that could drift from the registry.
+	 */
+	readonly foldsIntoPresence: boolean;
+	/**
+	 * Binding fields that must be free of unresolved `__ENV__` placeholders
+	 * before construction (cortex#1209 belt-and-suspenders) — checked against
+	 * the RAW binding value on every entry in a construction group.
+	 */
+	readonly secretFields: readonly string[];
+	/** binding → demux key. Used to build the default `{platform}:{demuxKey}`
+	 *  instance id when {@link groupBindings} is absent. */
+	demuxKey(binding: Record<string, unknown>): string;
+	/**
+	 * Optional: platforms that group multiple bindings onto ONE live
+	 * connection (Discord's token grouping — one gateway session per bot
+	 * token, not per guild). Absent = one adapter per binding entry, using
+	 * `demuxKey` to build the instance id.
+	 */
+	groupBindings?(entries: readonly SurfaceBindingEntry[]): BindingGroup[];
+	/**
+	 * Gateway-path ONLY. `buildGatewayAdapters`' generic loop calls this to
+	 * turn a raw-binding construction group into {@link createAdapter}'s args.
+	 * The per-stack boot path (`wireSurfaceAdapters`) NEVER calls this — it
+	 * already holds a fully-typed presence built from the richer `AgentConfig`
+	 * shape (`contextDepth`, `enableAgentLog`, `trust`, …) that a raw binding
+	 * does not carry, and calls {@link createAdapter} directly with its own
+	 * hand-built args (see `surface-adapter-boot.ts`'s `baseFactoryArgs`).
+	 */
+	buildGatewayConstructArgs(group: BindingGroup, base: GatewayConstructBase): Record<string, unknown>;
+	/** Construct (never start) the adapter. */
+	createAdapter(args: Record<string, unknown>): PlatformAdapter;
+}
+/**
+ * Per-kind renderer plugin descriptor (ADR-0024 D5). `configSchema` mirrors
+ * {@link AdapterPlugin.bindingSchema} — carried for S4, inert until then
+ * (`RendererSchema` stays the fixed discriminated union it is today,
+ * `src/common/types/cortex-config.ts:1193`).
+ */
+export interface RendererPlugin {
+	readonly kind: "renderer";
+	/** Registry key. Equals `rendererKind`. */
+	readonly id: string;
+	/** `renderers[].kind` discriminant (e.g. "pagerduty"). */
+	readonly rendererKind: string;
+	/**
+	 * cortex#1789 (S4) — the schema a `renderers[]` entry of this kind must
+	 * satisfy. Consumed by `src/renderers/index.ts`'s `resolveRendererPluginAndConfig`
+	 * (the REGISTRY pass) — the structural pass (`RendererSchema` in
+	 * `cortex-config.ts`) only checks `{kind, ...}`; this is the real per-kind
+	 * schema (`DashboardRendererSchema`/`PagerDutyRendererSchema`/etc,
+	 * `src/common/types/cortex-config.ts`) — byte-identical to what the old
+	 * discriminated union validated, only the call site moved (and now runs
+	 * with the RAW entry, so `parse()` still applies field defaults).
+	 */
+	readonly configSchema: z.ZodType;
+	/** Construct (never start) the renderer. */
+	createRenderer(config: unknown): Renderer;
+}
+export type SurfacePlugin = AdapterPlugin | RendererPlugin;
+/**
+ * cortex#1790 (S5, ADR-0024 D5) — the plugin SDK barrel.
+ *
+ * `CONTEXT.md` §Adapter/renderer SDK is authoritative vocabulary: "the
+ * stable, versioned contract surface a surface plugin compiles against —
+ * the one barrel of types (`PlatformAdapter`, `Renderer`, and the
+ * envelope/target types they need) plus the version constant the loader
+ * gates on. An out-of-tree plugin imports from here and nowhere else in
+ * cortex."
+ *
+ * ## What belongs here (and what doesn't)
+ *
+ * This barrel re-exports ONLY the shared plugin CONTRACT — the types a
+ * plugin author needs to implement `PlatformAdapter` or `Renderer` and to
+ * describe either as a `SurfacePlugin` the registry can load. It does NOT
+ * re-export cortex's internal implementation machinery (`MyelinRuntime`,
+ * `PolicyEngine`, `SystemEventSource`, config/presence types, per-kind
+ * renderer config schemas, tap readers, formatting helpers, …) — those are
+ * genuine cross-boundary imports the four in-tree adapters and the two
+ * in-tree renderers still reach for today (ADR-0024 residual couplings
+ * #5–#8/#13), and folding them into "the SDK" would make a breaking change
+ * to any of THEM force a plugin-SDK major bump, which is not what D1/D5
+ * pin: only a breaking change to `PlatformAdapter`, `Renderer`, or the
+ * `SurfacePlugin` descriptor shapes is a major bump. Full decoupling of the
+ * in-tree adapters from cortex internals is the S9–S12 extraction work,
+ * not this slice.
+ *
+ * The audit that produced this export list: every `../../` import in
+ * `src/adapters/{discord,slack,mattermost,web}/*.ts` and every `../`
+ * cross-boundary import in `src/renderers/*.ts`, intersected with the
+ * types actually referenced by the `PlatformAdapter` / `Renderer` /
+ * `SurfacePlugin` contracts (`adapters/types.ts`, `renderers/types.ts`,
+ * `bus/surface-router.ts`'s `SurfaceAdapter`, `bus/myelin/envelope-validator.ts`'s
+ * `Envelope`, `adapters/registry.ts`'s descriptor types). See
+ * `docs/plugin-sdk.md` for the worked audit command and the full list of
+ * cross-boundary imports that were deliberately left OUT.
+ *
+ * ## Compat rule (ADR-0024 D1, D5 — pinned)
+ *
+ * `SURFACE_SDK_VERSION` is a single-integer-major semver string. A plugin
+ * declares an `sdkRange` (e.g. `"^1"`) in its default-exported
+ * `SurfacePlugin`; the S6 loader is the SOLE authoritative gate — it checks
+ * `satisfies(SURFACE_SDK_VERSION, plugin.sdkRange)` at `import()` time and
+ * refuses a non-satisfying plugin with a `system.error` event, leaving the
+ * daemon and every other plugin live. **One SDK, one gate, both kinds**
+ * (D5): a breaking change to `PlatformAdapter` OR to `Renderer` bumps the
+ * SAME major, even though that conservatively refuses plugins of the
+ * *other*, unaffected kind — accepted as coarse-but-honest so two
+ * independently-versioned SDKs never reintroduce the two-loaders problem
+ * D5 exists to prevent. A `cortex: >=X <Y` range MAY appear in a bundle's
+ * `cortex-plugin.yaml` as ADVISORY metadata (arc install may surface it)
+ * but is never the load gate — only the running daemon's true
+ * `SURFACE_SDK_VERSION` is authoritative.
+ *
+ * Bumping this value is a disciplined act: a breaking change to
+ * `PlatformAdapter`, `Renderer`, `SurfacePlugin`/`AdapterPlugin`/
+ * `RendererPlugin`, or any type transitively exported below is a MAJOR
+ * bump with a documented plugin-author migration note (OQ5 — SDK changelog
+ * ownership, ratified "as recommended", still applies: record the
+ * migration in this file's history, not just the commit message).
+ */
+export declare const SURFACE_SDK_VERSION = "1.0.0";
+/**
+ * cortex#1794 (S9b) — the narrow, TYPE-ONLY behavioral contract an adapter
+ * uses to authorise an inbound message, in place of importing cortex's
+ * `PolicyEngine` / `PlatformPrincipalIndex` / `PrincipalRegistry`
+ * (`common/policy`) directly. Those three types are cortex-internal runtime
+ * machinery — genuinely out of scope for the SDK barrel (same reasoning as
+ * `MyelinRuntime`/`SystemEventSource`, see the module doc above) — so rather
+ * than re-export them, the SDK exposes only the SHAPE an adapter needs: given
+ * an inbound message (or a `(platform, platformId)` pair), decide access.
+ *
+ * The host binds both closures over its real `PolicyEngine` + index +
+ * registry at adapter-construction time (`adapters/plugin-support.ts`'s
+ * `buildAdapterPolicyPort`, cortex-side) and hands the bound port through
+ * `AdapterPlugin.createAdapter`'s `args` — the adapter body never imports
+ * `common/policy` itself, so it stays compilable against `surface-sdk` alone
+ * whether it lives in-tree or, after extraction, in its own package. This is
+ * a dependency-inversion PORT (Hexagonal architecture sense), not a data
+ * type: no `PolicyEngine`-shaped value crosses the barrel, only a bound
+ * behavior.
+ *
+ * First consumer: `WebAdapterInfra.policy`, originally at cortex's
+ * `src/adapters/web/index.ts` — relocated cortex#1794 (S9 MOVE) to the
+ * `metafactory-cortex-adapter-web` bundle's `src/index.ts`, which now
+ * imports this port from a vendored copy of this barrel (see that repo's
+ * `src/vendor/surface-sdk.ts`). Discord/Slack/Mattermost still import
+ * `common/policy` directly — their dependency-inversion pass is a later
+ * slice (cortex#1896).
+ */
+export interface AdapterPolicyPort {
+	/** Resolve `msg` to an `AccessDecision` via the host's bound policy engine
+	 *  (mirrors `common/policy`'s `resolvePolicyAccess`). */
+	resolveAccess(msg: InboundMessage): AccessDecision;
+	/** Whether `(platform, platformId)` maps to a principal holding the
+	 *  `operator` capability (mirrors `common/policy`'s `isOperatorPrincipal`). */
+	isOperatorPrincipal(platform: string, platformId: string): boolean;
+}
+
+export {
+	SurfaceAdapter as RenderTarget,
+};
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
     "noPropertyAccessFromIndexSignature": false
   },
   "exclude": [
+    "src/surface-sdk/generated",
     "src/worker",
     "src/webhook-proxy",
     "src/surface/mc/worker",


### PR DESCRIPTION
Closes #1950 (epic #1784 pattern-hardening, before slack/mattermost/discord extract). Gives plugin bundles a stable, resolvable, **drift-proof** surface-sdk type source so they stop vendoring their own copy (the web bundle vendored ~200 lines that would drift on `SURFACE_SDK_VERSION` bumps).

## Mechanism chosen (design fork resolved): single-file `.d.ts` sync, NOT a git dependency
A git dep on cortex would drag cortex's ENTIRE runtime tree (react, discord.js, @xyflow/react, elkjs, …) into a tiny types-only adapter bundle — semantically wrong + heavy. Instead:
- **cortex** ships `scripts/gen-surface-sdk-dts.ts` (`bun run sdk:dts`) that rolls the barrel into ONE flat, self-contained `src/surface-sdk/generated/surface-sdk.d.ts` (all transitive contract types inlined; only external import is `zod/v4`, which every bundle already has; the real `SURFACE_SDK_VERSION` inlined). `package.json` `exports["./surface-sdk"].types` → this artifact.
- **Anti-drift (the key safety property):** CI job `surface-sdk-dts-sync` runs `sdk:dts:check` (regenerate + `git diff --exit-code`) — the artifact CANNOT silently drift from the barrel. Verified: regenerating produces an empty diff.
- **web bundle** (already pushed to its main @ `7367b6e`): vendored copy DELETED; `scripts/sync-surface-sdk.ts` fetches the flat `.d.ts` from cortex at a pinned ref (`.cortex-sdk-ref`) into gitignored `sdk/`, wired via tsconfig `paths`. The file lands in the bundle tree so its `zod/v4` resolves the bundle's OWN zod (no cross-instance skew, no cortex dep tree). Standalone `tsc` + 44 tests pass with NO vendored copy.

## Scales
Each new bundle (slack/mattermost/discord) = copy `sync-surface-sdk.ts` + `.cortex-sdk-ref` + one `paths` entry (~3 files, zero per-bundle type maintenance).

## For the reviewer
- Does the drift-check genuinely catch drift? (Modify the barrel, don't regenerate → does `sdk:dts:check` fail?)
- Is the generated `.d.ts` self-contained + correct (all contract types, real SURFACE_SDK_VERSION, only zod/v4 external)?
- The web bundle's `postinstall` network fetch of a raw file at a pinned SHA — acceptable install-time dependency? (Repin `.cortex-sdk-ref` to a cortex release TAG once this merges + a release is cut — noted.)

## Gates
cortex: tsc 0 · lint 0 · `bun test src/surface-sdk` pass · vocab PASS (+ ratchet/eslint allowlists for the generated artifact). web bundle: tsc 0 · 44/0 · no vendored copy. Rebased on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)