### PR TITLE
fix(upgrade): slug_from_config_arg honors dir-layout marker precedence (closes #1960)

### DIFF
--- a/scripts/__tests__/plist-render-bin-cutover.sh
+++ b/scripts/__tests__/plist-render-bin-cutover.sh
@@ -352,6 +352,25 @@ assert_false "slug: unclassifiable path → non-zero" \
 assert_false "slug: empty --config → non-zero" \
   slug_from_config_arg ""
 
+# advw3c Attack 1 — marker-precedence: a dir-layout stack literally slugged
+# `cortex` must resolve to `cortex` (its system/system.yaml marker wins), NOT be
+# hijacked to meta-factory by config_file_to_slug. BOTH sides (argv-side
+# slug_from_config_arg + disk-side discover_stack_slugs) must agree, or the
+# 3a kill/reload desync re-opens.
+CORTEX_STACK_CFG="${TMPHOME}/cortex-slug-config"
+mkdir -p "${CORTEX_STACK_CFG}/cortex/system"
+: > "${CORTEX_STACK_CFG}/cortex/cortex.yaml"           # sentinel <slug>/<slug>.yaml
+: > "${CORTEX_STACK_CFG}/cortex/system/system.yaml"    # dir-layout marker
+assert_eq "slug(marker): argv-side dir-layout 'cortex' → cortex (not meta-factory)" \
+  "cortex" "$(slug_from_config_arg "${CORTEX_STACK_CFG}/cortex/cortex.yaml")"
+# disk-side authority agrees (run in-process; discover_stack_slugs is sourced).
+assert_eq "slug(marker): disk-side discover_stack_slugs yields 'cortex'" \
+  "cortex" "$(discover_stack_slugs "${CORTEX_STACK_CFG}" | grep -x cortex || true)"
+# The real meta-factory monolith (no sibling marker) still maps to meta-factory.
+: > "${CORTEX_STACK_CFG}/cortex.yaml"
+assert_eq "slug(marker): monolith cortex.yaml (no marker) still → meta-factory" \
+  "meta-factory" "$(slug_from_config_arg "${CORTEX_STACK_CFG}/cortex.yaml")"
+
 # filter_out_skipped_pids: reclassify a kill-list by SLUG and drop skip-listed
 # stacks. Mock `ps -o command= -p <pid>` from a pid→cmdline map (no real process
 # table consulted). Every mapped cmdline points at a REAL fixture path so slug
@@ -367,6 +386,8 @@ export PSMAP="${TMPHOME}/psmap"
   printf '1004 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${REAL_CFG}/random/other.yaml"
   # 1005: no --config at all.
   printf '1005 %s/.local/bin/cortex start\n' "${HOME}"
+  # 1006: a dir-layout stack literally slugged `cortex` (advw3c A1).
+  printf '1006 %s/.local/bin/cortex start --config %s\n' "${HOME}" "${CORTEX_STACK_CFG}/cortex/cortex.yaml"
 } > "${PSMAP}"
 cat > "${MOCK_BIN}/ps" <<'EOF'
 #!/bin/sh
@@ -392,6 +413,14 @@ chmod +x "${MOCK_BIN}/ps"
 ( unset CORTEX_UPGRADE_SKIP_RESTART
   KEPT="$(filter_out_skipped_pids "1001 1002" "${REAL_CFG}")"
   assert_eq "filter: empty skip list → both PIDs kept" "1001 1002" "${KEPT}" )
+
+# advw3c A1: a skip-listed dir-layout stack named `cortex` is correctly spared
+# (marker precedence → slug `cortex`, matches the skip list), while the real
+# meta-factory monolith daemon (1002) is untouched.
+( export CORTEX_UPGRADE_SKIP_RESTART="cortex"
+  KEPT="$(filter_out_skipped_pids "1006 1002" "${REAL_CFG}")"
+  assert_eq "filter: dir-layout 'cortex' stack (PID 1006) spared; meta-factory 1002 kept" \
+    "1002" "${KEPT}" )
 
 # (a) drift: the work daemon's argv --config is non-canonical, but slug keying
 # still spares it (path-substring keying would have MISSED and killed it).

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -579,23 +579,41 @@ extract_config_arg() {
 # Returns non-zero (prints nothing) when the path is empty or unclassifiable —
 # the caller treats that as a fail-safe abort when a skip-list is set.
 #
-# Known pathological corner (revw3c, non-deployment): a stack literally slugged
-# `cortex` in the dir layout has sentinel <config_dir>/cortex/cortex.yaml, whose
-# basename `cortex.yaml` hits the monolith special-case → meta-factory, while
-# discover_stack_slugs (dir basename) would call it `cortex`. This is a
-# pre-existing repo-wide ambiguity in config_file_to_slug's meta-factory
-# special-case, not introduced here; `cortex` is not a real deployed slug.
+# PRECEDENCE MIRROR (advw3c Attack 1): discover_stack_slugs treats the DIRECTORY
+# LAYOUT as authoritative — the presence of the <config_dir>/<slug>/system/
+# system.yaml marker means slug == the dir basename, and dir wins over any root
+# monolith. This function must mirror that precedence: check the marker FIRST,
+# BEFORE config_file_to_slug's filename map. Without it, a dir-layout stack
+# literally slugged `cortex` (sentinel <config_dir>/cortex/cortex.yaml) would be
+# argv-hijacked to `meta-factory` by the cortex.yaml special-case while discovery
+# calls it `cortex` — re-opening the exact kill/reload desync 3a closed. The
+# marker disambiguates cleanly because `~/.config/cortex/cortex.yaml` (the real
+# meta-factory monolith) has NO sibling system/system.yaml, so it still maps to
+# meta-factory.
 slug_from_config_arg() {
-  local raw="$1" path base slug parent
+  local raw="$1" path base slug parent dir
   [ -n "${raw}" ] || return 1
   path="$(realpath "${raw}" 2>/dev/null || printf '%s' "${raw}")"
+  dir="$(dirname "${path}")"
+  # 1. Dir-layout marker wins (mirrors discover_stack_slugs precedence). The
+  #    argv --config is the sentinel <config_dir>/<slug>/<slug>.yaml, whose
+  #    sibling system/system.yaml is the layout marker; slug = the dir basename.
+  if [ -f "${dir}/system/system.yaml" ]; then
+    printf '%s' "$(basename "${dir}")"
+    return 0
+  fi
   base="$(basename "${path}")"
+  # 2. Monolith: the repo's canonical filename→slug map (cortex.yaml → meta-
+  #    factory, cortex.<slug>.yaml → <slug>).
   if slug="$(config_file_to_slug "${base}")"; then
     printf '%s' "${slug}"
     return 0
   fi
+  # 3. Dir-layout sentinel whose marker is not on disk (transient / partially
+  #    removed config): accept the <slug>/<slug>.yaml shape (parent basename ==
+  #    file stem) as a weaker signal.
   slug="${base%.yaml}"
-  parent="$(basename "$(dirname "${path}")")"
+  parent="$(basename "${dir}")"
   if [ -n "${slug}" ] && [ "${base}" != "${slug}" ] && [ "${slug}" = "${parent}" ]; then
     printf '%s' "${slug}"
     return 0


### PR DESCRIPTION
Closes #1960. Re-homed from the wave-3 branch (cortex#1871 merged before this commit could land there; the fix was deferred to #1960 as non-blocking, then implemented by the wave-3 builder — cherry-picked here onto main).

## What
`slug_from_config_arg` inferred layout from filename shape and ran `config_file_to_slug` FIRST, without checking the `system/system.yaml` dir-layout marker that `discover_stack_slugs` uses for precedence. So the argv-side (kill) and disk-side (reload) skip-restart slugs could disagree for one pathological name — a dir-layout stack literally slugged `cortex` (`<cfg>/cortex/cortex.yaml`) was argv-hijacked to `meta-factory`, desyncing the skip → a forced (self-healing) bounce of an explicitly-spared stack.

Fix: check the dir-layout marker (`$(dirname realpath)/system/system.yaml`) BEFORE `config_file_to_slug`'s filename map — mirroring `discover_stack_slugs`' precedence. A dir-layout `cortex` stack now resolves to `cortex` on BOTH sides; the real `~/.config/cortex/cortex.yaml` monolith (no sibling marker) still maps to meta-factory. This makes the two slug-derivations truly identical (the point of the skip-restart key unification).

## Verification (builder, on the committed tree)
Darwin 47/47, simulated-Linux (mock uname) 44/44 — the 4 new marker tests are host-independent. shellcheck clean, vocab pass. Full CI runs here on the fresh PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)