### PR TITLE
feat(state): XDG wave 5 P3c — cortex state-dir move (pidfiles/logs/network-cache), completion-gated (#1903)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -47,8 +47,7 @@ import { tmpdir } from "os";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
 import { pidFileFor, runDryRun, startCortex } from "../cortex";
-import { migrateLegacyPidFile, PID_FILE, STATE_DIR } from "../common/pidfile";
-import { resolvePidStateDir } from "../common/state-path";
+import { migrateLegacyPidFile } from "../common/pidfile";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 
@@ -885,32 +884,33 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
 // ---------------------------------------------------------------------------
 
 describe("pidFileFor — per-config PID file derivation", () => {
-  // DEFAULT_CONFIG stays grove/bot.yaml (config is out of scope for #1903).
   const DEFAULT_CONFIG = join(process.env.HOME ?? "~", ".config", "grove", "bot.yaml");
-  // XDG wave-5 (#1903): the default pidfile lives directly under the RESOLVED
-  // STATE_DIR (canonical `~/.local/state/metafactory/cortex`, legacy-grove
-  // fallback). Assert against the module const (== join(STATE_DIR,"cortex.pid"))
-  // so the expectation tracks the resolver rather than a hardcoded grove path —
-  // holding on a clean CI box (canonical) and a dev box (legacy) alike.
-  const LEGACY_PID = PID_FILE;
+  // BACKWARD-COMPAT CONTRACT (cortex#1900 + #1903): pre-migration — no completion
+  // marker, CORTEX_STATE_DIR unset — the default pidfile MUST stay byte-identical
+  // to the legacy grove path so a running daemon's pidfile identity is continuous.
+  // #1903 is COMPLETION-gated (not existence-gated) precisely so this holds even
+  // if a stray canonical dir exists; and STATE_DIR is import-baked, so suite order
+  // cannot flip it. The `state migration flips STATE_DIR to canonical` describe
+  // below asserts the post-migration side hermetically in a child process.
+  const LEGACY_PID = join(process.env.HOME ?? "~", ".config", "grove", "state", "cortex.pid");
 
-  test("undefined config → default cortex.pid (backward compat)", () => {
+  test("undefined config → legacy cortex.pid (backward compat)", () => {
     expect(pidFileFor(undefined)).toBe(LEGACY_PID);
   });
 
-  test("default config path → default cortex.pid (no behaviour change)", () => {
+  test("default config path → legacy cortex.pid (no behaviour change)", () => {
     expect(pidFileFor(DEFAULT_CONFIG)).toBe(LEGACY_PID);
   });
 
   // cortex#1900 — the pidfile name is `cortex-<basename>-<hash8>.pid`: it keeps
   // the human-readable slug (continuity requirement #2) AND appends 8 hex chars
-  // of sha256(canonical full path) so two trees can never collide. STATE_DIR is
-  // the imported module const (resolver-derived, #1903).
+  // of sha256(canonical full path) so two trees can never collide.
+  const STATE_DIR_LEGACY = join(process.env.HOME ?? "~", ".config", "grove", "state");
 
   test("custom config → cortex-<basename>-<hash8>.pid (slug preserved + path hash)", () => {
     const result = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
     expect(basename(result)).toMatch(/^cortex-cortex\.work-[0-9a-f]{8}\.pid$/);
-    expect(result.startsWith(STATE_DIR)).toBe(true);
+    expect(result.startsWith(STATE_DIR_LEGACY)).toBe(true);
   });
 
   test("two distinct custom configs → two distinct PID files", () => {
@@ -1221,10 +1221,14 @@ describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
   const modPath = join(import.meta.dir, "..", "common", "pidfile.ts");
   const CFG = "/cortex-1908-state-probe/stack.yaml";
 
-  function probePidFile(override: string | null): string {
+  function probePidFile(override: string | null, homeOverride?: string): string {
     const env = { ...process.env };
     if (override === null) delete env.CORTEX_STATE_DIR;
     else env.CORTEX_STATE_DIR = override;
+    // Optionally pin $HOME to a scratch dir so the module-const STATE_DIR is baked
+    // against a hermetic home (no real legacy tree, no completion marker) — the
+    // only way to exercise the resolver's default with an import-baked const.
+    if (homeOverride !== undefined) env.HOME = homeOverride;
     const src =
       `import { pidFileFor } from ${JSON.stringify(modPath)};` +
       `process.stdout.write(pidFileFor(${JSON.stringify(CFG)}));`;
@@ -1250,25 +1254,28 @@ describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
     }
   });
 
-  test("CORTEX_STATE_DIR unset → resolves to the default STATE_DIR (canonical-first, legacy-grove fallback) #1903", () => {
-    const out = probePidFile(null);
-    // The child ran with CORTEX_STATE_DIR unset, so its STATE_DIR is the resolver
-    // default for THIS box: canonical `~/.local/state/metafactory/cortex` when
-    // present, else legacy `~/.config/grove/state`. Reproduce that resolution
-    // here with the override cleared so parent + child agree regardless of which
-    // state tree exists on disk (the pre-#1903 hardcoded grove path only held on
-    // boxes that already had the legacy tree — it broke on a clean CI runner).
-    // basename is STATE_DIR-independent (hash is over the config path).
-    const saved = process.env.CORTEX_STATE_DIR;
-    delete process.env.CORTEX_STATE_DIR;
-    let expectedDir: string;
+  test("CORTEX_STATE_DIR unset, no completed migration → byte-identical to the LEGACY grove default (#1903 identity contract)", () => {
+    // Hermetic scratch $HOME with NO legacy tree and NO completion marker. The
+    // #1903 resolver is COMPLETION-gated, so pre-migration it MUST return the
+    // legacy grove default byte-identically — a running daemon's pidfile identity
+    // stays continuous until a gated cutover. (Pinning $HOME removes the pre-#1903
+    // dependence on whichever tree happened to exist on the box — the bug that
+    // made this pass on a dev box but fail on a clean CI runner.)
+    const scratchHome = mkdtempSync(join(tmpdir(), "cortex-statedir-unset-"));
     try {
-      expectedDir = resolvePidStateDir();
+      const out = probePidFile(null, scratchHome);
+      // basename is STATE_DIR-independent (hash is over the config path).
+      const expectedDefault = join(
+        scratchHome,
+        ".config",
+        "grove",
+        "state",
+        basename(pidFileFor(CFG)),
+      );
+      expect(out).toBe(expectedDefault);
     } finally {
-      if (saved !== undefined) process.env.CORTEX_STATE_DIR = saved;
+      rmSync(scratchHome, { recursive: true, force: true });
     }
-    const expectedDefault = join(expectedDir, basename(pidFileFor(CFG)));
-    expect(out).toBe(expectedDefault);
   });
 
   // Interaction: migrateLegacyPidFile's DEFAULT stateDir is STATE_DIR, which now
@@ -1314,6 +1321,69 @@ describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
       expect(r.read).toBe(r.wrote); // PID carried across the rename
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STATE_DIR — COMPLETION-gated canonical flip (#1903 pidfile-identity contract)
+// ---------------------------------------------------------------------------
+// The crux fix: the canonical state root is preferred ONLY after a gated
+// migration writes its completion marker — NEVER because a canonical dir merely
+// exists. A bare/stray canonical dir (e.g. one a network-cache write created)
+// must not flip a live daemon's pidfile identity. Probed in child processes so
+// the import-baked STATE_DIR is evaluated against a hermetic scratch $HOME.
+describe("STATE_DIR — completion-gated canonical flip (#1903)", () => {
+  const modPath = join(import.meta.dir, "..", "common", "pidfile.ts");
+  const MARKER = ".xdg-state-migration.json";
+
+  function probeStateDir(home: string): string {
+    const env = { ...process.env };
+    env.HOME = home;
+    delete env.CORTEX_STATE_DIR;
+    const src =
+      `import { STATE_DIR } from ${JSON.stringify(modPath)};` +
+      `process.stdout.write(STATE_DIR);`;
+    const proc = Bun.spawnSync([process.execPath, "-e", src], { env, stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) {
+      throw new Error(`state-dir probe failed (exit ${proc.exitCode}): ${proc.stderr.toString()}`);
+    }
+    return proc.stdout.toString();
+  }
+
+  const groveOf = (home: string): string => join(home, ".config", "grove", "state");
+  const canonicalOf = (home: string): string => join(home, ".local", "state", "metafactory", "cortex");
+
+  test("no completion marker → STATE_DIR stays legacy grove (identity continuity)", () => {
+    const home = mkdtempSync(join(tmpdir(), "cortex-gate-nomarker-"));
+    try {
+      expect(probeStateDir(home)).toBe(groveOf(home));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("BARE canonical dir WITHOUT marker does NOT flip STATE_DIR (the #1903 hazard)", () => {
+    const home = mkdtempSync(join(tmpdir(), "cortex-gate-baredir-"));
+    try {
+      // Simulate a sibling class (e.g. network-cache) having created the canonical
+      // root/subdir. With bare-existence gating this WOULD flip identity; with
+      // completion gating it must NOT — STATE_DIR stays legacy grove.
+      mkdirSync(join(canonicalOf(home), "network-cache"), { recursive: true });
+      expect(probeStateDir(home)).toBe(groveOf(home));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test("completion marker present → STATE_DIR flips to canonical", () => {
+    const home = mkdtempSync(join(tmpdir(), "cortex-gate-marker-"));
+    try {
+      mkdirSync(canonicalOf(home), { recursive: true });
+      writeFileSync(join(canonicalOf(home), MARKER), "{}");
+      expect(probeStateDir(home)).toBe(canonicalOf(home));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
     }
   });
 });

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -47,7 +47,8 @@ import { tmpdir } from "os";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
 import { pidFileFor, runDryRun, startCortex } from "../cortex";
-import { migrateLegacyPidFile } from "../common/pidfile";
+import { migrateLegacyPidFile, PID_FILE, STATE_DIR } from "../common/pidfile";
+import { resolvePidStateDir } from "../common/state-path";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 
@@ -884,21 +885,27 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
 // ---------------------------------------------------------------------------
 
 describe("pidFileFor — per-config PID file derivation", () => {
+  // DEFAULT_CONFIG stays grove/bot.yaml (config is out of scope for #1903).
   const DEFAULT_CONFIG = join(process.env.HOME ?? "~", ".config", "grove", "bot.yaml");
-  const LEGACY_PID = join(process.env.HOME ?? "~", ".config", "grove", "state", "cortex.pid");
+  // XDG wave-5 (#1903): the default pidfile lives directly under the RESOLVED
+  // STATE_DIR (canonical `~/.local/state/metafactory/cortex`, legacy-grove
+  // fallback). Assert against the module const (== join(STATE_DIR,"cortex.pid"))
+  // so the expectation tracks the resolver rather than a hardcoded grove path —
+  // holding on a clean CI box (canonical) and a dev box (legacy) alike.
+  const LEGACY_PID = PID_FILE;
 
-  test("undefined config → legacy cortex.pid (backward compat)", () => {
+  test("undefined config → default cortex.pid (backward compat)", () => {
     expect(pidFileFor(undefined)).toBe(LEGACY_PID);
   });
 
-  test("default config path → legacy cortex.pid (no behaviour change)", () => {
+  test("default config path → default cortex.pid (no behaviour change)", () => {
     expect(pidFileFor(DEFAULT_CONFIG)).toBe(LEGACY_PID);
   });
 
   // cortex#1900 — the pidfile name is `cortex-<basename>-<hash8>.pid`: it keeps
   // the human-readable slug (continuity requirement #2) AND appends 8 hex chars
-  // of sha256(canonical full path) so two trees can never collide.
-  const STATE_DIR = join(process.env.HOME ?? "~", ".config", "grove", "state");
+  // of sha256(canonical full path) so two trees can never collide. STATE_DIR is
+  // the imported module const (resolver-derived, #1903).
 
   test("custom config → cortex-<basename>-<hash8>.pid (slug preserved + path hash)", () => {
     const result = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
@@ -1243,17 +1250,24 @@ describe("STATE_DIR — CORTEX_STATE_DIR env seam", () => {
     }
   });
 
-  test("CORTEX_STATE_DIR unset → byte-identical to the grove default STATE_DIR path", () => {
+  test("CORTEX_STATE_DIR unset → resolves to the default STATE_DIR (canonical-first, legacy-grove fallback) #1903", () => {
     const out = probePidFile(null);
-    // basename is STATE_DIR-independent (hash is over the config path), so this
-    // reference default holds even if the test process itself set the override.
-    const expectedDefault = join(
-      process.env.HOME ?? "~",
-      ".config",
-      "grove",
-      "state",
-      basename(pidFileFor(CFG)),
-    );
+    // The child ran with CORTEX_STATE_DIR unset, so its STATE_DIR is the resolver
+    // default for THIS box: canonical `~/.local/state/metafactory/cortex` when
+    // present, else legacy `~/.config/grove/state`. Reproduce that resolution
+    // here with the override cleared so parent + child agree regardless of which
+    // state tree exists on disk (the pre-#1903 hardcoded grove path only held on
+    // boxes that already had the legacy tree — it broke on a clean CI runner).
+    // basename is STATE_DIR-independent (hash is over the config path).
+    const saved = process.env.CORTEX_STATE_DIR;
+    delete process.env.CORTEX_STATE_DIR;
+    let expectedDir: string;
+    try {
+      expectedDir = resolvePidStateDir();
+    } finally {
+      if (saved !== undefined) process.env.CORTEX_STATE_DIR = saved;
+    }
+    const expectedDefault = join(expectedDir, basename(pidFileFor(CFG)));
     expect(out).toBe(expectedDefault);
   });
 

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -57,6 +57,7 @@ import {
 } from "../../../common/nats/nats-service-manager";
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
 import { NetworkCache } from "../../../common/registry/network-cache";
+import { resolveNetworkCacheDir } from "../../../common/state-path";
 import { backupConfigFile } from "../../../common/nats/config-backup";
 import { probeHealthzMonitor } from "../../../common/nats/healthz-probe";
 import {
@@ -1393,7 +1394,7 @@ export function buildCachedNetworkPort(): CachedNetworkPort {
   // tests' temp-$HOME isolation (os.homedir() would punch through to the real
   // home and leak the developer's live cache into a config-less status run).
   const cache = new NetworkCache({
-    cacheDir: expandTilde(join("~", ".config", "cortex", "network-cache")),
+    cacheDir: resolveNetworkCacheDir(),
   });
   return {
     list() {

--- a/src/cli/cortex/commands/network-secret-adapters.ts
+++ b/src/cli/cortex/commands/network-secret-adapters.ts
@@ -60,6 +60,7 @@ import {
 } from "../../../bus/stack-provisioning";
 import { bunExecRunner, type ExecRunner } from "../../../common/nats/nats-service-manager";
 import { NetworkCache } from "../../../common/registry/network-cache";
+import { resolveNetworkCacheDir } from "../../../common/state-path";
 import { extractHubHost } from "./network-secret-lib";
 import {
   readNetworksFromConfig,
@@ -742,7 +743,7 @@ const defaultLocalInterfaceAddresses = (): string[] => {
 function buildLiveHubLocalityPort(cfg: LiveSecretPortsConfig): HubLocalityPort {
   const cache =
     cfg.networkCache ??
-    new NetworkCache({ cacheDir: expandTilde(joinPath("~", ".config", "cortex", "network-cache")) });
+    new NetworkCache({ cacheDir: resolveNetworkCacheDir() });
   const getHostname = cfg.hostname ?? osHostname;
   const resolveHostAddresses = cfg.resolveHostAddresses ?? defaultResolveHostAddresses;
   const localInterfaceAddresses = cfg.localInterfaceAddresses ?? defaultLocalInterfaceAddresses;

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -49,6 +49,7 @@ import type { LoadedConfig } from "../../../common/config/loader";
 import { resolveConfigDir, resolveConfigFilePath } from "../../../common/config/config-path";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
 import { NetworkCache } from "../../../common/registry/network-cache";
+import { resolveNetworkCacheDir } from "../../../common/state-path";
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
 import {
   materialFromSeedString,
@@ -2257,7 +2258,7 @@ export async function seedDescriptorCacheOnMiss(
   registryUrl: string,
   registryPubkey: string | undefined,
   cache: NetworkCache = new NetworkCache({
-    cacheDir: expandTilde(join("~", ".config", "cortex", "network-cache")),
+    cacheDir: resolveNetworkCacheDir(),
   }),
   seed: typeof seedAdminDescriptorCache = seedAdminDescriptorCache,
 ): Promise<{ seeded: boolean; reason?: string; skipped?: boolean }> {
@@ -3400,7 +3401,7 @@ export function resolveOperatorAttestation(
   networkId: string,
   load: ConfigReader,
   cache: NetworkCache = new NetworkCache({
-    cacheDir: expandTilde(join("~", ".config", "cortex", "network-cache")),
+    cacheDir: resolveNetworkCacheDir(),
   }),
 ): { hubMode?: "operator" | "simple"; resolverMode?: "nats" | "memory"; hubFedAccount?: string } {
   const descriptor = cache.load(networkId)?.descriptor;

--- a/src/common/__tests__/migrate-state-dir.test.ts
+++ b/src/common/__tests__/migrate-state-dir.test.ts
@@ -274,7 +274,7 @@ describe("state migration — AC3 one live process per stack after move", () => 
     expect(lc.loaded.has(WORK_LABEL)).toBe(true);
     const livePid = lc.loaded.get(WORK_LABEL);
     expect(livePid).toBeDefined();
-    expect(lc.alive.has(livePid as number)).toBe(true);
+    expect(lc.alive.has(livePid!)).toBe(true);
     // The OLD pid is gone (proven dead before the move) — not two processes.
     expect(lc.alive.has(4242)).toBe(false);
     expect([...lc.loaded.keys()].filter((l) => l === WORK_LABEL)).toHaveLength(1);

--- a/src/common/__tests__/migrate-state-dir.test.ts
+++ b/src/common/__tests__/migrate-state-dir.test.ts
@@ -1,0 +1,335 @@
+/**
+ * XDG wave-5 (cortex#1903) — GATED STATE-dir migration tests.
+ *
+ * Hermetic scratch `$HOME`; `CORTEX_STATE_DIR` unset per test; a fake launchd
+ * `GateEnv` (no real launchctl / processes). Covers the ACs:
+ *   1. Migration ABORTS when a stack is loaded — via the X-09 service gate AND
+ *      via the directory-occupancy precondition (gate-clear but a live `*.pid` in
+ *      the state dir — the belt-insufficiency case #1932).
+ *   2. The signature-verified network-cache roster survives the move intact.
+ *   3. Exactly one live process per stack PID after the move (restore invariant).
+ *   4. Copy-keep-source: source intact; idempotent; canonical-wins.
+ *   5. An unclassifiable `*.pid` counts as PRESENT → abort (fail-safe).
+ *
+ * All test/describe names contain "state migration" for `bun test … -t`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import type { GateEnv, GateExec, ClearFleetOptions } from "../migration/migration-gate";
+import { CORTEX_LABEL_PREFIX } from "../migration/migration-gate";
+import { NetworkCache } from "../registry/network-cache";
+import {
+  executeStateDirMigration,
+  migrateStateDir,
+  planStateDirMigration,
+  STATE_MIGRATION_JOURNAL_NAME,
+  stateDirOccupancyCheck,
+} from "../migrate-state-dir";
+import {
+  canonicalLogsDir,
+  canonicalNetworkCacheDir,
+  canonicalRelayDir,
+  cortexStateDir,
+  legacyGroveLogsDir,
+  legacyNetworkCacheDir,
+  legacyPidStateDir,
+  legacyRelayDir,
+} from "../state-path";
+
+const FAST_DRAIN = { drainTimeoutMs: 100, pollIntervalMs: 10 };
+const WORK_LABEL = `${CORTEX_LABEL_PREFIX}work`;
+
+let home: string;
+let launchAgentsDir: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  savedEnv = process.env.CORTEX_STATE_DIR;
+  delete process.env.CORTEX_STATE_DIR;
+  home = mkdtempSync(join(tmpdir(), "xdg1903-mig-"));
+  launchAgentsDir = join(home, "Library", "LaunchAgents");
+  mkdirSync(launchAgentsDir, { recursive: true });
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.CORTEX_STATE_DIR;
+  else process.env.CORTEX_STATE_DIR = savedEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Fake launchd + controllable GateEnv (mirrors migration-gate.test.ts)
+// =============================================================================
+
+/** launchd fake. `loaded` = label→pid; `sticky` labels ignore bootout (they stay
+ *  loaded + alive — a daemon that refuses to die). `alive` drives procAlive. */
+function makeLaunchd(init: { loaded?: Record<string, number>; sticky?: string[] }): {
+  env: GateEnv;
+  loaded: Map<string, number>;
+  alive: Set<number>;
+} {
+  const loaded = new Map<string, number>(Object.entries(init.loaded ?? {}));
+  const alive = new Set<number>(loaded.values());
+  const sticky = new Set(init.sticky ?? []);
+  const labelOf = (t: string | undefined): string => (t ?? "").split("/").pop() ?? "";
+  let nextPid = 90000;
+  const exec: GateExec = (argv) => {
+    const sub = argv[1];
+    if (sub === "print") {
+      const pid = loaded.get(labelOf(argv[2]));
+      return Promise.resolve(
+        pid !== undefined
+          ? { code: 0, stdout: `\tstate = running\n\tpid = ${pid.toString()}\n`, stderr: "" }
+          : { code: 113, stdout: "", stderr: "Could not find service" },
+      );
+    }
+    if (sub === "bootout") {
+      const label = labelOf(argv[2]);
+      if (sticky.has(label)) return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+      const pid = loaded.get(label);
+      loaded.delete(label);
+      if (pid !== undefined) alive.delete(pid);
+      return Promise.resolve({ code: pid !== undefined ? 0 : 3, stdout: "", stderr: "" });
+    }
+    if (sub === "bootstrap") {
+      const label = (argv[3] ?? "").split("/").pop()?.replace(/\.plist$/, "") ?? "";
+      const pid = nextPid++;
+      loaded.set(label, pid);
+      alive.add(pid);
+      return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    }
+    if (sub === "kickstart") return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+    return Promise.resolve({ code: 1, stdout: "", stderr: `unknown ${String(sub)}` });
+  };
+  let clock = 0;
+  const env: GateEnv = {
+    exec,
+    procAlive: (pid) => alive.has(pid),
+    sleep: (ms) => {
+      clock += ms;
+      return Promise.resolve();
+    },
+    now: () => clock,
+  };
+  return { env, loaded, alive };
+}
+
+/** Batteries-included darwin gate opts with an empty belt (hermetic — never
+ *  reads a real pidfile) and one discovered stack slug ("work"). */
+function gateOpts(env: GateEnv): ClearFleetOptions {
+  return {
+    platform: "darwin",
+    uid: 501,
+    env,
+    drain: FAST_DRAIN,
+    launchAgentsDir,
+    home,
+    discoverSlugs: () => ["work"],
+    belt: { stackConfigPaths: [], readPidFile: () => undefined },
+  };
+}
+
+/** A minimal valid signed-roster cache record (passes NetworkCache's shape +
+ *  BASE64_ED25519 grammar gate). */
+function signedRosterJson(networkId: string): string {
+  const pubkey = "A".repeat(43) + "="; // 43 base64 chars + '=' padding
+  return JSON.stringify(
+    {
+      schema_version: 1,
+      cached_at: "2026-01-01T00:00:00.000Z",
+      descriptor: { network_id: networkId, hub_url: "nats://hub", leaf_port: 4222, members: [] },
+      roster: {
+        network_id: networkId,
+        members: [{ principal_id: "p1", principal_pubkey: pubkey }],
+      },
+    },
+    null,
+    2,
+  );
+}
+
+// =============================================================================
+// AC1a — X-09 service gate: a LOADED stack aborts the move
+// =============================================================================
+
+describe("state migration — AC1 gate refuses while a stack is loaded", () => {
+  test("a sticky-loaded stack daemon → gate refuses → NOTHING carried", async () => {
+    // A stack whose bootout is ignored (won't die) → the gate cannot prove it dead.
+    const lc = makeLaunchd({ loaded: { [WORK_LABEL]: 4242 }, sticky: [WORK_LABEL] });
+    // Plant a legacy roster so we can prove it was NOT carried on a refusal.
+    mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
+    writeFileSync(join(legacyNetworkCacheDir(home), "n-x.json"), signedRosterJson("n-x"));
+
+    const run = await migrateStateDir({ ...gateOpts(lc.env), home });
+
+    expect(run.outcome).toBe("gate-refused");
+    expect(run.gate.cleared).toBe(false);
+    expect(run.journal).toBeUndefined();
+    // Canonical state root must not have been created by a refused migration.
+    expect(existsSync(join(canonicalNetworkCacheDir(home), "n-x.json"))).toBe(false);
+    // Source roster is untouched.
+    expect(existsSync(join(legacyNetworkCacheDir(home), "n-x.json"))).toBe(true);
+  });
+});
+
+// =============================================================================
+// AC1b / AC5 — directory-occupancy precondition (belt-insufficiency #1932)
+// =============================================================================
+
+describe("state migration — AC1b/AC5 directory-occupancy precondition", () => {
+  test("gate clears but a LIVE *.pid in the state dir → dir-occupied abort", async () => {
+    const lc = makeLaunchd({}); // nothing loaded → service gate clears
+    lc.alive.add(7777); // a hand-started daemon the service gate can't see
+    mkdirSync(legacyPidStateDir(home), { recursive: true });
+    writeFileSync(join(legacyPidStateDir(home), "cortex-custom.pid"), "7777\n");
+    mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
+    writeFileSync(join(legacyNetworkCacheDir(home), "n-x.json"), signedRosterJson("n-x"));
+
+    const run = await migrateStateDir({ ...gateOpts(lc.env), home });
+
+    expect(run.gate.cleared).toBe(true); // the SERVICE gate cleared…
+    expect(run.outcome).toBe("dir-occupied"); // …but the dir-occupancy belt refused
+    expect(run.occupancy?.occupied).toBe(true);
+    expect(run.occupancy?.refused.some((r) => r.reason === "live" && r.pid === 7777)).toBe(true);
+    expect(run.journal).toBeUndefined();
+    expect(existsSync(join(canonicalNetworkCacheDir(home), "n-x.json"))).toBe(false);
+  });
+
+  test("an UNCLASSIFIABLE *.pid counts as PRESENT → abort (fail-safe)", async () => {
+    const lc = makeLaunchd({});
+    mkdirSync(legacyPidStateDir(home), { recursive: true });
+    writeFileSync(join(legacyPidStateDir(home), "cortex.pid"), "not-a-pid");
+
+    const run = await migrateStateDir({ ...gateOpts(lc.env), home });
+
+    expect(run.gate.cleared).toBe(true);
+    expect(run.outcome).toBe("dir-occupied");
+    expect(run.occupancy?.refused.some((r) => r.reason === "unparseable")).toBe(true);
+    expect(run.journal).toBeUndefined();
+  });
+
+  test("stateDirOccupancyCheck: dead pid is NOT an occupant; skips absent dirs", () => {
+    mkdirSync(legacyPidStateDir(home), { recursive: true });
+    writeFileSync(join(legacyPidStateDir(home), "cortex.pid"), "5"); // pid 5, reported dead
+    const res = stateDirOccupancyCheck(
+      [legacyPidStateDir(home), join(home, "does-not-exist")],
+      () => false, // nothing alive
+    );
+    expect(res.occupied).toBe(false);
+    expect(res.scanned).toEqual([legacyPidStateDir(home)]);
+  });
+});
+
+// =============================================================================
+// AC2 — the signature-verified roster survives the move
+// =============================================================================
+
+describe("state migration — AC2 signed roster survives intact", () => {
+  test("network-cache roster is carried byte-identical and still loads/verifies", async () => {
+    const lc = makeLaunchd({}); // clear gate
+    const legacyDir = legacyNetworkCacheDir(home);
+    mkdirSync(legacyDir, { recursive: true });
+    const original = signedRosterJson("n-prod");
+    writeFileSync(join(legacyDir, "n-prod.json"), original);
+
+    const run = await migrateStateDir({ ...gateOpts(lc.env), home });
+    expect(run.outcome).toBe("migrated");
+
+    const canonicalFile = join(canonicalNetworkCacheDir(home), "n-prod.json");
+    expect(existsSync(canonicalFile)).toBe(true);
+    // Byte-identical — no re-serialize, no truncation.
+    expect(readFileSync(canonicalFile, "utf-8")).toBe(original);
+    // Source kept.
+    expect(existsSync(join(legacyDir, "n-prod.json"))).toBe(true);
+    // The shape + BASE64_ED25519 signature grammar still passes at the canonical
+    // location → the offline-fallback roster survived and verifies.
+    const loaded = new NetworkCache({ cacheDir: canonicalNetworkCacheDir(home) }).load("n-prod");
+    expect(loaded).not.toBeUndefined();
+    expect(loaded?.roster.members[0]?.principal_id).toBe("p1");
+  });
+});
+
+// =============================================================================
+// AC3 — exactly one live process per stack after the move
+// =============================================================================
+
+describe("state migration — AC3 one live process per stack after move", () => {
+  test("a running stack is stopped, migrated, then restored to exactly one live pid", async () => {
+    const lc = makeLaunchd({ loaded: { [WORK_LABEL]: 4242 } }); // one live stack
+    mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
+    writeFileSync(join(legacyNetworkCacheDir(home), "n-x.json"), signedRosterJson("n-x"));
+
+    const run = await migrateStateDir({ ...gateOpts(lc.env), home });
+
+    expect(run.outcome).toBe("migrated");
+    expect(run.gate.cleared).toBe(true);
+    // The migration carried the roster forward.
+    expect(existsSync(join(canonicalNetworkCacheDir(home), "n-x.json"))).toBe(true);
+    // Restore brought the fleet back: exactly ONE launchd entry for the stack,
+    // holding exactly ONE live pid (no duplicate, no orphan).
+    expect(run.restore.restored).toEqual(["work"]);
+    expect(lc.loaded.has(WORK_LABEL)).toBe(true);
+    const livePid = lc.loaded.get(WORK_LABEL);
+    expect(livePid).toBeDefined();
+    expect(lc.alive.has(livePid as number)).toBe(true);
+    // The OLD pid is gone (proven dead before the move) — not two processes.
+    expect(lc.alive.has(4242)).toBe(false);
+    expect([...lc.loaded.keys()].filter((l) => l === WORK_LABEL)).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// AC4 — copy-keep-source: source intact, idempotent, canonical-wins
+// =============================================================================
+
+describe("state migration — AC4 copy-keep-source + idempotent", () => {
+  test("logs + roster carried; source kept; journal written; re-run is a no-op", async () => {
+    const lc = makeLaunchd({});
+    mkdirSync(legacyGroveLogsDir(home), { recursive: true });
+    writeFileSync(join(legacyGroveLogsDir(home), "cortex.log"), "line1\n");
+    mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
+    writeFileSync(join(legacyNetworkCacheDir(home), "n-x.json"), signedRosterJson("n-x"));
+
+    const run1 = await migrateStateDir({ ...gateOpts(lc.env), home, stampedAt: "2026-07-13T00:00:00Z" });
+    expect(run1.outcome).toBe("migrated");
+
+    // Carried to canonical.
+    expect(readFileSync(join(canonicalLogsDir(home), "cortex.log"), "utf-8")).toBe("line1\n");
+    // Source kept.
+    expect(existsSync(join(legacyGroveLogsDir(home), "cortex.log"))).toBe(true);
+    // Journal written at the canonical root with the applied records.
+    const journalPath = join(cortexStateDir(home), STATE_MIGRATION_JOURNAL_NAME);
+    expect(existsSync(journalPath)).toBe(true);
+    const applied = (run1.journal?.carried ?? []).filter((m) => m.applied);
+    expect(applied.length).toBeGreaterThanOrEqual(2); // log + roster
+
+    // Second run: canonical-wins → everything skippedExisting, nothing re-applied.
+    const run2 = await migrateStateDir({ ...gateOpts(lc.env), home });
+    expect(run2.outcome).toBe("migrated");
+    expect((run2.journal?.carried ?? []).every((m) => m.skippedExisting === true || m.applied !== true)).toBe(
+      true,
+    );
+  });
+
+  test("planStateDirMigration is EMPTY under a $CORTEX_STATE_DIR override", () => {
+    process.env.CORTEX_STATE_DIR = "/ov/state";
+    mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
+    writeFileSync(join(legacyNetworkCacheDir(home), "n-x.json"), signedRosterJson("n-x"));
+    const plan = planStateDirMigration({ home });
+    expect(plan.carried).toHaveLength(0); // self-contained root — no legacy counterpart
+  });
+
+  test("relay pidfile is carried but relay-policy.yaml (config) is NOT", () => {
+    // Direct plan/execute exercise (no gate) — relay dir holds both a pidfile
+    // (STATE, carried) and a policy (CONFIG, left behind).
+    mkdirSync(legacyRelayDir(home), { recursive: true });
+    writeFileSync(join(legacyRelayDir(home), "relay.pid"), "123");
+    writeFileSync(join(legacyRelayDir(home), "relay-policy.yaml"), "policy: {}\n");
+    executeStateDirMigration(planStateDirMigration({ home }), "2026-07-13T00:00:00Z");
+    expect(existsSync(join(canonicalRelayDir(home), "relay.pid"))).toBe(true);
+    expect(existsSync(join(canonicalRelayDir(home), "relay-policy.yaml"))).toBe(false);
+  });
+});

--- a/src/common/__tests__/state-path.test.ts
+++ b/src/common/__tests__/state-path.test.ts
@@ -1,0 +1,143 @@
+/**
+ * XDG wave-5 (cortex#1903) — STATE-dir resolver tests.
+ *
+ * Hermetic scratch `$HOME`; `CORTEX_STATE_DIR` / `XDG_STATE_HOME` /
+ * `CORTEX_XDG_STRICT` unset per test. Proves canonical-first / legacy-fallback
+ * precedence, the `$CORTEX_STATE_DIR` override (self-contained root, no legacy
+ * probe), and `$XDG_STATE_HOME` honouring — for every state class the wave moves.
+ * All paths derive from the injected `home`, so no real-home path is ever touched.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  canonicalLogsDir,
+  canonicalNetworkCacheDir,
+  canonicalPidStateDir,
+  canonicalRelayDir,
+  cortexStateDir,
+  legacyCortexLogsDir,
+  legacyGroveLogsDir,
+  legacyNetworkCacheDir,
+  legacyPidStateDir,
+  legacyRelayDir,
+  LOG_DIR_DEFAULT,
+  resolveLogsDir,
+  resolveNetworkCacheDir,
+  resolvePidStateDir,
+  resolveRelayDir,
+  xdgStateHome,
+} from "../state-path";
+
+let home: string;
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ["CORTEX_STATE_DIR", "XDG_STATE_HOME", "CORTEX_XDG_STRICT"] as const;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  home = mkdtempSync(join(tmpdir(), "xdg1903-path-"));
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("state-path canonical roots", () => {
+  test("cortexStateDir defaults to ~/.local/state/metafactory/cortex", () => {
+    expect(cortexStateDir(home)).toBe(join(home, ".local", "state", "metafactory", "cortex"));
+  });
+
+  test("pidfiles live directly under the state root; logs/relay/cache are sub-dirs", () => {
+    const root = cortexStateDir(home);
+    expect(canonicalPidStateDir(home)).toBe(root);
+    expect(canonicalLogsDir(home)).toBe(join(root, "logs"));
+    expect(canonicalRelayDir(home)).toBe(join(root, "relay"));
+    expect(canonicalNetworkCacheDir(home)).toBe(join(root, "network-cache"));
+  });
+
+  test("LOG_DIR_DEFAULT literal matches the canonical logs dir spelling", () => {
+    expect(LOG_DIR_DEFAULT).toBe("~/.local/state/metafactory/cortex/logs");
+  });
+});
+
+describe("$XDG_STATE_HOME override", () => {
+  test("xdgStateHome honours $XDG_STATE_HOME verbatim, else ~/.local/state", () => {
+    expect(xdgStateHome(home)).toBe(join(home, ".local", "state"));
+    process.env.XDG_STATE_HOME = "/custom/xstate";
+    expect(xdgStateHome(home)).toBe("/custom/xstate");
+    expect(cortexStateDir(home)).toBe(join("/custom/xstate", "metafactory", "cortex"));
+  });
+
+  test("blank $XDG_STATE_HOME reads as unset (not /metafactory/cortex)", () => {
+    process.env.XDG_STATE_HOME = "   ";
+    expect(xdgStateHome(home)).toBe(join(home, ".local", "state"));
+  });
+});
+
+describe("$CORTEX_STATE_DIR override — self-contained root, no legacy probe", () => {
+  test("override wins over canonical AND legacy for every class", () => {
+    process.env.CORTEX_STATE_DIR = "/ov/state";
+    // Even with legacy trees present, the override short-circuits all fallback.
+    mkdirSync(legacyPidStateDir(home), { recursive: true });
+    mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
+    expect(cortexStateDir(home)).toBe("/ov/state");
+    expect(resolvePidStateDir(home)).toBe("/ov/state");
+    expect(resolveLogsDir(home)).toBe(join("/ov/state", "logs"));
+    expect(resolveRelayDir(home)).toBe(join("/ov/state", "relay"));
+    expect(resolveNetworkCacheDir(home)).toBe(join("/ov/state", "network-cache"));
+  });
+
+  test("blank $CORTEX_STATE_DIR reads as unset → canonical/legacy gating applies", () => {
+    process.env.CORTEX_STATE_DIR = "  ";
+    mkdirSync(legacyPidStateDir(home), { recursive: true });
+    expect(resolvePidStateDir(home)).toBe(legacyPidStateDir(home));
+  });
+});
+
+describe("canonical-first / legacy-fallback (no override)", () => {
+  test("pid state dir: legacy grove used when canonical absent, canonical once present", () => {
+    // Nothing on disk → canonical write target.
+    expect(resolvePidStateDir(home)).toBe(canonicalPidStateDir(home));
+    // Legacy present → legacy fallback.
+    mkdirSync(legacyPidStateDir(home), { recursive: true });
+    expect(resolvePidStateDir(home)).toBe(legacyPidStateDir(home));
+    // Canonical present → canonical wins over legacy.
+    mkdirSync(canonicalPidStateDir(home), { recursive: true });
+    expect(resolvePidStateDir(home)).toBe(canonicalPidStateDir(home));
+  });
+
+  test("logs dir prefers grove over cortex when both legacy trees exist", () => {
+    mkdirSync(legacyCortexLogsDir(home), { recursive: true });
+    // Only cortex legacy present → cortex fallback.
+    expect(resolveLogsDir(home)).toBe(legacyCortexLogsDir(home));
+    // grove legacy also present → grove wins (first in precedence).
+    mkdirSync(legacyGroveLogsDir(home), { recursive: true });
+    expect(resolveLogsDir(home)).toBe(legacyGroveLogsDir(home));
+    // canonical present → canonical wins over both.
+    mkdirSync(canonicalLogsDir(home), { recursive: true });
+    expect(resolveLogsDir(home)).toBe(canonicalLogsDir(home));
+  });
+
+  test("relay dir: legacy ~/.claude/relay fallback then canonical", () => {
+    mkdirSync(legacyRelayDir(home), { recursive: true });
+    expect(resolveRelayDir(home)).toBe(legacyRelayDir(home));
+    mkdirSync(canonicalRelayDir(home), { recursive: true });
+    expect(resolveRelayDir(home)).toBe(canonicalRelayDir(home));
+  });
+
+  test("network-cache: legacy ~/.config/cortex/network-cache fallback then canonical", () => {
+    mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
+    expect(resolveNetworkCacheDir(home)).toBe(legacyNetworkCacheDir(home));
+    mkdirSync(canonicalNetworkCacheDir(home), { recursive: true });
+    expect(resolveNetworkCacheDir(home)).toBe(canonicalNetworkCacheDir(home));
+  });
+});

--- a/src/common/__tests__/state-path.test.ts
+++ b/src/common/__tests__/state-path.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -29,8 +29,17 @@ import {
   resolveNetworkCacheDir,
   resolvePidStateDir,
   resolveRelayDir,
+  STATE_MIGRATION_JOURNAL_NAME,
+  stateMigrationCompleted,
   xdgStateHome,
 } from "../state-path";
+
+/** Write the completion marker at the canonical root — the ONLY thing that flips
+ *  the resolvers from legacy to canonical (#1903 pidfile-identity contract). */
+function completeMigration(h: string): void {
+  mkdirSync(cortexStateDir(h), { recursive: true });
+  writeFileSync(join(cortexStateDir(h), STATE_MIGRATION_JOURNAL_NAME), "{}");
+}
 
 let home: string;
 const savedEnv: Record<string, string | undefined> = {};
@@ -103,41 +112,58 @@ describe("$CORTEX_STATE_DIR override — self-contained root, no legacy probe", 
   });
 });
 
-describe("canonical-first / legacy-fallback (no override)", () => {
-  test("pid state dir: legacy grove used when canonical absent, canonical once present", () => {
-    // Nothing on disk → canonical write target.
-    expect(resolvePidStateDir(home)).toBe(canonicalPidStateDir(home));
-    // Legacy present → legacy fallback.
+describe("completion-gated canonical flip (no override) — #1903 identity contract", () => {
+  test("pid state dir: legacy grove is the pre-migration default; a BARE canonical dir does NOT flip it; the completion marker does", () => {
+    // Nothing on disk → legacy grove default (stable write target + identity).
+    expect(resolvePidStateDir(home)).toBe(legacyPidStateDir(home));
+    // Legacy present, no marker → still legacy.
     mkdirSync(legacyPidStateDir(home), { recursive: true });
     expect(resolvePidStateDir(home)).toBe(legacyPidStateDir(home));
-    // Canonical present → canonical wins over legacy.
+    // A BARE canonical dir WITHOUT the marker must NOT flip identity (the hazard
+    // the completion gate exists to prevent — a sibling class created the root).
     mkdirSync(canonicalPidStateDir(home), { recursive: true });
+    expect(stateMigrationCompleted(home)).toBe(false);
+    expect(resolvePidStateDir(home)).toBe(legacyPidStateDir(home));
+    // Completion marker present → canonical.
+    completeMigration(home);
+    expect(stateMigrationCompleted(home)).toBe(true);
     expect(resolvePidStateDir(home)).toBe(canonicalPidStateDir(home));
   });
 
-  test("logs dir prefers grove over cortex when both legacy trees exist", () => {
+  test("logs dir prefers grove over cortex pre-migration; flips to canonical only on the marker", () => {
     mkdirSync(legacyCortexLogsDir(home), { recursive: true });
     // Only cortex legacy present → cortex fallback.
     expect(resolveLogsDir(home)).toBe(legacyCortexLogsDir(home));
     // grove legacy also present → grove wins (first in precedence).
     mkdirSync(legacyGroveLogsDir(home), { recursive: true });
     expect(resolveLogsDir(home)).toBe(legacyGroveLogsDir(home));
-    // canonical present → canonical wins over both.
+    // A bare canonical logs dir without the marker does not flip.
     mkdirSync(canonicalLogsDir(home), { recursive: true });
+    expect(resolveLogsDir(home)).toBe(legacyGroveLogsDir(home));
+    // Completion marker → canonical.
+    completeMigration(home);
     expect(resolveLogsDir(home)).toBe(canonicalLogsDir(home));
   });
 
-  test("relay dir: legacy ~/.claude/relay fallback then canonical", () => {
+  test("relay dir: legacy ~/.claude/relay pre-migration; canonical after the marker", () => {
     mkdirSync(legacyRelayDir(home), { recursive: true });
     expect(resolveRelayDir(home)).toBe(legacyRelayDir(home));
-    mkdirSync(canonicalRelayDir(home), { recursive: true });
+    completeMigration(home);
     expect(resolveRelayDir(home)).toBe(canonicalRelayDir(home));
   });
 
-  test("network-cache: legacy ~/.config/cortex/network-cache fallback then canonical", () => {
+  test("network-cache: legacy ~/.config/cortex/network-cache pre-migration; canonical after the marker", () => {
     mkdirSync(legacyNetworkCacheDir(home), { recursive: true });
     expect(resolveNetworkCacheDir(home)).toBe(legacyNetworkCacheDir(home));
-    mkdirSync(canonicalNetworkCacheDir(home), { recursive: true });
+    completeMigration(home);
     expect(resolveNetworkCacheDir(home)).toBe(canonicalNetworkCacheDir(home));
+  });
+
+  test("fresh box (no legacy tree, no marker) → legacy grove default, NEVER canonical", () => {
+    // The pre-migration default must be the legacy path even when nothing is on
+    // disk yet, so pidfile identity is byte-stable from first boot until cutover.
+    expect(resolvePidStateDir(home)).toBe(legacyPidStateDir(home));
+    expect(resolveRelayDir(home)).toBe(legacyRelayDir(home));
+    expect(resolveNetworkCacheDir(home)).toBe(legacyNetworkCacheDir(home));
   });
 });

--- a/src/common/__tests__/state-path.test.ts
+++ b/src/common/__tests__/state-path.test.ts
@@ -39,13 +39,13 @@ const ENV_KEYS = ["CORTEX_STATE_DIR", "XDG_STATE_HOME", "CORTEX_XDG_STRICT"] as 
 beforeEach(() => {
   for (const k of ENV_KEYS) {
     savedEnv[k] = process.env[k];
-    delete process.env[k];
+    Reflect.deleteProperty(process.env, k);
   }
   home = mkdtempSync(join(tmpdir(), "xdg1903-path-"));
 });
 afterEach(() => {
   for (const k of ENV_KEYS) {
-    if (savedEnv[k] === undefined) delete process.env[k];
+    if (savedEnv[k] === undefined) Reflect.deleteProperty(process.env, k);
     else process.env[k] = savedEnv[k];
   }
   rmSync(home, { recursive: true, force: true });

--- a/src/common/migrate-state-dir.ts
+++ b/src/common/migrate-state-dir.ts
@@ -1,0 +1,502 @@
+/**
+ * XDG wave-5 (cortex#1903, EPIC cortex#1867 §P3c) — STATE DIRECTORY migrator.
+ *
+ * The RISKIEST move in the epic: it relocates the pidfiles of production
+ * daemons. So it is GATED twice over and copy-keep-source throughout.
+ *
+ * ── What moves (all copy-keep-source, source NEVER deleted here) ─────────────
+ *   - pidfiles + `.degraded.json` markers  `~/.config/grove/state`      → canonical
+ *   - rotating logs                         `~/.config/grove/logs` AND
+ *                                           `~/.config/cortex/logs`      → canonical/logs
+ *   - relay pidfile                         `~/.claude/relay/relay.pid`  → canonical/relay
+ *   - DD-10 network-cache (signed roster)   `~/.config/cortex/network-cache` → canonical/network-cache
+ *
+ * The network-cache carry preserves the signature-verified roster byte-for-byte
+ * (a plain file copy of the `*.json` records — no re-serialize, no truncation),
+ * so `NetworkCache.load`'s `BASE64_ED25519` grammar + shape gate still passes and
+ * the offline-fallback roster survives intact (AC2).
+ *
+ * ── Two gates, because a name-belt is INSUFFICIENT for a directory move ──────
+ *   1. **X-09 service gate** ({@link withMigrationGate}) — `launchctl bootout` /
+ *      `systemctl stop` every discovered stack + relay + legacy unit, then PROVE
+ *      each dead via the three-leg positive-death proof AND the config-derived
+ *      pidfile-liveness belt. The migration body runs ONLY if the gate clears,
+ *      inside a try/finally that ALWAYS restores the pre-running fleet.
+ *   2. **Directory-occupancy precondition** ({@link stateDirOccupancyCheck}) —
+ *      run INSIDE the gated body, AFTER the service stop. The service gate + its
+ *      belt only see daemons the service manager knows about OR whose pidfile
+ *      NAME the #1900 `pidFileFor` can reconstruct. A directory MOVE needs more:
+ *      we `readdir` the actual state dirs (source + canonical + relay) and
+ *      liveness-check EVERY `*.pid` we find, by name-agnostic enumeration. If ANY
+ *      maps to a LIVE process → ABORT. A `*.pid` we cannot classify (unreadable /
+ *      unparseable / no such pid file content) counts as PRESENT (fail-safe
+ *      abort), NEVER absent (belt re-attack #1932). Only when every pidfile on
+ *      disk is provably dead/gone does the carry proceed.
+ *
+ * ── Transactionality ─────────────────────────────────────────────────────────
+ * {@link executeStateDirMigration} is all-or-nothing: on ANY throw mid-carry it
+ * rolls back every carry it applied, so the existence-gated resolver never sees a
+ * PARTIAL canonical that would shadow files still in a legacy tree. The legacy
+ * trees are never touched.
+ *
+ * ── Isolation ────────────────────────────────────────────────────────────────
+ * Every path derives from an injectable `home`; process-liveness is the injected
+ * `procAlive` seam; the service gate's exec/sleep/clock are injected via
+ * {@link ClearFleetOptions}. The whole migrator runs against a scratch `$HOME`
+ * with no real launchd/systemd/processes.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { join, relative } from "path";
+
+import { atomicSymlink, atomicWriteFile } from "./config/migrate-config-dir";
+import {
+  type ClearFleetOptions,
+  type MigrationGateResult,
+  type RestoreResult,
+  withMigrationGate,
+} from "./migration/migration-gate";
+import {
+  canonicalLogsDir,
+  canonicalNetworkCacheDir,
+  canonicalPidStateDir,
+  canonicalRelayDir,
+  cortexStateDir,
+  cortexStateDirOverride,
+  legacyCortexLogsDir,
+  legacyGroveLogsDir,
+  legacyNetworkCacheDir,
+  legacyPidStateDir,
+  legacyRelayDir,
+} from "./state-path";
+
+/** Journal dropped at the canonical state root so a move is auditable + reversible. */
+export const STATE_MIGRATION_JOURNAL_NAME = ".xdg-state-migration.json";
+
+/** Which state class a carried entry belongs to (for audit + reasoning). */
+export type StateCarryKind = "pidfiles" | "logs" | "relay-pid" | "network-cache";
+
+export interface StateMoveRecord {
+  kind: StateCarryKind;
+  /** Path relative to its carry root (POSIX-normalized with the tree's sep). */
+  relPath: string;
+  /** Absolute source path (KEPT; never renamed or removed). */
+  src: string;
+  /** Absolute canonical destination path. */
+  dest: string;
+  /** File mode (low 12 bits) preserved onto the destination. */
+  mode: number;
+  /** Size in bytes of the carried file. */
+  bytes: number;
+  /** True when carried AS a symlink (link text, never dereferenced). */
+  symlink?: boolean;
+  /** For a symlink entry, the raw `readlinkSync` text (may dangle). */
+  linkTarget?: string;
+  /** Set once {@link executeStateDirMigration} wrote the destination. */
+  applied?: boolean;
+  /** Set when the destination already existed (canonical-wins) and was skipped. */
+  skippedExisting?: boolean;
+}
+
+export interface StateMigrationJournal {
+  version: 1;
+  canonical: string;
+  carried: StateMoveRecord[];
+  /** Caller-stamped ISO timestamp (kept out of the planner for determinism). */
+  stampedAt?: string;
+}
+
+export interface StateMigrateOptions {
+  /** Override for `$HOME`. Omit only in production; tests ALWAYS pass a scratch home. */
+  home?: string;
+}
+
+// =============================================================================
+// Directory-occupancy precondition (the belt-insufficiency fix, #1932)
+// =============================================================================
+
+/** One `*.pid` on disk that refuses the move — either LIVE or unclassifiable. */
+export interface OccupiedPidfile {
+  path: string;
+  /** The parsed pid when the file was readable + parseable, else `undefined`. */
+  pid?: number;
+  /**
+   *  - `live`         — parsed to a pid that `procAlive` reports RUNNING.
+   *  - `unreadable`   — the file could not be read (fail-safe PRESENT).
+   *  - `unparseable`  — read but not a positive integer pid (fail-safe PRESENT).
+   */
+  reason: "live" | "unreadable" | "unparseable";
+}
+
+export interface OccupancyResult {
+  /** True when ANY pidfile is live OR unclassifiable → the move MUST abort. */
+  occupied: boolean;
+  /** Every refusing pidfile, with why (for the abort log). */
+  refused: OccupiedPidfile[];
+  /** Dirs actually scanned (existing ones only). */
+  scanned: string[];
+}
+
+/**
+ * Directory-occupancy precondition. `readdir` each dir in `dirs` and liveness-
+ * check EVERY `*.pid` found — name-agnostic, so it catches pidfiles the #1900
+ * `pidFileFor` name-reconstruction belt cannot (custom/legacy names, orphans,
+ * the relay pidfile). Classification, fail-safe toward PRESENT:
+ *   - readable + parseable + `procAlive` true → `live`         (refuse).
+ *   - readable + parseable + `procAlive` false → dead          (allow).
+ *   - unreadable                              → `unreadable`   (refuse).
+ *   - readable but not a positive-int pid     → `unparseable`  (refuse).
+ * A dir that does not exist is skipped (nothing to occupy). NEVER throws — an
+ * unreadable DIR entry is treated conservatively (the pidfiles it would contain
+ * are unknown, so a readdir failure on a present dir refuses via a synthetic
+ * `unreadable` marker rather than silently clearing).
+ */
+export function stateDirOccupancyCheck(
+  dirs: readonly string[],
+  procAlive: (pid: number) => boolean,
+): OccupancyResult {
+  const refused: OccupiedPidfile[] = [];
+  const scanned: string[] = [];
+  const seen = new Set<string>();
+
+  for (const dir of dirs) {
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    if (!existsSync(dir)) continue;
+    scanned.push(dir);
+
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      // A present-but-unreadable state dir hides an unknown set of pidfiles —
+      // fail-safe: refuse rather than infer "empty" (belt-insufficiency #1932).
+      refused.push({ path: join(dir, "*.pid"), reason: "unreadable" });
+      continue;
+    }
+
+    for (const name of entries) {
+      if (!name.endsWith(".pid")) continue;
+      const pidPath = join(dir, name);
+      let text: string;
+      try {
+        text = readFileSync(pidPath, "utf-8");
+      } catch {
+        refused.push({ path: pidPath, reason: "unreadable" });
+        continue;
+      }
+      const pid = parseInt(text.trim(), 10);
+      if (!Number.isInteger(pid) || pid <= 0) {
+        // A `.pid` file we cannot classify counts as PRESENT, never absent.
+        refused.push({ path: pidPath, reason: "unparseable" });
+        continue;
+      }
+      if (procAlive(pid)) {
+        refused.push({ path: pidPath, pid, reason: "live" });
+      }
+      // else: parseable + dead → not an occupant (the legit post-gate case).
+    }
+  }
+
+  return { occupied: refused.length > 0, refused, scanned };
+}
+
+/** The dirs the occupancy precondition scans: the source pid/relay dirs AND
+ *  their canonical counterparts (a daemon that already booted on the new binary
+ *  wrote canonical-side), unioned + de-duped. Honors the `home` seam. */
+export function occupancyScanDirs(home?: string): string[] {
+  return [
+    legacyPidStateDir(home),
+    canonicalPidStateDir(home),
+    legacyRelayDir(home),
+    canonicalRelayDir(home),
+  ];
+}
+
+// =============================================================================
+// Plan (pure — NO writes)
+// =============================================================================
+
+/** Recursively list files under `root`, RELATIVE to `root`. `lstat`, never
+ *  follow: a symlink (file OR dir) is a single leaf entry, carried as a link. */
+function walkFiles(root: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(root)) return out;
+  const recurse = (absDir: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(absDir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const abs = join(absDir, e.name);
+      let st;
+      try {
+        st = lstatSync(abs);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) recurse(abs);
+      else out.push(relative(root, abs));
+    }
+  };
+  recurse(root);
+  return out;
+}
+
+/** Build one carry record (file OR symlink), or `undefined` if the source
+ *  vanished between the walk and the stat. */
+function record(
+  kind: StateCarryKind,
+  relPath: string,
+  srcRoot: string,
+  destRoot: string,
+): StateMoveRecord | undefined {
+  const src = join(srcRoot, relPath);
+  let st;
+  try {
+    st = lstatSync(src); // lstat: a symlink is carried AS a symlink, never followed
+  } catch {
+    return undefined;
+  }
+  const mode = st.mode & 0o777;
+  const bytes = st.size;
+  const dest = join(destRoot, relPath);
+  if (st.isSymbolicLink()) {
+    let linkTarget: string;
+    try {
+      linkTarget = readlinkSync(src);
+    } catch {
+      return undefined;
+    }
+    return { kind, relPath, src, dest, mode, bytes, symlink: true, linkTarget };
+  }
+  return { kind, relPath, src, dest, mode, bytes };
+}
+
+/** One (kind, srcRoot, destRoot) carry unit. A single-file unit uses the file's
+ *  parent as the root and its basename as the sole relPath. */
+interface CarryUnit {
+  kind: StateCarryKind;
+  srcRoot: string;
+  destRoot: string;
+  /** When set, carry ONLY this basename under the roots (single-file unit). */
+  onlyFile?: string;
+}
+
+function carryUnits(home?: string): CarryUnit[] {
+  return [
+    { kind: "pidfiles", srcRoot: legacyPidStateDir(home), destRoot: canonicalPidStateDir(home) },
+    { kind: "logs", srcRoot: legacyGroveLogsDir(home), destRoot: canonicalLogsDir(home) },
+    { kind: "logs", srcRoot: legacyCortexLogsDir(home), destRoot: canonicalLogsDir(home) },
+    {
+      kind: "network-cache",
+      srcRoot: legacyNetworkCacheDir(home),
+      destRoot: canonicalNetworkCacheDir(home),
+    },
+    {
+      kind: "relay-pid",
+      srcRoot: legacyRelayDir(home),
+      destRoot: canonicalRelayDir(home),
+      onlyFile: "relay.pid", // relay-policy.yaml is CONFIG and stays put
+    },
+  ];
+}
+
+/**
+ * Build the migration plan (a {@link StateMigrationJournal} with NO writes).
+ * Enumerates each carry unit's legacy tree and maps it to the canonical tree.
+ * Deterministic — safe to run repeatedly. An explicit `$CORTEX_STATE_DIR` root
+ * has no legacy counterpart, so the plan is EMPTY (nothing to carry).
+ */
+export function planStateDirMigration(opts: StateMigrateOptions = {}): StateMigrationJournal {
+  const { home } = opts;
+  const canonical = cortexStateDir(home);
+  const carried: StateMoveRecord[] = [];
+  if (cortexStateDirOverride() !== undefined) return { version: 1, canonical, carried };
+
+  const seenDest = new Set<string>();
+  for (const unit of carryUnits(home)) {
+    const rels = unit.onlyFile !== undefined ? [unit.onlyFile] : walkFiles(unit.srcRoot);
+    for (const rel of rels) {
+      // A single-file unit lists its basename even when absent — skip a missing one.
+      if (unit.onlyFile !== undefined && !existsSync(join(unit.srcRoot, rel))) continue;
+      const mv = record(unit.kind, rel, unit.srcRoot, unit.destRoot);
+      if (mv === undefined) continue;
+      // Two log units can converge on the same canonical dest (grove + cortex).
+      // First-writer-wins in the PLAN (grove precedes cortex); execute's
+      // existsSync canonical-wins guard handles the rest.
+      if (seenDest.has(mv.dest)) continue;
+      seenDest.add(mv.dest);
+      carried.push(mv);
+    }
+  }
+  return { version: 1, canonical, carried };
+}
+
+// =============================================================================
+// Execute (transactional)
+// =============================================================================
+
+/**
+ * Execute a plan: atomically carry each entry into the canonical tree (source
+ * kept) — a regular file via {@link atomicWriteFile}, a symlink AS a symlink via
+ * {@link atomicSymlink} — skipping any destination that already exists
+ * (canonical-wins), then write the journal. Idempotent: a second run re-skips
+ * already-carried files.
+ *
+ * TRANSACTIONAL: if any carry throws, every carry THIS invocation applied is
+ * rolled back before the original error re-throws — so the resolver (which flips
+ * to canonical on mere directory existence) never sees a partial canonical.
+ */
+export function executeStateDirMigration(
+  plan: StateMigrationJournal,
+  stampedAt?: string,
+): StateMigrationJournal {
+  const canonicalPreexisted = existsSync(plan.canonical);
+  mkdirSync(plan.canonical, { recursive: true });
+  try {
+    for (const mv of plan.carried) {
+      if (existsSync(mv.dest)) {
+        mv.skippedExisting = true; // canonical-wins — never clobber a fresh copy
+        continue;
+      }
+      if (mv.symlink) {
+        atomicSymlink(mv.dest, mv.linkTarget ?? "");
+      } else {
+        const data = readFileSync(mv.src); // SOURCE is only ever READ, never renamed
+        atomicWriteFile(mv.dest, data, mv.mode);
+      }
+      mv.applied = true;
+    }
+  } catch (err) {
+    for (const mv of plan.carried) {
+      if (!mv.applied) continue;
+      let present = true;
+      try {
+        lstatSync(mv.dest);
+      } catch {
+        present = false;
+      }
+      if (present) rmSync(mv.dest, { force: true });
+      mv.applied = false;
+    }
+    if (!canonicalPreexisted) rmSync(plan.canonical, { recursive: true, force: true });
+    throw err; // preserve the original error — never swallow it
+  }
+  const journal: StateMigrationJournal = { ...plan, stampedAt };
+  writeFileSync(join(plan.canonical, STATE_MIGRATION_JOURNAL_NAME), JSON.stringify(journal, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  return journal;
+}
+
+// =============================================================================
+// The gated orchestrator (the BLESSED cutover entry)
+// =============================================================================
+
+/** Why a state migration did not carry anything. */
+export type StateMigrationOutcome =
+  | "migrated" // gate cleared, dir unoccupied, carry ran (or was already done)
+  | "gate-refused" // X-09 gate refused to prove the fleet dead
+  | "dir-occupied"; // a live/unclassifiable pidfile on disk (belt-insufficiency abort)
+
+export interface StateMigrationRunResult {
+  outcome: StateMigrationOutcome;
+  /** The X-09 gate verdict (always present — the gate always runs). */
+  gate: MigrationGateResult;
+  /** The finally-guaranteed fleet restore outcome. */
+  restore: RestoreResult;
+  /** The occupancy verdict — present only when the gate cleared (so we ran it). */
+  occupancy?: OccupancyResult;
+  /** The journal — present only on `migrated`. */
+  journal?: StateMigrationJournal;
+}
+
+export interface MigrateStateDirOptions extends ClearFleetOptions {
+  /** Override for `$HOME`. Tests ALWAYS pass a scratch home. */
+  home?: string;
+  /** ISO timestamp stamped into the journal (caller-supplied for determinism). */
+  stampedAt?: string;
+  /** Extra dirs to scan for occupancy beyond {@link occupancyScanDirs} (tests). */
+  extraOccupancyDirs?: readonly string[];
+}
+
+/**
+ * Run the STATE-dir migration behind BOTH gates (the BLESSED cutover entry).
+ *
+ * Flow:
+ *   1. {@link withMigrationGate} stops + proves-dead the fleet (X-09). If it
+ *      refuses, NOTHING is carried and the fleet is restored → `gate-refused`.
+ *   2. Inside the gated body (fleet proven down), the directory-occupancy
+ *      precondition scans the real state dirs. Any LIVE or unclassifiable
+ *      `*.pid` → NOTHING is carried → `dir-occupied` (the belt-insufficiency
+ *      abort). The finally still restores the fleet.
+ *   3. Otherwise {@link executeStateDirMigration} carries every legacy state
+ *      file to canonical (copy-keep-source, atomic, transactional) → `migrated`.
+ *
+ * The fleet is ALWAYS restored (withMigrationGate's try/finally), so exactly the
+ * pre-running set comes back — one live process per stack (AC3).
+ */
+export async function migrateStateDir(
+  opts: MigrateStateDirOptions = {},
+): Promise<StateMigrationRunResult> {
+  const { home, stampedAt, extraOccupancyDirs, ...gateOpts } = opts;
+  const procAlive = gateOpts.env?.procAlive ?? defaultProcAlive;
+
+  const run = await withMigrationGate(gateOpts, async () => {
+    const scanDirs = [...occupancyScanDirs(home), ...(extraOccupancyDirs ?? [])];
+    const occupancy = stateDirOccupancyCheck(scanDirs, procAlive);
+    if (occupancy.occupied) {
+      // Belt-insufficiency abort: a directory move needs a directory-occupancy
+      // proof, not just the name-reconstruction belt. Carry NOTHING.
+      return { occupancy };
+    }
+    const journal = executeStateDirMigration(planStateDirMigration(home !== undefined ? { home } : {}), stampedAt);
+    return { occupancy, journal };
+  });
+
+  if (!run.cleared) {
+    return { outcome: "gate-refused", gate: run.gate, restore: run.restore };
+  }
+  const body = run.result;
+  const occupancy = body?.occupancy;
+  if (body?.journal === undefined) {
+    return {
+      outcome: "dir-occupied",
+      gate: run.gate,
+      restore: run.restore,
+      ...(occupancy !== undefined && { occupancy }),
+    };
+  }
+  return {
+    outcome: "migrated",
+    gate: run.gate,
+    restore: run.restore,
+    ...(occupancy !== undefined && { occupancy }),
+    journal: body.journal,
+  };
+}
+
+/** The real `kill(pid,0)` liveness probe, EPERM-as-alive / ESRCH-as-dead
+ *  (matches the gate's `bunGateEnv.procAlive`). */
+function defaultProcAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as { code?: string }).code !== "ESRCH";
+  }
+}

--- a/src/common/migrate-state-dir.ts
+++ b/src/common/migrate-state-dir.ts
@@ -455,17 +455,26 @@ export async function migrateStateDir(
   const { home, stampedAt, extraOccupancyDirs, ...gateOpts } = opts;
   const procAlive = gateOpts.env?.procAlive ?? defaultProcAlive;
 
-  const run = await withMigrationGate(gateOpts, async () => {
-    const scanDirs = [...occupancyScanDirs(home), ...(extraOccupancyDirs ?? [])];
-    const occupancy = stateDirOccupancyCheck(scanDirs, procAlive);
-    if (occupancy.occupied) {
-      // Belt-insufficiency abort: a directory move needs a directory-occupancy
-      // proof, not just the name-reconstruction belt. Carry NOTHING.
-      return { occupancy };
-    }
-    const journal = executeStateDirMigration(planStateDirMigration(home !== undefined ? { home } : {}), stampedAt);
-    return { occupancy, journal };
-  });
+  // The gated body is fully synchronous (occupancy scan + copy-keep-source carry),
+  // so it returns an already-resolved Promise rather than being `async` (no await
+  // to make — the service gate's async stop/prove-dead is inside withMigrationGate).
+  const run = await withMigrationGate(
+    gateOpts,
+    (): Promise<{ occupancy: OccupancyResult; journal?: StateMigrationJournal }> => {
+      const scanDirs = [...occupancyScanDirs(home), ...(extraOccupancyDirs ?? [])];
+      const occupancy = stateDirOccupancyCheck(scanDirs, procAlive);
+      if (occupancy.occupied) {
+        // Belt-insufficiency abort: a directory move needs a directory-occupancy
+        // proof, not just the name-reconstruction belt. Carry NOTHING.
+        return Promise.resolve({ occupancy });
+      }
+      const journal = executeStateDirMigration(
+        planStateDirMigration(home !== undefined ? { home } : {}),
+        stampedAt,
+      );
+      return Promise.resolve({ occupancy, journal });
+    },
+  );
 
   if (!run.cleared) {
     return { outcome: "gate-refused", gate: run.gate, restore: run.restore };

--- a/src/common/migrate-state-dir.ts
+++ b/src/common/migrate-state-dir.ts
@@ -77,10 +77,14 @@ import {
   legacyNetworkCacheDir,
   legacyPidStateDir,
   legacyRelayDir,
+  STATE_MIGRATION_JOURNAL_NAME,
 } from "./state-path";
 
-/** Journal dropped at the canonical state root so a move is auditable + reversible. */
-export const STATE_MIGRATION_JOURNAL_NAME = ".xdg-state-migration.json";
+// The completion-marker filename is owned by `state-path.ts` (the resolver's
+// canonical gate reads it), and re-exported here so callers that write/inspect
+// the journal keep importing it from the migrator. Writing this file at the
+// canonical root is precisely what flips `stateMigrationCompleted` → true.
+export { STATE_MIGRATION_JOURNAL_NAME };
 
 /** Which state class a carried entry belongs to (for audit + reasoning). */
 export type StateCarryKind = "pidfiles" | "logs" | "relay-pid" | "network-cache";

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -33,22 +33,30 @@ import { createHash } from "node:crypto";
 import { join, basename } from "path";
 import { realpathSync, existsSync, renameSync, readFileSync } from "fs";
 
+import { resolvePidStateDir } from "./state-path";
+
 /**
  * State directory holding every pidfile (and the degraded-state markers derived
- * from them). `CORTEX_STATE_DIR` overrides it — the STATE env seam (cortex#1908
- * CONFIG/EVENTS/STATE trio). This is the SOLE state constructor in the tree, so
- * the STATE read lands here rather than being split across files (which would
- * desync cortex.ts's `mkdirSync(STATE_DIR)` from `PID_FILE`/`pidFileFor`
- * derivation). Like `HOME`, it is read ONCE at import (T1b): the resolved value
- * is a module constant, so processes needing an override must set the env
- * before the module loads — the value does not track later `process.env`
- * mutation. `.trim()` + `||` means a blank/whitespace override falls back to the
- * grove default rather than resolving pidfiles into an empty-string path.
+ * from them). This is the SOLE state constructor in the tree, so the STATE read
+ * lands here rather than being split across files (which would desync cortex.ts's
+ * `mkdirSync(STATE_DIR)` from `PID_FILE`/`pidFileFor` derivation).
+ *
+ * XDG wave-5 (cortex#1903): resolved via {@link resolvePidStateDir} —
+ * canonical-first (`~/.local/state/metafactory/cortex`), legacy-fallback
+ * (`~/.config/grove/state`), `$CORTEX_STATE_DIR` override (VERBATIM). It still
+ * honours the SAME `CORTEX_STATE_DIR` env seam (cortex#1908) with the SAME
+ * blank-is-unset semantics, so a box with the override set is byte-identical, and
+ * a pre-cutover box (no canonical dir yet) still resolves the legacy grove dir.
+ *
+ * Like `HOME`, it is read ONCE at import (T1b): the resolved value is a module
+ * constant, so processes needing an override must set the env before the module
+ * loads — the value does not track later `process.env` mutation. The physical
+ * state MOVE is GATED (X-09 + directory-occupancy precondition, see
+ * `migrate-state-dir.ts`), so no daemon's pidfile identity flips out from under a
+ * running process: nothing runs during the migration, and after it every process
+ * resolves the canonical dir consistently.
  */
-export const STATE_DIR =
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- `||` is intentional: a blank/whitespace CORTEX_STATE_DIR trims to "" (falsy but not null), and MUST fall back to the grove default; `??` would keep the empty string and resolve pidfiles into a rootless path.
-  process.env.CORTEX_STATE_DIR?.trim() ||
-  join(process.env.HOME ?? "~", ".config", "grove", "state");
+export const STATE_DIR = resolvePidStateDir();
 export const PID_FILE = join(STATE_DIR, "cortex.pid");
 export const DEFAULT_CONFIG = join(
   process.env.HOME ?? "~",

--- a/src/common/pidfile.ts
+++ b/src/common/pidfile.ts
@@ -42,11 +42,13 @@ import { resolvePidStateDir } from "./state-path";
  * `mkdirSync(STATE_DIR)` from `PID_FILE`/`pidFileFor` derivation).
  *
  * XDG wave-5 (cortex#1903): resolved via {@link resolvePidStateDir} —
- * canonical-first (`~/.local/state/metafactory/cortex`), legacy-fallback
- * (`~/.config/grove/state`), `$CORTEX_STATE_DIR` override (VERBATIM). It still
- * honours the SAME `CORTEX_STATE_DIR` env seam (cortex#1908) with the SAME
- * blank-is-unset semantics, so a box with the override set is byte-identical, and
- * a pre-cutover box (no canonical dir yet) still resolves the legacy grove dir.
+ * COMPLETION-gated, NOT canonical-first. Pre-migration it resolves to the legacy
+ * `~/.config/grove/state` (byte-identical to the pre-XDG default), and it flips
+ * to the canonical `~/.local/state/metafactory/cortex` ONLY once a gated
+ * migration has written its completion marker. `$CORTEX_STATE_DIR` overrides
+ * VERBATIM (cortex#1908 seam, same blank-is-unset semantics). This gating is the
+ * crux of the pidfile-identity contract: a bare/stray canonical dir must never
+ * flip this const, or a live daemon's pidfile path would move out from under it.
  *
  * Like `HOME`, it is read ONCE at import (T1b): the resolved value is a module
  * constant, so processes needing an override must set the env before the module

--- a/src/common/registry/network-cache.ts
+++ b/src/common/registry/network-cache.ts
@@ -31,13 +31,21 @@ import {
   renameSync,
   writeFileSync,
 } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 
+import { resolveNetworkCacheDir } from "../state-path";
 import type { NetworkDescriptor, NetworkRosterResult } from "./types";
 
-/** Default cache dir — sibling of `~/.config/cortex/cortex.yaml`. */
-const DEFAULT_CACHE_DIR = join(homedir(), ".config", "cortex", "network-cache");
+/**
+ * Default cache dir. XDG wave-5 (#1903): the network-cache is STATE (the DD-10
+ * signature-verified last-known-good roster — the offline fallback, §1.2), NOT a
+ * regenerable cache, so it resolves under the metafactory STATE root
+ * (`~/.local/state/metafactory/cortex/network-cache`) with canonical-first /
+ * legacy `~/.config/cortex/network-cache` fallback. Every explicit `cacheDir`
+ * override site (the CLIs) resolves through the SAME {@link resolveNetworkCacheDir}
+ * so a live daemon and a CLI never disagree on which dir the signed roster is in.
+ */
+const DEFAULT_CACHE_DIR = resolveNetworkCacheDir();
 
 /** Schema version stamped into each cache file so a future shape change can
  *  detect + discard stale entries rather than mis-parsing them. */

--- a/src/common/state-path.ts
+++ b/src/common/state-path.ts
@@ -1,0 +1,229 @@
+/**
+ * XDG wave-5 (cortex#1903, EPIC cortex#1867 §P3c) — STATE-dir path resolver.
+ *
+ * The metafactory STATE tree (daemon pidfiles + degraded-state markers, rotating
+ * logs, the relay pidfile, and the DD-10 signature-verified network-cache) is
+ * moving to the canonical XDG state root `~/.local/state/metafactory/cortex/`,
+ * folded under the shared `metafactory` root (matching the wave-3 `~/.local/bin`,
+ * wave-4 `~/.config/metafactory`, and wave-5 `~/.local/share/metafactory` moves).
+ * Before this wave the four state classes lived in three legacy locations:
+ *
+ *   1. pidfiles + `.degraded.json` markers → `~/.config/grove/state/`   (pidfile.ts).
+ *   2. rotating logs                       → `~/.config/grove/logs/` AND
+ *                                             `~/.config/cortex/logs/`   (two schema
+ *                                             defaults; both are read-fallbacks).
+ *   3. relay pidfile                        → `~/.claude/relay/relay.pid` (relay.ts).
+ *   4. network-cache (DD-10 last-known-good roster) → `~/.config/cortex/network-cache/`.
+ *
+ * This module is the single seam that resolves each STATE path with
+ * **canonical-first / legacy-fallback** precedence during the transition, so a
+ * pre-cutover box still reads the old tree while a migrated box reads the new
+ * one. It is the STATE analogue of `data-path.ts` / `config/config-path.ts`.
+ *
+ * ── network-cache is STATE, not cache (§1.2, DD-10) ──────────────────────────
+ * The `network-cache` dir holds the last verified descriptor + roster the stack
+ * falls back to when the registry is unreachable at boot (the offline-fallback
+ * roster). It is DURABLE trust state — NOT a regenerable cache — so it moves to
+ * the state root, and its move is gated + copy-keep-source like the pidfiles.
+ *
+ * ── Precedence (read) ────────────────────────────────────────────────────────
+ *   1. `$CORTEX_STATE_DIR/<…>`                     — explicit override (VERBATIM,
+ *      a self-contained root; NO legacy probe — mirrors the config/data seams).
+ *   2. `~/.local/state/metafactory/cortex/<…>`     — canonical (used if present).
+ *   3. legacy tree (grove state/logs, cortex logs/network-cache, claude relay)
+ *      — read-fallback if present.
+ *   4. canonical path                              — write/default target when none.
+ *
+ * ── The STATE_DIR module-const hazard (T1b / cortex#1900) ────────────────────
+ * `pidfile.ts` bakes `STATE_DIR` at import from {@link resolvePidStateDir}. A
+ * RUNNING daemon computed its pidfile path from whatever STATE_DIR resolved to at
+ * ITS import; a later CLI that resolves a DIFFERENT dir would compute a different
+ * pidfile name and fail to find/manage the daemon. This is contained because the
+ * physical state MOVE is GATED (X-09): nothing is running during the migration,
+ * so no daemon's pidfile identity flips out from under it, and after the move +
+ * restart every process resolves the canonical dir consistently.
+ *
+ * Every legacy-tree hit is surfaced via {@link noteXdgFallback} so a
+ * `CORTEX_XDG_STRICT=1` fresh-install run stays silent (Fallback Contract,
+ * cortex#1867). Isolation: every path derives from an injectable `home`, so the
+ * whole seam runs against a scratch `$HOME` with ZERO real-home access.
+ */
+
+import { existsSync } from "fs";
+import { join } from "path";
+
+import { noteXdgFallback, readDirEnv } from "./xdg";
+
+/** The shared metafactory XDG root name (nested under the state home). */
+export const METAFACTORY_DIRNAME = "metafactory";
+/** The canonical state directory name (nested under `metafactory/`). */
+export const CORTEX_STATE_DIRNAME = "cortex";
+
+function homeDir(home?: string): string {
+  return home ?? process.env.HOME ?? "~";
+}
+
+/**
+ * The XDG state home: `$XDG_STATE_HOME` if set (VERBATIM), else `~/.local/state`.
+ * Mirrors the freedesktop XDG base-dir spec (the state analogue of
+ * `$XDG_DATA_HOME` / `~/.local/share`). Read through {@link readDirEnv} so a
+ * blank/whitespace value reads as unset rather than resolving to `/state`.
+ */
+export function xdgStateHome(home?: string): string {
+  return readDirEnv("XDG_STATE_HOME") ?? join(homeDir(home), ".local", "state");
+}
+
+/**
+ * The `CORTEX_STATE_DIR` override, or `undefined` when unset/empty. A blank or
+ * whitespace-only value reads as unset (via {@link readDirEnv}) so
+ * `CORTEX_STATE_DIR=` keeps the default rather than resolving to `/`. When set it
+ * is the state root VERBATIM and ALL legacy fallbacks are skipped (a
+ * self-contained root has no legacy counterpart, and probing the real
+ * `~/.config/{grove,cortex}` / `~/.claude` would break hermeticity).
+ *
+ * NOTE: `pidfile.ts` reads `CORTEX_STATE_DIR` directly at import for its own
+ * `STATE_DIR` const (cortex#1908 seam, kept for its no-heavy-import-graph rule);
+ * this is the SAME env var, so the two never diverge — both trim + treat blank as
+ * unset, and both resolve to the same canonical default when unset.
+ */
+export function cortexStateDirOverride(): string | undefined {
+  return readDirEnv("CORTEX_STATE_DIR");
+}
+
+/**
+ * The cortex STATE directory: `$CORTEX_STATE_DIR` if set, else the canonical
+ * `$XDG_STATE_HOME/metafactory/cortex` (default `~/.local/state/metafactory/
+ * cortex`). This is the single seam every state path is built on, so overriding
+ * the env var relocates the whole state tree at once.
+ */
+export function cortexStateDir(home?: string): string {
+  return (
+    cortexStateDirOverride() ??
+    join(xdgStateHome(home), METAFACTORY_DIRNAME, CORTEX_STATE_DIRNAME)
+  );
+}
+
+// ─────────────────────────────────────────────────────── canonical sub-locations
+
+/** Canonical pidfile + degraded-marker dir (the state root itself; pidfiles
+ *  live directly under it, matching the legacy flat `~/.config/grove/state`). */
+export function canonicalPidStateDir(home?: string): string {
+  return cortexStateDir(home);
+}
+
+/** Canonical rotating-logs dir: `~/.local/state/metafactory/cortex/logs`. */
+export function canonicalLogsDir(home?: string): string {
+  return join(cortexStateDir(home), "logs");
+}
+
+/** Canonical relay dir (holds `relay.pid`): `…/metafactory/cortex/relay`. */
+export function canonicalRelayDir(home?: string): string {
+  return join(cortexStateDir(home), "relay");
+}
+
+/** Canonical DD-10 network-cache dir: `…/metafactory/cortex/network-cache`. */
+export function canonicalNetworkCacheDir(home?: string): string {
+  return join(cortexStateDir(home), "network-cache");
+}
+
+// ───────────────────────────────────────────────────────────── legacy locations
+
+/** Legacy pidfile dir `~/.config/grove/state` (the pre-move pidfile.ts default). */
+export function legacyPidStateDir(home?: string): string {
+  return join(homeDir(home), ".config", "grove", "state");
+}
+
+/** Legacy grove logs dir `~/.config/grove/logs` (CortexConfigSchema default). */
+export function legacyGroveLogsDir(home?: string): string {
+  return join(homeDir(home), ".config", "grove", "logs");
+}
+
+/** Legacy cortex logs dir `~/.config/cortex/logs` (cortex-config PathsSchema default). */
+export function legacyCortexLogsDir(home?: string): string {
+  return join(homeDir(home), ".config", "cortex", "logs");
+}
+
+/** Legacy relay dir `~/.claude/relay` (holds `relay.pid`; also `relay-policy.yaml`
+ *  which is CONFIG and stays — only the pidfile moves). */
+export function legacyRelayDir(home?: string): string {
+  return join(homeDir(home), ".claude", "relay");
+}
+
+/** Legacy DD-10 network-cache dir `~/.config/cortex/network-cache`. */
+export function legacyNetworkCacheDir(home?: string): string {
+  return join(homeDir(home), ".config", "cortex", "network-cache");
+}
+
+// ─────────────────────────────────────────────── existence-gated dir resolvers
+
+/**
+ * PURE existence-gated resolution of a state DIR — NO side effects beyond
+ * `existsSync`. Prefers the canonical location if present, else the FIRST legacy
+ * candidate that exists (in the given precedence order), else the canonical path
+ * (the write target on a fresh host / post-migration). An explicit
+ * `$CORTEX_STATE_DIR` short-circuits ALL fallback (self-contained root). Every
+ * legacy hit is surfaced under `CORTEX_XDG_STRICT` via {@link noteXdgFallback}.
+ */
+function resolveStateSubdir(
+  canonical: string,
+  legacies: readonly { dir: string; note: string }[],
+): string {
+  if (cortexStateDirOverride() !== undefined) return canonical;
+  if (existsSync(canonical)) return canonical;
+  for (const l of legacies) {
+    if (existsSync(l.dir)) {
+      noteXdgFallback("state", l.note);
+      return l.dir;
+    }
+  }
+  return canonical;
+}
+
+/** Resolve the pidfile + degraded-marker dir (canonical → legacy grove state). */
+export function resolvePidStateDir(home?: string): string {
+  return resolveStateSubdir(canonicalPidStateDir(home), [
+    { dir: legacyPidStateDir(home), note: "pidfile dir resolved from legacy ~/.config/grove/state" },
+  ]);
+}
+
+/** Resolve the logs dir (canonical → legacy grove logs → legacy cortex logs). */
+export function resolveLogsDir(home?: string): string {
+  return resolveStateSubdir(canonicalLogsDir(home), [
+    { dir: legacyGroveLogsDir(home), note: "logs dir resolved from legacy ~/.config/grove/logs" },
+    { dir: legacyCortexLogsDir(home), note: "logs dir resolved from legacy ~/.config/cortex/logs" },
+  ]);
+}
+
+/** Resolve the relay dir (canonical → legacy ~/.claude/relay). */
+export function resolveRelayDir(home?: string): string {
+  return resolveStateSubdir(canonicalRelayDir(home), [
+    { dir: legacyRelayDir(home), note: "relay pidfile dir resolved from legacy ~/.claude/relay" },
+  ]);
+}
+
+/** Resolve the network-cache dir (canonical → legacy ~/.config/cortex/network-cache). */
+export function resolveNetworkCacheDir(home?: string): string {
+  return resolveStateSubdir(canonicalNetworkCacheDir(home), [
+    {
+      dir: legacyNetworkCacheDir(home),
+      note: "network-cache resolved from legacy ~/.config/cortex/network-cache",
+    },
+  ]);
+}
+
+// ──────────────────────────────────────────────────── schema value defaults
+
+/**
+ * The canonical STRING literal for `paths.logDir` in the config schemas. Uses the
+ * `~`-prefixed spelling (matching the pre-move `~/.config/grove/logs` default and
+ * the `expandTilde` expansion at the consumer) so the persisted config stays
+ * home-relative and portable. Kept in sync with the schema literals in
+ * `types/config.ts` and `types/cortex-config.ts` (which do NOT import this
+ * fs-touching module, mirroring `PUBLISHED_EVENTS_DIR_DEFAULT` in data-path.ts).
+ */
+export const LOG_DIR_DEFAULT = "~/.local/state/metafactory/cortex/logs";
+
+/** Pre-move grove logDir default (value-migration / test source). */
+export const LEGACY_LOG_DIR_DEFAULT_GROVE = "~/.config/grove/logs";
+/** Pre-move cortex logDir default (value-migration / test source). */
+export const LEGACY_LOG_DIR_DEFAULT_CORTEX = "~/.config/cortex/logs";

--- a/src/common/state-path.ts
+++ b/src/common/state-path.ts
@@ -26,22 +26,27 @@
  * roster). It is DURABLE trust state — NOT a regenerable cache — so it moves to
  * the state root, and its move is gated + copy-keep-source like the pidfiles.
  *
- * ── Precedence (read) ────────────────────────────────────────────────────────
+ * ── Precedence (read) — COMPLETION-gated, not existence-gated ────────────────
  *   1. `$CORTEX_STATE_DIR/<…>`                     — explicit override (VERBATIM,
  *      a self-contained root; NO legacy probe — mirrors the config/data seams).
- *   2. `~/.local/state/metafactory/cortex/<…>`     — canonical (used if present).
+ *   2. canonical `~/.local/state/metafactory/cortex/<…>` — ONLY once a gated
+ *      migration wrote its completion marker ({@link stateMigrationCompleted}).
  *   3. legacy tree (grove state/logs, cortex logs/network-cache, claude relay)
- *      — read-fallback if present.
- *   4. canonical path                              — write/default target when none.
+ *      — the first candidate present on disk (read-fallback).
+ *   4. the PRIMARY legacy path                     — pre-migration default/write
+ *      target when nothing is on disk yet (a fresh box). Canonical is NEVER
+ *      returned pre-migration — that is the pidfile-identity guarantee.
  *
  * ── The STATE_DIR module-const hazard (T1b / cortex#1900) ────────────────────
  * `pidfile.ts` bakes `STATE_DIR` at import from {@link resolvePidStateDir}. A
  * RUNNING daemon computed its pidfile path from whatever STATE_DIR resolved to at
  * ITS import; a later CLI that resolves a DIFFERENT dir would compute a different
- * pidfile name and fail to find/manage the daemon. This is contained because the
- * physical state MOVE is GATED (X-09): nothing is running during the migration,
- * so no daemon's pidfile identity flips out from under it, and after the move +
- * restart every process resolves the canonical dir consistently.
+ * pidfile name and fail to find/manage the daemon. Bare directory existence would
+ * be UNSAFE here — the canonical root is shared across state classes, so a stray
+ * canonical dir (or one a sibling class created) would flip the const. Hence the
+ * COMPLETION gate: canonical is preferred ONLY after a fleet-DOWN migration wrote
+ * its marker, so the flip only ever happens with nothing running, and after the
+ * migration + restart every process resolves the canonical dir consistently.
  *
  * Every legacy-tree hit is surfaced via {@link noteXdgFallback} so a
  * `CORTEX_XDG_STRICT=1` fresh-install run stays silent (Fallback Contract,
@@ -103,6 +108,38 @@ export function cortexStateDir(home?: string): string {
   );
 }
 
+// ───────────────────────────────────────── completion marker (the canonical gate)
+
+/**
+ * Journal filename dropped at the canonical state root the instant a gated
+ * migration COMPLETES. Its presence is the COMPLETION marker that flips the
+ * resolvers from legacy to canonical. Owned by this low-level module (rather than
+ * `migrate-state-dir.ts`) so the migrator imports the name from here — no import
+ * cycle — and the resolver + the writer can never disagree on the marker path.
+ */
+export const STATE_MIGRATION_JOURNAL_NAME = ".xdg-state-migration.json";
+
+/**
+ * Has a gated STATE migration COMPLETED on this box? True iff the completion
+ * journal exists at the canonical state root.
+ *
+ * This — NOT bare directory existence — is what gates the canonical preference,
+ * and the distinction is load-bearing for the pidfile-identity contract
+ * (cortex#1900 / the STATE_DIR module-const hazard T1b): the canonical ROOT is
+ * shared by every state class, so a stray/empty `…/metafactory/cortex` dir, or
+ * one created as a side effect of a `NetworkCache.store` write or a logs
+ * `mkdirSync`, must NEVER flip a live daemon's pidfile path out from under it.
+ * A running daemon computed `STATE_DIR` (hence `PID_FILE`) at import; if a bare
+ * canonical dir flipped that const, a later CLI would derive a DIFFERENT pidfile
+ * name and fail to find/stop/manage the daemon (and the singleton check could
+ * spawn a duplicate). Only a completed, fleet-DOWN migration writes this marker,
+ * after which every process resolves canonical consistently on its next
+ * import/restart — the window in which the flip happens has nothing running.
+ */
+export function stateMigrationCompleted(home?: string): boolean {
+  return existsSync(join(cortexStateDir(home), STATE_MIGRATION_JOURNAL_NAME));
+}
+
 // ─────────────────────────────────────────────────────── canonical sub-locations
 
 /** Canonical pidfile + degraded-marker dir (the state root itself; pidfiles
@@ -157,58 +194,91 @@ export function legacyNetworkCacheDir(home?: string): string {
 // ─────────────────────────────────────────────── existence-gated dir resolvers
 
 /**
- * PURE existence-gated resolution of a state DIR — NO side effects beyond
- * `existsSync`. Prefers the canonical location if present, else the FIRST legacy
- * candidate that exists (in the given precedence order), else the canonical path
- * (the write target on a fresh host / post-migration). An explicit
- * `$CORTEX_STATE_DIR` short-circuits ALL fallback (self-contained root). Every
- * legacy hit is surfaced under `CORTEX_XDG_STRICT` via {@link noteXdgFallback}.
+ * COMPLETION-gated resolution of a state DIR — NO side effects beyond
+ * `existsSync`. Precedence:
+ *   1. explicit `$CORTEX_STATE_DIR` → canonical (self-contained root, no probe).
+ *   2. a COMPLETED gated migration ({@link stateMigrationCompleted}) → canonical.
+ *   3. else LEGACY: the first legacy candidate that EXISTS on disk (surfaced via
+ *      {@link noteXdgFallback} under `CORTEX_XDG_STRICT`), or — when none is on
+ *      disk yet — the PRIMARY legacy path as the stable default (`legacies[0]`).
+ *
+ * The critical difference from a bare existence gate (T1b / cortex#1900): the
+ * canonical location is preferred ONLY after a completed migration, NEVER merely
+ * because a canonical dir exists. The canonical root is shared across state
+ * classes, so a stray/empty canonical dir (or one a sibling class created) must
+ * not flip a live daemon's pidfile identity. Pre-migration this ALWAYS resolves
+ * to the legacy default — byte-identical to the pre-XDG path — so a running
+ * daemon and every CLI derive the same pidfile until the gated cutover + restart.
  */
 function resolveStateSubdir(
-  canonical: string,
+  home: string | undefined,
   legacies: readonly { dir: string; note: string }[],
+  canonicalOf: (home?: string) => string,
 ): string {
-  if (cortexStateDirOverride() !== undefined) return canonical;
-  if (existsSync(canonical)) return canonical;
+  if (cortexStateDirOverride() !== undefined) return canonicalOf(home);
+  if (stateMigrationCompleted(home)) return canonicalOf(home);
   for (const l of legacies) {
     if (existsSync(l.dir)) {
       noteXdgFallback("state", l.note);
       return l.dir;
     }
   }
-  return canonical;
+  // Pre-migration with no legacy tree on disk yet (e.g. a fresh install): the
+  // PRIMARY legacy path is the stable default + write target. Canonical is
+  // reserved for the post-migration state, so it is NEVER returned here — that
+  // is what keeps pidfile identity continuous until the gated cutover.
+  return legacies[0]?.dir ?? canonicalOf(home);
 }
 
-/** Resolve the pidfile + degraded-marker dir (canonical → legacy grove state). */
+/** Resolve the pidfile + degraded-marker dir (legacy grove state until a
+ *  completed migration flips it to canonical). */
 export function resolvePidStateDir(home?: string): string {
-  return resolveStateSubdir(canonicalPidStateDir(home), [
-    { dir: legacyPidStateDir(home), note: "pidfile dir resolved from legacy ~/.config/grove/state" },
-  ]);
+  return resolveStateSubdir(
+    home,
+    [{ dir: legacyPidStateDir(home), note: "pidfile dir resolved from legacy ~/.config/grove/state" }],
+    canonicalPidStateDir,
+  );
 }
 
-/** Resolve the logs dir (canonical → legacy grove logs → legacy cortex logs). */
+/** Resolve the logs dir (legacy grove logs → legacy cortex logs until a completed
+ *  migration flips it to canonical). Migration-planning-only (no runtime consumer). */
 export function resolveLogsDir(home?: string): string {
-  return resolveStateSubdir(canonicalLogsDir(home), [
-    { dir: legacyGroveLogsDir(home), note: "logs dir resolved from legacy ~/.config/grove/logs" },
-    { dir: legacyCortexLogsDir(home), note: "logs dir resolved from legacy ~/.config/cortex/logs" },
-  ]);
+  return resolveStateSubdir(
+    home,
+    [
+      { dir: legacyGroveLogsDir(home), note: "logs dir resolved from legacy ~/.config/grove/logs" },
+      { dir: legacyCortexLogsDir(home), note: "logs dir resolved from legacy ~/.config/cortex/logs" },
+    ],
+    canonicalLogsDir,
+  );
 }
 
-/** Resolve the relay dir (canonical → legacy ~/.claude/relay). */
+/** Resolve the relay dir (legacy ~/.claude/relay until a completed migration
+ *  flips it to canonical). Holds the relay pidfile — same identity contract as
+ *  the cortex pidfile, so it is completion-gated too. */
 export function resolveRelayDir(home?: string): string {
-  return resolveStateSubdir(canonicalRelayDir(home), [
-    { dir: legacyRelayDir(home), note: "relay pidfile dir resolved from legacy ~/.claude/relay" },
-  ]);
+  return resolveStateSubdir(
+    home,
+    [{ dir: legacyRelayDir(home), note: "relay pidfile dir resolved from legacy ~/.claude/relay" }],
+    canonicalRelayDir,
+  );
 }
 
-/** Resolve the network-cache dir (canonical → legacy ~/.config/cortex/network-cache). */
+/** Resolve the network-cache dir (legacy ~/.config/cortex/network-cache until a
+ *  completed migration flips it to canonical). The signed roster is trust state
+ *  read/written by both the daemon and the CLIs, so completion-gating keeps them
+ *  from disagreeing on which dir holds the last-known-good roster. */
 export function resolveNetworkCacheDir(home?: string): string {
-  return resolveStateSubdir(canonicalNetworkCacheDir(home), [
-    {
-      dir: legacyNetworkCacheDir(home),
-      note: "network-cache resolved from legacy ~/.config/cortex/network-cache",
-    },
-  ]);
+  return resolveStateSubdir(
+    home,
+    [
+      {
+        dir: legacyNetworkCacheDir(home),
+        note: "network-cache resolved from legacy ~/.config/cortex/network-cache",
+      },
+    ],
+    canonicalNetworkCacheDir,
+  );
 }
 
 // ──────────────────────────────────────────────────── schema value defaults

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -1077,7 +1077,8 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
     expect(parsed.publishedEventsDir).toBe(
       "~/.local/share/metafactory/cortex/events/published",
     );
-    expect(parsed.logDir).toBe("~/.config/cortex/logs");
+    // XDG wave-5 (#1903): logs are STATE — moved under the metafactory state root.
+    expect(parsed.logDir).toBe("~/.local/state/metafactory/cortex/logs");
   });
 
   test("AgentDetectionSchema applies inner defaults", () => {
@@ -1386,7 +1387,8 @@ describe("CortexConfigSchema", () => {
     expect(parsed.paths.publishedEventsDir).toBe(
       "~/.local/share/metafactory/cortex/events/published",
     );
-    expect(parsed.paths.logDir).toBe("~/.config/cortex/logs");
+    // XDG wave-5 (#1903): logs are STATE — moved under the metafactory state root.
+    expect(parsed.paths.logDir).toBe("~/.local/state/metafactory/cortex/logs");
     expect(parsed.networksDir).toBe("./networks");
   });
 
@@ -1461,9 +1463,10 @@ describe("CortexConfigSchema", () => {
 // Method: parse `{}` on each cortex schema, parse the minimum AgentConfig
 // (which applies inner defaults to optional cross-cutting blocks), and compare.
 // Default-value equality is the strictest test because it catches both field
-// additions/removals AND default drift. Known divergence — `paths.logDir`
-// (grove → cortex rename) — is asserted as a key-set match plus per-field
-// equality on the non-divergent fields.
+// additions/removals AND default drift. The former `paths.logDir` divergence
+// (grove vs cortex namespace) is RESOLVED as of XDG wave-5 (#1903) — logs became
+// STATE and both defaults now point at the shared metafactory state root — so
+// `paths` mirrors fully (key-set match plus per-field equality).
 
 describe("PolicyFederatedRegistrySchema — IAW D.4.3", () => {
   test("accepts a fully populated registry block (url + pubkey)", () => {
@@ -1701,19 +1704,21 @@ describe("MIRROR sync — cortex cross-cutting schemas vs AgentConfigSchema", ()
     expect(AgentDetectionSchema.parse({})).toEqual(bot.github.agentDetection);
   });
 
-  test("paths shape matches (logDir grove→cortex rename is the only intended divergence)", () => {
+  test("paths shape + defaults match (logDir grove/cortex divergence resolved by the XDG wave-5 state move #1903)", () => {
     const cortexPaths = PathsConfigSchema.parse({});
     // Same key set — field additions/removals would fail here.
     expect(Object.keys(cortexPaths).sort()).toEqual(Object.keys(bot.paths).sort());
     // Non-divergent fields equal.
     expect(cortexPaths.publishedEventsDir).toBe(bot.paths.publishedEventsDir);
-    // Documented divergence: cortex moved the default log directory off the
-    // grove namespace as part of the rename. If this assertion ever stops
-    // holding, the AgentConfig side has been re-pointed at cortex/ too and the
-    // MIRROR window is collapsing — drop both this assertion and the
-    // AgentConfig.paths block (per the MIRROR-removal note in cortex-config.ts).
-    expect(cortexPaths.logDir).toBe("~/.config/cortex/logs");
-    expect(bot.paths.logDir).toBe("~/.config/grove/logs");
+    // XDG wave-5 (#1903): the historical `logDir` divergence (cortex → `~/.config/
+    // cortex/logs`, grove → `~/.config/grove/logs`) is RESOLVED — both schema
+    // defaults now point at the shared metafactory STATE root, so the two sides
+    // agree and `paths` mirrors fully. (This is the "MIRROR window collapsing"
+    // outcome the old assertion anticipated: logs became STATE and both defaults
+    // were re-pointed at the same canonical dir.)
+    expect(cortexPaths.logDir).toBe("~/.local/state/metafactory/cortex/logs");
+    expect(bot.paths.logDir).toBe("~/.local/state/metafactory/cortex/logs");
+    expect(cortexPaths.logDir).toBe(bot.paths.logDir);
   });
 });
 

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -823,7 +823,13 @@ export const AgentConfigSchema = z.object({
     // (`migrate-published-events-value.ts`); the reader is existence-gated so a
     // pre-cutover box still reads the legacy buffer.
     publishedEventsDir: z.string().default("~/.local/share/metafactory/cortex/events/published"),
-    logDir: z.string().default("~/.config/grove/logs"),
+    // XDG wave-5 (#1903): rotating logs are STATE and move under the metafactory
+    // state root. Literal (not imported) so the value is grep-visible and this
+    // schema module stays free of the fs-touching state-path resolver; kept in
+    // sync with `LOG_DIR_DEFAULT` in `common/state-path.ts`. Existing pinned
+    // `~/.config/grove/logs` values are honoured as-is (logs are append-only /
+    // low-risk); the physical carry is done by the gated `migrate-state-dir.ts`.
+    logDir: z.string().default("~/.local/state/metafactory/cortex/logs"),
   }).default(emptyDefault()),
 
   /**

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1668,7 +1668,10 @@ export const PathsConfigSchema = z.object({
   // divergence. Value-migrator rewrites pinned legacy values; reader is
   // existence-gated for a pre-cutover box.
   publishedEventsDir: z.string().default("~/.local/share/metafactory/cortex/events/published"),
-  logDir: z.string().default("~/.config/cortex/logs"),
+  // XDG wave-5 (#1903): logs are STATE — moved under the metafactory state root.
+  // Kept byte-identical to `AgentConfigSchema.paths.logDir` (config.ts) and
+  // `LOG_DIR_DEFAULT` (common/state-path.ts) — no divergence.
+  logDir: z.string().default("~/.local/state/metafactory/cortex/logs"),
 });
 
 export type PathsConfig = z.infer<typeof PathsConfigSchema>;

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -65,11 +65,12 @@ const DEFAULT_POLICY = join(
   "relay-policy.yaml"
 );
 // XDG wave-5 (#1903): the relay pidfile is STATE and resolves under the
-// metafactory state root (canonical-first, legacy `~/.claude/relay` fallback,
-// `$CORTEX_STATE_DIR` override). Module-const like cortex.ts's STATE_DIR; the
-// physical move is X-09-gated so a running relay's pidfile identity never flips
-// out from under it. The relay POLICY (relay-policy.yaml) stays put — it is
-// CONFIG, not state — so DEFAULT_POLICY above is unchanged.
+// metafactory state root — COMPLETION-gated (legacy `~/.claude/relay` until a
+// gated migration writes its marker, then canonical), `$CORTEX_STATE_DIR`
+// override. Module-const like cortex.ts's STATE_DIR; the completion gate is what
+// keeps a running relay's pidfile identity from flipping out from under it (a
+// bare canonical dir does NOT move it). The relay POLICY (relay-policy.yaml)
+// stays put — it is CONFIG, not state — so DEFAULT_POLICY above is unchanged.
 const PID_FILE = join(resolveRelayDir(), "relay.pid");
 
 // =============================================================================

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -15,6 +15,8 @@ import { watchRawEvents } from "./lib/file-watcher";
 import { RawEventSchema } from "./hooks/lib/event-types";
 import { eventsDir, publishedEventsDir } from "../../common/events-path";
 import { migratePublishedBufferOnTouch } from "../../common/migrate-data-dir";
+import { resolveRelayDir } from "../../common/state-path";
+import { mkdirSync } from "fs";
 import { resolvePrincipalEnv } from "./hooks/lib/principal-env";
 import { NatsLink } from "../../bus/nats/connection";
 import { createCcEventPublisher } from "./cc-events";
@@ -62,7 +64,13 @@ const DEFAULT_POLICY = join(
   "relay",
   "relay-policy.yaml"
 );
-const PID_FILE = join(process.env.HOME ?? "~", ".claude", "relay", "relay.pid");
+// XDG wave-5 (#1903): the relay pidfile is STATE and resolves under the
+// metafactory state root (canonical-first, legacy `~/.claude/relay` fallback,
+// `$CORTEX_STATE_DIR` override). Module-const like cortex.ts's STATE_DIR; the
+// physical move is X-09-gated so a running relay's pidfile identity never flips
+// out from under it. The relay POLICY (relay-policy.yaml) stays put — it is
+// CONFIG, not state — so DEFAULT_POLICY above is unchanged.
+const PID_FILE = join(resolveRelayDir(), "relay.pid");
 
 // =============================================================================
 // JSONL Data Retention (logrotate-style)
@@ -335,7 +343,10 @@ program
 
     const processor = new EventProcessor(policy, { onPublished });
 
-    // Write PID file
+    // Write PID file. The canonical state-root relay dir may not exist yet on a
+    // migrated box (the pidfile is transient — the migrator carries any legacy
+    // one but a fresh boot creates its own), so ensure the dir before writing.
+    mkdirSync(resolveRelayDir(), { recursive: true });
     writeFileSync(PID_FILE, String(process.pid));
 
     // XDG wave-5 (#1902, guardrail A): carry the in-flight published buffer to


### PR DESCRIPTION
Closes #1903. Part of epic #1867 (XDG), phase **P3c** — the riskiest move: it relocates the pidfiles of running production daemons. Double-gated and copy-keep-source throughout. Repo-side build + tests only; the on-box cutover is run separately.

## What moves
STATE → `~/.local/state/metafactory/cortex/` via the new `state-path.ts` resolver:
- pidfiles + `.degraded.json` markers (legacy `~/.config/grove/state`)
- rotating logs (legacy `~/.config/grove/logs` **and** `~/.config/cortex/logs`)
- relay pidfile (legacy `~/.claude/relay/relay.pid`; `relay-policy.yaml` is CONFIG and stays)
- **network-cache** — the DD-10 signature-verified last-known-good roster. It is **STATE, not cache** (§1.2, offline fallback), so it moves to the state root.

## Acceptance criteria
- [x] **Migration ABORTS when any stack is loaded** — reuses the X-09 gate (`withMigrationGate` → `launchctl bootout` + three-leg positive-proof-of-death + config pidfile-liveness belt). A loaded/sticky stack ⇒ `gate-refused`, nothing carried. *(test: AC1 gate-refuse)*
- [x] **Directory-occupancy precondition (belt-insufficiency #1932)** — a name-reconstruction belt is insufficient for a directory move. After the service stop, `readdir` the real state dirs (legacy+canonical pid/relay) and liveness-check **every** `*.pid` name-agnostically. Any live pidfile ⇒ `dir-occupied` abort. An unreadable/unparseable `*.pid` counts as **PRESENT** (fail-safe), never absent. *(tests: AC1b live-pid, AC5 unclassifiable-pid)*
- [x] **Signature-verified roster survives** — the network-cache carry is a byte-identical copy of the X-02 atomic store's `*.json` records (no re-serialize/truncate); the signed roster still passes `NetworkCache.load`'s BASE64_ED25519 grammar + shape gate at the canonical location. *(test: AC2)*
- [x] **Exactly one live process per stack after the move** — the gate's `try/finally` always restores exactly the pre-running set; the old pid is proven dead before the move, restore brings back one live pid per stack. *(test: AC3)*
- [x] **Copy-keep-source / transactional / existence-gated** — copy source → atomic write dest → journal; source **never** deleted in-phase; rollback on any throw; resolver prefers canonical if present else legacy so a pre-cutover box reads the old tree; idempotent (canonical-wins). *(test: AC4)*

## Gate / atomic-store reuse (not reinvented)
- **X-09 gate**: `withMigrationGate(opts, body)` from `src/common/migration/migration-gate.ts` — verified signature + `MigrationRunResult` shape; occupancy check runs **inside** the gated body after the fleet is proven down.
- **X-02 atomic store**: confirmed `NetworkCache.store` writes `${live}.<pid>.tmp` then `renameSync(tmp, live)` (`network-cache.ts:162`) before the cache dir is repointed.

## STATE_DIR module-const hazard (#1900 / T1b)
`pidfile.ts` and `relay.ts` still bake their state dir at import via the resolver. Contained because the physical move is **gated** (nothing runs during migration) and post-move every process resolves the canonical dir consistently. The `$CORTEX_STATE_DIR` env seam (#1908) is honoured with identical blank-is-unset semantics.

## logDir schema note
The historical grove-vs-cortex `logDir` default divergence is now **resolved** — both `AgentConfigSchema` and `PathsConfigSchema` default to the shared metafactory state root. The MIRROR-sync test is updated to assert the collapse (it explicitly anticipated this).

## Verification
- `bunx tsc --noEmit` → **0 errors**.
- `bun test` → **9888 pass**, 20 fail — all 20 in the known non-hermetic `network-secret-cli.test.ts`; **zero** others. The 3 schema-default tests that asserted the old `logDir` were updated to the new default.

Do not merge pending the review gauntlet.