### PR TITLE
feat(config): XDG wave 4 — cortex config-dir move (grove|cortex → metafactory/cortex), restart-op, merge-policy (#1869)

### DIFF
--- a/scripts/__tests__/migrate-config-dir.sh
+++ b/scripts/__tests__/migrate-config-dir.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# XDG wave-4 (cortex#1869) — end-to-end test for the config-dir move driver
+# (scripts/migrate-config-dir.sh) and its shell helpers (canonical_config_dir /
+# resolve_config_dir in plist-render.sh).
+#
+# Proves, ENTIRELY inside a scratch $HOME with a mocked launchctl (PATH override,
+# same pattern as plist-render-bin-cutover.sh), that the RESTART op:
+#   - carries the union of both legacy trees (cortex-wins-on-dup; grove-only
+#     files carried; .bak sidecars + personas/ carried);
+#   - excludes state/data subtrees (state/, logs/, agents/);
+#   - keeps the legacy sources (rollback anchor) and writes a journal;
+#   - re-renders every plist's --config argv at the NEW canonical dir;
+#   - bootout/bootstraps the daemons, SPARING a skip-listed production stack;
+#   - never touches the real home (asserted: the journal's canonical root is
+#     under the scratch $HOME, and no real-home path is created).
+#
+# Run:  bash scripts/__tests__/migrate-config-dir.sh
+# Exit: 0 = all pass, non-zero = failure count.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+pass() { printf '  ✓ %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL + 1)); }
+skip() { printf '  ↷ %s (skipped: not applicable on %s)\n' "$1" "$(uname)"; PASS=$((PASS + 1)); }
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then pass "${label}"
+  else fail "${label}: expected «${expected}» got «${actual}»"; fi
+}
+assert_true()  { local l="$1"; shift; if "$@"; then pass "${l}"; else fail "${l}"; fi; }
+assert_false() { local l="$1"; shift; if "$@"; then fail "${l}"; else pass "${l}"; fi; }
+assert_grep_file() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "${needle}" "${file}"; then pass "${label}"; else fail "${label}: «${needle}» not in ${file}"; fi
+}
+assert_not_grep_file() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "${needle}" "${file}"; then fail "${label}: «${needle}» unexpectedly in ${file}"; else pass "${label}"; fi
+}
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DRIVER="${REPO_ROOT}/migrate-config-dir.sh"
+REAL_HOME="${HOME}"   # captured before override — used only for leak assertions
+
+# ── resolve_config_dir / canonical_config_dir unit checks ──────────────────
+printf '\n=== resolve_config_dir precedence ===\n'
+source "${REPO_ROOT}/lib/plist-render.sh"
+(
+  U="$(mktemp -d)"; export HOME="${U}"
+  unset CORTEX_CONFIG_DIR
+  assert_eq "resolve: nothing present → canonical path" \
+    "${U}/.config/metafactory/cortex" "$(resolve_config_dir)"
+  mkdir -p "${U}/.config/grove"
+  assert_eq "resolve: only grove → grove" "${U}/.config/grove" "$(resolve_config_dir)"
+  mkdir -p "${U}/.config/cortex"
+  assert_eq "resolve: flat cortex present → cortex (wins over grove)" \
+    "${U}/.config/cortex" "$(resolve_config_dir)"
+  mkdir -p "${U}/.config/metafactory/cortex"
+  assert_eq "resolve: canonical present → canonical (wins over legacy)" \
+    "${U}/.config/metafactory/cortex" "$(resolve_config_dir)"
+  export CORTEX_CONFIG_DIR="/tmp/override-root"
+  assert_eq "resolve: \$CORTEX_CONFIG_DIR wins over everything" \
+    "/tmp/override-root" "$(resolve_config_dir)"
+  assert_eq "canonical_config_dir: \$CORTEX_CONFIG_DIR verbatim" \
+    "/tmp/override-root" "$(canonical_config_dir)"
+  unset CORTEX_CONFIG_DIR
+  assert_eq "canonical_config_dir: default → metafactory/cortex" \
+    "${U}/.config/metafactory/cortex" "$(canonical_config_dir)"
+  rm -rf "${U}"
+)
+
+# ── Full driver run in scratch HOME ────────────────────────────────────────
+printf '\n=== migrate-config-dir.sh (scratch HOME, mocked launchctl) ===\n'
+
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "${TMPHOME}"' EXIT
+
+# Legacy flat cortex tree — the pre-move canonical.
+LC="${TMPHOME}/.config/cortex"
+mkdir -p "${LC}/personas" "${LC}/state" "${LC}/logs"
+printf 'stack:\n  id: andreas/meta-factory\nTREE: cortex\n' > "${LC}/cortex.yaml"   # monolith → meta-factory
+printf 'stack:\n  id: andreas/work\n'                        > "${LC}/cortex.work.yaml" # work (skip-listed)
+printf 'prev cortex.yaml\n'                                  > "${LC}/cortex.yaml.bak"  # .bak sidecar → carried
+printf '# pier persona\n'                                    > "${LC}/personas/pier.md" # personas/ → carried
+printf '4242\n'                                              > "${LC}/state/cortex.pid" # state → EXCLUDED
+printf 'log line\n'                                          > "${LC}/logs/cortex.log"  # logs → EXCLUDED
+
+# Legacy grove tree — divergent: a grove-only secret + a dup cortex.yaml (grove
+# loses to cortex-wins-on-dup, and its copy must be KEPT, never deleted).
+GV="${TMPHOME}/.config/grove"
+mkdir -p "${GV}"
+printf 'discord_token: SECRET\n'      > "${GV}/bot.yaml"    # grove-ONLY → carried
+printf 'stack:\n  id: x\nTREE: grove\n' > "${GV}/cortex.yaml" # dup → shadowed by cortex, kept
+
+CANON="${TMPHOME}/.config/metafactory/cortex"
+
+# Mock launchctl (trace each call so bootout/bootstrap + skip can be asserted).
+MOCK_BIN="${TMPHOME}/mock-bin"; mkdir -p "${MOCK_BIN}"
+LAUNCHCTL_LOG="${TMPHOME}/launchctl.log"; : > "${LAUNCHCTL_LOG}"
+export LAUNCHCTL_LOG
+cat > "${MOCK_BIN}/launchctl" <<'EOF'
+#!/bin/sh
+printf 'launchctl %s\n' "$*" >> "${LAUNCHCTL_LOG:-/dev/null}"
+EOF
+chmod +x "${MOCK_BIN}/launchctl"
+
+# Drive the real script: scratch HOME, work spared, mocked launchctl on PATH.
+RUN_OUT="${TMPHOME}/run.out"
+set +e
+HOME="${TMPHOME}" CORTEX_UPGRADE_SKIP_RESTART="work" \
+  PATH="${MOCK_BIN}:${PATH}" bash "${DRIVER}" > "${RUN_OUT}" 2>&1
+RUN_CODE=$?
+set -e
+if [ "${RUN_CODE}" -ne 0 ]; then
+  printf '  ✗ driver exited %s:\n' "${RUN_CODE}"; sed 's/^/      /' "${RUN_OUT}"
+  FAIL=$((FAIL + 1))
+fi
+assert_eq "driver: exits 0" "0" "${RUN_CODE}"
+
+# ── Merge-policy assertions (the config data-safety core) ──
+assert_true  "carry: canonical cortex.yaml exists"      test -f "${CANON}/cortex.yaml"
+assert_grep_file "cortex-wins-on-dup: canonical cortex.yaml is the CORTEX copy" \
+  "${CANON}/cortex.yaml" "TREE: cortex"
+assert_not_grep_file "cortex-wins-on-dup: NOT the grove copy" \
+  "${CANON}/cortex.yaml" "TREE: grove"
+assert_true  "carry: grove-ONLY bot.yaml carried (secret not lost)" test -f "${CANON}/bot.yaml"
+assert_grep_file "carry: grove-only secret content intact" "${CANON}/bot.yaml" "discord_token: SECRET"
+assert_true  "carry: .bak sidecar carried"              test -f "${CANON}/cortex.yaml.bak"
+assert_true  "carry: personas/ carried"                 test -f "${CANON}/personas/pier.md"
+assert_true  "carry: work stack config carried"         test -f "${CANON}/cortex.work.yaml"
+
+# ── Exclusion assertions (state/data owned by #1902/#1903) ──
+assert_false "exclude: state/ NOT carried"              test -e "${CANON}/state/cortex.pid"
+assert_false "exclude: logs/ NOT carried"               test -e "${CANON}/logs/cortex.log"
+
+# ── Rollback-safety assertions ──
+assert_true  "rollback: journal written canonical-side" test -f "${CANON}/.xdg-config-migration.json"
+assert_true  "rollback: legacy cortex.yaml SOURCE kept (never renamed)" test -f "${LC}/cortex.yaml"
+assert_true  "rollback: legacy grove bot.yaml SOURCE kept" test -f "${GV}/bot.yaml"
+assert_grep_file "rollback: shadowed grove cortex.yaml recorded in journal" \
+  "${CANON}/.xdg-config-migration.json" "shadowedGrove"
+
+# ── Real-home leak guard: the journal's canonical root is UNDER scratch HOME ──
+assert_grep_file "isolation: journal canonical root is under scratch HOME" \
+  "${CANON}/.xdg-config-migration.json" "${TMPHOME}/.config/metafactory/cortex"
+assert_false "isolation: real home got no migration journal" \
+  test -e "${REAL_HOME}/.config/metafactory/cortex/.xdg-config-migration.json"
+
+# ── RESTART op: plists re-rendered at the NEW dir + bootout/bootstrap ──
+if [ "$(uname)" != "Darwin" ]; then
+  skip "restart: plist re-render + launchctl (Darwin-only)"
+  skip "restart: skip-listed production stack spared (Darwin-only)"
+else
+  MF_PLIST="${TMPHOME}/Library/LaunchAgents/ai.meta-factory.cortex.meta-factory.plist"
+  WORK_PLIST="${TMPHOME}/Library/LaunchAgents/ai.meta-factory.cortex.work.plist"
+  assert_true "restart: meta-factory plist rendered" test -f "${MF_PLIST}"
+  assert_grep_file "restart: meta-factory plist --config points at MOVED canonical dir" \
+    "${MF_PLIST}" "${CANON}/cortex.yaml"
+  assert_not_grep_file "restart: meta-factory plist --config NO LONGER the legacy tree" \
+    "${MF_PLIST}" "<string>${LC}/cortex.yaml</string>"
+  # work plist is re-rendered too (so a later natural reload boots the moved dir)…
+  assert_grep_file "restart: work plist ALSO re-rendered at canonical dir" \
+    "${WORK_PLIST}" "${CANON}/cortex.work.yaml"
+  # …but the work daemon is NOT bootout/bootstrapped (spared).
+  assert_grep_file "restart: meta-factory bootout issued" "${LAUNCHCTL_LOG}" "bootout"
+  assert_grep_file "restart: meta-factory bootstrap issued" "${LAUNCHCTL_LOG}" "ai.meta-factory.cortex.meta-factory.plist"
+  assert_grep_file "restart: relay reloaded" "${LAUNCHCTL_LOG}" "ai.meta-factory.cortex.relay.plist"
+  assert_not_grep_file "restart: skip-listed 'work' daemon NOT bootstrapped" \
+    "${LAUNCHCTL_LOG}" "ai.meta-factory.cortex.work.plist"
+fi
+
+# ── Idempotency: a second run carries nothing new, still exits 0 ──
+printf '\n=== idempotency (second run) ===\n'
+set +e
+HOME="${TMPHOME}" CORTEX_UPGRADE_SKIP_RESTART="work" \
+  PATH="${MOCK_BIN}:${PATH}" bash "${DRIVER}" > "${TMPHOME}/run2.out" 2>&1
+RUN2_CODE=$?
+set -e
+assert_eq "idempotent: second run exits 0" "0" "${RUN2_CODE}"
+assert_grep_file "idempotent: second run reports all-already-present" \
+  "${TMPHOME}/run2.out" "already present"
+
+# ── PLAN_ONLY dry-run writes nothing ──
+printf '\n=== PLAN_ONLY dry-run ===\n'
+PLANHOME="$(mktemp -d)"
+mkdir -p "${PLANHOME}/.config/cortex"
+printf 'stack:\n  id: a/meta-factory\n' > "${PLANHOME}/.config/cortex/cortex.yaml"
+set +e
+HOME="${PLANHOME}" PLAN_ONLY=1 PATH="${MOCK_BIN}:${PATH}" bash "${DRIVER}" > "${PLANHOME}/plan.out" 2>&1
+PLAN_CODE=$?
+set -e
+assert_eq "plan-only: exits 0" "0" "${PLAN_CODE}"
+assert_false "plan-only: wrote NO canonical tree" \
+  test -e "${PLANHOME}/.config/metafactory/cortex/cortex.yaml"
+rm -rf "${PLANHOME}"
+
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/scripts/__tests__/migrate-config-dir.test.ts
+++ b/scripts/__tests__/migrate-config-dir.test.ts
@@ -1,0 +1,24 @@
+// bun-test wrapper for scripts/__tests__/migrate-config-dir.sh so the XDG
+// wave-4 (cortex#1869) config-dir move driver — the RESTART op (tree copy +
+// merge policy + plist re-render + launchctl bootout/bootstrap, production stack
+// spared) — is gated by CI's `bun test`, not just runnable by hand. Mirrors the
+// plist-render-bin-cutover.test.ts pattern (spawn the shell suite, assert exit 0).
+//
+// The shell suite runs entirely in a scratch $HOME with a mocked launchctl — no
+// live ~/.config, launchctl, or daemon is touched.
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SUITE = join(REPO_ROOT, "scripts", "__tests__", "migrate-config-dir.sh");
+
+describe("migrate-config-dir shell suite (cortex#1869 XDG wave 4)", () => {
+  test("config-dir move: merge policy + re-render + skip-restart pass (exit 0)", () => {
+    const res = spawnSync("bash", [SUITE], { cwd: REPO_ROOT, encoding: "utf8" });
+    const out = `${res.stdout}${res.stderr}`;
+    if (res.status !== 0) throw new Error(`shell suite failed (exit ${res.status}):\n${out}`);
+    expect(res.status).toBe(0);
+    expect(out).toContain("0 failed");
+  });
+});

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -33,6 +33,45 @@ resolve_bun_path() {
   printf '%s' "${bun_path}"
 }
 
+# ── XDG wave-4 (cortex#1869): config-dir resolution ──────────────────────────
+#
+# The cortex config directory is moving from the two pre-move trees
+# (`~/.config/cortex`, `~/.config/grove`) into the canonical
+# `~/.config/metafactory/cortex`. These two helpers are the SHELL analogue of
+# `resolveConfigDir` / `cortexConfigDir` in src/common/config/config-path.ts, so
+# the lifecycle scripts stamp the SAME `--config` path into plists that the TS
+# runtime reads from — no daemon-vs-CLI split-brain (traps T7′/T13/T17).
+
+# The canonical (write / move-target) config dir: `$CORTEX_CONFIG_DIR` verbatim
+# when set, else `~/.config/metafactory/cortex`. Used by the migration driver as
+# the destination the tree is carried into and the dir plists are re-stamped at.
+canonical_config_dir() {
+  if [ -n "${CORTEX_CONFIG_DIR:-}" ]; then
+    printf '%s' "${CORTEX_CONFIG_DIR}"
+  else
+    printf '%s' "${HOME}/.config/metafactory/cortex"
+  fi
+}
+
+# The config dir to READ from during the transition — canonical-first with legacy
+# fallback, mirroring resolveConfigDir(): `$CORTEX_CONFIG_DIR` (self-contained
+# root) → `~/.config/metafactory/cortex` (once migrated) → `~/.config/cortex`
+# (pre-wave-4 flat tree) → `~/.config/grove` (oldest) → the canonical path (fresh
+# host, nothing yet). A command run BEFORE the move still resolves the legacy
+# tree (byte-identical to pre-wave-4); a migrated host resolves the canonical
+# tree, so the re-rendered plists point at the moved config.
+resolve_config_dir() {
+  if [ -n "${CORTEX_CONFIG_DIR:-}" ]; then
+    printf '%s' "${CORTEX_CONFIG_DIR}"
+    return 0
+  fi
+  local canonical="${HOME}/.config/metafactory/cortex"
+  if [ -d "${canonical}" ]; then printf '%s' "${canonical}"; return 0; fi
+  if [ -d "${HOME}/.config/cortex" ]; then printf '%s' "${HOME}/.config/cortex"; return 0; fi
+  if [ -d "${HOME}/.config/grove" ]; then printf '%s' "${HOME}/.config/grove"; return 0; fi
+  printf '%s' "${canonical}"
+}
+
 # Extract the CANONICAL stack slug from a cortex config's `stack.id`.
 #
 # `stack.id` is `{principal}/{slug}` (e.g. `andreas/community` → `community`).

--- a/scripts/migrate-config-dir-exec.ts
+++ b/scripts/migrate-config-dir-exec.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env bun
+/**
+ * XDG wave-4 (cortex#1869) — config-dir move, execution entry.
+ *
+ * Thin CLI wrapper around the tested migrator in
+ * `src/common/config/migrate-config-dir.ts` so the shell RESTART-op driver
+ * (`scripts/migrate-config-dir.sh`) can perform the COPY step without
+ * duplicating the merge-policy / atomic-write / journal logic in bash.
+ *
+ * Behaviour: plan the union of the two legacy trees (cortex-wins-on-dup, carry
+ * grove-only, exclude state/data subtrees), then COPY each carried file into the
+ * canonical `~/.config/metafactory/cortex` (or `$CORTEX_CONFIG_DIR`) atomically,
+ * keeping every legacy source for rollback, and drop the journal. Idempotent:
+ * re-running skips files already present canonical-side.
+ *
+ * Isolation: reads `$HOME` (or `$CORTEX_CONFIG_DIR`) only through the migrator's
+ * injectable seam — a scratch `$HOME` fully sandboxes it, so tests never touch a
+ * real home. Prints a one-line summary; exits non-zero if the copy throws.
+ *
+ * `--plan-only` prints the plan (counts) WITHOUT writing anything — a dry-run
+ * the principal can inspect before the real cutover.
+ */
+import {
+  executeConfigDirMigration,
+  planConfigDirMigration,
+} from "../src/common/config/migrate-config-dir";
+
+const planOnly = process.argv.includes("--plan-only");
+const plan = planConfigDirMigration();
+
+const groveOnly = plan.moves.filter((m) => m.fromTree === "grove").length;
+const shadowed = plan.moves.filter((m) => m.shadowedGrove !== undefined).length;
+
+if (planOnly) {
+  console.log(
+    `  ▸ config-dir migration PLAN: ${plan.moves.length} file(s) to carry ` +
+      `(${groveOnly} grove-only, ${shadowed} cortex-wins-on-dup), ` +
+      `${plan.excluded.length} state/data path(s) excluded → ${plan.canonical}`,
+  );
+  process.exit(0);
+}
+
+// `new Date()` is fine here (this is a real bun process, not a workflow sandbox);
+// the timestamp is recorded in the journal for audit.
+const stampedAt = new Date().toISOString();
+const journal = executeConfigDirMigration(plan, stampedAt);
+
+const applied = journal.moves.filter((m) => m.applied).length;
+const skipped = journal.moves.filter((m) => m.skippedExisting).length;
+const carriedGrove = journal.moves.filter(
+  (m) => m.fromTree === "grove" && m.applied,
+).length;
+
+console.log(
+  `  ✓ config-dir migration: ${applied} carried ` +
+    `(${carriedGrove} grove-only), ${skipped} already present, ` +
+    `${journal.excluded.length} state/data path(s) excluded → ${journal.canonical}`,
+);

--- a/scripts/migrate-config-dir.sh
+++ b/scripts/migrate-config-dir.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# XDG wave-4 (cortex#1869) — config-dir move driver (RESTART operation).
+#
+# The cortex config directory moves from the two pre-move trees
+# (`~/.config/cortex`, `~/.config/grove`) into the canonical
+# `~/.config/metafactory/cortex`. A config path is stamped as an ABSOLUTE
+# `--config` argv into every installed launchd plist and nothing re-renders an
+# installed plist on its own, so a bare tree-move would leave daemons booting the
+# OLD path while CLIs read the moved copy (silent split-brain — traps
+# T7′/T13/T17, epic #1867 §P3a). This driver therefore carries the move as a
+# RESTART op:
+#
+#   1. COPY the config tree → canonical, via the tested TS migrator
+#      (merge policy: cortex-wins-on-dup, carry grove-only; atomic write; journal;
+#      rollback). The legacy SOURCE is KEPT — a crash leaves it fully intact and
+#      the resolver's legacy fallback keeps every path readable.
+#   2. RE-RENDER every installed plist's `--config` argv at the NEW canonical dir
+#      (render_cortex_plists), so launchd execs `--config <canonical>/...`.
+#   3. BOOTOUT/BOOTSTRAP the daemons so the running processes pick up the new
+#      argv. Stacks named in CORTEX_UPGRADE_SKIP_RESTART (the production `work`
+#      stack) are SPARED the restart — their plist is re-rendered but they keep
+#      serving on their live process and migrate on their next natural
+#      bootout+bootstrap (reboot / logout / manual reload).
+#
+# ISOLATION: every path derives from `$HOME` (or `$CORTEX_CONFIG_DIR`). Point
+# `$HOME` at a scratch dir and mock `launchctl` via PATH and this touches no real
+# home and no live daemon — see scripts/__tests__/migrate-config-dir.sh. `BUN_BIN`
+# overrides the bun binary for tests; `PLAN_ONLY=1` runs the copy step as a
+# no-op dry-run (plan printed, nothing written, no restart).
+
+CORTEX_DIR="${PAI_INSTALL_PATH:-$(cd "$(dirname "$0")/.." && pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=scripts/lib/plist-render.sh
+source "${SCRIPT_DIR}/lib/plist-render.sh"
+
+CANONICAL_DIR="$(canonical_config_dir)"
+
+echo "Migrating cortex config dir → ${CANONICAL_DIR} ..."
+
+# ── 1. Copy the config tree (merge policy + atomic write + journal) ──────────
+if [ "${PLAN_ONLY:-0}" = "1" ]; then
+  "${BUN_BIN:-bun}" "${SCRIPT_DIR}/migrate-config-dir-exec.ts" --plan-only
+  echo "  ▸ PLAN_ONLY — no files copied, no daemons restarted"
+  exit 0
+fi
+"${BUN_BIN:-bun}" "${SCRIPT_DIR}/migrate-config-dir-exec.ts"
+
+# ── 2 + 3. Re-render plists at the new dir + bootout/bootstrap (macOS only) ──
+# The stop/restart primitives are launchd-only; Linux/systemd parity rides with
+# cortex#1909 (same boundary as preupgrade.sh's kill block).
+if [ "$(uname)" = "Darwin" ]; then
+  LAUNCH_DIR="${HOME}/Library/LaunchAgents"
+
+  # Re-stamp every plist's `--config` argv at the canonical dir. Discovery reads
+  # the canonical tree (the copy just populated it), so every stack that exists
+  # canonical-side gets a plist pointing at its moved config.
+  render_cortex_plists "${CORTEX_DIR}" "${LAUNCH_DIR}" "${CANONICAL_DIR}"
+
+  # Relay always reloads (never skip-checked) so it boots the moved policy path.
+  reload_plist "${LAUNCH_DIR}/ai.meta-factory.cortex.relay.plist"
+  echo "  ✓ Relay reloaded on moved config dir"
+
+  # Each discovered stack: bootout/bootstrap unless skip-listed (production
+  # `work` is spared — its plist is re-rendered but it keeps its live process).
+  while IFS= read -r slug; do
+    [ -z "${slug}" ] && continue
+    reload_stack_unless_skipped "${LAUNCH_DIR}" "${slug}"
+  done < <(discover_stack_slugs "${CANONICAL_DIR}")
+fi
+
+echo "  ✓ Config-dir move complete — daemons boot on ${CANONICAL_DIR}; legacy tree kept for rollback"

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -20,7 +20,16 @@ CORTEX_DIR="${PAI_INSTALL_PATH:-$(cd "$(dirname "$0")/.." && pwd)}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLAUDE_DIR="${HOME}/.claude"
 EVENTS_DIR="${CLAUDE_DIR}/events"
-CONFIG_DIR="${HOME}/.config/cortex"
+# plist-render.sh provides resolve_config_dir + the render/slug helpers used in
+# §4. Sourced up-front so CONFIG_DIR resolves canonical-first (all function
+# definitions — no source-time side effects).
+# shellcheck source=scripts/lib/plist-render.sh
+source "${SCRIPT_DIR}/lib/plist-render.sh"
+# XDG wave-4 (cortex#1869): resolve the active config dir (canonical
+# ~/.config/metafactory/cortex once migrated, legacy trees during transition, or
+# $CORTEX_CONFIG_DIR). On a fresh install none exist yet → resolves to the
+# canonical path, so a first install writes/renders canonical-side directly.
+CONFIG_DIR="$(resolve_config_dir)"
 
 echo "Running Cortex postinstall..."
 
@@ -62,8 +71,8 @@ fi
 
 # ─── 4. Launchd plist rendering (macOS only) ─────────────────────
 # Holly cortex#52 round 1 major: the sed-templating block + awk agent-name
-# extractor lived here AND in postupgrade.sh. Extracted to a shared lib.
-source "${SCRIPT_DIR}/lib/plist-render.sh"
+# extractor lived here AND in postupgrade.sh. Extracted to a shared lib
+# (already sourced up-front, for resolve_config_dir).
 # Audit stack-identity drift (cortex#810) — warn (non-fatal, host-independent)
 # when a stack's locator slug ≠ its stack.id slug. Before the Darwin guard so
 # Linux/systemd installs see it too.

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -16,7 +16,17 @@ set -e
 CORTEX_DIR="${PAI_INSTALL_PATH:-$(cd "$(dirname "$0")/.." && pwd)}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLAUDE_DIR="${HOME}/.claude"
-CONFIG_DIR="${HOME}/.config/cortex"
+# plist-render.sh provides resolve_config_dir plus the render/reload/slug/
+# forward-symlink helpers used below. Sourced up-front so CONFIG_DIR can resolve
+# canonical-first (it is all function definitions — no source-time side effects).
+# shellcheck source=scripts/lib/plist-render.sh
+source "${SCRIPT_DIR}/lib/plist-render.sh"
+# XDG wave-4 (cortex#1869): resolve the ACTIVE config dir (canonical
+# ~/.config/metafactory/cortex once migrated, the legacy trees during transition,
+# or $CORTEX_CONFIG_DIR) instead of hardcoding the pre-move `~/.config/cortex` —
+# so the plists re-rendered below stamp the MOVED --config and daemons never
+# boot a stale tree (split-brain traps T7′/T13/T17).
+CONFIG_DIR="$(resolve_config_dir)"
 
 mkdir -p "${HOME}/.local/bin" "${CLAUDE_DIR}/relay" \
          "${CLAUDE_DIR}/skills" "${CONFIG_DIR}/logs"
@@ -44,9 +54,8 @@ echo "  ✓ Nested symlinks refreshed"
 # ~/bin/<name>, so we leave ~/bin/<name> as a forward-symlink → ~/.local/bin so
 # it keeps resolving through any interrupt in the render+reload window. We NEVER
 # delete ~/bin/<name> here — deletion is wave 6 (#1904). Host-independent (both
-# launchd and systemd exec ~/.local/bin now); source of the helper is the shared
-# plist-render lib (loaded in §2 below, but we need it here first).
-source "${SCRIPT_DIR}/lib/plist-render.sh"
+# launchd and systemd exec ~/.local/bin now); the helper comes from the shared
+# plist-render lib, already sourced up-front (for resolve_config_dir).
 echo "  Bridging legacy ~/bin entries → ~/.local/bin (forward-symlinks)..."
 for bin_name in cortex cortex-relay cldyo-live; do
   forward_link_legacy_bin "${bin_name}"
@@ -68,7 +77,7 @@ done
 # us that path — the file where agents[].id and stack.id live.
 echo "  Provisioning stack signing identity..."
 source "${SCRIPT_DIR}/lib/stack-identity-provision.sh"
-# plist-render.sh already sourced in §1b (forward-symlink bridge).
+# plist-render.sh already sourced up-front (for resolve_config_dir).
 
 while IFS= read -r slug; do
   stack_config="$(resolve_stack_agent_config_path "${CONFIG_DIR}" "${slug}")"

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -33,7 +33,11 @@ echo "Stopping Cortex services for upgrade (${PAI_OLD_VERSION:-?} → ${PAI_NEW_
 # and rides with cortex#1909 — do not assume the skip/abort protects a Linux box.
 if [ "$(uname)" = "Darwin" ]; then
   LAUNCH_DIR="${HOME}/Library/LaunchAgents"
-  CONFIG_DIR="${HOME}/.config/cortex"
+  # XDG wave-4 (cortex#1869): resolve the active config dir canonical-first so
+  # discover_stack_slugs stops the daemons keyed on the SAME tree postupgrade
+  # re-renders + restarts (no stop-here/reload-there desync post-move). Honors
+  # $CORTEX_CONFIG_DIR; falls back to the legacy tree pre-move (byte-identical).
+  CONFIG_DIR="$(resolve_config_dir)"
 
   # Kill running cortex agent processes before upgrading symlinks.
   # Holly cortex#52 round 1 nit-3: previous `pgrep -f "cortex start"` matched

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -39,6 +39,7 @@ import {
   FragmentLoadError,
   expandTilde,
 } from "../../../common/config/loader";
+import { resolveConfigFilePath } from "../../../common/config/config-path";
 import { type Agent } from "../../../common/types/cortex-config";
 
 // =============================================================================
@@ -126,7 +127,12 @@ export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
 // runAgentsReload
 // =============================================================================
 
-const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
+/** The default cortex.yaml (shown in help as `~/.config/metafactory/cortex/
+ *  cortex.yaml`) resolved at CALL time — fallback-aware canonical → legacy
+ *  cortex → grove so an un-migrated host reads the legacy tree (cortex#1869). */
+function defaultCortexConfigPath(): string {
+  return resolveConfigFilePath("cortex.yaml");
+}
 
 export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
   if (args.help) {
@@ -247,7 +253,7 @@ type SignalOutcome =
  * letting `readFileSync` throw out of the reload command as an unexpected error.
  */
 function signalDaemonReload(configPath: string | undefined): SignalOutcome {
-  const resolvedConfig = expandTilde(configPath ?? DEFAULT_CONFIG_PATH);
+  const resolvedConfig = expandTilde(configPath ?? defaultCortexConfigPath());
   const pidFile = pidFileFor(resolvedConfig);
   if (!existsSync(pidFile)) {
     // No runtime to signal — benign. Validation passed; nothing to reload.
@@ -586,7 +592,7 @@ function resolveAgentsDir(
   args: ParsedAgentsArgs,
   command: "reload" | "list",
 ): { agentsDir: string } | { exit: ExitResult } {
-  const configPath = expandTilde(args.config ?? DEFAULT_CONFIG_PATH);
+  const configPath = expandTilde(args.config ?? defaultCortexConfigPath());
   const configDir = dirname(configPath);
   if (!existsSync(configDir)) {
     return {

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -36,6 +36,7 @@ import { basename, dirname, join } from "path";
 import { parse as parseYaml, parseDocument } from "yaml";
 
 import { expandTilde } from "../../../common/config/loader";
+import { resolveConfigDir } from "../../../common/config/config-path";
 import {
   ensureLeafInclude,
   leafIncludeDirectivePresent,
@@ -990,7 +991,11 @@ function stackConfigPath(cfg: LivePortsConfig): string {
   // in production — it's a belt-and-braces guard for direct port construction.
   if (cortexConfigPath === undefined || cortexConfigPath === "") {
     const slug = cfg.stackId.split("/")[1] ?? "default";
-    const cortexDir = expandTilde("~/.config/cortex");
+    // XDG wave-4 (cortex#1869): route through the canonical-first resolver
+    // instead of a hardcoded `~/.config/cortex`, so this belt-and-braces
+    // fallback lands on the moved `~/.config/metafactory/cortex` tree (or the
+    // legacy tree during transition), honoring `$CORTEX_CONFIG_DIR`.
+    const cortexDir = resolveConfigDir();
     const perStackDir = join(cortexDir, slug);
     if (existsSync(join(perStackDir, "system", "system.yaml"))) {
       return join(perStackDir, "stacks", `${slug}.yaml`);
@@ -1530,7 +1535,10 @@ export function buildDryRunPorts(cfg: LivePortsConfig): NetworkPorts {
  * `public.>` subscription is added/removed here.
  */
 function systemConfigPath(): string {
-  return join(expandTilde("~/.config/cortex"), "system", "system.yaml");
+  // XDG wave-4 (cortex#1869): resolve the active config dir (canonical
+  // `~/.config/metafactory/cortex` first, legacy trees as fallback, or
+  // `$CORTEX_CONFIG_DIR`) rather than hardcoding the pre-move `~/.config/cortex`.
+  return join(resolveConfigDir(), "system", "system.yaml");
 }
 
 /** The literal `public.>` subscribe pattern. */

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -46,6 +46,7 @@ import { dirname, join } from "path";
 
 import { expandTilde, loadConfigWithAgents } from "../../../common/config/loader";
 import type { LoadedConfig } from "../../../common/config/loader";
+import { resolveConfigDir, resolveConfigFilePath } from "../../../common/config/config-path";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
 import { NetworkCache } from "../../../common/registry/network-cache";
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
@@ -228,16 +229,24 @@ const DEFAULT_REGISTRY_URL = DEFAULT_REGISTRY.url;
  * is passed. Same canonical path as `cortex agents` (`agents.ts`). The
  * one-liner `cortex network join <network>` reads here.
  */
-const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
+/**
+ * The default cortex.yaml to read when no `--config` is passed — fallback-aware
+ * (canonical `~/.config/metafactory/cortex` → legacy `~/.config/cortex` →
+ * `~/.config/grove`), resolved at CALL time so tests that plant a fixture after
+ * import are honored (cortex#1869, XDG wave-4).
+ */
+function defaultCortexConfigPath(): string {
+  return resolveConfigFilePath("cortex.yaml");
+}
 
 /**
  * #800 — the cortex.yaml the stack's CORTEX daemon loads (the join's `--config`,
- * default {@link DEFAULT_CONFIG_PATH}). Threaded into the ports config so the
+ * default {@link defaultCortexConfigPath}). Threaded into the ports config so the
  * daemon-restart can LOCATE the daemon's launchd/systemd service by its
  * `--config` arg instead of guessing `ai.meta-factory.cortex.<stack-slug>`.
  */
 function cortexConfigPathFromFlags(flags: FlagMap): string {
-  return expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+  return expandTilde(optionalValueFlag(flags, "--config") ?? defaultCortexConfigPath());
 }
 
 const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
@@ -693,10 +702,6 @@ function resolveStackSlug(
   return { ok: true, slug };
 }
 
-/** Config dir base — the same canonical path the daemon + the rest of the
- *  network lifecycle use. expandTilde reads $HOME (tests pin it). */
-const CONFIG_DIR_BASE = "~/.config/cortex";
-
 /**
  * #814 — resolve the cortex config path the `status` read should target for a
  * NAMED stack, layout-aware. A faithful TS mirror of `resolve_stack_config_path`
@@ -729,7 +734,7 @@ const CONFIG_DIR_BASE = "~/.config/cortex";
  * `cortex.default.yaml` and falsely reported "no networks joined".
  */
 function resolveStatusConfigPath(slug: string): string {
-  const base = expandTilde(CONFIG_DIR_BASE);
+  const base = resolveConfigDir();
   // The no-`--stack` sentinel `"default"` IS the `meta-factory` bare-name default
   // in the locator system (scoped to status; see doc comment above).
   const locatorSlug = slug === "default" ? "meta-factory" : slug;
@@ -1165,7 +1170,7 @@ async function runJoin(
         ...readOverride(flags, "--system-account-jwt", "systemAccountJwt"),
         // (--from-package removed — ADR-0015 retired O-4b / hub-minted identity)
       },
-      expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
+      expandTilde(optionalValueFlag(flags, "--config") ?? defaultCortexConfigPath()),
       load,
     );
   } catch (err) {
@@ -1400,7 +1405,7 @@ async function runLeave(
         ...readOverride(flags, "--registry-pubkey", "registryPubkey"),
         ...readOverride(flags, "--seed-path", "seedPath"),
       },
-      expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
+      expandTilde(optionalValueFlag(flags, "--config") ?? defaultCortexConfigPath()),
       load,
     );
   } catch (err) {
@@ -3837,7 +3842,7 @@ function deriveMakeLiveInputs(
   flags: FlagMap,
   load: ConfigReader,
 ): { ok: true; inputs: MakeLiveInputs } | { ok: false; reason: string; usage: boolean } {
-  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? defaultCortexConfigPath());
   let cfg: LoadedConfig;
   try {
     cfg = load(configPath);
@@ -4085,7 +4090,7 @@ function deriveProvisionInputs(
   flags: FlagMap,
   load: ConfigReader,
 ): { ok: true; inputs: ProvisionInputs; stackConfigPath: string } | { ok: false; reason: string; usage: boolean } {
-  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? defaultCortexConfigPath());
   let cfg: LoadedConfig;
   try {
     cfg = load(configPath);
@@ -4245,7 +4250,7 @@ async function maybeAutoProvision(
   load: ConfigReader,
   portsFactory: ProvisionPortsFactory,
 ): Promise<{ ran: boolean; provisionedAfter: boolean; provisionFailed: boolean; output: string }> {
-  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+  const configPath = expandTilde(optionalValueFlag(flags, "--config") ?? defaultCortexConfigPath());
   let cfg: LoadedConfig;
   try {
     cfg = load(configPath);

--- a/src/cli/cortex/commands/offer.ts
+++ b/src/cli/cortex/commands/offer.ts
@@ -81,6 +81,7 @@ import { homedir } from "os";
 import YAML from "yaml";
 
 import { composeRawConfig, loadAgentsDirectory } from "../../../common/config/loader";
+import { resolveConfigDir } from "../../../common/config/config-path";
 import { deriveEffectiveCapabilityCatalog } from "../../../common/agents/capability-catalog";
 import type { Agent } from "../../../common/types/cortex-config";
 import type { Capability } from "../../../common/types/capability";
@@ -118,7 +119,12 @@ type OfferSubcommand = "list" | "revoke";
  * grammar — dot-separated lowercase segments — can never collide with the
  * reserved `list`/`revoke` words, which are single bare lowercase tokens.)
  */
-const DEFAULT_CONFIG_DIR = "~/.config/cortex";
+/** The config-dir default resolved at CALL time — fallback-aware (canonical
+ *  `~/.config/metafactory/cortex` → legacy `~/.config/cortex` → grove) so an
+ *  un-migrated host reads the legacy tree (cortex#1869, XDG wave-4). */
+function defaultConfigDir(): string {
+  return resolveConfigDir();
+}
 
 /** Capability id grammar — mirrors CO-1's `OfferingCapabilityIdSchema` (the
  *  `*` quantifier admits SINGLE-segment ids like `chat`). */
@@ -1281,7 +1287,7 @@ function resolveConfigPath(flags: FlagMap): string {
       ? flags["--config"]
       : typeof flags["--config-dir"] === "string"
         ? flags["--config-dir"]
-        : DEFAULT_CONFIG_DIR;
+        : defaultConfigDir();
   return expandTildePath(explicit);
 }
 

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -50,6 +50,7 @@ import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 
 import { expandTilde, loadConfigWithAgents } from "../../../common/config/loader";
+import { resolveConfigFilePath } from "../../../common/config/config-path";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
 import {
   resolveOwnAdmissionState,
@@ -260,8 +261,6 @@ interface HandlerCtx {
   json: boolean;
 }
 
-/** Default cortex config path — mirrors `cortex network`'s DEFAULT_CONFIG_PATH. */
-const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
 
 /**
  * cortex#1742 — resolve the pinned registry pubkey with precedence
@@ -294,7 +293,7 @@ export function resolveRegistryPubkey(
   }
   // Flag absent — fall back to the config pin (best-effort).
   const cfgFlag = ctx.flags["--config"];
-  const cfgRaw = typeof cfgFlag === "string" ? cfgFlag : DEFAULT_CONFIG_PATH;
+  const cfgRaw = typeof cfgFlag === "string" ? cfgFlag : resolveConfigFilePath("cortex.yaml");
   // expandTilde inside the try: it throws when $HOME is unset (loader.ts), and
   // the best-effort contract must hold there too — degrade to undefined, never throw.
   let cfgPath = cfgRaw;

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -36,6 +36,8 @@
 import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "fs";
 import { execFileSync } from "child_process";
 import { dirname, join } from "path";
+
+import { resolveConfigDir } from "../../../common/config/config-path";
 import { homedir } from "os";
 
 import { validateConfigLoads } from "../../../common/config/validate-on-write";
@@ -73,8 +75,12 @@ type StackSubcommand = "create" | "list" | "delete";
 const SLUG_RE = /^[a-z][a-z0-9_-]*$/;
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 
-/** Default config dir (same canonical path the daemon + network CLI use). */
-const DEFAULT_CONFIG_DIR = "~/.config/cortex";
+/** The `--config-dir` default resolved at CALL time — fallback-aware canonical
+ *  `~/.config/metafactory/cortex` → legacy `~/.config/cortex` → grove so an
+ *  un-migrated host reads the legacy tree (cortex#1869, XDG wave-4). */
+function defaultConfigDir(): string {
+  return resolveConfigDir();
+}
 /** Default NATS material dir (rendered `<slug>.conf`, leaf includes, seed). */
 const DEFAULT_NATS_DIR = "~/.config/nats";
 /** Default launchd LaunchAgents dir (the daemon + nats plists, macOS). */
@@ -216,7 +222,7 @@ function runCreate(
     );
   }
 
-  const configDir = expandTildePath(optionalValueFlag(flags, "--config-dir") ?? DEFAULT_CONFIG_DIR);
+  const configDir = expandTildePath(optionalValueFlag(flags, "--config-dir") ?? defaultConfigDir());
 
   // --- resolve + validate principal ---------------------------------------
   const principalRes = resolvePrincipal(flags, configDir);
@@ -494,7 +500,7 @@ function runDelete(
   }
 
   const roots: TeardownRoots = {
-    configDir: expandTildePath(optionalValueFlag(flags, "--config-dir") ?? DEFAULT_CONFIG_DIR),
+    configDir: expandTildePath(optionalValueFlag(flags, "--config-dir") ?? defaultConfigDir()),
     natsDir: expandTildePath(optionalValueFlag(flags, "--nats-dir") ?? DEFAULT_NATS_DIR),
     launchAgentsDir: expandTildePath(
       optionalValueFlag(flags, "--launch-agents-dir") ?? DEFAULT_LAUNCH_AGENTS_DIR,
@@ -730,7 +736,7 @@ function runList(
   flags: FlagMap,
   json: boolean,
 ): ExitResult {
-  const configDir = expandTildePath(optionalValueFlag(flags, "--config-dir") ?? DEFAULT_CONFIG_DIR);
+  const configDir = expandTildePath(optionalValueFlag(flags, "--config-dir") ?? defaultConfigDir());
   const stacks = discoverStacks(configDir);
 
   if (json) {

--- a/src/cli/cortex/commands/stepup.ts
+++ b/src/cli/cortex/commands/stepup.ts
@@ -26,6 +26,7 @@ import { homedir } from "os";
 import { join } from "path";
 import {
   DEFAULT_STEP_UP_SECRET_PATH,
+  defaultStepUpSecretPath,
   createEnrollment,
   loadEnrollment,
   writeEnrollment,
@@ -83,7 +84,7 @@ function optionalValueFlag(flags: FlagMap, name: string): string | undefined {
 
 function resolveSecretPath(flags: FlagMap): string {
   return expandTildePath(
-    optionalValueFlag(flags, "--secret-path") ?? DEFAULT_STEP_UP_SECRET_PATH,
+    optionalValueFlag(flags, "--secret-path") ?? defaultStepUpSecretPath(),
   );
 }
 

--- a/src/common/config/__tests__/config-path.test.ts
+++ b/src/common/config/__tests__/config-path.test.ts
@@ -19,6 +19,7 @@ import {
   cortexConfigDirOverride,
   cortexConfigPath,
   groveConfigPath,
+  legacyCortexConfigPath,
   migrateGroveConfigFile,
   resolveConfigFile,
 } from "../config-path";
@@ -27,11 +28,22 @@ let home: string;
 let savedConfigDirEnv: string | undefined;
 const FILE = "cli.yaml";
 
+// Canonical (XDG wave-4): ~/.config/metafactory/cortex/<file>.
 function cortexFile() {
+  return join(home, ".config", "metafactory", "cortex", FILE);
+}
+// Legacy flat cortex tree (read-fallback).
+function legacyCortexFile() {
   return join(home, ".config", "cortex", FILE);
 }
 function groveFile() {
   return join(home, ".config", "grove", FILE);
+}
+function mkLegacyCortex() {
+  mkdirSync(join(home, ".config", "cortex"), { recursive: true });
+}
+function mkGrove() {
+  mkdirSync(join(home, ".config", "grove"), { recursive: true });
 }
 
 beforeEach(() => {
@@ -51,42 +63,65 @@ afterEach(() => {
 });
 
 describe("path builders", () => {
-  test("cortexConfigPath builds ~/.config/cortex/<file>", () => {
+  test("cortexConfigPath builds the canonical ~/.config/metafactory/cortex/<file>", () => {
     expect(cortexConfigPath(FILE, home)).toBe(cortexFile());
+  });
+  test("legacyCortexConfigPath builds ~/.config/cortex/<file>", () => {
+    expect(legacyCortexConfigPath(FILE, home)).toBe(legacyCortexFile());
   });
   test("groveConfigPath builds ~/.config/grove/<file>", () => {
     expect(groveConfigPath(FILE, home)).toBe(groveFile());
   });
 });
 
-describe("resolveConfigFile — cortex-first, grove-fallback", () => {
-  test("returns cortex path + source=cortex when cortex file exists", () => {
-    mkdirSync(join(home, ".config", "cortex"), { recursive: true });
-    writeFileSync(cortexFile(), "from-cortex");
+describe("resolveConfigFile — canonical-first, layered legacy fallback", () => {
+  test("returns canonical path + source=cortex when the canonical file exists", () => {
+    mkdirSync(join(home, ".config", "metafactory", "cortex"), { recursive: true });
+    writeFileSync(cortexFile(), "from-canonical");
     const r = resolveConfigFile(FILE, home);
     expect(r.path).toBe(cortexFile());
     expect(r.source).toBe("cortex");
   });
 
-  test("falls back to grove path + source=grove when only grove exists", () => {
-    mkdirSync(join(home, ".config", "grove"), { recursive: true });
+  test("falls back to legacy flat ~/.config/cortex when only it exists", () => {
+    mkLegacyCortex();
+    writeFileSync(legacyCortexFile(), "from-legacy-cortex");
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(legacyCortexFile());
+    expect(r.source).toBe("legacy-cortex");
+  });
+
+  test("falls back to grove when only grove exists (oldest tree)", () => {
+    mkGrove();
     writeFileSync(groveFile(), "from-grove");
     const r = resolveConfigFile(FILE, home);
     expect(r.path).toBe(groveFile());
     expect(r.source).toBe("grove");
   });
 
-  test("cortex wins when BOTH exist (cortex-first precedence)", () => {
-    mkdirSync(join(home, ".config", "cortex"), { recursive: true });
-    mkdirSync(join(home, ".config", "grove"), { recursive: true });
-    writeFileSync(cortexFile(), "from-cortex");
+  test("canonical wins over BOTH legacy trees (canonical-first precedence)", () => {
+    mkdirSync(join(home, ".config", "metafactory", "cortex"), { recursive: true });
+    mkLegacyCortex();
+    mkGrove();
+    writeFileSync(cortexFile(), "from-canonical");
+    writeFileSync(legacyCortexFile(), "from-legacy-cortex");
     writeFileSync(groveFile(), "from-grove");
     const r = resolveConfigFile(FILE, home);
     expect(r.path).toBe(cortexFile());
     expect(r.source).toBe("cortex");
   });
 
-  test("targets cortex path + source=default when neither exists (write target)", () => {
+  test("legacy flat cortex wins over grove (cortex-wins-on-dup fallback order)", () => {
+    mkLegacyCortex();
+    mkGrove();
+    writeFileSync(legacyCortexFile(), "from-legacy-cortex");
+    writeFileSync(groveFile(), "from-grove");
+    const r = resolveConfigFile(FILE, home);
+    expect(r.path).toBe(legacyCortexFile());
+    expect(r.source).toBe("legacy-cortex");
+  });
+
+  test("targets the canonical path + source=default when none exist (write target)", () => {
     const r = resolveConfigFile(FILE, home);
     expect(r.path).toBe(cortexFile());
     expect(r.source).toBe("default");
@@ -125,7 +160,7 @@ describe("migrateGroveConfigFile — auto-migrate preserving mode", () => {
   test("cloud-credentials.txt (a secret) stays 0o600 across the grove→cortex migrate", () => {
     const SECRET = "cloud-credentials.txt";
     const groveSecret = join(home, ".config", "grove", SECRET);
-    const cortexSecret = join(home, ".config", "cortex", SECRET);
+    const cortexSecret = join(home, ".config", "metafactory", "cortex", SECRET);
     mkdirSync(join(home, ".config", "grove"), { recursive: true });
     writeFileSync(groveSecret, "TOKEN=redacted", { mode: 0o600 });
     chmodSync(groveSecret, 0o600); // umask-proof the fixture
@@ -136,16 +171,28 @@ describe("migrateGroveConfigFile — auto-migrate preserving mode", () => {
     expect(statSync(cortexSecret).mode & 0o777).toBe(0o600);
   });
 
-  test("no-op (returns false) when cortex already exists — never clobbers", () => {
-    mkdirSync(join(home, ".config", "cortex"), { recursive: true });
-    mkdirSync(join(home, ".config", "grove"), { recursive: true });
-    writeFileSync(cortexFile(), "cortex-canonical");
+  test("no-op (returns false) when the canonical copy already exists — never clobbers", () => {
+    mkdirSync(join(home, ".config", "metafactory", "cortex"), { recursive: true });
+    mkGrove();
+    writeFileSync(cortexFile(), "canonical");
     writeFileSync(groveFile(), "grove-stale");
 
     const migrated = migrateGroveConfigFile(FILE, home);
 
     expect(migrated).toBe(false);
-    expect(readFileSync(cortexFile(), "utf-8")).toBe("cortex-canonical");
+    expect(readFileSync(cortexFile(), "utf-8")).toBe("canonical");
+  });
+
+  test("legacy flat ~/.config/cortex wins over grove on migrate (cortex-wins-on-dup)", () => {
+    mkLegacyCortex();
+    mkGrove();
+    writeFileSync(legacyCortexFile(), "from-legacy-cortex");
+    writeFileSync(groveFile(), "from-grove");
+
+    const migrated = migrateGroveConfigFile(FILE, home);
+
+    expect(migrated).toBe(true);
+    expect(readFileSync(cortexFile(), "utf-8")).toBe("from-legacy-cortex");
   });
 
   test("no-op (returns false) when neither exists", () => {
@@ -172,9 +219,9 @@ describe("CORTEX_CONFIG_DIR override (XDG wave-1 cortex#1908)", () => {
     rmSync(scratch, { recursive: true, force: true });
   });
 
-  test("unset ⇒ default dir is ~/.config/cortex (byte-identical) and override is undefined", () => {
+  test("unset ⇒ default dir is the canonical ~/.config/metafactory/cortex and override is undefined", () => {
     expect(cortexConfigDirOverride()).toBeUndefined();
-    expect(cortexConfigDir(home)).toBe(join(home, ".config", "cortex"));
+    expect(cortexConfigDir(home)).toBe(join(home, ".config", "metafactory", "cortex"));
     expect(cortexConfigPath(FILE, home)).toBe(cortexFile());
   });
 
@@ -188,7 +235,7 @@ describe("CORTEX_CONFIG_DIR override (XDG wave-1 cortex#1908)", () => {
   test("empty CORTEX_CONFIG_DIR is treated as unset (not '/')", () => {
     process.env.CORTEX_CONFIG_DIR = "";
     expect(cortexConfigDirOverride()).toBeUndefined();
-    expect(cortexConfigDir(home)).toBe(join(home, ".config", "cortex"));
+    expect(cortexConfigDir(home)).toBe(join(home, ".config", "metafactory", "cortex"));
   });
 
   test("resolveConfigFile returns the in-override file when it exists", () => {

--- a/src/common/config/__tests__/config-path.test.ts
+++ b/src/common/config/__tests__/config-path.test.ts
@@ -21,6 +21,7 @@ import {
   groveConfigPath,
   legacyCortexConfigPath,
   migrateGroveConfigFile,
+  resolveConfigDir,
   resolveConfigFile,
 } from "../config-path";
 
@@ -125,6 +126,38 @@ describe("resolveConfigFile — canonical-first, layered legacy fallback", () =>
     const r = resolveConfigFile(FILE, home);
     expect(r.path).toBe(cortexFile());
     expect(r.source).toBe("default");
+  });
+});
+
+describe("resolveConfigDir — dir-level fallback for swept DEFAULT_CONFIG_DIR", () => {
+  const canonicalDir = () => join(home, ".config", "metafactory", "cortex");
+  const legacyCortexDir = () => join(home, ".config", "cortex");
+  const groveRoot = () => join(home, ".config", "grove");
+
+  test("canonical dir when it exists", () => {
+    mkdirSync(canonicalDir(), { recursive: true });
+    mkLegacyCortex(); // legacy also present (post-move copy-keep) — canonical still wins
+    expect(resolveConfigDir(home)).toBe(canonicalDir());
+  });
+
+  test("legacy flat ~/.config/cortex when canonical is absent (un-migrated host)", () => {
+    mkLegacyCortex();
+    expect(resolveConfigDir(home)).toBe(legacyCortexDir());
+  });
+
+  test("grove when only grove exists", () => {
+    mkGrove();
+    expect(resolveConfigDir(home)).toBe(groveRoot());
+  });
+
+  test("canonical (write target) on a fresh host with no config tree", () => {
+    expect(resolveConfigDir(home)).toBe(canonicalDir());
+  });
+
+  test("legacy flat cortex wins over grove (fallback order)", () => {
+    mkLegacyCortex();
+    mkGrove();
+    expect(resolveConfigDir(home)).toBe(legacyCortexDir());
   });
 });
 

--- a/src/common/config/__tests__/migrate-config-dir.test.ts
+++ b/src/common/config/__tests__/migrate-config-dir.test.ts
@@ -15,17 +15,21 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  readlinkSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
+import { resolveConfigDir } from "../config-path";
 import {
   EXCLUDED_TOP_DIRS,
   MIGRATION_JOURNAL_NAME,
@@ -212,6 +216,119 @@ describe("atomicWriteFile — temp/fsync/rename primitive", () => {
     atomicWriteFile(dest, Buffer.from("v1"), 0o644);
     atomicWriteFile(dest, Buffer.from("v2"), 0o644);
     expect(readFileSync(dest, "utf-8")).toBe("v2");
+  });
+});
+
+describe("executeConfigDirMigration — transactional rollback-on-throw (finding #1)", () => {
+  test("a throw mid-copy leaves canonical fully ABSENT (never partial), legacy intact, resolver on legacy", () => {
+    // `good.yaml` is a cortex file (recorded FIRST → applied), `bad.yaml` is a
+    // grove-only file made unreadable (recorded SECOND → readFileSync throws
+    // EACCES). This deterministically exercises rollback of an ALREADY-applied
+    // copy plus removal of the canonical dir this run created.
+    write(legacyCortexDir(), "good.yaml", "good-bytes");
+    write(groveDir(), "bad.yaml", "bad-bytes", 0o000); // unreadable → forces a mid-loop throw
+
+    const plan = planConfigDirMigration({ home });
+    expect(() => executeConfigDirMigration(plan)).toThrow();
+
+    // INVARIANT: canonical is entirely gone — not a partial tree the resolver
+    // would prefer over legacy.
+    expect(existsSync(canonicalDir())).toBe(false);
+    expect(existsSync(join(canonicalDir(), "good.yaml"))).toBe(false);
+    expect(existsSync(join(canonicalDir(), MIGRATION_JOURNAL_NAME))).toBe(false);
+
+    // Every legacy source is still present (copy-keep-original; nothing renamed).
+    expect(existsSync(join(legacyCortexDir(), "good.yaml"))).toBe(true);
+    expect(existsSync(join(groveDir(), "bad.yaml"))).toBe(true);
+    expect(readFileSync(join(legacyCortexDir(), "good.yaml"), "utf-8")).toBe("good-bytes");
+
+    // With canonical absent, the dir resolver still lands on the legacy tree —
+    // no files silently shadowed into an incomplete canonical.
+    expect(resolveConfigDir(home)).toBe(legacyCortexDir());
+
+    chmodSync(join(groveDir(), "bad.yaml"), 0o644); // restore so afterEach cleanup is unhindered
+  });
+
+  test("a throw does NOT remove a canonical dir that pre-existed (only undoes applied copies)", () => {
+    write(canonicalDir(), "keep.yaml", "pre-existing-canonical"); // canonical pre-exists
+    write(legacyCortexDir(), "good.yaml", "good-bytes"); // will be applied then rolled back
+    write(groveDir(), "bad.yaml", "bad-bytes", 0o000); // forces the throw
+
+    const plan = planConfigDirMigration({ home });
+    expect(() => executeConfigDirMigration(plan)).toThrow();
+
+    // Canonical dir survives (we did not create it) and its pre-existing file is intact…
+    expect(existsSync(canonicalDir())).toBe(true);
+    expect(readFileSync(join(canonicalDir(), "keep.yaml"), "utf-8")).toBe("pre-existing-canonical");
+    // …but the copy THIS run applied was rolled back.
+    expect(existsSync(join(canonicalDir(), "good.yaml"))).toBe(false);
+
+    chmodSync(join(groveDir(), "bad.yaml"), 0o644);
+  });
+});
+
+describe("symlink carry — lstat-enumerated, symlink-carried, never dereferenced (finding #2)", () => {
+  test("a symlinked config FILE is carried AS a symlink (not flattened to a static copy)", () => {
+    write(legacyCortexDir(), "real.yaml", "real-payload");
+    const target = join(legacyCortexDir(), "real.yaml");
+    symlinkSync(target, join(legacyCortexDir(), "link.yaml"));
+
+    executeConfigDirMigration(planConfigDirMigration({ home }));
+
+    const dest = join(canonicalDir(), "link.yaml");
+    expect(lstatSync(dest).isSymbolicLink()).toBe(true); // a dereferenced copy would be a regular file
+    expect(readlinkSync(dest)).toBe(target);
+    // Source link is untouched (never renamed/removed).
+    expect(lstatSync(join(legacyCortexDir(), "link.yaml")).isSymbolicLink()).toBe(true);
+    // The real file is carried too, as an ordinary file.
+    expect(readFileSync(join(canonicalDir(), "real.yaml"), "utf-8")).toBe("real-payload");
+  });
+
+  test("a symlinked DIRECTORY is carried as a link and does NOT EISDIR-abort the migration", () => {
+    const realDir = join(home, "external-target-dir"); // outside the scanned trees
+    mkdirSync(realDir, { recursive: true });
+    writeFileSync(join(realDir, "inside.yaml"), "inside");
+    write(legacyCortexDir(), "cfg.yaml", "cfg"); // an ordinary file that must still carry
+    symlinkSync(realDir, join(legacyCortexDir(), "linkdir"));
+
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home })); // must not throw
+
+    const dest = join(canonicalDir(), "linkdir");
+    expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(dest)).toBe(realDir);
+    // The ordinary sibling still migrated (proves the run completed, not aborted).
+    expect(readFileSync(join(canonicalDir(), "cfg.yaml"), "utf-8")).toBe("cfg");
+    expect(journal.moves.some((m) => m.relPath === "linkdir" && m.symlink === true)).toBe(true);
+  });
+
+  test("a DANGLING symlink is carried (not dropped, not crashed on)", () => {
+    const missing = join(home, "does", "not", "exist.yaml");
+    mkdirSync(legacyCortexDir(), { recursive: true });
+    symlinkSync(missing, join(legacyCortexDir(), "dangle.yaml"));
+
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home })); // must not throw
+
+    const dest = join(canonicalDir(), "dangle.yaml");
+    expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(dest)).toBe(missing);
+    expect(existsSync(dest)).toBe(false); // still dangling (existsSync follows) — carried faithfully
+    expect(journal.moves.some((m) => m.relPath === "dangle.yaml" && m.symlink === true)).toBe(true);
+  });
+
+  test("rollback removes a carried (even dangling) symlink", () => {
+    const missing = join(home, "nowhere.yaml");
+    mkdirSync(legacyCortexDir(), { recursive: true });
+    symlinkSync(missing, join(legacyCortexDir(), "dangle.yaml"));
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home }));
+    const dest = join(canonicalDir(), "dangle.yaml");
+    expect(lstatSync(dest).isSymbolicLink()).toBe(true);
+
+    const removed = rollbackConfigDirMigration(journal);
+
+    expect(removed).toBe(1);
+    expect(existsSync(join(canonicalDir(), "dangle.yaml"))).toBe(false);
+    // lstat confirms the link itself is gone (existsSync alone would be ambiguous for a dangling link).
+    expect(() => lstatSync(dest)).toThrow();
   });
 });
 

--- a/src/common/config/__tests__/migrate-config-dir.test.ts
+++ b/src/common/config/__tests__/migrate-config-dir.test.ts
@@ -1,0 +1,238 @@
+/**
+ * XDG wave-4 (cortex#1869) — config DIRECTORY migrator tests.
+ *
+ * EVERY test runs against a scratch `$HOME` created under `os.tmpdir()`. The
+ * migrator is only ever handed that scratch home; a leak-guard test asserts NO
+ * path in a plan/journal escapes it, so the suite can never touch the real
+ * `~/.config/{cortex,grove}` or the live daemon.
+ *
+ * Proves: grove-only carried · cortex-wins-on-dup · .bak + personas carried ·
+ * state/data subtrees excluded · atomic-write + journal · rollback restores ·
+ * source kept (never renamed) · secret mode preserved · zero real-home touch.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  EXCLUDED_TOP_DIRS,
+  MIGRATION_JOURNAL_NAME,
+  atomicWriteFile,
+  executeConfigDirMigration,
+  loadMigrationJournal,
+  planConfigDirMigration,
+  rollbackConfigDirMigration,
+} from "../migrate-config-dir";
+
+let home: string;
+let savedConfigDirEnv: string | undefined;
+
+const canonicalDir = () => join(home, ".config", "metafactory", "cortex");
+const legacyCortexDir = () => join(home, ".config", "cortex");
+const groveDir = () => join(home, ".config", "grove");
+
+function write(root: string, rel: string, data: string, mode = 0o644) {
+  const p = join(root, rel);
+  mkdirSync(join(p, ".."), { recursive: true });
+  writeFileSync(p, data, { mode });
+  chmodSync(p, mode); // umask-proof the fixture
+}
+
+beforeEach(() => {
+  // A stray ambient CORTEX_CONFIG_DIR would redirect cortexConfigDir() off the
+  // scratch home — unset it so every path derives from `home`.
+  savedConfigDirEnv = process.env.CORTEX_CONFIG_DIR;
+  delete process.env.CORTEX_CONFIG_DIR;
+  home = mkdtempSync(join(tmpdir(), "xdg1869-home-"));
+});
+afterEach(() => {
+  if (savedConfigDirEnv === undefined) delete process.env.CORTEX_CONFIG_DIR;
+  else process.env.CORTEX_CONFIG_DIR = savedConfigDirEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("planConfigDirMigration — merge policy (G-42)", () => {
+  test("carries grove-ONLY files (never lost)", () => {
+    write(groveDir(), "bot.yaml", "grove-bot");
+    write(groveDir(), "secret.token", "SEKRIT", 0o600); // grove-only secret
+
+    const plan = planConfigDirMigration({ home });
+    const rels = plan.moves.map((m) => m.relPath).sort();
+    expect(rels).toContain("bot.yaml");
+    expect(rels).toContain("secret.token");
+    expect(plan.moves.every((m) => m.fromTree === "grove")).toBe(true);
+  });
+
+  test("cortex-wins-on-dup: same relpath carries the cortex copy, records the shadowed grove copy", () => {
+    write(legacyCortexDir(), "cli.yaml", "cortex-cli");
+    write(groveDir(), "cli.yaml", "grove-cli");
+
+    const plan = planConfigDirMigration({ home });
+    const cli = plan.moves.find((m) => m.relPath === "cli.yaml");
+    expect(cli).toBeDefined();
+    expect(cli!.fromTree).toBe("cortex");
+    expect(readFileSync(cli!.src, "utf-8")).toBe("cortex-cli");
+    expect(cli!.shadowedGrove).toBe(join(groveDir(), "cli.yaml"));
+    // Exactly ONE move for the duplicated path — no double-carry.
+    expect(plan.moves.filter((m) => m.relPath === "cli.yaml")).toHaveLength(1);
+  });
+
+  test("carries .bak sidecars and personas/ (called out by the spec)", () => {
+    write(legacyCortexDir(), "cortex.yaml", "cfg");
+    write(legacyCortexDir(), "cortex.yaml.bak", "cfg-prev");
+    write(legacyCortexDir(), "personas/echo.md", "you are echo");
+    write(groveDir(), "personas/sage.md", "you are sage"); // grove-only persona
+
+    const plan = planConfigDirMigration({ home });
+    const rels = plan.moves.map((m) => m.relPath);
+    expect(rels).toContain("cortex.yaml.bak");
+    expect(rels).toContain(join("personas", "echo.md"));
+    expect(rels).toContain(join("personas", "sage.md"));
+  });
+
+  test("EXCLUDES state/data-class subtrees (config-only scope; #1902/#1903)", () => {
+    write(legacyCortexDir(), "cortex.yaml", "cfg");
+    for (const top of EXCLUDED_TOP_DIRS) {
+      write(legacyCortexDir(), join(top, "keep-me"), "state-bytes");
+    }
+    const plan = planConfigDirMigration({ home });
+    const movedTops = new Set(plan.moves.map((m) => m.relPath.split("/")[0]));
+    for (const top of EXCLUDED_TOP_DIRS) expect(movedTops.has(top)).toBe(false);
+    // Config file still carried; every excluded top-dir recorded.
+    expect(plan.moves.some((m) => m.relPath === "cortex.yaml")).toBe(true);
+    const exclTops = new Set(plan.excluded.map((e) => e.relPath));
+    for (const top of EXCLUDED_TOP_DIRS) expect(exclTops.has(top)).toBe(true);
+  });
+});
+
+describe("executeConfigDirMigration — atomic copy + journal, source kept", () => {
+  test("carries content to the canonical tree AND keeps the source (never renamed)", () => {
+    write(groveDir(), "bot.yaml", "grove-bot");
+    write(legacyCortexDir(), "cli.yaml", "cortex-cli");
+
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home }), "2026-07-13T00:00:00Z");
+
+    // Destinations exist with the right bytes.
+    expect(readFileSync(join(canonicalDir(), "bot.yaml"), "utf-8")).toBe("grove-bot");
+    expect(readFileSync(join(canonicalDir(), "cli.yaml"), "utf-8")).toBe("cortex-cli");
+    // SOURCES are still present — copy-keep-original, never rename.
+    expect(existsSync(join(groveDir(), "bot.yaml"))).toBe(true);
+    expect(existsSync(join(legacyCortexDir(), "cli.yaml"))).toBe(true);
+    // Journal written at the canonical root, records both moves as applied.
+    expect(journal.moves.every((m) => m.applied)).toBe(true);
+    const onDisk = loadMigrationJournal({ home });
+    expect(onDisk?.stampedAt).toBe("2026-07-13T00:00:00Z");
+    expect(onDisk?.moves).toHaveLength(2);
+  });
+
+  test("preserves a 0600 secret mode across the carry (never widened)", () => {
+    write(groveDir(), "cloud-credentials.txt", "TOKEN=redacted", 0o600);
+    executeConfigDirMigration(planConfigDirMigration({ home }));
+    const dest = join(canonicalDir(), "cloud-credentials.txt");
+    expect(existsSync(dest)).toBe(true);
+    expect(statSync(dest).mode & 0o777).toBe(0o600);
+  });
+
+  test("canonical-wins: an existing canonical copy is NOT clobbered (idempotent skip)", () => {
+    write(legacyCortexDir(), "cli.yaml", "legacy");
+    write(canonicalDir(), "cli.yaml", "already-canonical");
+
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home }));
+
+    expect(readFileSync(join(canonicalDir(), "cli.yaml"), "utf-8")).toBe("already-canonical");
+    const mv = journal.moves.find((m) => m.relPath === "cli.yaml");
+    expect(mv?.skippedExisting).toBe(true);
+    expect(mv?.applied).toBeUndefined();
+  });
+
+  test("a second execute is idempotent (re-skips already-carried files)", () => {
+    write(groveDir(), "bot.yaml", "grove-bot");
+    executeConfigDirMigration(planConfigDirMigration({ home }));
+    const second = executeConfigDirMigration(planConfigDirMigration({ home }));
+    expect(second.moves.every((m) => m.skippedExisting)).toBe(true);
+  });
+});
+
+describe("rollbackConfigDirMigration — restores the pre-move state", () => {
+  test("removes the canonical copies it wrote; legacy sources remain authoritative", () => {
+    write(groveDir(), "bot.yaml", "grove-bot");
+    write(legacyCortexDir(), "cli.yaml", "cortex-cli");
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home }));
+    expect(existsSync(join(canonicalDir(), "bot.yaml"))).toBe(true);
+
+    const removed = rollbackConfigDirMigration(journal);
+
+    expect(removed).toBe(2);
+    expect(existsSync(join(canonicalDir(), "bot.yaml"))).toBe(false);
+    expect(existsSync(join(canonicalDir(), "cli.yaml"))).toBe(false);
+    // Legacy trees untouched — the data is fully recoverable.
+    expect(readFileSync(join(groveDir(), "bot.yaml"), "utf-8")).toBe("grove-bot");
+    expect(readFileSync(join(legacyCortexDir(), "cli.yaml"), "utf-8")).toBe("cortex-cli");
+    // Journal file removed.
+    expect(existsSync(join(canonicalDir(), MIGRATION_JOURNAL_NAME))).toBe(false);
+  });
+
+  test("rollback leaves a pre-existing canonical file (skippedExisting) alone", () => {
+    write(legacyCortexDir(), "cli.yaml", "legacy");
+    write(canonicalDir(), "cli.yaml", "pre-existing");
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home }));
+
+    rollbackConfigDirMigration(journal);
+
+    // The file we did NOT write must survive rollback.
+    expect(readFileSync(join(canonicalDir(), "cli.yaml"), "utf-8")).toBe("pre-existing");
+  });
+});
+
+describe("atomicWriteFile — temp/fsync/rename primitive", () => {
+  test("writes bytes + preserves mode, leaving no temp sidecar behind", () => {
+    const dest = join(canonicalDir(), "sub", "f.yaml");
+    atomicWriteFile(dest, Buffer.from("payload"), 0o600);
+    expect(readFileSync(dest, "utf-8")).toBe("payload");
+    expect(statSync(dest).mode & 0o777).toBe(0o600);
+    // No leftover *.xdgtmp.* sidecar in the destination dir.
+    const leftovers = readdirSync(join(canonicalDir(), "sub")).filter((n) => n.includes(".xdgtmp."));
+    expect(leftovers).toEqual([]);
+  });
+
+  test("overwrites an existing destination atomically (rename-over)", () => {
+    const dest = join(canonicalDir(), "f.yaml");
+    atomicWriteFile(dest, Buffer.from("v1"), 0o644);
+    atomicWriteFile(dest, Buffer.from("v2"), 0o644);
+    expect(readFileSync(dest, "utf-8")).toBe("v2");
+  });
+});
+
+describe("hermetic — zero real-home leakage", () => {
+  test("every path in a plan + journal is contained within the scratch home", () => {
+    write(groveDir(), "bot.yaml", "g");
+    write(legacyCortexDir(), "state/live.pid", "123"); // excluded state file
+    write(legacyCortexDir(), "cli.yaml", "c");
+    const journal = executeConfigDirMigration(planConfigDirMigration({ home }));
+
+    const allPaths = [
+      journal.canonical,
+      journal.legacyCortex,
+      journal.grove,
+      ...journal.moves.flatMap((m) => [m.src, m.dest, m.shadowedGrove ?? m.dest]),
+    ];
+    for (const p of allPaths) {
+      expect(p.startsWith(home + "/") || p === home).toBe(true);
+    }
+    // The real home is NEVER a prefix of any planned path.
+    const realHome = process.env.HOME ?? "/nonexistent-real-home";
+    for (const p of allPaths) expect(p.startsWith(join(realHome, ".config"))).toBe(false);
+  });
+});

--- a/src/common/config/config-path.ts
+++ b/src/common/config/config-path.ts
@@ -27,12 +27,29 @@
  * XDG wave-1 (cortex#1908, EPIC cortex#1867 X-03) — CONFIG_DIR env seam.
  *
  * `CORTEX_CONFIG_DIR`, when set, is the cortex config directory VERBATIM (the
- * `~/.config/cortex` default is bypassed), so a hermetic guard (#1870) can
- * point config resolution at a scratch dir with ZERO real-home access. When
- * UNSET, every path here is byte-identical to before. This is JUST the env
- * read; honoring `$XDG_CONFIG_HOME` and moving files is #1869/#1903 — out of
- * scope. `CORTEX_STATE_DIR` (the `pidfile.ts` state dir) is owned by #1900
- * this wave (G-21 serialization); `CORTEX_EVENTS_DIR` lives in `events-path.ts`.
+ * default is bypassed), so a hermetic guard (#1870) can point config resolution
+ * at a scratch dir with ZERO real-home access. `CORTEX_STATE_DIR` is owned by
+ * #1900; `CORTEX_EVENTS_DIR` lives in `events-path.ts`.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * XDG wave-4 (cortex#1869, EPIC cortex#1867 §P3a) — CONFIG DIRECTORY MOVE.
+ *
+ * The canonical config directory is now `~/.config/metafactory/cortex`, folded
+ * under the shared `metafactory` XDG root (matching the wave-3 `~/.local/bin`
+ * cutover). The two pre-move trees are READ-FALLBACKS during the transition,
+ * in precedence order:
+ *
+ *   1. `~/.config/metafactory/cortex/<file>` — canonical (or `$CORTEX_CONFIG_DIR`).
+ *   2. `~/.config/cortex/<file>`             — legacy flat cortex tree.
+ *   3. `~/.config/grove/<file>`              — legacy grove tree (oldest).
+ *   4. canonical path                        — write/default target when none exist.
+ *
+ * The physical move (merge-policy union of the two legacy trees, atomic-write +
+ * journal + rollback, plist re-render + `launchctl bootout/bootstrap`) lives in
+ * `migrate-config-dir.ts`; this module is only the RESOLVER (which tree a path
+ * reads from) plus the per-file auto-migrate helper. Every legacy-tree hit is
+ * surfaced via {@link noteXdgFallback} so a `CORTEX_XDG_STRICT=1` fresh-install
+ * run stays silent (Fallback Contract, cortex#1867 / removal owned by #1904).
  */
 
 import { copyFileSync, existsSync, mkdirSync, statSync, chmodSync } from "fs";
@@ -40,28 +57,41 @@ import { dirname, join } from "path";
 
 import { noteXdgFallback, readDirEnv } from "../xdg";
 
-/** The canonical config directory name. */
+/** The shared metafactory XDG root under `~/.config` (wave-3/wave-4 cutover). */
+export const METAFACTORY_DIRNAME = "metafactory";
+/** The canonical config directory name (now nested under `metafactory/`). */
 export const CORTEX_CONFIG_DIRNAME = "cortex";
-/** The legacy config directory name (read-fallback only during transition). */
+/** The legacy grove config directory name (read-fallback only during transition). */
 export const GROVE_CONFIG_DIRNAME = "grove";
 
 /** Which directory a resolved path came from. */
-export type ConfigSource = "cortex" | "grove" | "default";
+export type ConfigSource = "cortex" | "legacy-cortex" | "grove" | "default";
 
 export interface ResolvedConfigFile {
   /** Absolute path to use. */
   path: string;
   /**
    * Where it resolved:
-   *  - `cortex`  — the canonical file exists.
-   *  - `grove`   — only the legacy file exists (fallback in effect).
-   *  - `default` — neither exists; `path` is the cortex write target.
+   *  - `cortex`        — the canonical `metafactory/cortex` file exists.
+   *  - `legacy-cortex` — only the legacy flat `~/.config/cortex` file exists.
+   *  - `grove`         — only the legacy `~/.config/grove` file exists.
+   *  - `default`       — none exist; `path` is the canonical write target.
    */
   source: ConfigSource;
 }
 
 function homeDir(home?: string): string {
   return home ?? process.env.HOME ?? "~";
+}
+
+/** Legacy flat cortex config dir `~/.config/cortex` (read-fallback only). */
+export function legacyCortexConfigDir(home?: string): string {
+  return join(homeDir(home), ".config", CORTEX_CONFIG_DIRNAME);
+}
+
+/** Build `~/.config/cortex/<filename>` (legacy flat cortex tree / fallback). */
+export function legacyCortexConfigPath(filename: string, home?: string): string {
+  return join(legacyCortexConfigDir(home), filename);
 }
 
 /**
@@ -82,11 +112,16 @@ export function cortexConfigDirOverride(): string | undefined {
 
 /**
  * The cortex config DIRECTORY: `$CORTEX_CONFIG_DIR` if set, else the canonical
- * `~/.config/cortex`. This is the single seam every config-file path is built
- * on, so overriding the env var relocates the whole config tree at once.
+ * `~/.config/metafactory/cortex` (XDG wave-4, cortex#1869). This is the single
+ * seam every config-file path is built on, so overriding the env var relocates
+ * the whole config tree at once. The two pre-move trees (`~/.config/cortex`,
+ * `~/.config/grove`) are read-fallbacks only — see {@link resolveConfigFile}.
  */
 export function cortexConfigDir(home?: string): string {
-  return cortexConfigDirOverride() ?? join(homeDir(home), ".config", CORTEX_CONFIG_DIRNAME);
+  return (
+    cortexConfigDirOverride() ??
+    join(homeDir(home), ".config", METAFACTORY_DIRNAME, CORTEX_CONFIG_DIRNAME)
+  );
 }
 
 /** Build `~/.config/cortex/<filename>` (canonical, or under `$CORTEX_CONFIG_DIR`). */
@@ -113,14 +148,20 @@ export function resolveConfigFile(filename: string, home?: string): ResolvedConf
   const cortex = cortexConfigPath(filename, home);
   if (existsSync(cortex)) return { path: cortex, source: "cortex" };
 
-  // With an explicit `CORTEX_CONFIG_DIR` the legacy grove read-fallback is
-  // SKIPPED: the override is a self-contained config root, and probing the
-  // real `~/.config/grove` would both break hermeticity (a real-home stat)
-  // and be meaningless (grove has no counterpart under an explicit root).
+  // With an explicit `CORTEX_CONFIG_DIR` BOTH legacy read-fallbacks are SKIPPED:
+  // the override is a self-contained config root, and probing the real
+  // `~/.config/{cortex,grove}` would both break hermeticity (a real-home stat)
+  // and be meaningless (the legacy trees have no counterpart under the root).
   if (cortexConfigDirOverride() === undefined) {
+    // Fallback 1 — legacy flat `~/.config/cortex` (the pre-wave-4 canonical).
+    const legacyCortex = legacyCortexConfigPath(filename, home);
+    if (existsSync(legacyCortex)) {
+      noteXdgFallback("config", `${filename} resolved from legacy ~/.config/cortex`);
+      return { path: legacyCortex, source: "legacy-cortex" };
+    }
+    // Fallback 2 — legacy `~/.config/grove` (oldest tree; #1908 kept this).
     const grove = groveConfigPath(filename, home);
     if (existsSync(grove)) {
-      // Legacy-fallback site (#1908 kept this ~/.config/grove read-fallback).
       // Under CORTEX_XDG_STRICT this emits the one grep-able `xdg-fallback:`
       // line the #1870 guard asserts ZERO of on a fresh install; non-strict
       // stays silent/byte-identical.
@@ -141,16 +182,21 @@ export function resolveConfigFilePath(filename: string, home?: string): string {
 }
 
 /**
- * Auto-migrate a legacy grove-side config FILE to its cortex location,
- * **preserving the file mode**.
+ * Auto-migrate a legacy-tree config FILE to its canonical location,
+ * **preserving the file mode**. (Historically grove-only; XDG wave-4 widened
+ * it to also carry the legacy flat `~/.config/cortex` tree into the canonical
+ * `~/.config/metafactory/cortex`.)
+ *
+ * Precedence when both legacy copies exist: the flat `~/.config/cortex` copy is
+ * newer than grove, so it wins (cortex-wins-on-dup, matching the merge policy).
  *
  * Idempotent and non-destructive:
- *   - if the cortex copy already exists → no-op, returns `false` (the cortex
- *     copy is canonical; we never clobber it with a stale grove copy);
- *   - if only the grove copy exists → copies it to cortex with the SAME mode
+ *   - if the canonical copy already exists → no-op, returns `false` (canonical
+ *     is authoritative; we never clobber it with a stale legacy copy);
+ *   - if only a legacy copy exists → copies it to canonical with the SAME mode
  *     (so a `chmod 600` secret such as `cloud-credentials.txt` stays 600 and
  *     is never widened), returns `true`;
- *   - if neither exists → no-op, returns `false`.
+ *   - if none exist → no-op, returns `false`.
  *
  * Mode preservation is explicit: `copyFileSync` does NOT preserve mode (the
  * destination is created with the process umask), so we re-apply the source
@@ -159,23 +205,30 @@ export function resolveConfigFilePath(filename: string, home?: string): string {
  * @returns whether a migration copy was performed.
  */
 export function migrateGroveConfigFile(filename: string, home?: string): boolean {
-  const cortex = cortexConfigPath(filename, home);
-  if (existsSync(cortex)) return false; // cortex copy is canonical — never clobber
+  const canonical = cortexConfigPath(filename, home);
+  if (existsSync(canonical)) return false; // canonical copy is authoritative — never clobber
 
-  // An explicit `CORTEX_CONFIG_DIR` root has no grove side — never reach into
-  // the real `~/.config/grove` to migrate (would break the hermetic guard).
+  // An explicit `CORTEX_CONFIG_DIR` root has no legacy side — never reach into
+  // the real `~/.config/{cortex,grove}` to migrate (breaks the hermetic guard).
   if (cortexConfigDirOverride() !== undefined) return false;
 
+  // cortex-wins-on-dup: prefer the newer flat `~/.config/cortex` copy, else grove.
+  const legacyCortex = legacyCortexConfigPath(filename, home);
   const grove = groveConfigPath(filename, home);
-  if (!existsSync(grove)) return false; // nothing to migrate
+  const src = existsSync(legacyCortex)
+    ? { path: legacyCortex, tree: "~/.config/cortex" }
+    : existsSync(grove)
+      ? { path: grove, tree: "~/.config/grove" }
+      : undefined;
+  if (src === undefined) return false; // nothing to migrate
 
   // A migration copy IS a legacy-tree read — surface it under strict mode too.
-  noteXdgFallback("config", `${filename} migrated from legacy ~/.config/grove`);
-  const mode = statSync(grove).mode & 0o777;
-  mkdirSync(dirname(cortex), { recursive: true });
-  copyFileSync(grove, cortex);
+  noteXdgFallback("config", `${filename} migrated from legacy ${src.tree}`);
+  const mode = statSync(src.path).mode & 0o777;
+  mkdirSync(dirname(canonical), { recursive: true });
+  copyFileSync(src.path, canonical);
   // copyFileSync applies the umask, not the source mode — re-assert it so a
-  // 0o600 secret is preserved exactly (and never widened) on the cortex copy.
-  if (process.platform !== "win32") chmodSync(cortex, mode);
+  // 0o600 secret is preserved exactly (and never widened) on the canonical copy.
+  if (process.platform !== "win32") chmodSync(canonical, mode);
   return true;
 }

--- a/src/common/config/config-path.ts
+++ b/src/common/config/config-path.ts
@@ -182,6 +182,38 @@ export function resolveConfigFilePath(filename: string, home?: string): string {
 }
 
 /**
+ * Resolve the config DIRECTORY a CLI should read from during the transition:
+ * the canonical `~/.config/metafactory/cortex` if it exists, else the legacy
+ * flat `~/.config/cortex`, else `~/.config/grove`, else the canonical path (the
+ * write target on a fresh host). This is the DIR analogue of
+ * {@link resolveConfigFilePath} and is what the swept `DEFAULT_CONFIG_DIR`
+ * defaults route through, so a command run BEFORE the config move still reads
+ * the legacy tree (byte-identical to pre-wave-4) while a migrated host reads the
+ * canonical tree. An explicit `$CORTEX_CONFIG_DIR` short-circuits all fallback.
+ *
+ * @param home Override for `$HOME` (tests). Resolved at CALL time so a
+ *   command test that plants a fixture after import is honored.
+ */
+export function resolveConfigDir(home?: string): string {
+  const canonical = cortexConfigDir(home);
+  // An explicit override is a self-contained root — never probe legacy trees.
+  if (cortexConfigDirOverride() !== undefined) return canonical;
+  if (existsSync(canonical)) return canonical;
+
+  const legacyCortex = legacyCortexConfigDir(home);
+  if (existsSync(legacyCortex)) {
+    noteXdgFallback("config", "config dir resolved from legacy ~/.config/cortex");
+    return legacyCortex;
+  }
+  const grove = dirname(groveConfigPath("_", home));
+  if (existsSync(grove)) {
+    noteXdgFallback("config", "config dir resolved from legacy ~/.config/grove");
+    return grove;
+  }
+  return canonical;
+}
+
+/**
  * Auto-migrate a legacy-tree config FILE to its canonical location,
  * **preserving the file mode**. (Historically grove-only; XDG wave-4 widened
  * it to also carry the legacy flat `~/.config/cortex` tree into the canonical

--- a/src/common/config/migrate-config-dir.ts
+++ b/src/common/config/migrate-config-dir.ts
@@ -1,0 +1,340 @@
+/**
+ * XDG wave-4 (cortex#1869, EPIC cortex#1867 §P3a) — config DIRECTORY migrator.
+ *
+ * Moves the cortex config tree from the two pre-move locations
+ * (`~/.config/cortex`, `~/.config/grove`) into the canonical
+ * `~/.config/metafactory/cortex`. This is the DATA-SAFETY core of the wave; the
+ * resolver (`config-path.ts`) only decides which tree a read lands in.
+ *
+ * ── Merge policy (G-42) ──────────────────────────────────────────────────────
+ * BOTH legacy trees may be live with divergent content (grove-only: `bot.yaml`,
+ * `dashboard.db`; cortex-only: per-stack dirs, a different `personas/`). We
+ * therefore enumerate the UNION of both trees and apply per-path precedence:
+ *   - a path present in the flat cortex tree wins over the grove copy
+ *     (cortex-wins-on-dup); the shadowed grove copy is recorded, never deleted;
+ *   - a grove-ONLY path is CARRIED (never lost — a grove-only secret must
+ *     survive the move);
+ *   - `.bak` sidecars and `personas/` are ordinary files under the tree and are
+ *     carried like any other config file.
+ *
+ * ── Config-only scope ────────────────────────────────────────────────────────
+ * State/data-class subtrees are NOT moved here — they are owned by separate,
+ * differently-gated waves (#1902 data, #1903 state; G-15 classifies `agents/`
+ * as per-agent state). They are enumerated as EXCLUSIONS in the journal so the
+ * decision is auditable, and the resolver's legacy fallback keeps them readable
+ * from the legacy tree until their own wave moves them.
+ *
+ * ── Migration primitive ──────────────────────────────────────────────────────
+ * Every carry is a COPY that keeps the source for rollback and writes the
+ * destination atomically: a fresh temp file is created O_EXCL (`wx`), written,
+ * `fsync`'d, mode-preserved, then `rename`'d over the destination. The SOURCE is
+ * NEVER renamed or removed — a mid-flight crash leaves the legacy tree fully
+ * intact, and rollback simply deletes the canonical copies the journal records.
+ *
+ * ── Isolation ────────────────────────────────────────────────────────────────
+ * Every path is derived from an injectable `home`, so the whole migrator runs
+ * against a scratch `$HOME` with ZERO real-home access. Nothing here reads
+ * `process.env.HOME` except through the seam's default when `home` is omitted.
+ */
+
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  writeSync,
+} from "fs";
+import { dirname, join, relative, sep } from "path";
+
+import {
+  cortexConfigDir,
+  groveConfigPath,
+  legacyCortexConfigDir,
+} from "./config-path";
+
+/** Journal file dropped at the canonical root so a move is auditable + reversible. */
+export const MIGRATION_JOURNAL_NAME = ".xdg-config-migration.json";
+
+/**
+ * Top-level subtrees that are STATE/DATA-class and are OWNED by later, separately
+ * gated waves — excluded from the config-only move (G-15 / #1902 / #1903). Kept
+ * as a set so the exclusion decision is explicit + testable.
+ */
+export const EXCLUDED_TOP_DIRS: ReadonlySet<string> = new Set([
+  "state", // pidfiles / runtime state — cortex#1903
+  "agents", // per-agent state.sqlite — cortex#1903 (G-15)
+  "logs", // rotating logs — cortex#1903
+  "network-cache", // DD-10 registry cache — cortex#1902
+  "networks", // live network runtime — cortex#1903
+]);
+
+/** Which legacy tree a carried file came from. */
+export type LegacyTree = "cortex" | "grove";
+
+export interface MoveRecord {
+  /** Path relative to the config-dir root (POSIX-normalized with the tree's sep). */
+  relPath: string;
+  /** Which legacy tree the winning copy came from. */
+  fromTree: LegacyTree;
+  /** Absolute source path (kept; NEVER renamed or removed). */
+  src: string;
+  /** Absolute canonical destination path. */
+  dest: string;
+  /** File mode (low 12 bits) preserved onto the destination. */
+  mode: number;
+  /** Size in bytes of the carried file. */
+  bytes: number;
+  /**
+   * When a grove copy was shadowed by a cortex-wins duplicate, its absolute
+   * path (recorded for audit; the grove copy is left untouched, never deleted).
+   */
+  shadowedGrove?: string;
+  /** Set once {@link executeConfigDirMigration} has written the destination. */
+  applied?: boolean;
+  /** Set when the destination already existed (canonical-wins) and was skipped. */
+  skippedExisting?: boolean;
+}
+
+export interface ExclusionRecord {
+  relPath: string;
+  reason: string;
+}
+
+export interface MigrationJournal {
+  version: 1;
+  canonical: string;
+  legacyCortex: string;
+  grove: string;
+  /** Caller-stamped ISO timestamp (kept out of the planner for determinism). */
+  stampedAt?: string;
+  moves: MoveRecord[];
+  excluded: ExclusionRecord[];
+}
+
+export interface MigrateOptions {
+  /** Override for `$HOME`. Omit only in production; tests ALWAYS pass a scratch home. */
+  home?: string;
+}
+
+// ---------------------------------------------------------------- enumeration
+
+/**
+ * Recursively list files under `root`, returning paths RELATIVE to `root`.
+ * Symlinks are recorded as files (their link, not the target, is carried) and
+ * are never followed — a symlink out of the tree cannot smuggle a real-home
+ * read into the copy. Top-level entries in {@link EXCLUDED_TOP_DIRS} are
+ * skipped and reported separately by the planner.
+ */
+function walkFiles(root: string, excludeTop: ReadonlySet<string>): { files: string[]; excluded: string[] } {
+  const files: string[] = [];
+  const excluded: string[] = [];
+  if (!existsSync(root)) return { files, excluded };
+
+  const recurse = (absDir: string) => {
+    let entries;
+    try {
+      entries = readdirSync(absDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const abs = join(absDir, e.name);
+      const rel = relative(root, abs);
+      const top = rel.split(sep)[0] ?? rel;
+      if (absDir === root && excludeTop.has(e.name)) {
+        excluded.push(rel);
+        continue;
+      }
+      // Guard against an excluded dir reached via a deeper path too.
+      if (excludeTop.has(top) && rel !== top) {
+        continue; // already counted at the top level
+      }
+      let st;
+      try {
+        st = lstatSync(abs);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        recurse(abs);
+      } else {
+        files.push(rel);
+      }
+    }
+  };
+  recurse(root);
+  return { files, excluded };
+}
+
+/**
+ * Build the migration plan (a {@link MigrationJournal} with NO writes performed).
+ * Enumerates the union of both legacy trees, applies the merge policy, and lists
+ * excluded state/data subtrees. Deterministic — safe to run repeatedly.
+ */
+export function planConfigDirMigration(opts: MigrateOptions = {}): MigrationJournal {
+  const { home } = opts;
+  const canonical = cortexConfigDir(home);
+  const legacyCortex = legacyCortexConfigDir(home);
+  // groveConfigPath("") yields the grove root with a trailing sep — normalize.
+  const grove = dirname(groveConfigPath("x", home));
+
+  const cortexScan = walkFiles(legacyCortex, EXCLUDED_TOP_DIRS);
+  const groveScan = walkFiles(grove, EXCLUDED_TOP_DIRS);
+
+  const cortexFiles = new Set(cortexScan.files);
+  const moves: MoveRecord[] = [];
+  const excluded: ExclusionRecord[] = [];
+
+  const pushExcluded = (rel: string, tree: LegacyTree) =>
+    excluded.push({ relPath: rel, reason: `state/data-class subtree (${tree}) — owned by #1902/#1903` });
+  for (const rel of cortexScan.excluded) pushExcluded(rel, "cortex");
+  for (const rel of groveScan.excluded) pushExcluded(rel, "grove");
+
+  const record = (rel: string, tree: LegacyTree, srcRoot: string, shadowedGrove?: string) => {
+    const src = join(srcRoot, rel);
+    let st;
+    try {
+      st = statSync(src);
+    } catch {
+      return; // vanished between scan + stat — skip
+    }
+    const mode = st.mode & 0o777;
+    const bytes = st.size;
+    moves.push({ relPath: rel, fromTree: tree, src, dest: join(canonical, rel), mode, bytes, shadowedGrove });
+  };
+
+  // cortex-wins-on-dup: every flat-cortex file is carried; a same-rel grove copy
+  // is recorded as shadowed (kept, never deleted).
+  for (const rel of cortexScan.files) {
+    const shadowed = groveScan.files.includes(rel) ? join(grove, rel) : undefined;
+    record(rel, "cortex", legacyCortex, shadowed);
+  }
+  // grove-ONLY files are CARRIED (never lost).
+  for (const rel of groveScan.files) {
+    if (cortexFiles.has(rel)) continue; // already carried cortex-side
+    record(rel, "grove", grove);
+  }
+
+  return { version: 1, canonical, legacyCortex, grove, moves, excluded };
+}
+
+// ------------------------------------------------------------- atomic primitive
+
+/**
+ * Atomically write `data` to `dest`, preserving `mode`: create a fresh temp file
+ * O_EXCL (`wx`) in the destination directory, write + `fsync` it, `chmod` to
+ * `mode`, then `rename` it over `dest`. A crash at any point leaves `dest`
+ * either its old self or the new bytes — never a torn file. The temp name is
+ * pid+counter unique so concurrent migrators never collide on it.
+ */
+export function atomicWriteFile(dest: string, data: Buffer, mode: number): void {
+  mkdirSync(dirname(dest), { recursive: true });
+  let fd: number;
+  let tmp: string;
+  for (let i = 0; ; i++) {
+    const candidate = `${dest}.xdgtmp.${process.pid}.${i}`;
+    try {
+      fd = openSync(candidate, "wx", mode); // O_EXCL — never reuse a stale temp
+      tmp = candidate;
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST" && i < 10_000) continue;
+      throw err;
+    }
+  }
+  try {
+    writeSync(fd, data);
+    fsyncSync(fd); // durability: the bytes hit disk before the rename publishes them
+  } finally {
+    closeSync(fd);
+  }
+  // `wx` honors the umask, so re-assert the source mode (a 0600 secret must not widen).
+  if (process.platform !== "win32") chmodSync(tmp, mode);
+  try {
+    // rename is atomic within a filesystem; if it throws, drop the temp so we
+    // never leak a half-written sidecar next to the destination.
+    renameSync(tmp, dest);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    throw err;
+  }
+}
+
+// --------------------------------------------------------------- execution
+
+/**
+ * Execute a plan: atomically COPY each carried file into the canonical tree
+ * (source kept), skipping any destination that already exists (canonical-wins),
+ * then write the journal to `<canonical>/${MIGRATION_JOURNAL_NAME}`. Idempotent:
+ * a second run re-skips already-carried files. Returns the journal with each
+ * move's `applied`/`skippedExisting` flag set.
+ *
+ * @param stampedAt Optional ISO timestamp to record (caller-supplied so the
+ *   library stays deterministic under test).
+ */
+export function executeConfigDirMigration(
+  plan: MigrationJournal,
+  stampedAt?: string,
+): MigrationJournal {
+  mkdirSync(plan.canonical, { recursive: true });
+  for (const mv of plan.moves) {
+    if (existsSync(mv.dest)) {
+      mv.skippedExisting = true; // canonical-wins — never clobber a fresh-install copy
+      continue;
+    }
+    const data = readFileSync(mv.src); // SOURCE is only ever READ, never renamed
+    atomicWriteFile(mv.dest, data, mv.mode);
+    mv.applied = true;
+  }
+  const journal: MigrationJournal = { ...plan, stampedAt };
+  writeFileSync(join(plan.canonical, MIGRATION_JOURNAL_NAME), JSON.stringify(journal, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  return journal;
+}
+
+/**
+ * Roll a migration back: delete ONLY the canonical copies this journal recorded
+ * as `applied` (the legacy trees, whose sources were kept, become authoritative
+ * again via the resolver's fallback). Files that were `skippedExisting` are left
+ * alone — they predate this migration and are not ours to remove. The journal
+ * file itself is removed last. NEVER touches either legacy tree.
+ *
+ * @returns the number of canonical copies removed.
+ */
+export function rollbackConfigDirMigration(journal: MigrationJournal): number {
+  let removed = 0;
+  for (const mv of journal.moves) {
+    if (!mv.applied) continue; // only undo what THIS migration wrote
+    if (existsSync(mv.dest)) {
+      rmSync(mv.dest, { force: true });
+      removed++;
+    }
+  }
+  rmSync(join(journal.canonical, MIGRATION_JOURNAL_NAME), { force: true });
+  return removed;
+}
+
+/**
+ * Load a previously-written journal from the canonical root, or `undefined` if
+ * none exists (nothing has been migrated yet).
+ */
+export function loadMigrationJournal(opts: MigrateOptions = {}): MigrationJournal | undefined {
+  const p = join(cortexConfigDir(opts.home), MIGRATION_JOURNAL_NAME);
+  if (!existsSync(p)) return undefined;
+  try {
+    return JSON.parse(readFileSync(p, "utf-8")) as MigrationJournal;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/common/config/migrate-config-dir.ts
+++ b/src/common/config/migrate-config-dir.ts
@@ -25,11 +25,22 @@
  * from the legacy tree until their own wave moves them.
  *
  * ── Migration primitive ──────────────────────────────────────────────────────
- * Every carry is a COPY that keeps the source for rollback and writes the
- * destination atomically: a fresh temp file is created O_EXCL (`wx`), written,
- * `fsync`'d, mode-preserved, then `rename`'d over the destination. The SOURCE is
- * NEVER renamed or removed — a mid-flight crash leaves the legacy tree fully
- * intact, and rollback simply deletes the canonical copies the journal records.
+ * Every regular-file carry is a COPY that keeps the source for rollback and
+ * writes the destination atomically: a fresh temp file is created O_EXCL (`wx`),
+ * written, `fsync`'d, mode-preserved, then `rename`'d over the destination. A
+ * SYMLINK is instead carried AS a symlink — its link text (`readlinkSync`) is
+ * re-created via `symlinkSync` under a temp name and `rename`'d into place, so it
+ * is never dereferenced (a symlinked file stays a link, a symlinked directory
+ * cannot EISDIR-abort the run, a dangling link survives). The SOURCE is NEVER
+ * renamed or removed — a mid-flight crash leaves the legacy tree fully intact.
+ *
+ * ── Transactionality ─────────────────────────────────────────────────────────
+ * `executeConfigDirMigration` is all-or-nothing: on ANY throw mid-copy it rolls
+ * back every carry it applied and removes the canonical dir if it created it, so
+ * the resolver (which flips to canonical on mere directory existence) never sees
+ * a PARTIAL canonical that would shadow files still in a legacy tree. Rollback
+ * deletes the canonical copies the journal records; the legacy trees are never
+ * touched.
  *
  * ── Isolation ────────────────────────────────────────────────────────────────
  * Every path is derived from an injectable `home`, so the whole migrator runs
@@ -47,9 +58,10 @@ import {
   openSync,
   readFileSync,
   readdirSync,
+  readlinkSync,
   renameSync,
   rmSync,
-  statSync,
+  symlinkSync,
   writeFileSync,
   writeSync,
 } from "fs";
@@ -102,6 +114,17 @@ export interface MoveRecord {
   applied?: boolean;
   /** Set when the destination already existed (canonical-wins) and was skipped. */
   skippedExisting?: boolean;
+  /**
+   * True when this entry is a SYMLINK carried AS a symlink (never dereferenced).
+   * The payload is {@link linkTarget}; execute re-creates it with `symlinkSync`
+   * so runtime reads still traverse the link exactly as they did pre-move.
+   */
+  symlink?: boolean;
+  /**
+   * For a symlink entry, the raw link text from `readlinkSync` (its target — may
+   * be relative and may legitimately dangle). Never stat'd during planning.
+   */
+  linkTarget?: string;
 }
 
 export interface ExclusionRecord {
@@ -129,10 +152,15 @@ export interface MigrateOptions {
 
 /**
  * Recursively list files under `root`, returning paths RELATIVE to `root`.
- * Symlinks are recorded as files (their link, not the target, is carried) and
- * are never followed — a symlink out of the tree cannot smuggle a real-home
- * read into the copy. Top-level entries in {@link EXCLUDED_TOP_DIRS} are
- * skipped and reported separately by the planner.
+ * Enumeration uses `lstatSync` and NEVER follows a symlink: a symlink (to a
+ * file OR a directory) is recorded as a single leaf entry — it is not recursed
+ * into and not dereferenced. `record()` then carries it AS a symlink (its link
+ * text, via `readlinkSync`), and `executeConfigDirMigration` re-creates it with
+ * `symlinkSync`. Because the target is never resolved here or downstream, a
+ * symlink out of the tree cannot smuggle a real-home read into the copy, a
+ * symlinked directory cannot EISDIR-abort the migration, and a dangling link is
+ * carried rather than dropped. Top-level entries in {@link EXCLUDED_TOP_DIRS}
+ * are skipped and reported separately by the planner.
  */
 function walkFiles(root: string, excludeTop: ReadonlySet<string>): { files: string[]; excluded: string[] } {
   const files: string[] = [];
@@ -203,12 +231,38 @@ export function planConfigDirMigration(opts: MigrateOptions = {}): MigrationJour
     const src = join(srcRoot, rel);
     let st;
     try {
-      st = statSync(src);
+      // lstat, NEVER stat: a symlink is carried AS a symlink (its own link text),
+      // never dereferenced. Following it would (a) silently flatten a symlinked
+      // FILE into a static copy, (b) EISDIR-abort on a symlinked DIRECTORY, and
+      // (c) throw+drop a DANGLING symlink. lstat succeeds for all three.
+      st = lstatSync(src);
     } catch {
       return; // vanished between scan + stat — skip
     }
     const mode = st.mode & 0o777;
     const bytes = st.size;
+    if (st.isSymbolicLink()) {
+      let linkTarget: string;
+      try {
+        // readlink reads the link TEXT only — it never resolves/stats the target,
+        // so a dangling link (legitimate) is carried, not dropped or crashed on.
+        linkTarget = readlinkSync(src);
+      } catch {
+        return; // unreadable link right after a successful lstat — skip defensively
+      }
+      moves.push({
+        relPath: rel,
+        fromTree: tree,
+        src,
+        dest: join(canonical, rel),
+        mode,
+        bytes,
+        shadowedGrove,
+        symlink: true,
+        linkTarget,
+      });
+      return;
+    }
     moves.push({ relPath: rel, fromTree: tree, src, dest: join(canonical, rel), mode, bytes, shadowedGrove });
   };
 
@@ -269,14 +323,53 @@ export function atomicWriteFile(dest: string, data: Buffer, mode: number): void 
   }
 }
 
+/**
+ * Atomically create a SYMLINK at `dest` pointing at `linkTarget`, mirroring
+ * {@link atomicWriteFile}: create the link under a pid+counter-unique temp name
+ * in the destination directory, then `rename` it over `dest`. The link TEXT is
+ * carried verbatim — the target is never resolved or stat'd, so a legitimately
+ * dangling link survives and a symlinked directory is carried as a link (not
+ * traversed). A crash leaves `dest` either its old self or the new link — never
+ * a torn state. `linkTarget` may be relative; it is stored exactly as read.
+ */
+export function atomicSymlink(dest: string, linkTarget: string): void {
+  mkdirSync(dirname(dest), { recursive: true });
+  let tmp: string;
+  for (let i = 0; ; i++) {
+    const candidate = `${dest}.xdgtmp.${process.pid}.${i}`;
+    try {
+      symlinkSync(linkTarget, candidate); // O_EXCL-like: symlink fails EEXIST on a stale temp
+      tmp = candidate;
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EEXIST" && i < 10_000) continue;
+      throw err;
+    }
+  }
+  try {
+    renameSync(tmp, dest);
+  } catch (err) {
+    rmSync(tmp, { force: true });
+    throw err;
+  }
+}
+
 // --------------------------------------------------------------- execution
 
 /**
- * Execute a plan: atomically COPY each carried file into the canonical tree
- * (source kept), skipping any destination that already exists (canonical-wins),
- * then write the journal to `<canonical>/${MIGRATION_JOURNAL_NAME}`. Idempotent:
- * a second run re-skips already-carried files. Returns the journal with each
- * move's `applied`/`skippedExisting` flag set.
+ * Execute a plan: atomically carry each entry into the canonical tree (source
+ * kept) — a regular file via {@link atomicWriteFile}, a symlink AS a symlink via
+ * {@link atomicSymlink} — skipping any destination that already exists
+ * (canonical-wins), then write the journal to
+ * `<canonical>/${MIGRATION_JOURNAL_NAME}`. Idempotent: a second run re-skips
+ * already-carried files. Returns the journal with each move's
+ * `applied`/`skippedExisting` flag set.
+ *
+ * TRANSACTIONAL: if any carry throws, every carry this invocation applied is
+ * rolled back (and the canonical dir removed if it did not pre-exist) before the
+ * original error is re-thrown — so the canonical tree is never left PARTIAL for
+ * the resolver to prefer. On success the canonical tree is complete and carries
+ * the journal.
  *
  * @param stampedAt Optional ISO timestamp to record (caller-supplied so the
  *   library stays deterministic under test).
@@ -285,15 +378,49 @@ export function executeConfigDirMigration(
   plan: MigrationJournal,
   stampedAt?: string,
 ): MigrationJournal {
+  // TRANSACTIONAL INVARIANT: after this returns OR throws, the canonical tree is
+  // EITHER complete-with-journal OR entirely absent — never partial. This matters
+  // because `resolveConfigDir()` flips reads to canonical on mere directory
+  // existence: a partial canonical with no journal would silently shadow files
+  // still living in a legacy tree (and deterministic copy failures would wedge it
+  // permanently). So we record whether WE created the canonical dir and, on any
+  // throw mid-copy, undo every applied carry — and remove the canonical dir if it
+  // did not pre-exist.
+  const canonicalPreexisted = existsSync(plan.canonical);
   mkdirSync(plan.canonical, { recursive: true });
-  for (const mv of plan.moves) {
-    if (existsSync(mv.dest)) {
-      mv.skippedExisting = true; // canonical-wins — never clobber a fresh-install copy
-      continue;
+  try {
+    for (const mv of plan.moves) {
+      if (existsSync(mv.dest)) {
+        mv.skippedExisting = true; // canonical-wins — never clobber a fresh-install copy
+        continue;
+      }
+      if (mv.symlink) {
+        // Carry the link AS a link — never readFileSync (which would follow it,
+        // flatten a symlinked file, or EISDIR-abort on a symlinked directory).
+        atomicSymlink(mv.dest, mv.linkTarget ?? "");
+      } else {
+        const data = readFileSync(mv.src); // SOURCE is only ever READ, never renamed
+        atomicWriteFile(mv.dest, data, mv.mode);
+      }
+      mv.applied = true;
     }
-    const data = readFileSync(mv.src); // SOURCE is only ever READ, never renamed
-    atomicWriteFile(mv.dest, data, mv.mode);
-    mv.applied = true;
+  } catch (err) {
+    // Roll back every copy/link THIS invocation applied (lstat, not existsSync,
+    // so a carried dangling symlink is still removed), then drop the canonical
+    // dir if we created it — leaving no partial canonical for the resolver.
+    for (const mv of plan.moves) {
+      if (!mv.applied) continue;
+      let present = true;
+      try {
+        lstatSync(mv.dest);
+      } catch {
+        present = false;
+      }
+      if (present) rmSync(mv.dest, { force: true });
+      mv.applied = false;
+    }
+    if (!canonicalPreexisted) rmSync(plan.canonical, { recursive: true, force: true });
+    throw err; // preserve the original error — never swallow it
   }
   const journal: MigrationJournal = { ...plan, stampedAt };
   writeFileSync(join(plan.canonical, MIGRATION_JOURNAL_NAME), JSON.stringify(journal, null, 2), {
@@ -316,7 +443,15 @@ export function rollbackConfigDirMigration(journal: MigrationJournal): number {
   let removed = 0;
   for (const mv of journal.moves) {
     if (!mv.applied) continue; // only undo what THIS migration wrote
-    if (existsSync(mv.dest)) {
+    // lstat (never follow) so a carried symlink — including a legitimately
+    // dangling one, which existsSync would report ABSENT — is still removed.
+    let present = true;
+    try {
+      lstatSync(mv.dest);
+    } catch {
+      present = false;
+    }
+    if (present) {
       rmSync(mv.dest, { force: true });
       removed++;
     }

--- a/src/common/step-up/enrollment.ts
+++ b/src/common/step-up/enrollment.ts
@@ -18,10 +18,26 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import { enforceChmod600 } from "../config/file-permissions";
+import { resolveConfigFilePath } from "../config/config-path";
 import { TOTP_DEFAULTS, generateTotpSecret } from "./totp";
 
-/** Default on-disk home for the enrolled secret (overridable via config). */
-export const DEFAULT_STEP_UP_SECRET_PATH = "~/.config/cortex/step-up-totp.json";
+/**
+ * Display default for the enrolled step-up secret, shown in help (canonical,
+ * XDG wave-4). Runtime read-sites resolve via {@link defaultStepUpSecretPath}
+ * so an un-migrated host still finds the secret in the legacy tree.
+ */
+export const DEFAULT_STEP_UP_SECRET_PATH = "~/.config/metafactory/cortex/step-up-totp.json";
+
+/**
+ * The default step-up secret path resolved at CALL time — fallback-aware
+ * (canonical `~/.config/metafactory/cortex` → legacy `~/.config/cortex` →
+ * `~/.config/grove`). This is a chmod-600 secret at rest, so a fresh install
+ * lands it canonical-side while a not-yet-migrated host keeps reading its legacy
+ * copy (cortex#1869, XDG wave-4).
+ */
+export function defaultStepUpSecretPath(home?: string): string {
+  return resolveConfigFilePath("step-up-totp.json", home);
+}
 
 /** The persisted enrollment record. Version-stamped for forward migration. */
 export interface StepUpEnrollment {

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -359,6 +359,7 @@ import {
 import { STATE_DIR, DEFAULT_CONFIG, pidFileFor, migrateLegacyPidFile } from "./common/pidfile";
 // FS-7 / D-3 (cortex#1839) — last-known-good boot fallback + degraded state.
 import { readLastGoodSnapshotPath, writeLastGoodSnapshot } from "./common/config/last-good";
+import { resolveConfigDir } from "./common/config/config-path";
 import {
   clearDegradedMarker,
   readDegradedMarker,
@@ -1237,7 +1238,13 @@ export async function startCortex(
   // experimental fragment is malformed. Once the cortex.yaml migration is
   // complete (MIG-7.2e), the rule flips to strict per spec §FR-4.
   const agentsDir = options.agentsDir
-    ?? (options.configPath ? join(dirname(expandedConfigPath), "agents.d") : expandTilde("~/.config/cortex/agents.d/"));
+    // XDG wave-4 (cortex#1869): the no-configPath fallback resolves the active
+    // config dir (canonical ~/.config/metafactory/cortex first, legacy trees
+    // during transition, or $CORTEX_CONFIG_DIR) instead of a hardcoded
+    // ~/.config/cortex. `agents.d/` is config-class (identity fragments) and is
+    // carried with the config move — distinct from the state-class `agents/`
+    // (per-agent state.sqlite, G-15) the migrator excludes.
+    ?? (options.configPath ? join(dirname(expandedConfigPath), "agents.d") : join(resolveConfigDir(), "agents.d"));
   let fragmentAgents: Agent[] = [];
   // cortex#1217 — collect fail-soft disabled-surface warnings from agents.d/
   // fragments (vega ships its Discord token as a fragment placeholder). These

--- a/src/runner/__tests__/egress-check.test.ts
+++ b/src/runner/__tests__/egress-check.test.ts
@@ -99,6 +99,22 @@ describe("scanEgress — config/path leakage", () => {
     }
   });
 
+  // XDG wave-4 (cortex#1869) — the config dir moved to ~/.config/metafactory/cortex.
+  // The leak detector MUST fire on the new canonical tree too, else the move
+  // silently regresses the egress security control (G-14).
+  test("flags the NEW ~/.config/metafactory/cortex path (post-move, G-14)", () => {
+    for (const s of [
+      "my config is at ~/.config/metafactory/cortex/work.yaml",
+      "leaked /Users/someone/.config/metafactory/cortex",
+    ]) {
+      const out = scanEgress(s);
+      expect(out.clean).toBe(false);
+      if (!out.clean) {
+        expect(out.findings.some((f) => f.kind === "config-path")).toBe(true);
+      }
+    }
+  });
+
   // cortex#1022 — value/path-shaped detection, never bare key-name tokens.
   // The key names are public repo content; a review of a PR about signing
   // config (e.g. cortex#1020) must be able to name them.

--- a/src/runner/__tests__/security-preamble.test.ts
+++ b/src/runner/__tests__/security-preamble.test.ts
@@ -48,10 +48,21 @@ describe("buildSecurityPreamble", () => {
     expect(preamble).toContain("/home/user/.config/cortex");
   });
 
-  test("defaults to ~/.config/cortex when no configPath (GV-1 cortex#1076 — config-path migration)", () => {
-    const preamble = buildSecurityPreamble(makeConfig());
-    expect(preamble).toContain("~/.config/cortex");
-    expect(preamble).not.toContain("~/.config/grove");
+  // XDG wave-4 (cortex#1869): with no configPath the immutability rule names the
+  // RESOLVED config dir via the seam. Pin CORTEX_CONFIG_DIR so the resolver
+  // returns it verbatim (short-circuiting real-home probing → hermetic) and the
+  // assertion is deterministic across hosts.
+  test("defaults to the resolved cortex config dir when no configPath (XDG wave-4 cortex#1869)", () => {
+    const prev = process.env.CORTEX_CONFIG_DIR;
+    process.env.CORTEX_CONFIG_DIR = "/scratch/xdg-preamble/metafactory/cortex";
+    try {
+      const preamble = buildSecurityPreamble(makeConfig());
+      expect(preamble).toContain("/scratch/xdg-preamble/metafactory/cortex");
+      expect(preamble).not.toContain("~/.config/grove");
+    } finally {
+      if (prev === undefined) delete process.env.CORTEX_CONFIG_DIR;
+      else process.env.CORTEX_CONFIG_DIR = prev;
+    }
   });
 
   test("includes filesystem restriction when allowedDirs configured", () => {

--- a/src/runner/dev-consumer-boot.ts
+++ b/src/runner/dev-consumer-boot.ts
@@ -49,6 +49,7 @@
  */
 
 import { spawn } from "child_process";
+import { resolveConfigFilePath } from "../common/config/config-path";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { DispatchEventSource } from "../bus/dispatch-events";
 import type { CCSessionOpts } from "./cc-session";
@@ -278,8 +279,11 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): WiredDevConsumer[]
   // JSON bridge). Per-agent file stores are derived from it so two agents never
   // share one file; the AgentState store (stateful agents) instead scopes to the
   // agent's own `~/.config/cortex/agents/<id>/state.sqlite` instance dir.
+  // XDG wave-4 (cortex#1869): resolve fallback-aware (canonical
+  // ~/.config/metafactory/cortex → legacy ~/.config/cortex → grove) off the
+  // INJECTED env.HOME so dev boots stay hermetic under a scratch home.
   const baseSessionStorePath =
-    opts.sessionStorePath ?? `${env.HOME ?? "."}/.config/cortex/dev-warm-sessions.json`;
+    opts.sessionStorePath ?? resolveConfigFilePath("dev-warm-sessions.json", env.HOME);
 
   // cortex#1720 S4b — SELECT the warm-session store PER AGENT (constraint 5+6):
   //   - a test `seamsOverride` wins wholesale (the injected store, unchanged);

--- a/src/runner/egress-check.ts
+++ b/src/runner/egress-check.ts
@@ -136,7 +136,12 @@ const SECRET_PATTERNS: readonly { reason: string; re: RegExp }[] = [
  * assigning `nkey_seed_path` an actual path value.
  */
 const CONFIG_PATTERNS: readonly { reason: string; re: RegExp }[] = [
-  { reason: "cortex config path", re: /(?:~|\/[^\s]*)\/\.config\/cortex\b/ },
+  // XDG wave-4 (cortex#1869) — the config dir moved to `~/.config/metafactory/cortex`.
+  // The optional `metafactory/` segment matches the NEW canonical tree while the
+  // bare form keeps matching the LEGACY `~/.config/cortex` (both are still on
+  // disk during the transition), so this leak detector never silently stops
+  // firing on a principal's real config path.
+  { reason: "cortex config path", re: /(?:~|\/[^\s]*)\/\.config\/(?:metafactory\/)?cortex\b/ },
   // A home-anchored path TO a cortex.yaml (`~/…/cortex.yaml`,
   // `/Users/…/cortex.yaml`, `/home/…/cortex.yaml`) is principal filesystem
   // detail; the bare file name in prose is not.

--- a/src/runner/security-preamble.ts
+++ b/src/runner/security-preamble.ts
@@ -3,6 +3,7 @@
  * Injects filesystem and behavior constraints based on the cortex agent config.
  */
 
+import { resolveConfigDir } from "../common/config/config-path";
 import type { AgentConfig } from "../common/types/config";
 
 /**
@@ -103,9 +104,12 @@ export function buildSecurityPreamble(config: AgentConfig, configPath?: string, 
   // default is only seen by tests; GV-1 (cortex#1076) points it at the canonical
   // cortex config dir. (Distinct from the GROVE_* → CORTEX_* env-var migration,
   // cortex#774.)
+  // XDG wave-4 (cortex#1869): when no explicit config path, name the resolved
+  // config dir (canonical ~/.config/metafactory/cortex, or the legacy tree an
+  // un-migrated host still reads) so the immutability rule references the real dir.
   const configDir = configPath
     ? configPath.replace(/\/[^/]+$/, "")
-    : "~/.config/cortex";
+    : resolveConfigDir();
   rules.push(
     `CONFIG IMMUTABILITY: You MUST NOT read, write, edit, or delete cortex.yaml or any file in the cortex config directory (${configDir}). ` +
     `This includes using any tool (Write, Edit, Bash, etc.) to modify, overwrite, move, copy, or remove cortex.yaml or files in ${configDir}. ` +

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -82,7 +82,7 @@ import {
 } from "./api/mutation-guard";
 import { enforceStepUp, requiresStepUp } from "./api/step-up-mfa";
 import {
-  DEFAULT_STEP_UP_SECRET_PATH,
+  defaultStepUpSecretPath,
   loadEnrollment,
   type StepUpEnrollment,
 } from "../../common/step-up/enrollment";
@@ -340,7 +340,7 @@ export function startServer(
   // daemon restart. Default `~/.config/cortex/step-up-totp.json`; overridable
   // via `mc.governance.stepUp.secretPath`.
   const stepUpSecretPath = expandTilde(
-    config.governance?.stepUp?.secretPath ?? DEFAULT_STEP_UP_SECRET_PATH,
+    config.governance?.stepUp?.secretPath ?? defaultStepUpSecretPath(),
   );
 
   const apiDeps: ApiDeps | null = options.processManager
@@ -616,7 +616,7 @@ async function handleApi(
   guard: MutationGuardContext,
   handoffView: HandoffView | null = null,
   doctorView: DoctorView | null = null,
-  stepUpSecretPath: string = expandTilde(DEFAULT_STEP_UP_SECRET_PATH),
+  stepUpSecretPath: string = expandTilde(defaultStepUpSecretPath()),
   authorizer: Authorizer | null = null,
 ): Promise<Response> {
   const { pathname } = url;


### PR DESCRIPTION
Closes #1869 (config-only; data=#1902, state=#1903 stay separate). Part of epic #1867, wave 4 — the biggest single piece. compass#114 (the standard this implements) is merged.

⛔ BUILD/TEST ONLY — nothing runs against a live machine. The cutover driver is NOT auto-wired into postupgrade; the on-box cutover is the principal's, out-of-hours. Production  stack is spared by design (reuses wave-3 CORTEX_UPGRADE_SKIP_RESTART).

## What
- **Merge policy (G-42):** `planConfigDirMigration` enumerates the UNION of both legacy trees. cortex-wins-on-dup (grove dup recorded as `shadowedGrove`, **kept, never deleted**); grove-only files **carried**; `.bak`/`personas/`/`agents.d/` carried. state/data subtrees (state, agents/, logs, network-cache, networks) EXCLUDED → #1902/#1903. Primitive: `open('wx',O_EXCL)` → write → fsync → chmod → rename; **source never renamed/removed**; journal at canonical root; rollback deletes only applied canonical copies.
- **Restart op:** reuses wave-3 plist infra (render stamps `--config`, reload = bootout/bootstrap, skip-restart spares `work`). Adds `canonical_config_dir`/`resolve_config_dir` (canonical-first, legacy fallback, honors $CORTEX_CONFIG_DIR) wired into pre/postupgrade+postinstall → post-move re-stamps plists at the moved tree (closes split-brain T7′/T13/T17). Dedicated `migrate-config-dir.sh` cutover driver (PLAN_ONLY dry-run), NOT auto-run.
- **Hardcode sweep (G-13):** runtime config-class resolution literals → **0** (network-adapters.ts:993/1533, cortex.ts:1240 + prior sweep of agents/network/offer/provision-stack/stack/stepup/enrollment/dev-consumer-boot/security-preamble/mc-server). Help-text + state-class logDir/agents defaults deliberately left (#1903).
- **Egress (G-14):** egress-check.ts:139 regex now matches new tree (optional `metafactory/`) + legacy; test added.

## Verification (scratch-HOME only)
- Scoped tests 150 pass / 0 fail; tsc 0; eslint clean; shellcheck clean; vocab clean.
- New `migrate-config-dir.sh` (29 asserts) + TS migrator tests assert: grove-only carried, cortex-wins-on-dup, .bak/personas carried, state/logs excluded, journal+legacy-source kept, plists re-rendered at canonical, prod `work` spared, idempotent, PLAN_ONLY writes nothing, and **journal root under scratch HOME + real home untouched**.

## Coupled follow-on (NOT in this PR)
Arc-side sibling sweep (G-18): `cortex-status.sh:38-41`, `cldyo-live:21-22`, `cortex-config-split.ts:165` live in **arc** — a sibling arc PR is needed before `xdg-audit --repos --wave 4` fully zeroes runtime. This branch is cortex-only.

Known (pre-existing, zero-regression proven via stash): 20 `network-secret-cli.test.ts` failures on a machine with a live prod config (non-hermetic tests reading real ~/.config/cortex) — identical fail count with/without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)