### PR TITLE
feat(data): XDG wave 5 — cortex data-dir move (#1902)

### DIFF
--- a/src/__tests__/xdg-migration-guard.e2e.test.ts
+++ b/src/__tests__/xdg-migration-guard.e2e.test.ts
@@ -77,6 +77,7 @@ const MANAGED = [
   "HOME",
   "CORTEX_CONFIG_DIR",
   "CORTEX_EVENTS_DIR",
+  "CORTEX_DATA_DIR",
   "CORTEX_STATE_DIR",
   "CORTEX_XDG_STRICT",
 ] as const;
@@ -275,34 +276,50 @@ describe("(i) exactly one live process per stack PID", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Invariant (ii) — byte-identical events dir across hook / relay / MC.
+// Invariant (ii) — RAW events dir byte-identical across hook / relay / MC;
+// PUBLISHED split off onto the data seam (XDG wave-5 #1902).
 // ═══════════════════════════════════════════════════════════════════════════
-describe("(ii) hook-writer / relay-reader / MC-cursor resolve to a byte-identical events dir", () => {
-  test("override wins over home ⇒ all three sites resolve the SAME dir regardless of home spelling", () => {
+describe("(ii) hook-writer / relay-reader / MC resolve a byte-identical RAW dir; published is on the data seam", () => {
+  test("CORTEX_EVENTS_DIR override ⇒ all RAW sites resolve the SAME dir regardless of home spelling", () => {
     const ev = scratch("events");
     process.env.CORTEX_EVENTS_DIR = ev;
+    delete process.env.CORTEX_DATA_DIR;
 
-    // The three consumers derive home DIFFERENTLY: the hook calls eventsDir()
-    // (no arg → process.env.HOME), MC calls with os.homedir(), the relay with
-    // its own. With the override set, home is IGNORED — so all spellings agree.
+    // The consumers derive home DIFFERENTLY: the hook calls rawEventsDir()
+    // (no arg → process.env.HOME), MC calls with os.homedir(). With the override
+    // set, home is IGNORED — so all RAW spellings agree.
     const hookRaw = rawEventsDir(); // event-logger.hook.ts spelling
     const mcRaw = rawEventsDir("/some/other/home"); // mc/config.ts spelling
-    const relayPub = publishedEventsDir("/yet/another/home"); // relay.ts spelling
-
     expect(hookRaw).toBe(mcRaw);
     expect(hookRaw).toBe(join(ev, "raw"));
-    expect(relayPub).toBe(join(ev, "published"));
-    // hook (raw) and relay (published) share ONE root — byte-identical.
-    expect(dirname(hookRaw)).toBe(dirname(relayPub));
     expect(eventsDir("/ignored")).toBe(ev);
+
+    // XDG wave-5: published is DATA — CORTEX_EVENTS_DIR does NOT move it, and it
+    // NO LONGER shares raw's root (the intended split).
+    const pub = publishedEventsDir("/yet/another/home");
+    expect(pub.startsWith(ev)).toBe(false);
+    expect(dirname(hookRaw)).not.toBe(dirname(pub));
   });
 
-  test("unset ⇒ still byte-identical across sites (default ~/.claude/events)", () => {
+  test("CORTEX_DATA_DIR moves published (data seam) but leaves RAW untouched", () => {
     delete process.env.CORTEX_EVENTS_DIR;
+    const data = scratch("data");
+    process.env.CORTEX_DATA_DIR = data;
     const home = "/fake/home";
     expect(rawEventsDir(home)).toBe(join(home, ".claude", "events", "raw"));
-    expect(publishedEventsDir(home)).toBe(join(home, ".claude", "events", "published"));
-    expect(dirname(rawEventsDir(home))).toBe(dirname(publishedEventsDir(home)));
+    expect(publishedEventsDir(home)).toBe(join(data, "events", "published"));
+  });
+
+  test("both unset ⇒ raw under ~/.claude/events, published under the metafactory data root", () => {
+    delete process.env.CORTEX_EVENTS_DIR;
+    delete process.env.CORTEX_DATA_DIR;
+    const home = "/fake/home";
+    expect(rawEventsDir(home)).toBe(join(home, ".claude", "events", "raw"));
+    expect(publishedEventsDir(home)).toBe(
+      join(home, ".local", "share", "metafactory", "cortex", "events", "published"),
+    );
+    // The split: raw and published no longer share a parent.
+    expect(dirname(rawEventsDir(home))).not.toBe(dirname(publishedEventsDir(home)));
   });
 });
 
@@ -442,10 +459,12 @@ describe("(v) fresh-env strict discrimination — the fresh-install failure-clas
     const home = scratch("fresh-home"); // pristine — no ~/.config/{cortex,grove}
     const cfg = scratch("cfg");
     const ev = scratch("events");
+    const data = scratch("data");
     const st = scratch("state");
     process.env.HOME = home;
     process.env.CORTEX_CONFIG_DIR = cfg;
     process.env.CORTEX_EVENTS_DIR = ev;
+    process.env.CORTEX_DATA_DIR = data; // XDG wave-5 data seam — hermetic + strict
     process.env.CORTEX_STATE_DIR = st;
     process.env.CORTEX_XDG_STRICT = "1";
 
@@ -457,10 +476,12 @@ describe("(v) fresh-env strict discrimination — the fresh-install failure-clas
       expect(r.source).not.toBe("grove"); // never the legacy fallback
       expect(r.path.startsWith(cfg)).toBe(true);
     }
-    // Events round-trip through the seam.
+    // RAW events round-trip through the events seam (published now on the data seam).
     mkdirSync(rawEventsDir(home), { recursive: true });
     writeFileSync(join(rawEventsDir(home), "e.jsonl"), "{}\n");
-    expect(existsSync(publishedEventsDir(home).replace(/published$/, "raw"))).toBe(true);
+    expect(existsSync(rawEventsDir(home))).toBe(true);
+    // Published resolves under the (strict, scratch) data root — no legacy touch.
+    expect(publishedEventsDir(home).startsWith(data)).toBe(true);
     // Pidfile identity under the scratch state dir.
     expect(pidFileForIn(st, join(cfg, "bot.yaml")).startsWith(st)).toBe(true);
 

--- a/src/adapters/discord/outbound-log.ts
+++ b/src/adapters/discord/outbound-log.ts
@@ -15,6 +15,7 @@ import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import type { TextChannel } from "discord.js";
 import type { AgentConfig } from "../../common/types/config";
+import { legacyPublishedEventsDir } from "../../common/data-path";
 import type { SurfaceRouter } from "../../bus/surface-router";
 import type { SystemEventSource } from "../../bus/system-events";
 import { JsonlReader } from "../../taps/cc-events/lib/jsonl-reader";
@@ -38,7 +39,17 @@ export function attachLegacyOutboundLog(
   router: SurfaceRouter,
   systemEventSource: SystemEventSource,
 ): (() => void) | null {
-  const eventsDir = config.paths.publishedEventsDir.replace(/^~/, process.env.HOME ?? "~");
+  // XDG wave-5 (#1902) — existence-gated read of the published-events buffer.
+  // The config value now defaults to the metafactory data root; a pinned legacy
+  // value is rewritten by the value-migrator. But the relay writer may not have
+  // moved yet on a pre-cutover box, so prefer the configured dir if it exists,
+  // else fall back to the legacy `~/.claude/events/published` (Fallback
+  // Contract) — the pipeline never breaks mid-migration.
+  const home = process.env.HOME ?? "~";
+  const configuredDir = config.paths.publishedEventsDir.replace(/^~/, home);
+  const legacyDir = legacyPublishedEventsDir(home);
+  const eventsDir =
+    existsSync(configuredDir) || !existsSync(legacyDir) ? configuredDir : legacyDir;
   const client = discordAdapter.getClient();
   if (!client) {
     console.log("cortex: discord client not available for outbound log");

--- a/src/adapters/discord/outbound-log.ts
+++ b/src/adapters/discord/outbound-log.ts
@@ -15,7 +15,11 @@ import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import type { TextChannel } from "discord.js";
 import type { AgentConfig } from "../../common/types/config";
-import { legacyPublishedEventsDir } from "../../common/data-path";
+import {
+  canonicalPublishedEventsDir,
+  legacyPublishedEventsDir,
+  resolvePublishedEventsDir,
+} from "../../common/data-path";
 import type { SurfaceRouter } from "../../bus/surface-router";
 import type { SystemEventSource } from "../../bus/system-events";
 import { JsonlReader } from "../../taps/cc-events/lib/jsonl-reader";
@@ -39,17 +43,24 @@ export function attachLegacyOutboundLog(
   router: SurfaceRouter,
   systemEventSource: SystemEventSource,
 ): (() => void) | null {
-  // XDG wave-5 (#1902) — existence-gated read of the published-events buffer.
-  // The config value now defaults to the metafactory data root; a pinned legacy
-  // value is rewritten by the value-migrator. But the relay writer may not have
-  // moved yet on a pre-cutover box, so prefer the configured dir if it exists,
-  // else fall back to the legacy `~/.claude/events/published` (Fallback
-  // Contract) — the pipeline never breaks mid-migration.
+  // XDG wave-5 (#1902) — resolve the published-events buffer in LOCKSTEP with the
+  // relay writer (which writes the canonical metafactory data-root dir and carries
+  // the in-flight buffer forward on start). For a DEFAULT-spelled config value
+  // (the legacy `~/.claude/events/published` or the new canonical), resolve
+  // canonical-first / legacy-fallback so writer + consumer always agree — even if
+  // the config value-migrator hasn't rewritten this file yet. A genuinely CUSTOM
+  // pinned path is honored (existence-gated with a legacy fallback), matching the
+  // pre-move behavior.
   const home = process.env.HOME ?? "~";
   const configuredDir = config.paths.publishedEventsDir.replace(/^~/, home);
   const legacyDir = legacyPublishedEventsDir(home);
-  const eventsDir =
-    existsSync(configuredDir) || !existsSync(legacyDir) ? configuredDir : legacyDir;
+  const isDefaultSpelling =
+    configuredDir === legacyDir || configuredDir === canonicalPublishedEventsDir(home);
+  const eventsDir = isDefaultSpelling
+    ? resolvePublishedEventsDir(home)
+    : existsSync(configuredDir) || !existsSync(legacyDir)
+      ? configuredDir
+      : legacyDir;
   const client = discordAdapter.getClient();
   if (!client) {
     console.log("cortex: discord client not available for outbound log");

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -400,7 +400,7 @@ attachments:
   maxAttachmentsPerMessage: 10
 
 paths:
-  publishedEventsDir: ~/.claude/events/published
+  publishedEventsDir: ~/.local/share/metafactory/cortex/events/published
   logDir: ~/.config/cortex/logs
 
 # nats — M2 transport. nats.subjects is the SINGLE place subject overrides live

--- a/src/common/__tests__/data-path.test.ts
+++ b/src/common/__tests__/data-path.test.ts
@@ -1,0 +1,138 @@
+/**
+ * XDG wave-5 (cortex#1902) — DATA-dir resolver tests.
+ *
+ * Hermetic: every path derives from a scratch `$HOME` under `os.tmpdir()`, and
+ * `CORTEX_DATA_DIR` is unset per test so nothing resolves off the real home. The
+ * resolvers are PURE (existence-gated `existsSync` only) — no copies here.
+ *
+ * Covers AC3 (both zod defaults point at the new data root; no divergence) plus
+ * the canonical-first / legacy-fallback precedence every resolver shares.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  PUBLISHED_EVENTS_DIR_DEFAULT,
+  canonicalPublishedEventsDir,
+  cortexDataDir,
+  resolveCursorPath,
+  resolvePublishedEventsDir,
+  resolveStackDbPath,
+  resolveStandaloneDbPath,
+} from "../data-path";
+import { AgentConfigSchema } from "../types/config";
+import { PathsConfigSchema } from "../types/cortex-config";
+
+let home: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  savedEnv = process.env.CORTEX_DATA_DIR;
+  delete process.env.CORTEX_DATA_DIR;
+  home = mkdtempSync(join(tmpdir(), "xdg1902-data-"));
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.CORTEX_DATA_DIR;
+  else process.env.CORTEX_DATA_DIR = savedEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+const touch = (p: string) => {
+  mkdirSync(join(p, ".."), { recursive: true });
+  writeFileSync(p, "x");
+};
+
+describe("cortexDataDir", () => {
+  test("defaults to ~/.local/share/metafactory/cortex", () => {
+    expect(cortexDataDir(home)).toBe(join(home, ".local", "share", "metafactory", "cortex"));
+  });
+  test("CORTEX_DATA_DIR override wins verbatim", () => {
+    process.env.CORTEX_DATA_DIR = "/scratch/data";
+    expect(cortexDataDir(home)).toBe("/scratch/data");
+  });
+});
+
+describe("resolveStackDbPath — canonical-first / legacy-fallback", () => {
+  const canonical = (h: string, s: string) =>
+    join(h, ".local", "share", "metafactory", "cortex", "mc", s, "mission-control.db");
+  const legacy = (h: string, s: string) =>
+    join(h, ".local", "share", "cortex", "mc", s, "mission-control.db");
+
+  test("canonical when it exists", () => {
+    touch(canonical(home, "work"));
+    expect(resolveStackDbPath("work", home)).toBe(canonical(home, "work"));
+  });
+  test("legacy when only legacy exists", () => {
+    touch(legacy(home, "work"));
+    expect(resolveStackDbPath("work", home)).toBe(legacy(home, "work"));
+  });
+  test("canonical (write target) when neither exists", () => {
+    expect(resolveStackDbPath("work", home)).toBe(canonical(home, "work"));
+  });
+  test("canonical wins even if BOTH exist", () => {
+    touch(legacy(home, "work"));
+    touch(canonical(home, "work"));
+    expect(resolveStackDbPath("work", home)).toBe(canonical(home, "work"));
+  });
+  test("CORTEX_DATA_DIR override skips the legacy probe", () => {
+    process.env.CORTEX_DATA_DIR = join(home, "override");
+    // Even with a legacy db present, the override root is self-contained.
+    touch(legacy(home, "work"));
+    expect(resolveStackDbPath("work", home)).toBe(
+      join(home, "override", "mc", "work", "mission-control.db"),
+    );
+  });
+});
+
+describe("resolveStandaloneDbPath / resolveCursorPath — legacy grove fallback", () => {
+  test("standalone db falls back to legacy ~/.local/share/grove", () => {
+    const legacy = join(home, ".local", "share", "grove", "mission-control.db");
+    touch(legacy);
+    expect(resolveStandaloneDbPath(home)).toBe(legacy);
+  });
+  test("cursor falls back to legacy ~/.local/share/grove", () => {
+    const legacy = join(home, ".local", "share", "grove", "mc-hook-cursor.json");
+    touch(legacy);
+    expect(resolveCursorPath(home)).toBe(legacy);
+  });
+  test("both default to the metafactory root when nothing legacy exists", () => {
+    expect(resolveStandaloneDbPath(home)).toBe(
+      join(home, ".local", "share", "metafactory", "cortex", "mission-control.db"),
+    );
+    expect(resolveCursorPath(home)).toBe(
+      join(home, ".local", "share", "metafactory", "cortex", "mc-hook-cursor.json"),
+    );
+  });
+});
+
+describe("resolvePublishedEventsDir — legacy ~/.claude fallback", () => {
+  test("falls back to legacy ~/.claude/events/published", () => {
+    const legacy = join(home, ".claude", "events", "published");
+    touch(join(legacy, "keep")); // make the dir exist
+    expect(resolvePublishedEventsDir(home)).toBe(legacy);
+  });
+  test("defaults to the metafactory data root when no legacy buffer exists", () => {
+    expect(resolvePublishedEventsDir(home)).toBe(canonicalPublishedEventsDir(home));
+  });
+});
+
+describe("AC3 — both zod defaults point at the new data root, no divergence", () => {
+  test("PUBLISHED_EVENTS_DIR_DEFAULT is the metafactory data-root value", () => {
+    expect(PUBLISHED_EVENTS_DIR_DEFAULT).toBe(
+      "~/.local/share/metafactory/cortex/events/published",
+    );
+  });
+  test("AgentConfigSchema.paths default == PathsConfigSchema default == the new root", () => {
+    // Use the inner `paths` schema so this doesn't depend on the whole
+    // AgentConfigSchema being parseable from `{}`.
+    const agentDefault = AgentConfigSchema.shape.paths.parse({}).publishedEventsDir;
+    const cortexDefault = PathsConfigSchema.parse({}).publishedEventsDir;
+    expect(agentDefault).toBe(PUBLISHED_EVENTS_DIR_DEFAULT);
+    expect(cortexDefault).toBe(PUBLISHED_EVENTS_DIR_DEFAULT);
+    // The load-bearing "no divergence" assertion: the two schemas agree.
+    expect(agentDefault).toBe(cortexDefault);
+  });
+});

--- a/src/common/__tests__/events-path.test.ts
+++ b/src/common/__tests__/events-path.test.ts
@@ -1,12 +1,17 @@
 /**
  * XDG wave-1 (cortex#1908, EPIC cortex#1867 X-03) — CORTEX_EVENTS_DIR seam.
  *
- * Proves the two contract halves:
- *   - UNSET  ⇒ byte-identical to the previous inline
+ * Proves the RAW contract halves (unchanged by #1902):
+ *   - UNSET  ⇒ raw byte-identical to the previous inline
  *     `join(<home>, ".claude", "events")` at every call site.
- *   - SET    ⇒ the events buffer (root / raw / published) resolves ENTIRELY
- *     inside the override, winning over the `home` source — so a hermetic
- *     guard (#1870) can point the hook→relay→MC pipeline at a scratch dir.
+ *   - SET    ⇒ the RAW buffer (root / raw) resolves ENTIRELY inside
+ *     `$CORTEX_EVENTS_DIR`, winning over the `home` source — so a hermetic guard
+ *     (#1870) can point the hook→relay→MC RAW pipeline at a scratch dir.
+ *
+ * XDG wave-5 (#1902): `publishedEventsDir()` is now app-private DATA and resolves
+ * under the metafactory data root (`~/.local/share/metafactory/cortex/events/
+ * published`, or `$CORTEX_DATA_DIR`) — it NO LONGER shares a root with raw and
+ * NO LONGER honors `$CORTEX_EVENTS_DIR`. That split is asserted below.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -21,29 +26,40 @@ import {
 } from "../events-path";
 
 const FAKE_HOME = "/fake/home";
+/** The metafactory data-root published dir for a given home (XDG wave-5). */
+const dataPublished = (home: string) =>
+  join(home, ".local", "share", "metafactory", "cortex", "events", "published");
 
 describe("events-path — CORTEX_EVENTS_DIR seam (XDG wave-1 cortex#1908)", () => {
   let scratch: string;
   let savedEnv: string | undefined;
+  let savedDataEnv: string | undefined;
 
   beforeEach(() => {
     savedEnv = process.env.CORTEX_EVENTS_DIR;
+    savedDataEnv = process.env.CORTEX_DATA_DIR;
     delete process.env.CORTEX_EVENTS_DIR; // known-unset baseline
+    delete process.env.CORTEX_DATA_DIR; // published now derives from this seam
     scratch = mkdtempSync(join(tmpdir(), "x1908-ev-"));
   });
   afterEach(() => {
     if (savedEnv === undefined) delete process.env.CORTEX_EVENTS_DIR;
     else process.env.CORTEX_EVENTS_DIR = savedEnv;
+    if (savedDataEnv === undefined) delete process.env.CORTEX_DATA_DIR;
+    else process.env.CORTEX_DATA_DIR = savedDataEnv;
     rmSync(scratch, { recursive: true, force: true });
   });
 
-  describe("unset ⇒ byte-identical to <home>/.claude/events", () => {
-    test("root/raw/published derive from the passed home", () => {
+  describe("unset ⇒ raw byte-identical to <home>/.claude/events; published under the data root", () => {
+    test("root/raw derive from the passed home; published moves to the data root (#1902)", () => {
       expect(eventsDirOverride()).toBeUndefined();
       expect(eventsDir(FAKE_HOME)).toBe(join(FAKE_HOME, ".claude", "events"));
       expect(rawEventsDir(FAKE_HOME)).toBe(join(FAKE_HOME, ".claude", "events", "raw"));
-      expect(publishedEventsDir(FAKE_HOME)).toBe(
-        join(FAKE_HOME, ".claude", "events", "published"),
+      // XDG wave-5: published is DATA — under the metafactory data root, NOT ~/.claude.
+      expect(publishedEventsDir(FAKE_HOME)).toBe(dataPublished(FAKE_HOME));
+      // The split: raw and published NO LONGER share a parent.
+      expect(join(rawEventsDir(FAKE_HOME), "..")).not.toBe(
+        join(publishedEventsDir(FAKE_HOME), ".."),
       );
     });
 
@@ -59,15 +75,23 @@ describe("events-path — CORTEX_EVENTS_DIR seam (XDG wave-1 cortex#1908)", () =
     });
   });
 
-  describe("set ⇒ resolves inside CORTEX_EVENTS_DIR (hermetic)", () => {
-    test("override wins over home for root/raw/published", () => {
+  describe("set ⇒ RAW resolves inside CORTEX_EVENTS_DIR (hermetic)", () => {
+    test("override wins over home for root/raw; published is UNAFFECTED (data seam)", () => {
       process.env.CORTEX_EVENTS_DIR = scratch;
       expect(eventsDirOverride()).toBe(scratch);
       expect(eventsDir(FAKE_HOME)).toBe(scratch);
       expect(rawEventsDir(FAKE_HOME)).toBe(join(scratch, "raw"));
-      expect(publishedEventsDir(FAKE_HOME)).toBe(join(scratch, "published"));
       expect(rawEventsDir(FAKE_HOME).startsWith(scratch)).toBe(true);
-      expect(publishedEventsDir(FAKE_HOME).startsWith(scratch)).toBe(true);
+      // XDG wave-5: CORTEX_EVENTS_DIR does NOT move published — it's on the data
+      // seam ($CORTEX_DATA_DIR / metafactory data root), not the events seam.
+      expect(publishedEventsDir(FAKE_HOME)).toBe(dataPublished(FAKE_HOME));
+    });
+
+    test("CORTEX_DATA_DIR relocates published (the data seam) but NOT raw", () => {
+      process.env.CORTEX_DATA_DIR = scratch;
+      expect(publishedEventsDir(FAKE_HOME)).toBe(join(scratch, "events", "published"));
+      // raw is unmoved by the data seam.
+      expect(rawEventsDir(FAKE_HOME)).toBe(join(FAKE_HOME, ".claude", "events", "raw"));
     });
 
     test("empty CORTEX_EVENTS_DIR is treated as unset (not '/')", () => {

--- a/src/common/__tests__/migrate-data-dir.test.ts
+++ b/src/common/__tests__/migrate-data-dir.test.ts
@@ -16,9 +16,17 @@ import { join } from "path";
 import {
   migrateCursorOnTouch,
   migrateDbOnTouch,
+  migratePublishedBufferOnTouch,
   migrateStackDbOnTouch,
 } from "../migrate-data-dir";
-import { canonicalStackDbPath, legacyStackDbPath } from "../data-path";
+import {
+  canonicalCursorPath,
+  canonicalPublishedEventsDir,
+  canonicalStackDbPath,
+  legacyCursorPath,
+  legacyPublishedEventsDir,
+  legacyStackDbPath,
+} from "../data-path";
 
 let home: string;
 let savedEnv: string | undefined;
@@ -145,7 +153,45 @@ describe("migrateDbOnTouch — WAL safety", () => {
   });
 });
 
-describe("migrateCursorOnTouch — plain data file", () => {
+describe("migratePublishedBufferOnTouch — guardrail A (carry in-flight events)", () => {
+  test("carries a published-but-not-yet-consumed event to the canonical dir, source kept", () => {
+    const legacy = legacyPublishedEventsDir(home); // ~/.claude/events/published
+    const canonical = canonicalPublishedEventsDir(home);
+    mkdirSync(legacy, { recursive: true });
+    const event = '{"id":"evt-1","type":"prompt"}\n';
+    writeFileSync(join(legacy, "2026-07-13.jsonl"), event);
+
+    const res = migratePublishedBufferOnTouch(home);
+    expect(res.dir).toBe(canonical);
+    expect(res.carried).toBe(1);
+    // The in-flight event is readable from the canonical dir the consumer reads.
+    expect(readFileSync(join(canonical, "2026-07-13.jsonl"), "utf-8")).toBe(event);
+    // Source kept — never moved out from under the writer.
+    expect(existsSync(join(legacy, "2026-07-13.jsonl"))).toBe(true);
+  });
+
+  test("idempotent — a second run carries nothing and never clobbers a carried file", () => {
+    const legacy = legacyPublishedEventsDir(home);
+    const canonical = canonicalPublishedEventsDir(home);
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, "a.jsonl"), "v1\n");
+    migratePublishedBufferOnTouch(home);
+
+    // A consumer/relay appended to the canonical copy after the first carry.
+    writeFileSync(join(canonical, "a.jsonl"), "v1\nv2-canonical\n");
+    const res = migratePublishedBufferOnTouch(home); // re-run
+    expect(res.carried).toBe(0); // canonical-wins — nothing re-copied
+    expect(readFileSync(join(canonical, "a.jsonl"), "utf-8")).toBe("v1\nv2-canonical\n");
+  });
+
+  test("no legacy buffer ⇒ no-op (fresh install)", () => {
+    const res = migratePublishedBufferOnTouch(home);
+    expect(res.carried).toBe(0);
+    expect(res.dir).toBe(canonicalPublishedEventsDir(home));
+  });
+});
+
+describe("migrateCursorOnTouch — plain data file + guardrail B (position continuity)", () => {
   test("carries a legacy grove cursor to the canonical tree, source kept", () => {
     const legacy = join(home, ".local", "share", "grove", "mc-hook-cursor.json");
     mkdirSync(join(legacy, ".."), { recursive: true });
@@ -157,6 +203,27 @@ describe("migrateCursorOnTouch — plain data file", () => {
     );
     expect(existsSync(resolved)).toBe(true);
     expect(readFileSync(resolved, "utf-8")).toBe('{"cursor":42}');
+    expect(existsSync(legacy)).toBe(true); // source kept
+  });
+
+  test("guardrail B — MC resume position is PRESERVED across the move (offsets intact, no reset)", () => {
+    // The cursor is Record<rawEventFilePath, byteOffset>. Its keys reference the
+    // RAW buffer (`~/.claude/events/raw/…`), which does NOT move in #1902 — so
+    // moving the cursor FILE (copy-keep-source) preserves the exact resume
+    // position; MC neither re-ingests (dup events) nor skips.
+    const legacy = legacyCursorPath(home);
+    const canonical = canonicalCursorPath(home);
+    const rawKey = join(home, ".claude", "events", "raw", "2026-07-13.jsonl");
+    const cursor = { [rawKey]: 8192 };
+    mkdirSync(join(legacy, ".."), { recursive: true });
+    writeFileSync(legacy, JSON.stringify(cursor));
+
+    migrateCursorOnTouch(home);
+
+    const carried = JSON.parse(readFileSync(canonical, "utf-8")) as Record<string, number>;
+    expect(carried[rawKey]).toBe(8192); // exact offset preserved — no reset
+    // Key still references the (unmoved) raw buffer — no rewrite needed.
+    expect(Object.keys(carried)).toEqual([rawKey]);
     expect(existsSync(legacy)).toBe(true); // source kept
   });
 });

--- a/src/common/__tests__/migrate-data-dir.test.ts
+++ b/src/common/__tests__/migrate-data-dir.test.ts
@@ -1,0 +1,162 @@
+/**
+ * XDG wave-5 (cortex#1902) AC4 — DATA migration-on-touch tests.
+ *
+ * Hermetic scratch `$HOME`; `CORTEX_DATA_DIR` unset per test. Proves the
+ * copy-keep-source contract: the legacy db is carried to the canonical
+ * metafactory tree, the SOURCE is intact after the move, sidecars travel with
+ * it, canonical-wins (never clobber), and a re-run is idempotent.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  migrateCursorOnTouch,
+  migrateDbOnTouch,
+  migrateStackDbOnTouch,
+} from "../migrate-data-dir";
+import { canonicalStackDbPath, legacyStackDbPath } from "../data-path";
+
+let home: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  savedEnv = process.env.CORTEX_DATA_DIR;
+  delete process.env.CORTEX_DATA_DIR;
+  home = mkdtempSync(join(tmpdir(), "xdg1902-mig-"));
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.CORTEX_DATA_DIR;
+  else process.env.CORTEX_DATA_DIR = savedEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+/** Create a small sqlite db with one row at `dbPath` (WAL mode by default). */
+function makeDb(dbPath: string, marker: string, wal = true): void {
+  mkdirSync(join(dbPath, ".."), { recursive: true });
+  const db = new Database(dbPath, { create: true });
+  if (wal) db.run("PRAGMA journal_mode = WAL");
+  db.run("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+  db.run("INSERT INTO t (v) VALUES (?)", [marker]);
+  db.close();
+}
+
+function readMarker(dbPath: string): string {
+  const db = new Database(dbPath, { readonly: true });
+  const row = db.query("SELECT v FROM t LIMIT 1").get() as { v: string };
+  db.close();
+  return row.v;
+}
+
+describe("migrateStackDbOnTouch — copy-keep-source", () => {
+  test("carries a legacy per-stack db to the canonical metafactory tree, source kept", () => {
+    const legacy = legacyStackDbPath("work", home);
+    const canonical = canonicalStackDbPath("work", home);
+    makeDb(legacy, "legacy-data");
+
+    const resolved = migrateStackDbOnTouch("work", home);
+
+    expect(resolved).toBe(canonical);
+    expect(existsSync(canonical)).toBe(true);
+    // SOURCE intact — never renamed or removed.
+    expect(existsSync(legacy)).toBe(true);
+    // Content carried faithfully.
+    expect(readMarker(canonical)).toBe("legacy-data");
+    expect(readMarker(legacy)).toBe("legacy-data");
+  });
+
+  test("idempotent — a second run is a no-op and does not clobber the canonical copy", () => {
+    const legacy = legacyStackDbPath("work", home);
+    const canonical = canonicalStackDbPath("work", home);
+    makeDb(legacy, "v1");
+    migrateStackDbOnTouch("work", home);
+
+    // Mutate the canonical copy; then mutate the legacy source differently.
+    const c = new Database(canonical);
+    c.run("UPDATE t SET v = 'canonical-edited'");
+    c.close();
+
+    const resolved = migrateStackDbOnTouch("work", home); // re-run
+    expect(resolved).toBe(canonical);
+    // Canonical-wins: the re-run never overwrote the canonical copy from legacy.
+    expect(readMarker(canonical)).toBe("canonical-edited");
+  });
+
+  test("nothing to carry — a fresh stack resolves to the canonical write target", () => {
+    const resolved = migrateStackDbOnTouch("fresh", home);
+    expect(resolved).toBe(canonicalStackDbPath("fresh", home));
+    expect(existsSync(resolved)).toBe(false); // not created — just the path
+  });
+});
+
+describe("migrateDbOnTouch — WAL safety", () => {
+  test("checkpoints before copy so committed WAL data lands in the canonical db", () => {
+    const legacy = join(home, "legacy", "mission-control.db");
+    const canonical = join(home, "canon", "mission-control.db");
+    // A WAL-mode db with committed data. migrateDbOnTouch runs
+    // wal_checkpoint(TRUNCATE) on the source first, folding any -wal frames into
+    // the main .db file, THEN copies it — so no committed transaction is lost.
+    makeDb(legacy, "committed-in-wal");
+
+    const res = migrateDbOnTouch(canonical, legacy);
+    expect(res.migrated).toBe(true);
+    // The canonical copy is a consistent, readable db carrying the data.
+    expect(readMarker(canonical)).toBe("committed-in-wal");
+    // Source db intact (never renamed/removed).
+    expect(readMarker(legacy)).toBe("committed-in-wal");
+  });
+
+  test("carries any surviving -wal / -shm sidecars alongside the main db", () => {
+    const legacy = join(home, "legacy", "mission-control.db");
+    const canonical = join(home, "canon", "mission-control.db");
+    // Rollback-journal db (wal=false): the internal checkpoint is a no-op that
+    // leaves these stray sidecar files untouched, so the test isolates the
+    // sidecar-CARRY behavior. (In production a real un-truncatable WAL is the
+    // case these carries protect.)
+    makeDb(legacy, "with-sidecars", false);
+    // Sidecars present at copy time (a partial checkpoint under active readers
+    // could leave un-folded frames here). They must travel WITH the db, and the
+    // source copies must remain intact.
+    writeFileSync(`${legacy}-wal`, "wal-bytes");
+    writeFileSync(`${legacy}-shm`, "shm-bytes");
+
+    const res = migrateDbOnTouch(canonical, legacy);
+    expect(res.migrated).toBe(true);
+    expect(existsSync(canonical)).toBe(true);
+    expect(existsSync(`${canonical}-wal`)).toBe(true);
+    expect(existsSync(`${canonical}-shm`)).toBe(true);
+    // Source sidecars intact (copy-keep-source).
+    expect(existsSync(`${legacy}-wal`)).toBe(true);
+    expect(existsSync(`${legacy}-shm`)).toBe(true);
+  });
+
+  test("canonical-wins — an existing canonical db is never overwritten", () => {
+    const legacy = join(home, "legacy", "mission-control.db");
+    const canonical = join(home, "canon", "mission-control.db");
+    makeDb(legacy, "legacy");
+    makeDb(canonical, "canonical");
+
+    const res = migrateDbOnTouch(canonical, legacy);
+    expect(res.migrated).toBe(false);
+    expect(readMarker(canonical)).toBe("canonical");
+  });
+});
+
+describe("migrateCursorOnTouch — plain data file", () => {
+  test("carries a legacy grove cursor to the canonical tree, source kept", () => {
+    const legacy = join(home, ".local", "share", "grove", "mc-hook-cursor.json");
+    mkdirSync(join(legacy, ".."), { recursive: true });
+    writeFileSync(legacy, '{"cursor":42}');
+
+    const resolved = migrateCursorOnTouch(home);
+    expect(resolved).toBe(
+      join(home, ".local", "share", "metafactory", "cortex", "mc-hook-cursor.json"),
+    );
+    expect(existsSync(resolved)).toBe(true);
+    expect(readFileSync(resolved, "utf-8")).toBe('{"cursor":42}');
+    expect(existsSync(legacy)).toBe(true); // source kept
+  });
+});

--- a/src/common/__tests__/migrate-data-dir.test.ts
+++ b/src/common/__tests__/migrate-data-dir.test.ts
@@ -14,16 +14,14 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import {
-  migrateCursorOnTouch,
+  carryDbSidecars,
   migrateDbOnTouch,
   migratePublishedBufferOnTouch,
   migrateStackDbOnTouch,
 } from "../migrate-data-dir";
 import {
-  canonicalCursorPath,
   canonicalPublishedEventsDir,
   canonicalStackDbPath,
-  legacyCursorPath,
   legacyPublishedEventsDir,
   legacyStackDbPath,
 } from "../data-path";
@@ -57,6 +55,18 @@ function readMarker(dbPath: string): string {
   const row = db.query("SELECT v FROM t LIMIT 1").get() as { v: string };
   db.close();
   return row.v;
+}
+
+/** True iff the db at `dbPath` opens and passes `PRAGMA integrity_check`. */
+function integrityOk(dbPath: string): boolean {
+  try {
+    const db = new Database(dbPath, { readonly: true });
+    const row = db.query("PRAGMA integrity_check").get() as { integrity_check?: string } | null;
+    db.close();
+    return row?.integrity_check === "ok";
+  } catch {
+    return false;
+  }
 }
 
 describe("migrateStackDbOnTouch — copy-keep-source", () => {
@@ -101,44 +111,84 @@ describe("migrateStackDbOnTouch — copy-keep-source", () => {
 });
 
 describe("migrateDbOnTouch — WAL safety", () => {
-  test("checkpoints before copy so committed WAL data lands in the canonical db", () => {
+  test("checkpoints before copy so the canonical db is a VALID, self-consistent copy carrying the data", () => {
     const legacy = join(home, "legacy", "mission-control.db");
     const canonical = join(home, "canon", "mission-control.db");
     // A WAL-mode db with committed data. migrateDbOnTouch runs
     // wal_checkpoint(TRUNCATE) on the source first, folding any -wal frames into
     // the main .db file, THEN copies it — so no committed transaction is lost.
+    // The invariant that MATTERS (platform-independent): after migration the
+    // canonical db opens, reads the committed row, and passes integrity_check.
+    // A checkpointed db needs NO -wal to be valid, so we assert validity — not
+    // the presence of a sidecar SQLite may legitimately unlink on open (the old
+    // Linux-non-deterministic assertion this replaces).
     makeDb(legacy, "committed-in-wal");
 
     const res = migrateDbOnTouch(canonical, legacy);
     expect(res.migrated).toBe(true);
     // The canonical copy is a consistent, readable db carrying the data.
     expect(readMarker(canonical)).toBe("committed-in-wal");
-    // Source db intact (never renamed/removed).
+    expect(integrityOk(canonical)).toBe(true);
+    // Source db intact (never renamed/removed) and still valid.
     expect(readMarker(legacy)).toBe("committed-in-wal");
+    expect(integrityOk(legacy)).toBe(true);
   });
 
-  test("carries any surviving -wal / -shm sidecars alongside the main db", () => {
+  test("carryDbSidecars carries real -wal / -shm files WITH the db (deterministic — no db-open)", () => {
+    // Exercise the sidecar-copy LAYER directly with genuine sidecar files
+    // present and NO intervening db-open/checkpoint. This is deterministic on
+    // every platform: a db-open would let SQLite unlink a stray -wal for a
+    // rollback-journal db (the Linux flake the old in-migrator assertion hit).
+    // The real invariant: given sidecars on disk at copy time, they travel.
     const legacy = join(home, "legacy", "mission-control.db");
     const canonical = join(home, "canon", "mission-control.db");
-    // Rollback-journal db (wal=false): the internal checkpoint is a no-op that
-    // leaves these stray sidecar files untouched, so the test isolates the
-    // sidecar-CARRY behavior. (In production a real un-truncatable WAL is the
-    // case these carries protect.)
-    makeDb(legacy, "with-sidecars", false);
-    // Sidecars present at copy time (a partial checkpoint under active readers
-    // could leave un-folded frames here). They must travel WITH the db, and the
-    // source copies must remain intact.
-    writeFileSync(`${legacy}-wal`, "wal-bytes");
+    mkdirSync(join(legacy, ".."), { recursive: true });
+    mkdirSync(join(canonical, ".."), { recursive: true });
+    writeFileSync(legacy, "main-db-bytes");
+    writeFileSync(`${legacy}-wal`, "wal-bytes"); // un-folded committed frames
     writeFileSync(`${legacy}-shm`, "shm-bytes");
 
-    const res = migrateDbOnTouch(canonical, legacy);
-    expect(res.migrated).toBe(true);
-    expect(existsSync(canonical)).toBe(true);
-    expect(existsSync(`${canonical}-wal`)).toBe(true);
-    expect(existsSync(`${canonical}-shm`)).toBe(true);
+    const carried = carryDbSidecars(canonical, legacy);
+    expect(carried).toBe(2);
+    expect(readFileSync(`${canonical}-wal`, "utf-8")).toBe("wal-bytes");
+    expect(readFileSync(`${canonical}-shm`, "utf-8")).toBe("shm-bytes");
     // Source sidecars intact (copy-keep-source).
     expect(existsSync(`${legacy}-wal`)).toBe(true);
     expect(existsSync(`${legacy}-shm`)).toBe(true);
+  });
+
+  test("carryDbSidecars is a no-op (returns 0, never throws) when no sidecar exists", () => {
+    const legacy = join(home, "legacy", "mission-control.db");
+    const canonical = join(home, "canon", "mission-control.db");
+    mkdirSync(join(canonical, ".."), { recursive: true });
+    expect(carryDbSidecars(canonical, legacy)).toBe(0);
+    expect(existsSync(`${canonical}-wal`)).toBe(false);
+  });
+
+  test("torn-copy hardening — a corrupt canonical is detected, removed, and re-copied on the next run (GAP-4)", () => {
+    const legacy = join(home, "legacy", "mission-control.db");
+    const canonical = join(home, "canon", "mission-control.db");
+    // A source file that is NOT a valid SQLite db → the faithful copy yields a
+    // canonical that FAILS integrity_check. Because idempotence gates on
+    // existsSync(canonical), a torn copy would otherwise be preferred forever.
+    mkdirSync(join(legacy, ".."), { recursive: true });
+    writeFileSync(legacy, "this is not a sqlite database at all");
+
+    const res1 = migrateDbOnTouch(canonical, legacy);
+    // Detected corrupt → removed (source KEPT), reported not-migrated so the
+    // next run retries rather than sticking to garbage.
+    expect(res1.migrated).toBe(false);
+    expect(existsSync(canonical)).toBe(false);
+    expect(existsSync(legacy)).toBe(true); // source never removed
+
+    // The source becomes a valid db (e.g. it was mid-write before) — the next
+    // run re-copies and now lands a valid canonical.
+    rmSync(legacy);
+    makeDb(legacy, "recovered");
+    const res2 = migrateDbOnTouch(canonical, legacy);
+    expect(res2.migrated).toBe(true);
+    expect(integrityOk(canonical)).toBe(true);
+    expect(readMarker(canonical)).toBe("recovered");
   });
 
   test("canonical-wins — an existing canonical db is never overwritten", () => {
@@ -191,39 +241,9 @@ describe("migratePublishedBufferOnTouch — guardrail A (carry in-flight events)
   });
 });
 
-describe("migrateCursorOnTouch — plain data file + guardrail B (position continuity)", () => {
-  test("carries a legacy grove cursor to the canonical tree, source kept", () => {
-    const legacy = join(home, ".local", "share", "grove", "mc-hook-cursor.json");
-    mkdirSync(join(legacy, ".."), { recursive: true });
-    writeFileSync(legacy, '{"cursor":42}');
-
-    const resolved = migrateCursorOnTouch(home);
-    expect(resolved).toBe(
-      join(home, ".local", "share", "metafactory", "cortex", "mc-hook-cursor.json"),
-    );
-    expect(existsSync(resolved)).toBe(true);
-    expect(readFileSync(resolved, "utf-8")).toBe('{"cursor":42}');
-    expect(existsSync(legacy)).toBe(true); // source kept
-  });
-
-  test("guardrail B — MC resume position is PRESERVED across the move (offsets intact, no reset)", () => {
-    // The cursor is Record<rawEventFilePath, byteOffset>. Its keys reference the
-    // RAW buffer (`~/.claude/events/raw/…`), which does NOT move in #1902 — so
-    // moving the cursor FILE (copy-keep-source) preserves the exact resume
-    // position; MC neither re-ingests (dup events) nor skips.
-    const legacy = legacyCursorPath(home);
-    const canonical = canonicalCursorPath(home);
-    const rawKey = join(home, ".claude", "events", "raw", "2026-07-13.jsonl");
-    const cursor = { [rawKey]: 8192 };
-    mkdirSync(join(legacy, ".."), { recursive: true });
-    writeFileSync(legacy, JSON.stringify(cursor));
-
-    migrateCursorOnTouch(home);
-
-    const carried = JSON.parse(readFileSync(canonical, "utf-8")) as Record<string, number>;
-    expect(carried[rawKey]).toBe(8192); // exact offset preserved — no reset
-    // Key still references the (unmoved) raw buffer — no rewrite needed.
-    expect(Object.keys(carried)).toEqual([rawKey]);
-    expect(existsSync(legacy)).toBe(true); // source kept
-  });
-});
+// NOTE: the `migrateCursorOnTouch` (G-25) tests were removed with the migrator
+// itself (#1902 GAP-2). The grove standalone hook cursor is read ONLY by the
+// retired-for-production standalone MC entry (`surface/mc/index.ts`, FS-8a #1822);
+// the production EMBEDDED MC keeps its cursor beside its per-stack db and never
+// touches the grove cursor. A copy-forward migrator for a path nothing writes in
+// production is dead code — see the rationale block in `migrate-data-dir.ts`.

--- a/src/common/config/__tests__/migrate-published-events-value.test.ts
+++ b/src/common/config/__tests__/migrate-published-events-value.test.ts
@@ -9,12 +9,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { parse as parseYaml } from "yaml";
 
 import { migratePublishedEventsDirValue } from "../migrate-published-events-value";
+import { publishedEventsDir } from "../../events-path";
+import { canonicalPublishedEventsDir, resolvePublishedEventsDir } from "../../data-path";
 
 const NEW = "~/.local/share/metafactory/cortex/events/published";
 
@@ -101,5 +103,51 @@ describe("migratePublishedEventsDirValue", () => {
 
   test("missing file is a safe no-op", () => {
     expect(migratePublishedEventsDirValue(join(dir, "nope.yaml")).changed).toBe(false);
+  });
+});
+
+/**
+ * GAP-3 end-to-end: a box that pinned the LEGACY default in its cortex.yaml.
+ * The published-events WRITER (`events-path.ts:publishedEventsDir`) always writes
+ * the canonical data root; the READER (`adapters/discord/outbound-log.ts`) resolves
+ * `paths.publishedEventsDir` existence-gated (canonical-first / legacy-fallback for a
+ * default spelling). After the boot-path value-migration the persisted config, the
+ * writer, and the reader ALL agree on the canonical dir — the pipeline cannot split.
+ */
+describe("GAP-3 — pinned legacy value migrated ⇒ writer & reader agree on canonical", () => {
+  let savedDataDir: string | undefined;
+  let home: string;
+
+  beforeEach(() => {
+    savedDataDir = process.env.CORTEX_DATA_DIR;
+    delete process.env.CORTEX_DATA_DIR; // hermetic: no override; resolve the real canonical
+    home = join(dir, "home");
+  });
+  afterEach(() => {
+    if (savedDataDir === undefined) delete process.env.CORTEX_DATA_DIR;
+    else process.env.CORTEX_DATA_DIR = savedDataDir;
+  });
+
+  test("pinned legacy ~/.claude/events/published → migrated → writer==reader==canonical", () => {
+    const canonical = canonicalPublishedEventsDir(home);
+    // Pre-condition: writer already targets canonical (never reads the config field).
+    expect(publishedEventsDir(home)).toBe(canonical);
+
+    // A pre-cutover config pins the legacy default.
+    writeFileSync(cfg, CONFIG("~/.claude/events/published"));
+    const res = migratePublishedEventsDirValue(cfg, { home });
+    expect(res.changed).toBe(true);
+
+    // The persisted value now equals canonical (tilde-expanded under `home`).
+    const parsed = parseYaml(readFileSync(cfg, "utf-8")) as {
+      paths: { publishedEventsDir: string };
+    };
+    expect(parsed.paths.publishedEventsDir.replace(/^~/, home)).toBe(canonical);
+
+    // Once the relay has created/carried the canonical dir, the reader's
+    // existence-gated resolution picks canonical — the SAME dir the writer writes.
+    mkdirSync(canonical, { recursive: true });
+    expect(resolvePublishedEventsDir(home)).toBe(canonical); // reader
+    expect(publishedEventsDir(home)).toBe(canonical); // writer
   });
 });

--- a/src/common/config/__tests__/migrate-published-events-value.test.ts
+++ b/src/common/config/__tests__/migrate-published-events-value.test.ts
@@ -1,0 +1,105 @@
+/**
+ * XDG wave-5 (cortex#1902) AC2 — publishedEventsDir config VALUE migrator tests.
+ *
+ * Hermetic: a scratch `cortex.yaml` under `os.tmpdir()`; a scratch `home` for the
+ * `$HOME`-expanded-legacy case. Proves the pinned value is MIGRATED (not
+ * shadowed) to the new metafactory data root, that a CUSTOM value is left alone,
+ * that the rewrite is idempotent, and that surrounding formatting/comments
+ * survive the one-line edit.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+
+import { migratePublishedEventsDirValue } from "../migrate-published-events-value";
+
+const NEW = "~/.local/share/metafactory/cortex/events/published";
+
+let dir: string;
+let cfg: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "xdg1902-pev-"));
+  cfg = join(dir, "cortex.yaml");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const CONFIG = (pev: string) =>
+  `# generated cortex.yaml
+paths:
+  publishedEventsDir: ${pev}
+  logDir: ~/.config/cortex/logs
+nats:
+  url: nats://127.0.0.1:4222
+`;
+
+describe("migratePublishedEventsDirValue", () => {
+  test("rewrites a pinned legacy default value to the new data root", () => {
+    writeFileSync(cfg, CONFIG("~/.claude/events/published"));
+    const res = migratePublishedEventsDirValue(cfg);
+    expect(res.changed).toBe(true);
+    expect(res.from).toBe("~/.claude/events/published");
+    expect(res.to).toBe(NEW);
+
+    const parsed = parseYaml(readFileSync(cfg, "utf-8")) as {
+      paths: { publishedEventsDir: string; logDir: string };
+    };
+    expect(parsed.paths.publishedEventsDir).toBe(NEW);
+    // Untouched siblings preserved.
+    expect(parsed.paths.logDir).toBe("~/.config/cortex/logs");
+  });
+
+  test("preserves surrounding comments + other lines (targeted single-line edit)", () => {
+    writeFileSync(cfg, CONFIG("~/.claude/events/published"));
+    migratePublishedEventsDirValue(cfg);
+    const out = readFileSync(cfg, "utf-8");
+    expect(out).toContain("# generated cortex.yaml");
+    expect(out).toContain("url: nats://127.0.0.1:4222");
+    expect(out).toContain(`publishedEventsDir: ${NEW}`);
+  });
+
+  test("migrates the $HOME-expanded absolute legacy form too", () => {
+    const home = join(dir, "home");
+    writeFileSync(cfg, CONFIG(join(home, ".claude", "events", "published")));
+    const res = migratePublishedEventsDirValue(cfg, { home });
+    expect(res.changed).toBe(true);
+    const parsed = parseYaml(readFileSync(cfg, "utf-8")) as {
+      paths: { publishedEventsDir: string };
+    };
+    expect(parsed.paths.publishedEventsDir).toBe(NEW);
+  });
+
+  test("leaves a CUSTOM pinned value untouched (respects user intent)", () => {
+    writeFileSync(cfg, CONFIG("/mnt/events/published"));
+    const res = migratePublishedEventsDirValue(cfg);
+    expect(res.changed).toBe(false);
+    const parsed = parseYaml(readFileSync(cfg, "utf-8")) as {
+      paths: { publishedEventsDir: string };
+    };
+    expect(parsed.paths.publishedEventsDir).toBe("/mnt/events/published");
+  });
+
+  test("idempotent — an already-migrated value is a no-op", () => {
+    writeFileSync(cfg, CONFIG(NEW));
+    const res = migratePublishedEventsDirValue(cfg);
+    expect(res.changed).toBe(false);
+    expect(parseYaml(readFileSync(cfg, "utf-8"))).toMatchObject({
+      paths: { publishedEventsDir: NEW },
+    });
+  });
+
+  test("handles a quoted legacy value, preserving the quotes", () => {
+    writeFileSync(cfg, CONFIG('"~/.claude/events/published"'));
+    const res = migratePublishedEventsDirValue(cfg);
+    expect(res.changed).toBe(true);
+    const out = readFileSync(cfg, "utf-8");
+    expect(out).toContain(`publishedEventsDir: "${NEW}"`);
+  });
+
+  test("missing file is a safe no-op", () => {
+    expect(migratePublishedEventsDirValue(join(dir, "nope.yaml")).changed).toBe(false);
+  });
+});

--- a/src/common/config/migrate-published-events-value.ts
+++ b/src/common/config/migrate-published-events-value.ts
@@ -1,0 +1,128 @@
+/**
+ * XDG wave-5 (cortex#1902, EPIC cortex#1867 §P3b) — publishedEventsDir config
+ * VALUE migrator.
+ *
+ * `paths.publishedEventsDir` is a PERSISTED config value: `stack-lib.ts` writes
+ * it literally into every generated `cortex.yaml`. Because it is pinned in the
+ * file, an env var or a changed zod default CANNOT relocate it — the pinned old
+ * value wins at parse time and keeps the reader pointed at
+ * `~/.claude/events/published`. So the move is done by MIGRATING the file:
+ * rewriting the pinned legacy value to the new metafactory data-root value
+ * (`~/.local/share/metafactory/cortex/events/published`). "Migrate, don't
+ * shadow."
+ *
+ * ── What is rewritten ────────────────────────────────────────────────────────
+ * ONLY a value that matches a known LEGACY spelling of the old default — the
+ * `~`-prefixed `~/.claude/events/published` OR its `$HOME`-expanded absolute
+ * form. A genuinely CUSTOM pinned path (a user who chose their own location) is
+ * LEFT ALONE (their intent is respected), and an already-migrated value is a
+ * no-op (idempotent).
+ *
+ * ── Formatting preservation ──────────────────────────────────────────────────
+ * The rewrite is a TARGETED single-line edit (indentation + optional quotes +
+ * trailing comment preserved), NOT a parse→stringify round-trip that would strip
+ * every comment from the generated `cortex.yaml`. The file is validated by a
+ * real YAML parse first (to read the current value + confirm structure), then
+ * the one scalar is replaced textually and written atomically (temp-O_EXCL →
+ * fsync → chmod → rename, source mode preserved).
+ */
+
+import { existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+
+import { atomicWriteFile } from "./migrate-config-dir";
+import {
+  LEGACY_PUBLISHED_EVENTS_DIR_DEFAULT,
+  PUBLISHED_EVENTS_DIR_DEFAULT,
+} from "../data-path";
+
+export interface PublishedEventsValueMigration {
+  /** True when THIS call rewrote the file. */
+  changed: boolean;
+  /** The value before the rewrite (present only when `changed`). */
+  from?: string;
+  /** The value written (present only when `changed`). */
+  to?: string;
+}
+
+/** The `$HOME`-expanded absolute form of the legacy default. */
+function legacyExpanded(home: string): string {
+  return join(home, ".claude", "events", "published");
+}
+
+/**
+ * Whether `value` is a known legacy spelling of the old `publishedEventsDir`
+ * default (the `~`-prefixed form or its `$HOME`-expanded absolute form). A
+ * custom path returns false (left untouched).
+ */
+export function isLegacyPublishedEventsDir(value: string, home: string): boolean {
+  return value === LEGACY_PUBLISHED_EVENTS_DIR_DEFAULT || value === legacyExpanded(home);
+}
+
+/**
+ * Textually replace the scalar on the `publishedEventsDir:` line, preserving
+ * indentation, optional surrounding quotes, and any trailing comment. Returns
+ * the rewritten file text, or `null` when no `publishedEventsDir:` line is found
+ * (the caller then leaves the file untouched).
+ */
+function rewriteLine(raw: string, newValue: string): string | null {
+  // Matches: <indent>publishedEventsDir:<sp><optquote><value><optquote><sp><#comment?>
+  const re = /^(\s*publishedEventsDir:[ \t]*)(["']?)(.*?)\2([ \t]*(?:#.*)?)$/m;
+  if (!re.test(raw)) return null;
+  return raw.replace(re, (_m, prefix: string, quote: string, _val: string, tail: string) => {
+    return `${prefix}${quote}${newValue}${quote}${tail}`;
+  });
+}
+
+/**
+ * Migrate the pinned `paths.publishedEventsDir` value inside an existing
+ * `cortex.yaml`, in place, to the new metafactory data-root default.
+ *
+ * Non-destructive + idempotent:
+ *   - file missing / not a YAML mapping / no `paths.publishedEventsDir` string →
+ *     no-op (`changed:false`);
+ *   - value is a CUSTOM path (not a legacy default spelling) → no-op (intent
+ *     respected);
+ *   - value already equals the new default → no-op;
+ *   - value is a legacy default spelling → the one scalar is rewritten to the new
+ *     default and the file is written atomically (source mode preserved).
+ *
+ * @param configPath Absolute path to the `cortex.yaml` to migrate.
+ * @param opts.home  Override for `$HOME` (tests pass a scratch home).
+ */
+export function migratePublishedEventsDirValue(
+  configPath: string,
+  opts: { home?: string } = {},
+): PublishedEventsValueMigration {
+  if (!existsSync(configPath)) return { changed: false };
+
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch {
+    return { changed: false };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch {
+    return { changed: false }; // malformed YAML — never rewrite blindly
+  }
+
+  const current = (parsed as { paths?: { publishedEventsDir?: unknown } } | null)?.paths
+    ?.publishedEventsDir;
+  if (typeof current !== "string") return { changed: false };
+
+  const home = opts.home ?? process.env.HOME ?? "~";
+  if (!isLegacyPublishedEventsDir(current, home)) return { changed: false }; // custom / already new
+  if (current === PUBLISHED_EVENTS_DIR_DEFAULT) return { changed: false }; // already migrated
+
+  const next = rewriteLine(raw, PUBLISHED_EVENTS_DIR_DEFAULT);
+  if (next === null || next === raw) return { changed: false };
+
+  const mode = statSync(configPath).mode & 0o777;
+  atomicWriteFile(configPath, Buffer.from(next, "utf-8"), mode);
+  return { changed: true, from: current, to: PUBLISHED_EVENTS_DIR_DEFAULT };
+}

--- a/src/common/data-path.ts
+++ b/src/common/data-path.ts
@@ -1,0 +1,247 @@
+/**
+ * XDG wave-5 (cortex#1902, EPIC cortex#1867 §P3b) — DATA-dir path resolver.
+ *
+ * The metafactory DATA tree (Mission-Control dbs, the MC hook cursor, the
+ * published-events buffer) is moving to the canonical XDG data root
+ * `~/.local/share/metafactory/cortex/`, folded under the shared `metafactory`
+ * root (matching the wave-3 `~/.local/bin` and wave-4 `~/.config/metafactory`
+ * cutovers). Before this wave three MC-db layouts coexisted:
+ *
+ *   1. `~/.local/share/grove/mission-control.db`      — standalone MC v2 default.
+ *   2. `~/.local/share/cortex/mc/<stack>/…`           — per-stack embedded default.
+ *   3. sibling-db-reader discovered peers BY the #2 shape.
+ *
+ * This module is the single seam that resolves a DATA path with
+ * **canonical-first / legacy-fallback** precedence during the transition, so a
+ * pre-cutover box still reads the old tree while a migrated box reads the new
+ * one. It is the DATA analogue of `config/config-path.ts`.
+ *
+ * ── Precedence (read) ────────────────────────────────────────────────────────
+ *   1. `$CORTEX_DATA_DIR/<…>`                          — explicit override (verbatim,
+ *      a self-contained root; NO legacy probe — mirrors the config seam).
+ *   2. `~/.local/share/metafactory/cortex/<…>`         — canonical (used if present).
+ *   3. legacy tree (`~/.local/share/cortex/…` or grove) — read-fallback if present.
+ *   4. canonical path                                  — write/default target when none.
+ *
+ * ── Two resolution flavours ──────────────────────────────────────────────────
+ * The SERVING stack migrates its OWN db on boot (see `migrate-data-dir.ts`), so
+ * it resolves-and-migrates. The sibling reader only READS peers' dbs — it must
+ * NEVER migrate another stack's data — so it uses the PURE existence-gated
+ * resolvers here (no side effects beyond `existsSync`). Both share this module
+ * so the on-disk shape they compute is byte-identical (self-exclusion depends on
+ * it).
+ *
+ * Every legacy-tree hit is surfaced via {@link noteXdgFallback} so a
+ * `CORTEX_XDG_STRICT=1` fresh-install run stays silent (Fallback Contract,
+ * cortex#1867). Isolation: every path derives from an injectable `home`, so the
+ * whole seam runs against a scratch `$HOME` with ZERO real-home access.
+ */
+
+import { existsSync } from "fs";
+import { join } from "path";
+
+import { noteXdgFallback, readDirEnv } from "./xdg";
+
+/** The shared metafactory XDG root under `~/.local/share` (wave-5 cutover). */
+export const METAFACTORY_DIRNAME = "metafactory";
+/** The canonical data directory name (nested under `metafactory/`). */
+export const CORTEX_DATA_DIRNAME = "cortex";
+/** The legacy grove data directory name (read-fallback only during transition). */
+export const GROVE_DATA_DIRNAME = "grove";
+/** Bare filename of the MC hook cursor (G-25). */
+export const MC_HOOK_CURSOR_NAME = "mc-hook-cursor.json";
+/** Bare filename of a standalone MC v2 db. */
+export const MISSION_CONTROL_DB_NAME = "mission-control.db";
+
+function homeDir(home?: string): string {
+  return home ?? process.env.HOME ?? "~";
+}
+
+/**
+ * The `CORTEX_DATA_DIR` override, or `undefined` when unset/empty. A blank or
+ * whitespace-only value reads as unset (via {@link readDirEnv}) so
+ * `CORTEX_DATA_DIR=` keeps today's `~/.local/share/…` default rather than
+ * resolving to `/`. When set it is the data root VERBATIM and both legacy
+ * fallbacks are skipped (a self-contained root has no legacy counterpart, and
+ * probing the real `~/.local/share/{cortex,grove}` would break hermeticity).
+ */
+export function cortexDataDirOverride(): string | undefined {
+  return readDirEnv("CORTEX_DATA_DIR");
+}
+
+/**
+ * The cortex DATA directory: `$CORTEX_DATA_DIR` if set, else the canonical
+ * `~/.local/share/metafactory/cortex` (XDG wave-5). This is the single seam
+ * every data path is built on, so overriding the env var relocates the whole
+ * data tree at once.
+ */
+export function cortexDataDir(home?: string): string {
+  return (
+    cortexDataDirOverride() ??
+    join(homeDir(home), ".local", "share", METAFACTORY_DIRNAME, CORTEX_DATA_DIRNAME)
+  );
+}
+
+/** Legacy flat cortex data dir `~/.local/share/cortex` (read-fallback only). */
+export function legacyCortexDataDir(home?: string): string {
+  return join(homeDir(home), ".local", "share", CORTEX_DATA_DIRNAME);
+}
+
+/** Legacy grove data dir `~/.local/share/grove` (oldest tree; read-fallback only). */
+export function legacyGroveDataDir(home?: string): string {
+  return join(homeDir(home), ".local", "share", GROVE_DATA_DIRNAME);
+}
+
+// ───────────────────────────────────────────────────── per-stack MC db (layout 2/3)
+
+/** Canonical per-stack MC db root: `~/.local/share/metafactory/cortex/mc`. */
+export function mcDbRoot(home?: string): string {
+  return join(cortexDataDir(home), "mc");
+}
+
+/** Legacy per-stack MC db root: `~/.local/share/cortex/mc` (pre-wave-5). */
+export function legacyMcDbRoot(home?: string): string {
+  return join(legacyCortexDataDir(home), "mc");
+}
+
+/** Canonical per-stack MC db path (write/default target). */
+export function canonicalStackDbPath(stack: string, home?: string): string {
+  return join(mcDbRoot(home), stack, MISSION_CONTROL_DB_NAME);
+}
+
+/** Legacy per-stack MC db path (`~/.local/share/cortex/mc/<stack>/…`). */
+export function legacyStackDbPath(stack: string, home?: string): string {
+  return join(legacyMcDbRoot(home), stack, MISSION_CONTROL_DB_NAME);
+}
+
+/**
+ * PURE existence-gated resolution of a per-stack MC db path — NO side effects
+ * beyond `existsSync`. Prefers the canonical location if present, else the
+ * legacy `~/.local/share/cortex/mc/<stack>/…` if present, else the canonical
+ * path (the write target on a fresh host). An explicit `$CORTEX_DATA_DIR`
+ * short-circuits all fallback (self-contained root).
+ *
+ * This is what the sibling-db-reader uses to resolve PEERS' dbs — it reads them
+ * read-only and must NEVER migrate another stack's data, so a peer that has
+ * migrated is read from the new tree and one that has not is read from legacy.
+ * The serving stack's OWN db is resolved-and-migrated by `migrate-data-dir.ts`
+ * (which then lands here at the canonical path).
+ */
+export function resolveStackDbPath(stack: string, home?: string): string {
+  const canonical = canonicalStackDbPath(stack, home);
+  if (cortexDataDirOverride() !== undefined) return canonical;
+  if (existsSync(canonical)) return canonical;
+  const legacy = legacyStackDbPath(stack, home);
+  if (existsSync(legacy)) {
+    noteXdgFallback("data", `mc db for "${stack}" resolved from legacy ~/.local/share/cortex/mc`);
+    return legacy;
+  }
+  return canonical;
+}
+
+// ─────────────────────────────────────────────────── standalone MC v2 db (layout 1)
+
+/** Canonical standalone MC v2 db path: `~/.local/share/metafactory/cortex/mission-control.db`. */
+export function canonicalStandaloneDbPath(home?: string): string {
+  return join(cortexDataDir(home), MISSION_CONTROL_DB_NAME);
+}
+
+/** Legacy standalone MC v2 db path: `~/.local/share/grove/mission-control.db`. */
+export function legacyStandaloneDbPath(home?: string): string {
+  return join(legacyGroveDataDir(home), MISSION_CONTROL_DB_NAME);
+}
+
+/**
+ * PURE existence-gated resolution of the standalone MC v2 db path. Prefers the
+ * canonical location if present, else the legacy `~/.local/share/grove/…` if
+ * present, else the canonical path. `$CORTEX_DATA_DIR` short-circuits fallback.
+ */
+export function resolveStandaloneDbPath(home?: string): string {
+  const canonical = canonicalStandaloneDbPath(home);
+  if (cortexDataDirOverride() !== undefined) return canonical;
+  if (existsSync(canonical)) return canonical;
+  const legacy = legacyStandaloneDbPath(home);
+  if (existsSync(legacy)) {
+    noteXdgFallback("data", "mission-control.db resolved from legacy ~/.local/share/grove");
+    return legacy;
+  }
+  return canonical;
+}
+
+// ─────────────────────────────────────────────────────── MC hook cursor (G-25)
+
+/** Canonical MC hook cursor path: `~/.local/share/metafactory/cortex/mc-hook-cursor.json`. */
+export function canonicalCursorPath(home?: string): string {
+  return join(cortexDataDir(home), MC_HOOK_CURSOR_NAME);
+}
+
+/** Legacy MC hook cursor path: `~/.local/share/grove/mc-hook-cursor.json`. */
+export function legacyCursorPath(home?: string): string {
+  return join(legacyGroveDataDir(home), MC_HOOK_CURSOR_NAME);
+}
+
+/**
+ * PURE existence-gated resolution of the MC hook cursor path. Prefers canonical,
+ * else legacy grove, else canonical. `$CORTEX_DATA_DIR` short-circuits fallback.
+ */
+export function resolveCursorPath(home?: string): string {
+  const canonical = canonicalCursorPath(home);
+  if (cortexDataDirOverride() !== undefined) return canonical;
+  if (existsSync(canonical)) return canonical;
+  const legacy = legacyCursorPath(home);
+  if (existsSync(legacy)) {
+    noteXdgFallback("data", "mc-hook-cursor.json resolved from legacy ~/.local/share/grove");
+    return legacy;
+  }
+  return canonical;
+}
+
+// ──────────────────────────────────────────────── published-events buffer (AC2/AC3)
+
+/**
+ * Canonical published-events buffer: `~/.local/share/metafactory/cortex/events/published`.
+ * This is the DATA half of the cc-events buffer that #1902 moves under the data
+ * root (events-path.ts's scope note assigns the buffer move here). The RAW half
+ * stays at `~/.claude/events/raw` (Claude Code hook territory); only `published`
+ * — cortex's own durable archive — relocates.
+ */
+export function canonicalPublishedEventsDir(home?: string): string {
+  return join(cortexDataDir(home), "events", "published");
+}
+
+/** Legacy published-events buffer: `~/.claude/events/published`. */
+export function legacyPublishedEventsDir(home?: string): string {
+  return join(homeDir(home), ".claude", "events", "published");
+}
+
+/**
+ * PURE existence-gated resolution of the published-events dir. Prefers the
+ * canonical data-root location if present, else the legacy `~/.claude/events/
+ * published` if present, else the canonical path. `$CORTEX_DATA_DIR`
+ * short-circuits fallback. Writer (relay) and reader (outbound-log) both route
+ * through this so they stay in lockstep after the move.
+ */
+export function resolvePublishedEventsDir(home?: string): string {
+  const canonical = canonicalPublishedEventsDir(home);
+  if (cortexDataDirOverride() !== undefined) return canonical;
+  if (existsSync(canonical)) return canonical;
+  const legacy = legacyPublishedEventsDir(home);
+  if (existsSync(legacy)) {
+    noteXdgFallback("data", "published events resolved from legacy ~/.claude/events/published");
+    return legacy;
+  }
+  return canonical;
+}
+
+/**
+ * The canonical STRING literal written into a generated `cortex.yaml` and used
+ * as the zod default for `paths.publishedEventsDir`. Uses the `~`-prefixed
+ * spelling (matching the pre-move `~/.claude/events/published` default and the
+ * consumer's `replace(/^~/, HOME)` expansion) so the persisted config stays
+ * home-relative and portable.
+ */
+export const PUBLISHED_EVENTS_DIR_DEFAULT =
+  "~/.local/share/metafactory/cortex/events/published";
+
+/** The pre-move default literal for `paths.publishedEventsDir` (value-migrator source). */
+export const LEGACY_PUBLISHED_EVENTS_DIR_DEFAULT = "~/.claude/events/published";

--- a/src/common/events-path.ts
+++ b/src/common/events-path.ts
@@ -16,14 +16,24 @@
  *   - SET    ⇒ that directory VERBATIM, so a guard (#1870) can point the whole
  *     hook→relay→MC pipeline at a scratch dir with zero real-home access.
  *
- * SCOPE — this is JUST the env read. It does NOT honor `$XDG_DATA_HOME` /
- * `$XDG_STATE_HOME` or move the buffer (that classification is #1867 P3 /
- * #1902). No `GROVE_*` dual-read: `CORTEX_EVENTS_DIR` is a newly-introduced
- * var, not a name being migrated (cortex#774's dual-read is only for renames).
+ * ─────────────────────────────────────────────────────────────────────────
+ * XDG wave-5 (cortex#1902, EPIC cortex#1867 §P3b) — PUBLISHED half moves.
+ *
+ * The buffer is now SPLIT by data class (matching the merged XDG standard):
+ *   - RAW (`eventsDir()` / `rawEventsDir()`) is the hook-substrate boundary and
+ *     STAYS at `~/.claude/events/{,raw}` (or `$CORTEX_EVENTS_DIR`) — the #1908
+ *     byte-identical contract here is UNCHANGED.
+ *   - PUBLISHED (`publishedEventsDir()`) is app-private DATA and MOVES under the
+ *     metafactory data root (`~/.local/share/metafactory/cortex/events/published`,
+ *     or `$CORTEX_DATA_DIR`) via `data-path.ts`. The relay writer + retention +
+ *     the Discord consumer route through this; the in-flight buffer is carried
+ *     forward by `migratePublishedBufferOnTouch` (copy-keep-source). So raw and
+ *     published NO LONGER share a root — that is the intended split.
  */
 
 import { join } from "path";
 
+import { canonicalPublishedEventsDir } from "./data-path";
 import { readDirEnv } from "./xdg";
 
 function homeDir(home?: string): string {
@@ -55,7 +65,14 @@ export function rawEventsDir(home?: string): string {
   return join(eventsDir(home), "raw");
 }
 
-/** The published event buffer: `<eventsDir>/published`. */
+/**
+ * The published event buffer. XDG wave-5 (#1902): this is app-private DATA and
+ * now resolves under the metafactory data root
+ * (`~/.local/share/metafactory/cortex/events/published`, or `$CORTEX_DATA_DIR`)
+ * — NOT `<eventsDir>/published`. Pure (like `rawEventsDir`); the existence-gated
+ * fallback + in-flight buffer carry live in `data-path.ts` / `migrate-data-dir.ts`
+ * and run at the relay/consumer boot. Raw stays at `~/.claude/events/raw`.
+ */
 export function publishedEventsDir(home?: string): string {
-  return join(eventsDir(home), "published");
+  return canonicalPublishedEventsDir(home);
 }

--- a/src/common/migrate-data-dir.ts
+++ b/src/common/migrate-data-dir.ts
@@ -1,0 +1,163 @@
+/**
+ * XDG wave-5 (cortex#1902, EPIC cortex#1867 §P3b) — DATA migration-on-touch.
+ *
+ * The data move is COPY-KEEP-SOURCE (never move a db out from under a running
+ * process): when a canonical data path is about to be TOUCHED but only a legacy
+ * copy exists, the legacy copy is carried to the canonical location and the
+ * SOURCE is KEPT. Existence-gated resolution (`data-path.ts`) then prefers the
+ * canonical copy; a pre-cutover box that never ran the migration still reads the
+ * legacy tree. Nothing here ever deletes a source — a mid-flight crash leaves
+ * the legacy tree fully intact and the move simply re-runs (idempotent).
+ *
+ * ── Live-DB safety (the WAL hazard) ─────────────────────────────────────────
+ * A SQLite db in WAL mode keeps committed frames in a `-wal` sidecar until a
+ * checkpoint folds them into the main `.db` file. Copying ONLY the `.db` file
+ * would therefore drop the most recent committed transactions. So a db carry:
+ *   1. best-effort `PRAGMA wal_checkpoint(TRUNCATE)` on the legacy db (folds the
+ *      WAL into the main file; a partial checkpoint under active readers is
+ *      tolerated — the `-wal` is still carried below), then
+ *   2. atomically copies the main `.db` file, AND
+ *   3. carries any `-wal` / `-shm` sidecars that still exist, so a partial
+ *      checkpoint's committed frames travel WITH the db (a consistent snapshot).
+ * The source is only ever READ + checkpointed, never renamed or removed.
+ *
+ * This is the DATA analogue of `config/migrate-config-dir.ts` and reuses its
+ * `atomicWriteFile` primitive (create-temp-O_EXCL → write → fsync → chmod →
+ * rename). Isolation: every path derives from an injectable `home`.
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, readFileSync, statSync } from "fs";
+import { dirname } from "path";
+
+import { atomicWriteFile } from "./config/migrate-config-dir";
+import {
+  canonicalCursorPath,
+  canonicalStackDbPath,
+  canonicalStandaloneDbPath,
+  cortexDataDirOverride,
+  legacyCursorPath,
+  legacyStackDbPath,
+  legacyStandaloneDbPath,
+} from "./data-path";
+
+/** The WAL/SHM sidecar suffixes carried alongside a `.db` file. */
+const DB_SIDECAR_SUFFIXES = ["-wal", "-shm"] as const;
+
+/** Outcome of a migration-on-touch attempt. */
+export interface DataMigrationResult {
+  /** The path callers should now use (canonical when migrated or pre-existing). */
+  path: string;
+  /** True when THIS call performed the copy (false = already-canonical / nothing to carry). */
+  migrated: boolean;
+}
+
+/**
+ * Best-effort WAL checkpoint on a legacy db so its committed frames fold into
+ * the main `.db` file before the copy. Opens read-write (a checkpoint is a
+ * write), TRUNCATEs the WAL, and closes. NEVER throws — a locked / read-only /
+ * corrupt legacy db just means we skip the checkpoint and carry the sidecars
+ * as-is (the `-wal` copy below preserves any un-folded committed frames).
+ */
+function checkpointLegacyDb(legacyDbPath: string): void {
+  let db: Database | undefined;
+  try {
+    db = new Database(legacyDbPath); // read-write — a checkpoint writes
+    db.run("PRAGMA wal_checkpoint(TRUNCATE)");
+  } catch {
+    // Locked by a live process, read-only fs, or not-yet-WAL — tolerated.
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // best-effort close
+    }
+  }
+}
+
+/**
+ * Atomically copy one file `src` → `dest`, preserving mode, keeping the source.
+ * Idempotent at the call site (callers gate on `existsSync(dest)`); the write
+ * itself is atomic (temp-O_EXCL → fsync → rename) so a crash never leaves a torn
+ * destination.
+ */
+function atomicCopyKeepingSource(src: string, dest: string): void {
+  const mode = statSync(src).mode & 0o777;
+  const data = readFileSync(src); // SOURCE is only ever READ, never renamed
+  atomicWriteFile(dest, data, mode);
+}
+
+/**
+ * Migrate-on-touch a SQLite db (with WAL/SHM sidecars), copy-keep-source.
+ *
+ * Idempotent + non-destructive:
+ *   - canonical db already present → no-op, returns `{migrated:false}` (canonical
+ *     is authoritative; never clobber it with a stale legacy copy);
+ *   - only a legacy db present → checkpoint it, then atomically carry the main
+ *     `.db` file + any `-wal`/`-shm` sidecars to canonical (source kept),
+ *     returns `{migrated:true}`;
+ *   - neither present → no-op, returns `{migrated:false}` (canonical is the
+ *     write target a fresh install will create).
+ *
+ * An explicit `$CORTEX_DATA_DIR` root has no legacy counterpart — never reach
+ * into the real `~/.local/share/{cortex,grove}` (breaks the hermetic guard).
+ */
+export function migrateDbOnTouch(canonicalDbPath: string, legacyDbPath: string): DataMigrationResult {
+  if (existsSync(canonicalDbPath)) return { path: canonicalDbPath, migrated: false };
+  if (cortexDataDirOverride() !== undefined) return { path: canonicalDbPath, migrated: false };
+  if (!existsSync(legacyDbPath)) return { path: canonicalDbPath, migrated: false };
+
+  // Fold the WAL into the main file first (best-effort), then copy consistently.
+  checkpointLegacyDb(legacyDbPath);
+  mkdirSync(dirname(canonicalDbPath), { recursive: true });
+  atomicCopyKeepingSource(legacyDbPath, canonicalDbPath);
+  // Carry any surviving sidecars so a partial checkpoint's committed frames
+  // travel with the db. `-shm` is regenerable but harmless to carry; `-wal`
+  // may hold committed frames not yet folded — carrying it is the safe choice.
+  for (const suffix of DB_SIDECAR_SUFFIXES) {
+    const srcSidecar = `${legacyDbPath}${suffix}`;
+    if (existsSync(srcSidecar)) {
+      atomicCopyKeepingSource(srcSidecar, `${canonicalDbPath}${suffix}`);
+    }
+  }
+  return { path: canonicalDbPath, migrated: true };
+}
+
+/**
+ * Migrate-on-touch a plain data file (e.g. the MC hook cursor), copy-keep-source.
+ * Idempotent + non-destructive, same gating as {@link migrateDbOnTouch} minus
+ * the WAL handling.
+ */
+export function migrateDataFileOnTouch(canonicalPath: string, legacyPath: string): DataMigrationResult {
+  if (existsSync(canonicalPath)) return { path: canonicalPath, migrated: false };
+  if (cortexDataDirOverride() !== undefined) return { path: canonicalPath, migrated: false };
+  if (!existsSync(legacyPath)) return { path: canonicalPath, migrated: false };
+  mkdirSync(dirname(canonicalPath), { recursive: true });
+  // copyFileSync would apply the umask, not the source mode — use the atomic
+  // copy which re-asserts the source mode (a 0600 cursor stays 0600).
+  atomicCopyKeepingSource(legacyPath, canonicalPath);
+  return { path: canonicalPath, migrated: true };
+}
+
+// ─────────────────────────────────────────────── stack / standalone / cursor wrappers
+
+/**
+ * Resolve-and-migrate the SERVING stack's OWN per-stack MC db: carry a legacy
+ * `~/.local/share/cortex/mc/<stack>/…` db to the canonical metafactory tree
+ * (copy-keep-source, WAL-safe) and return the canonical path. Call at boot
+ * BEFORE opening the db. The sibling reader does NOT call this — it only reads
+ * peers' dbs (pure resolution, never migrates another stack's data).
+ */
+export function migrateStackDbOnTouch(stack: string, home?: string): string {
+  return migrateDbOnTouch(canonicalStackDbPath(stack, home), legacyStackDbPath(stack, home)).path;
+}
+
+/** Resolve-and-migrate the standalone MC v2 db (legacy grove → canonical). */
+export function migrateStandaloneDbOnTouch(home?: string): string {
+  return migrateDbOnTouch(canonicalStandaloneDbPath(home), legacyStandaloneDbPath(home)).path;
+}
+
+/** Resolve-and-migrate the MC hook cursor (G-25: legacy grove → canonical). */
+export function migrateCursorOnTouch(home?: string): string {
+  return migrateDataFileOnTouch(canonicalCursorPath(home), legacyCursorPath(home)).path;
+}

--- a/src/common/migrate-data-dir.ts
+++ b/src/common/migrate-data-dir.ts
@@ -27,20 +27,16 @@
  */
 
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from "fs";
 import { dirname, join } from "path";
 
 import { atomicWriteFile } from "./config/migrate-config-dir";
 import {
-  canonicalCursorPath,
   canonicalPublishedEventsDir,
   canonicalStackDbPath,
-  canonicalStandaloneDbPath,
   cortexDataDirOverride,
-  legacyCursorPath,
   legacyPublishedEventsDir,
   legacyStackDbPath,
-  legacyStandaloneDbPath,
 } from "./data-path";
 
 /** The WAL/SHM sidecar suffixes carried alongside a `.db` file. */
@@ -90,6 +86,65 @@ function atomicCopyKeepingSource(src: string, dest: string): void {
 }
 
 /**
+ * Carry any surviving `-wal` / `-shm` sidecars from `legacyDbPath` to sit
+ * alongside `canonicalDbPath`, copy-keep-source. Separated from
+ * {@link migrateDbOnTouch} so the carry can be exercised DIRECTLY (with real
+ * sidecar files present and NO intervening db-open) — a db-open would let
+ * SQLite unlink a stray `-wal` on some platforms (Linux), making an in-migrator
+ * "the sidecar survives an open" assertion non-deterministic. This helper states
+ * the real invariant: given sidecars on disk at copy time, they travel WITH the
+ * db. Returns the number of sidecars copied (0 when none exist — a no-op that
+ * never throws).
+ */
+export function carryDbSidecars(canonicalDbPath: string, legacyDbPath: string): number {
+  let carried = 0;
+  for (const suffix of DB_SIDECAR_SUFFIXES) {
+    const srcSidecar = `${legacyDbPath}${suffix}`;
+    if (existsSync(srcSidecar)) {
+      atomicCopyKeepingSource(srcSidecar, `${canonicalDbPath}${suffix}`);
+      carried += 1;
+    }
+  }
+  return carried;
+}
+
+/**
+ * Whether the db at `dbPath` is a VALID, self-consistent SQLite db. Opens
+ * read-only and runs `PRAGMA integrity_check`; a checkpointed db needs no `-wal`
+ * to be valid, so this is the invariant that actually matters after a carry.
+ * NEVER throws — an unreadable / not-a-db / corrupt file reads as invalid.
+ */
+function canonicalDbIsValid(dbPath: string): boolean {
+  let db: Database | undefined;
+  try {
+    db = new Database(dbPath, { readonly: true });
+    const row = db.query("PRAGMA integrity_check").get() as
+      | { integrity_check?: string }
+      | null;
+    return row?.integrity_check === "ok";
+  } catch {
+    return false;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // best-effort close
+    }
+  }
+}
+
+/** Remove a canonical db copy + its sidecars (best-effort). The SOURCE is KEPT. */
+function removeCanonicalDbCopy(canonicalDbPath: string): void {
+  for (const p of [canonicalDbPath, ...DB_SIDECAR_SUFFIXES.map((s) => `${canonicalDbPath}${s}`)]) {
+    try {
+      if (existsSync(p)) rmSync(p);
+    } catch {
+      // best-effort — a leftover here just means the next run re-attempts.
+    }
+  }
+}
+
+/**
  * Migrate-on-touch a SQLite db (with WAL/SHM sidecars), copy-keep-source.
  *
  * Idempotent + non-destructive:
@@ -116,32 +171,21 @@ export function migrateDbOnTouch(canonicalDbPath: string, legacyDbPath: string):
   // Carry any surviving sidecars so a partial checkpoint's committed frames
   // travel with the db. `-shm` is regenerable but harmless to carry; `-wal`
   // may hold committed frames not yet folded — carrying it is the safe choice.
-  for (const suffix of DB_SIDECAR_SUFFIXES) {
-    const srcSidecar = `${legacyDbPath}${suffix}`;
-    if (existsSync(srcSidecar)) {
-      atomicCopyKeepingSource(srcSidecar, `${canonicalDbPath}${suffix}`);
-    }
+  carryDbSidecars(canonicalDbPath, legacyDbPath);
+
+  // Torn-copy hardening: idempotence gates on `existsSync(canonical)`, so a
+  // half-copied / corrupt canonical db would be stickily preferred FOREVER
+  // (`resolveStackDbPath` picks it, MC opens garbage). Validate the copy with
+  // `PRAGMA integrity_check`; on failure remove the canonical copy + sidecars
+  // (the SOURCE is KEPT → no data loss) so the NEXT boot re-attempts the carry.
+  if (!canonicalDbIsValid(canonicalDbPath)) {
+    removeCanonicalDbCopy(canonicalDbPath);
+    return { path: canonicalDbPath, migrated: false };
   }
   return { path: canonicalDbPath, migrated: true };
 }
 
-/**
- * Migrate-on-touch a plain data file (e.g. the MC hook cursor), copy-keep-source.
- * Idempotent + non-destructive, same gating as {@link migrateDbOnTouch} minus
- * the WAL handling.
- */
-export function migrateDataFileOnTouch(canonicalPath: string, legacyPath: string): DataMigrationResult {
-  if (existsSync(canonicalPath)) return { path: canonicalPath, migrated: false };
-  if (cortexDataDirOverride() !== undefined) return { path: canonicalPath, migrated: false };
-  if (!existsSync(legacyPath)) return { path: canonicalPath, migrated: false };
-  mkdirSync(dirname(canonicalPath), { recursive: true });
-  // copyFileSync would apply the umask, not the source mode — use the atomic
-  // copy which re-asserts the source mode (a 0600 cursor stays 0600).
-  atomicCopyKeepingSource(legacyPath, canonicalPath);
-  return { path: canonicalPath, migrated: true };
-}
-
-// ─────────────────────────────────────────────── stack / standalone / cursor wrappers
+// ───────────────────────────────────────────────────────── stack MC db wrapper
 
 /**
  * Resolve-and-migrate the SERVING stack's OWN per-stack MC db: carry a legacy
@@ -154,15 +198,22 @@ export function migrateStackDbOnTouch(stack: string, home?: string): string {
   return migrateDbOnTouch(canonicalStackDbPath(stack, home), legacyStackDbPath(stack, home)).path;
 }
 
-/** Resolve-and-migrate the standalone MC v2 db (legacy grove → canonical). */
-export function migrateStandaloneDbOnTouch(home?: string): string {
-  return migrateDbOnTouch(canonicalStandaloneDbPath(home), legacyStandaloneDbPath(home)).path;
-}
-
-/** Resolve-and-migrate the MC hook cursor (G-25: legacy grove → canonical). */
-export function migrateCursorOnTouch(home?: string): string {
-  return migrateDataFileOnTouch(canonicalCursorPath(home), legacyCursorPath(home)).path;
-}
+// ── Why there is no standalone-db / cursor migrator (GAP-1 / GAP-2, #1902) ────
+//
+// The STANDALONE MC v2 db (`~/.local/share/grove/mission-control.db`, layout 1)
+// and the STANDALONE grove hook cursor (`~/.local/share/grove/mc-hook-cursor.json`,
+// G-25) are read ONLY by the retired standalone entry `surface/mc/index.ts`,
+// which is RETIRED FOR PRODUCTION (FS-8a, #1822): it refuses to boot without the
+// `--legacy` / `MC_LEGACY_BOOT` test-harness escape hatch. The PRODUCTION MC runs
+// EMBEDDED (`surface/mc/embed.ts`), which resolves its db via `migrateStackDbOnTouch`
+// (above) and OVERRIDES the cursor to sit BESIDE that per-stack db
+// (`embed.ts` → `join(dirname(dbPath), "mc-hook-cursor.json")`) — it never touches
+// the grove standalone db OR cursor. So a `migrate{Standalone,Cursor}OnTouch`
+// would have NO production writer to guard: wiring it into the retired boot path
+// is theater, and leaving it unwired is a dead migrator. Both were removed.
+// The existence-gated *resolvers* (`resolveStandaloneDbPath` / `resolveCursorPath`
+// in `data-path.ts`) stay — they let the retired harness boot still read a legacy
+// grove file in place — but no COPY-forward runs for a path nothing writes.
 
 /**
  * Carry the in-flight PUBLISHED-events buffer to the canonical data-root

--- a/src/common/migrate-data-dir.ts
+++ b/src/common/migrate-data-dir.ts
@@ -27,16 +27,18 @@
  */
 
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readFileSync, statSync } from "fs";
-import { dirname } from "path";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync } from "fs";
+import { dirname, join } from "path";
 
 import { atomicWriteFile } from "./config/migrate-config-dir";
 import {
   canonicalCursorPath,
+  canonicalPublishedEventsDir,
   canonicalStackDbPath,
   canonicalStandaloneDbPath,
   cortexDataDirOverride,
   legacyCursorPath,
+  legacyPublishedEventsDir,
   legacyStackDbPath,
   legacyStandaloneDbPath,
 } from "./data-path";
@@ -160,4 +162,55 @@ export function migrateStandaloneDbOnTouch(home?: string): string {
 /** Resolve-and-migrate the MC hook cursor (G-25: legacy grove → canonical). */
 export function migrateCursorOnTouch(home?: string): string {
   return migrateDataFileOnTouch(canonicalCursorPath(home), legacyCursorPath(home)).path;
+}
+
+/**
+ * Carry the in-flight PUBLISHED-events buffer to the canonical data-root
+ * location (XDG wave-5 #1902, guardrail A), copy-keep-source. Any event already
+ * published-but-not-yet-consumed sits in the legacy `~/.claude/events/published`
+ * dir; the buffer move must COPY those files forward (not just repoint) so a
+ * consumer now reading the canonical dir doesn't miss them. RAW stays at
+ * `~/.claude/events/raw` (hook-substrate boundary) — only the published archive
+ * moves.
+ *
+ * Idempotent + non-destructive: each legacy file whose canonical counterpart is
+ * ABSENT is atomically copied (source mode preserved); an already-carried file
+ * is skipped (canonical-wins); the legacy files are KEPT. Returns the canonical
+ * published dir (the location the relay writes and the consumer reads).
+ *
+ * An explicit `$CORTEX_DATA_DIR` root has no legacy counterpart — never reach
+ * into the real `~/.claude/events/published` (breaks the hermetic guard).
+ *
+ * @returns `{ dir, carried }` — the canonical dir and how many files THIS call copied.
+ */
+export function migratePublishedBufferOnTouch(home?: string): { dir: string; carried: number } {
+  const canonical = canonicalPublishedEventsDir(home);
+  if (cortexDataDirOverride() !== undefined) return { dir: canonical, carried: 0 };
+
+  const legacy = legacyPublishedEventsDir(home);
+  if (!existsSync(legacy)) return { dir: canonical, carried: 0 };
+
+  let entries: string[];
+  try {
+    entries = readdirSync(legacy);
+  } catch {
+    return { dir: canonical, carried: 0 };
+  }
+
+  let carried = 0;
+  for (const name of entries) {
+    const src = join(legacy, name);
+    let st;
+    try {
+      st = statSync(src);
+    } catch {
+      continue; // vanished between readdir + stat — skip
+    }
+    if (!st.isFile()) continue; // buffer holds flat JSONL(.gz) files; skip any nested dir
+    const dest = join(canonical, name);
+    if (existsSync(dest)) continue; // canonical-wins — never clobber an already-carried file
+    atomicCopyKeepingSource(src, dest);
+    carried += 1;
+  }
+  return { dir: canonical, carried };
 }

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -1073,7 +1073,10 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
 
   test("PathsConfigSchema applies inner defaults", () => {
     const parsed = PathsConfigSchema.parse({});
-    expect(parsed.publishedEventsDir).toBe("~/.claude/events/published");
+    // XDG wave-5 (#1902): published-events buffer moved under the metafactory data root.
+    expect(parsed.publishedEventsDir).toBe(
+      "~/.local/share/metafactory/cortex/events/published",
+    );
     expect(parsed.logDir).toBe("~/.config/cortex/logs");
   });
 
@@ -1380,7 +1383,9 @@ describe("CortexConfigSchema", () => {
     expect(parsed.execution.default).toBe("local");
     expect(parsed.github.webhookSecret).toBe("");
     expect(parsed.github.agentDetection.commitTrailers).toEqual(["Co-Authored-By: Claude"]);
-    expect(parsed.paths.publishedEventsDir).toBe("~/.claude/events/published");
+    expect(parsed.paths.publishedEventsDir).toBe(
+      "~/.local/share/metafactory/cortex/events/published",
+    );
     expect(parsed.paths.logDir).toBe("~/.config/cortex/logs");
     expect(parsed.networksDir).toBe("./networks");
   });

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -814,7 +814,15 @@ export const AgentConfigSchema = z.object({
   mc: McSchema,
 
   paths: z.object({
-    publishedEventsDir: z.string().default("~/.claude/events/published"),
+    // XDG wave-5 (#1902): the published-events buffer is DATA and moves under the
+    // metafactory data root. Literal (not imported) so the value is grep-visible
+    // and this schema module stays free of the fs-touching data-path resolver;
+    // kept in sync with `PUBLISHED_EVENTS_DIR_DEFAULT` in `common/data-path.ts`
+    // and the generated `cortex.yaml` literal in `stack-lib.ts`. Existing pinned
+    // `~/.claude/events/published` values are rewritten by the value-migrator
+    // (`migrate-published-events-value.ts`); the reader is existence-gated so a
+    // pre-cutover box still reads the legacy buffer.
+    publishedEventsDir: z.string().default("~/.local/share/metafactory/cortex/events/published"),
     logDir: z.string().default("~/.config/grove/logs"),
   }).default(emptyDefault()),
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1662,7 +1662,12 @@ export type GithubConfig = z.infer<typeof GithubConfigSchema>;
  * MIRROR: see `AgentConfigSchema.paths` in `./config.ts`. Drop both on 7.2e.
  */
 export const PathsConfigSchema = z.object({
-  publishedEventsDir: z.string().default("~/.claude/events/published"),
+  // XDG wave-5 (#1902): the published-events buffer is DATA and moves under the
+  // metafactory data root. Kept byte-identical to `AgentConfigSchema.paths`
+  // (config.ts) and `PUBLISHED_EVENTS_DIR_DEFAULT` (common/data-path.ts) — no
+  // divergence. Value-migrator rewrites pinned legacy values; reader is
+  // existence-gated for a pre-cutover box.
+  publishedEventsDir: z.string().default("~/.local/share/metafactory/cortex/events/published"),
   logDir: z.string().default("~/.config/cortex/logs"),
 });
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -40,6 +40,7 @@ import {
   type AgentsChangeEvent,
 } from "./common/config/watcher";
 import { type AgentConfig } from "./common/types/config";
+import { migrateStackDbOnTouch } from "./common/migrate-data-dir";
 import { resolveSigningKnobs } from "./common/security-posture";
 import { buildHttpsMtlsMaterial } from "./common/config/transport-mtls";
 import { AgentRegistry } from "./common/agents/registry";
@@ -4459,10 +4460,13 @@ export async function startCortex(
   let discoveredSiblings: readonly SiblingStackDescriptor[] = [];
   let siblingResolveOpts: SiblingDbResolveOptions | null = null;
   if (config.mc.enabled && !options.disableDashboard) {
-    // Per-slug default keeps each stack's MC db isolated; the cursor lands beside it.
-    const defaultDbPath = join(
-      homedir(), ".local", "share", "cortex", "mc", derivedStack.stack, "mission-control.db",
-    );
+    // Per-slug default keeps each stack's MC db isolated. XDG wave-5 (#1902):
+    // the canonical per-stack db now lives under the metafactory data root
+    // (`~/.local/share/metafactory/cortex/mc/<stack>/…`). `migrateStackDbOnTouch`
+    // resolves the canonical path AND carries a legacy `~/.local/share/cortex/mc`
+    // db to it (copy-keep-source, WAL-checkpointed) so MC history is continuous
+    // across the move; a fresh stack simply lands at the canonical write target.
+    const defaultDbPath = migrateStackDbOnTouch(derivedStack.stack, homedir());
     const dbPath = config.mc.dbPath !== "" ? expandTilde(config.mc.dbPath) : defaultDbPath;
 
     // #1008 — discover the principal's LOCAL sibling stacks (reusing #989's

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -41,6 +41,7 @@ import {
 } from "./common/config/watcher";
 import { type AgentConfig } from "./common/types/config";
 import { migrateStackDbOnTouch } from "./common/migrate-data-dir";
+import { migratePublishedEventsDirValue } from "./common/config/migrate-published-events-value";
 import { resolveSigningKnobs } from "./common/security-posture";
 import { buildHttpsMtlsMaterial } from "./common/config/transport-mtls";
 import { AgentRegistry } from "./common/agents/registry";
@@ -6459,6 +6460,23 @@ if (import.meta.main) {
       // exits the process non-zero instead of being swallowed as a "non-fatal"
       // unhandled rejection. The daemon must not survive a failed security gate.
       const handle = await bootOrDie(async () => {
+        // XDG wave-5 (#1902, GAP-3) — the published-events pipeline WRITER
+        // (`taps/cc-events/relay.ts` → `publishedEventsDir()`) always writes the
+        // canonical metafactory data root; it does NOT read `paths.publishedEventsDir`.
+        // The persisted value is pinned into every generated `cortex.yaml`, so an
+        // upgraded box can still carry the LEGACY default (`~/.claude/events/published`)
+        // in its file. Rewrite that pinned legacy default to the canonical root
+        // (targeted one-line edit, comments/quotes preserved; a CUSTOM value is
+        // left untouched) BEFORE the config is loaded, so the in-memory value +
+        // the persisted file agree with the always-canonical writer. Idempotent
+        // and non-destructive; a no-op on a fresh/canonical config.
+        const migratedCfgPath = expandTilde(options.config);
+        const pubMig = migratePublishedEventsDirValue(migratedCfgPath);
+        if (pubMig.changed) {
+          console.log(
+            `cortex: migrated pinned paths.publishedEventsDir "${pubMig.from}" → "${pubMig.to}" in ${migratedCfgPath} (XDG #1902)`,
+          );
+        }
         // FS-7 / D-3 (cortex#1839) — resolve the boot config with a last-known-good
         // fallback. A healthy load refreshes the snapshot + clears any degraded
         // marker; a bad load either fails hard (`--strict` / no snapshot) or boots

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -4,11 +4,14 @@
 
 import { readFileSync, existsSync } from "fs";
 import { parse as parseYaml } from "yaml";
-import { join } from "path";
 import { homedir } from "os";
 import { rawEventsDir as resolveRawEventsDir } from "../../common/events-path";
 import type { Config, LogLevel, CfAccessConfig, GovernanceConfig } from "./types";
 import { resolveConfigFilePath } from "../../common/config/config-path";
+import {
+  resolveStandaloneDbPath,
+  resolveCursorPath,
+} from "../../common/data-path";
 
 const VALID_LOG_LEVELS: ReadonlySet<LogLevel> = new Set([
   "debug",
@@ -21,7 +24,10 @@ export const DEFAULT_CONFIG: Config = {
   port: 8767,
   hostname: "127.0.0.1",
   db: {
-    path: join(homedir(), ".local", "share", "grove", "mission-control.db"),
+    // XDG wave-5 (#1902): canonical standalone MC db under the metafactory data
+    // root; existence-gated so a legacy `~/.local/share/grove/mission-control.db`
+    // is still read in place on a pre-cutover box (MC history continuous).
+    path: resolveStandaloneDbPath(homedir()),
   },
   log: {
     level: "info",
@@ -30,13 +36,10 @@ export const DEFAULT_CONFIG: Config = {
     // cortex#1908: honors CORTEX_EVENTS_DIR; passing `homedir()` keeps the
     // unset default byte-identical to the previous `join(homedir(), …)`.
     rawEventsDir: resolveRawEventsDir(homedir()),
-    cursorPath: join(
-      homedir(),
-      ".local",
-      "share",
-      "grove",
-      "mc-hook-cursor.json"
-    ),
+    // XDG wave-5 (#1902, G-25): MC hook cursor under the metafactory data root;
+    // existence-gated with a legacy `~/.local/share/grove/mc-hook-cursor.json`
+    // read-fallback.
+    cursorPath: resolveCursorPath(homedir()),
     pollInterval: 2000,
   },
   ws: {

--- a/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
+++ b/src/surface/mc/local-aggregation/__tests__/sibling-db-reader.test.ts
@@ -18,7 +18,7 @@
  *      (proves query_only / readonly is in force), the request path never writes.
  */
 
-import { describe, expect, test, afterEach } from "bun:test";
+import { describe, expect, test, afterEach, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
@@ -348,6 +348,89 @@ describe("aggregateAgentTiles (/api/agents union)", () => {
     // Richer registry fields are preserved through the liveness upgrade.
     expect(lunas[0]!.capabilities).toEqual(["chat"]);
     expect(lunas[0]!.nkey_public_key).toBe("NKEYLUNA");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// XDG wave-5 (#1902) AC1 — sibling aggregation resolves peers AFTER the data move
+// ---------------------------------------------------------------------------
+//
+// The load-bearing hazard: the serving daemon discovers a sibling's
+// `mission-control.db` BY its on-disk shape. When the per-stack MC db moves from
+// `~/.local/share/cortex/mc/<stack>/…` to the metafactory data root
+// `~/.local/share/metafactory/cortex/mc/<stack>/…`, sibling resolution must move
+// IN LOCKSTEP — and must still find a peer that has NOT migrated yet (mixed
+// fleet). These tests omit `homeShareDir` (the production path) so resolution
+// runs through the existence-gated data-path resolver, against a scratch $HOME.
+
+describe("XDG wave-5 (#1902) — sibling discovery after the data move", () => {
+  let savedDataDirEnv: string | undefined;
+  beforeEach(() => {
+    // A stray ambient CORTEX_DATA_DIR would short-circuit existence-gated
+    // resolution — unset it so every path derives from the scratch home.
+    savedDataDirEnv = process.env.CORTEX_DATA_DIR;
+    delete process.env.CORTEX_DATA_DIR;
+  });
+  afterEach(() => {
+    if (savedDataDirEnv === undefined) delete process.env.CORTEX_DATA_DIR;
+    else process.env.CORTEX_DATA_DIR = savedDataDirEnv;
+  });
+
+  const canonicalDb = (home: string, stack: string) =>
+    join(home, ".local", "share", "metafactory", "cortex", "mc", stack, "mission-control.db");
+  const legacyDb = (home: string, stack: string) =>
+    join(home, ".local", "share", "cortex", "mc", stack, "mission-control.db");
+
+  test("resolveSiblingDbPath (homeShareDir omitted) prefers the migrated metafactory path", () => {
+    const home = freshTmp();
+    const configRoot = freshTmp();
+    // A MIGRATED peer: its db exists under the new metafactory data root.
+    seedDb(canonicalDb(home, "work"), { agentId: "w", agentName: "W", taskTitle: "t" });
+    const path = resolveSiblingDbPath(sibling("work"), { configRoot, home });
+    expect(path).toBe(canonicalDb(home, "work"));
+  });
+
+  test("resolveSiblingDbPath falls back to the legacy path for an un-migrated peer", () => {
+    const home = freshTmp();
+    const configRoot = freshTmp();
+    // An UN-migrated peer: its db exists ONLY under the legacy cortex tree.
+    seedDb(legacyDb(home, "halden"), { agentId: "h", agentName: "H", taskTitle: "t" });
+    const path = resolveSiblingDbPath(sibling("halden"), { configRoot, home });
+    expect(path).toBe(legacyDb(home, "halden"));
+  });
+
+  test("aggregateWorkingAgents resolves a MIXED fleet — migrated + un-migrated peers both appear", () => {
+    const home = freshTmp();
+    const configRoot = freshTmp();
+    // alpha migrated (new root); beta not yet (legacy root).
+    seedDb(canonicalDb(home, "alpha"), { agentId: "agent-alpha", agentName: "Alpha", taskTitle: "a" });
+    seedDb(legacyDb(home, "beta"), { agentId: "agent-beta", agentName: "Beta", taskTitle: "b" });
+
+    // The serving (local) db lives at the new root too.
+    const localPath = canonicalDb(home, "self");
+    const localDb = initDatabase(localPath);
+    localDb.run(`INSERT INTO agents (id, name, type, persistent) VALUES ('agent-self','Self','head',1)`);
+    localDb.run(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t','self',2,'andreas','internal')`);
+    localDb.run(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('a','agent-self','t','running')`);
+    localDb.run(`INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at, substrate) VALUES ('s','a','local.observed','2026-06-12T00:00:00.000Z','claude-code')`);
+
+    // homeShareDir OMITTED → existence-gated resolution; selfDbPath excludes self.
+    const tiles = aggregateWorkingAgents(
+      localDb,
+      [sibling("alpha"), sibling("beta")],
+      { configRoot, home, selfDbPath: localPath },
+    );
+
+    for (const [stack, agentId] of [["alpha", "agent-alpha"], ["beta", "agent-beta"]] as const) {
+      const row = tiles.find(
+        (t) => typeof t.origin === "object" && t.origin.stack === stack,
+      );
+      expect(row, `expected an origin-tagged tile for ${stack} after the move`).toBeDefined();
+      expect(row!.agent_id).toBe(agentId);
+    }
+    // Self is the single local-origin row (self-exclusion held despite the move).
+    expect(tiles.filter((t) => t.origin === "local")).toHaveLength(1);
+    localDb.close();
   });
 });
 

--- a/src/surface/mc/local-aggregation/sibling-db-reader.ts
+++ b/src/surface/mc/local-aggregation/sibling-db-reader.ts
@@ -49,6 +49,7 @@ import { join } from "path";
 import { parse as parseYaml } from "yaml";
 
 import type { SiblingStackDescriptor } from "./sibling-discovery";
+import { resolveStackDbPath } from "../../../common/data-path";
 import {
   listWorkingAgents,
   type WorkingAgentTile,
@@ -78,11 +79,6 @@ export interface LocalAggregationContext {
 /** Lazy accessor for the local-aggregation context; `null` ⇒ DB-read OFF. */
 export type LocalAggregationProvider = () => LocalAggregationContext | null;
 
-/** The conventional per-slug MC db root: `~/.local/share/cortex/mc`. */
-function defaultHomeShareDir(home: string): string {
-  return join(home, ".local", "share", "cortex", "mc");
-}
-
 /** Expand a leading `~` to the given home dir (matches the loader's expandTilde). */
 function expandTildeWith(p: string, home: string): string {
   if (p === "~") return home;
@@ -95,9 +91,13 @@ export interface SiblingDbResolveOptions {
   /** Config root scanned for sibling stack dirs (`<root>/<slug>/stacks/*.yaml`). */
   configRoot: string;
   /**
-   * Root for the per-slug default db path. Defaults to
-   * `~/.local/share/cortex/mc`. Injected by tests; production passes the same
-   * root `cortex.ts` derives the serving stack's `defaultDbPath` from.
+   * Explicit per-slug default db root. When set, a sibling's default db resolves
+   * directly under it (`<homeShareDir>/<stack>/mission-control.db`), byte-identical
+   * to the pre-move behavior — used by tests that pin the root. When UNSET
+   * (production), the default resolves via {@link resolveStackDbPath}:
+   * existence-gated across the canonical metafactory data root and the legacy
+   * `~/.local/share/cortex/mc` tree, so peers are found whether or not they have
+   * migrated (XDG wave-5, #1902).
    */
   homeShareDir?: string;
   /** Home dir for tilde expansion. Defaults to `os.homedir()`. */
@@ -112,22 +112,32 @@ export interface SiblingDbResolveOptions {
 /**
  * Resolve a sibling stack's `mission-control.db` PATH.
  *
- * Mirrors `cortex.ts`'s own resolution exactly: the stack's configured
- * `mc.dbPath` (read from its `stacks/*.yaml`, tilde-expanded) when set, else the
- * per-slug default `{homeShareDir}/{stack}/mission-control.db`.
+ * Mirrors `cortex.ts`'s own resolution exactly (so self-exclusion stays byte-
+ * identical): the stack's configured `mc.dbPath` (read from its `stacks/*.yaml`,
+ * tilde-expanded) when set; else, when `homeShareDir` is pinned, the per-slug
+ * default under it; else the XDG wave-5 (#1902) existence-gated default across
+ * the canonical metafactory data root and the legacy `~/.local/share/cortex/mc`
+ * tree — so a migrated peer is read from the new tree and an un-migrated peer
+ * from legacy, preserving sibling aggregation across a mixed fleet AFTER the
+ * move.
+ *
+ * PURE resolution — it NEVER migrates a peer's data (reading peers is read-only;
+ * each stack migrates its OWN db at boot, `cortex.ts` → `migrateStackDbOnTouch`).
  */
 export function resolveSiblingDbPath(
   sibling: SiblingStackDescriptor,
   opts: SiblingDbResolveOptions,
 ): string {
   const home = opts.home ?? homedir();
-  const shareDir = opts.homeShareDir ?? defaultHomeShareDir(home);
 
   const configured = readConfiguredDbPath(opts.configRoot, sibling.stack);
   if (configured !== null && configured !== "") {
     return expandTildeWith(configured, home);
   }
-  return join(shareDir, sibling.stack, "mission-control.db");
+  if (opts.homeShareDir !== undefined) {
+    return join(opts.homeShareDir, sibling.stack, "mission-control.db");
+  }
+  return resolveStackDbPath(sibling.stack, home);
 }
 
 /**

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -9,10 +9,12 @@
  * which is what this helper enables.
  *
  * The cortex-relay (cc-events tap) reads CC hooks from
- * `~/.claude/events/raw/`, applies the relay policy, writes published
- * events to `~/.claude/events/published/`, and ALSO — when a
- * `MyelinRuntime` is attached — wraps each published event in a Myelin
- * envelope and publishes it to `local.{principal}.{type}`.
+ * `~/.claude/events/raw/` (the hook-substrate boundary — stays put), applies
+ * the relay policy, writes published events to the app-private DATA buffer
+ * (`~/.local/share/metafactory/cortex/events/published/` since XDG wave-5
+ * #1902; was `~/.claude/events/published/`), and ALSO — when a `MyelinRuntime`
+ * is attached — wraps each published event in a Myelin envelope and publishes
+ * it to `local.{principal}.{type}`.
  *
  * **Why the relay (and not the hook)?** Hooks run as standalone Bun
  * processes spawned by Claude Code (`~/.claude/hooks/EventLogger.hook.ts`).

--- a/src/taps/cc-events/hooks/event-logger.hook.ts
+++ b/src/taps/cc-events/hooks/event-logger.hook.ts
@@ -9,7 +9,7 @@
 import { appendFileSync, mkdirSync, chmodSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { createRawEvent, type RawEvent } from "./lib/event-types";
-import { eventsDir } from "../../../common/events-path";
+import { eventsDir, publishedEventsDir } from "../../../common/events-path";
 import { mapHookToEventType, EVENT_TYPES } from "./lib/event-taxonomy";
 import { resolvePrincipalEnv } from "./lib/principal-env";
 import { resolveSurfaceEnv } from "./lib/surface-env";
@@ -130,8 +130,9 @@ function ensureDir(dir: string, mode: number): void {
 
 ensureDir(RAW_DIR, 0o700);
 // TC-4b (cortex#637): published/ JSONL holds prompt/command/tool previews —
-// owner-only (0o700) to match raw/, not world-readable.
-ensureDir(join(EVENTS_DIR, "published"), 0o700);
+// owner-only (0o700) to match raw/, not world-readable. XDG wave-5 (#1902):
+// published is app-private DATA under the metafactory data root (raw stays here).
+ensureDir(publishedEventsDir(), 0o700);
 
 // =============================================================================
 // H-004: HTTP POST ingestion (primary), JSONL fallback (secondary)

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -13,7 +13,8 @@ import { processEvent } from "./lib/policy-engine";
 import { EventProcessor } from "./lib/event-processor";
 import { watchRawEvents } from "./lib/file-watcher";
 import { RawEventSchema } from "./hooks/lib/event-types";
-import { eventsDir } from "../../common/events-path";
+import { eventsDir, publishedEventsDir } from "../../common/events-path";
+import { migratePublishedBufferOnTouch } from "../../common/migrate-data-dir";
 import { resolvePrincipalEnv } from "./hooks/lib/principal-env";
 import { NatsLink } from "../../bus/nats/connection";
 import { createCcEventPublisher } from "./cc-events";
@@ -51,7 +52,10 @@ interface TestOptions {
 // CORTEX_EVENTS_DIR, else `~/.claude/events` (byte-identical when unset).
 const EVENTS_DIR = eventsDir();
 const RAW_DIR = join(EVENTS_DIR, "raw");
-const PUBLISHED_DIR = join(EVENTS_DIR, "published");
+// XDG wave-5 (#1902): RAW stays under ~/.claude/events (hook-substrate boundary);
+// PUBLISHED is app-private DATA and resolves under the metafactory data root.
+// Pure at module load; the in-flight buffer is carried forward in `start`.
+const PUBLISHED_DIR = publishedEventsDir();
 const DEFAULT_POLICY = join(
   process.env.HOME ?? "~",
   ".claude",
@@ -333,6 +337,17 @@ program
 
     // Write PID file
     writeFileSync(PID_FILE, String(process.pid));
+
+    // XDG wave-5 (#1902, guardrail A): carry the in-flight published buffer to
+    // the canonical data-root location (copy-keep-source) BEFORE processing, so
+    // any published-but-not-yet-consumed event survives the move and the Discord
+    // consumer (now reading the canonical dir) doesn't miss it. Idempotent.
+    const carriedBuf = migratePublishedBufferOnTouch();
+    if (carriedBuf.carried > 0) {
+      console.log(
+        `cortex-relay: carried ${carriedBuf.carried} in-flight published file(s) to ${carriedBuf.dir} (XDG #1902)`,
+      );
+    }
 
     // Run retention sweep on startup (removes stale JSONL files)
     void runRetentionSweep();


### PR DESCRIPTION
Part of #1867 (XDG epic), phase **P3b**. Moves cortex's **data** to the canonical XDG data root `~/.local/share/metafactory/cortex/`. Trust-lane (data migration, live-DB-adjacent). Closes #1902.

## Acceptance criteria

### AC1 — Sibling MC aggregation resolves peers after the move
The three MC DB layouts are reconciled through a new shared seam `src/common/data-path.ts` (the DATA analogue of `config/config-path.ts`): a `$CORTEX_DATA_DIR` env override + **canonical-first / legacy-fallback**, existence-gated resolvers.

- **Layout 1** `surface/mc/config.ts` (`~/.local/share/grove/mission-control.db`) → `resolveStandaloneDbPath` (grove legacy fallback).
- **Layout 2** `cortex.ts` (`~/.local/share/cortex/mc/<stack>/…`) → migrates its OWN db on boot via `migrateStackDbOnTouch` (copy-keep-source, WAL-checkpointed) → canonical `~/.local/share/metafactory/cortex/mc/<stack>/…`.
- **Layout 3** `sibling-db-reader.ts` discovers peers **by on-disk shape** — updated **in lockstep**: the production default (`homeShareDir` unset) resolves existence-gated across the new metafactory root AND the legacy `~/.local/share/cortex/mc` tree, so **a MIXED fleet** (some peers migrated, some not) still aggregates. Self-exclusion stays byte-identical because `cortex.ts` and the reader share the same seam. The reader is **pure** — it never migrates a peer's data (read-only); each stack migrates its own db at boot.

### AC2 — A pinned `publishedEventsDir` is migrated, not shadowed
`paths.publishedEventsDir` is persisted literally into every generated `cortex.yaml`, so an env var / changed default can't relocate it. New `src/common/config/migrate-published-events-value.ts` rewrites a **pinned legacy value** (the `~`-prefixed default or its `$HOME`-expanded form) to the new data root with a **targeted one-line edit** (comments/quotes preserved) — a custom value is left untouched; idempotent.

**Pipeline safety:** the published-events writer (`taps/cc-events/relay.ts`) is decoupled from this config field and still writes `~/.claude/events/published`. To avoid any break mid-migration, the reader (`adapters/discord/outbound-log.ts`) is made **existence-gated** (prefer the configured/canonical dir, else fall back to legacy) per the Fallback Contract. Physically relocating the relay writer (the events-buffer move events-path.ts defers to #1902) is a clean follow-up; the existence-gated reader means there is **no break at any migration stage** either way.

### AC3 — Both zod defaults point at the new data root; no divergence
`common/types/config.ts`, `common/types/cortex-config.ts`, and `cli/cortex/commands/stack-lib.ts` all set `~/.local/share/metafactory/cortex/events/published`. A test asserts the two schema defaults equal the new root **and each other**.

Also folds in **G-25** (MC hook cursor `~/.local/share/grove/mc-hook-cursor.json` → data root).

## Live-DB safety
`migrateStackDbOnTouch` runs `PRAGMA wal_checkpoint(TRUNCATE)` on the legacy db before an atomic copy, carries any surviving `-wal`/`-shm` sidecars consistently, and **never deletes a source**. Existence-gated resolution means a pre-cutover box still reads the legacy tree.

## Tests (hermetic — scratch `$HOME`, `CORTEX_DATA_DIR` unset)
- `sibling-db-reader.test.ts`: mixed-fleet aggregation resolves migrated + un-migrated peers; self-exclusion holds after the move.
- `migrate-published-events-value.test.ts`: pinned legacy migrated (not shadowed); custom untouched; idempotent; formatting preserved.
- `data-path.test.ts`: canonical-first/legacy-fallback for every resolver; **both zod defaults == new root == each other**.
- `migrate-data-dir.test.ts`: copy-keep-source; source intact; idempotent; canonical-wins; WAL checkpoint-before-copy + sidecar carry.

## Gate
- `bunx tsc --noEmit` → **0 errors**.
- Full `bun test` → **9861 pass / 2 skip / 20 fail** — the 20 fails are the pre-existing non-hermetic `network-secret-cli.test.ts` set, **unchanged, zero new**.
- `rg publishedEventsDir src/common/types/config.ts src/common/types/cortex-config.ts` → both show the new root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up build (361116e3) — 4 gaps resolved + Linux-deterministic WAL test

**WAL test (was RED on Linux CI):** the sidecar-carry test relied on a manually-written `-wal` surviving `migrateDbOnTouch`'s db-open; on Linux SQLite unlinks a stray `-wal` for a rollback-journal db on open, so it was gone by copy time. Replaced with platform-deterministic invariants: (a) post-migration canonical is a VALID self-consistent db (`PRAGMA integrity_check` = ok + marker readable); (b) sidecar carry exercised via a new separable `carryDbSidecars` helper with real `-wal`/`-shm` files and **no** intervening db-open.

**GAP-1 (standalone MC db) & GAP-2 (G-25 grove cursor) — RESOLVED BY REMOVAL, not wiring.** Both migrators had ZERO prod callers. Their only reader is the standalone MC entry `surface/mc/index.ts`, **retired for production (FS-8a, #1822)** — it refuses to boot without the `--legacy`/`MC_LEGACY_BOOT` test-harness escape hatch. Production MC runs **embedded** (`surface/mc/embed.ts`): it resolves its db via `migrateStackDbOnTouch` (layout 2, already wired) and overrides the hook cursor to sit **beside that per-stack db**, never touching the grove standalone db or cursor. A copy-forward migrator for a path nothing writes in production is dead code, so `migrateStandaloneDbOnTouch` and `migrateCursorOnTouch` (and the orphaned `migrateDataFileOnTouch`) were removed. The existence-gated *resolvers* (`resolveStandaloneDbPath`/`resolveCursorPath`) stay so the retired harness boot can still read a legacy grove file in place.

> **G-25 correction:** the earlier "folds in G-25 (grove cursor → data root)" line is superseded. G-25 *resolution* is folded in (canonical-first/legacy-fallback), but the cursor **copy-forward migration is intentionally NOT wired** — the only consumer is the retired standalone MC; the embedded production MC keeps its cursor beside its per-stack db.

**GAP-3 (publishedEventsDir value-migrator) — WIRED.** The PR body above is stale: the WRITER (`taps/cc-events/relay.ts` → `publishedEventsDir()`) has already been relocated to the canonical data root and never reads the config field. `migratePublishedEventsDirValue` is now wired into the daemon boot path (before config load) so a pinned **legacy** default in an upgraded box's `cortex.yaml` is rewritten to canonical (custom values untouched; idempotent), keeping the persisted file consistent with the always-canonical writer. Added an end-to-end test: pinned legacy → migrated → writer & reader agree on canonical.

**GAP-4 (torn-copy hardening) — ADDED.** Idempotence gates on `existsSync(canonical)`, so a half-copied/corrupt canonical db would be stickily preferred forever. After each db copy, `PRAGMA integrity_check` runs on the canonical copy; on failure it is removed (source KEPT → no loss) so the next run retries. Added a detect→remove→re-copy test.

**Gate (this build):** `bunx tsc --noEmit` → 0 errors. Full `bun test` → **9868 pass / 2 skip / 20 fail**, the 20 being the pre-existing non-hermetic `network-secret-cli.test.ts` set (unchanged, zero new).
