### PR TITLE
fix(cortex): boot hard-fail when system.> renderer coverage drops below two classes (#1893, epic #1784 S12b-pre)

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -390,12 +390,26 @@ agents:
 # -----------------------------------------------------------------------------
 # renderers — non-agent-bound surfaces (dashboards, pagerduty, etc.)
 # -----------------------------------------------------------------------------
+# G-1111 §4.6 / ADR-0024 §OQ9 — a stack that configures a renderer covering
+# `local.{principal}.system.>` MUST provide at least TWO distinct platform
+# classes there, with at least one EFFECTIVE (delivering) sink. The `dashboard`
+# renderer is INERT (ADR-0005 §4 — it buffers but delivers nothing), so it
+# cannot be that effective sink: `dashboard` ALONE fails the boot coverage guard
+# (cortex#1893). Pair it with an effective system sink (e.g. `pagerduty`) so an
+# operational alert reliably reaches the principal even if one sink is the thing
+# that broke.
 renderers:
   - kind: dashboard
     port: 8766
     subscribe:
-      - local.{org}.>
+      - local.{principal}.>
     projections: []
+  - kind: pagerduty
+    # Secret — supply via a `${PAGERDUTY_ROUTING_KEY}` env placeholder; never a
+    # literal in a committed config.
+    routingKey: ${PAGERDUTY_ROUTING_KEY}
+    subscribe:
+      - local.{principal}.system.>
 
 # -----------------------------------------------------------------------------
 # claude — runtime config shared across all agents' dispatch sessions

--- a/src/cli/cortex/commands/__tests__/config-validate.test.ts
+++ b/src/cli/cortex/commands/__tests__/config-validate.test.ts
@@ -220,6 +220,51 @@ describe("cortex config validate — invalid config", () => {
   });
 });
 
+describe("cortex config validate — renderer coverage guard (cortex#1893, ADR-0024 §OQ9)", () => {
+  test("zero-renderer config still validates (out of scope → no false hard-fail)", async () => {
+    // validConfig() declares no renderers — the guard must not touch it.
+    const path = writeConfig(validConfig());
+    const result = await dispatchConfig(["validate", "--config", path]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("✓ config valid:");
+  });
+
+  test("AC5: dashboard + system-covering pagerduty validates through the real loader", async () => {
+    const cfg = validConfig();
+    cfg.renderers = [
+      { kind: "dashboard", subscribe: ["local.{principal}.>"] },
+      { kind: "pagerduty", routingKey: "unit-test-routing-key", subscribe: ["local.{principal}.system.>"] },
+    ];
+    const path = writeConfig(cfg);
+    const result = await dispatchConfig(["validate", "--config", path]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("✓ config valid:");
+  });
+
+  test("AC3: dashboard-alone fails config-load with the CONFIG coverage error (no secret echoed)", async () => {
+    const cfg = validConfig();
+    cfg.renderers = [{ kind: "dashboard", subscribe: ["local.{principal}.>"] }];
+    const path = writeConfig(cfg);
+    const result = await dispatchConfig(["validate", "--config", path]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("renderer coverage check FAILED (config)");
+    expect(result.stderr).toContain("[dashboard]");
+  });
+
+  test("AC4: the CONFIG coverage error never echoes the pagerduty routingKey", async () => {
+    // pagerduty alone (a single sink) fails, and it carries a secret — prove
+    // the failure text never surfaces it.
+    const secret = "SUPER-SECRET-ROUTING-KEY-do-not-leak";
+    const cfg = validConfig();
+    cfg.renderers = [{ kind: "pagerduty", routingKey: secret, subscribe: ["local.{principal}.system.>"] }];
+    const path = writeConfig(cfg);
+    const result = await dispatchConfig(["validate", "--config", path]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("renderer coverage check FAILED (config)");
+    expect(result.stderr).not.toContain(secret);
+  });
+});
+
 describe("cortex config validate — CLI grammar", () => {
   test("no subcommand → usage error (exit 2)", async () => {
     const result = await dispatchConfig([]);

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -38,6 +38,11 @@ import {
   type SurfacePluginRegistry,
 } from "../../adapters/registry";
 import { resolveRendererPluginAndConfig } from "../../renderers";
+import {
+  assertConfiguredSystemCoverage,
+  type RendererCoverageInput,
+} from "../../renderers/coverage";
+import { deriveStackId } from "../types/stack";
 import { enforceChmod600 } from "./file-permissions";
 import {
   resolveAgentPresenceTokens,
@@ -944,9 +949,37 @@ function loadCortexShape(
   // `common/types/config.ts`): it only ever validated at `cortex.ts` boot,
   // and that asymmetry is preserved rather than newly tightened.
   const rendererRegistry = createDefaultSurfacePluginRegistry();
+  const configuredRendererCoverage: RendererCoverageInput[] = [];
   for (const entry of cortexConfig.renderers) {
-    resolveRendererPluginAndConfig(entry, rendererRegistry);
+    const { plugin, config } = resolveRendererPluginAndConfig(entry, rendererRegistry);
+    // Capture the class + defaults-applied subscribe set for the §4.6
+    // coverage check below (dashboard/cli-tail default to a system-covering
+    // `local.{principal}.>`; pagerduty/webhook-out default to `[]`).
+    const subscribe = (config as Record<string, unknown>).subscribe;
+    configuredRendererCoverage.push({
+      kind: plugin.rendererKind,
+      subscribe: Array.isArray(subscribe) ? (subscribe as string[]) : [],
+    });
   }
+
+  // cortex#1893 (S12b-pre, ADR-0024 §OQ9) — the CONFIG-LOAD half of the
+  // G-1111 §4.6 renderer-coverage HARD-FAIL guard. Fails LOUDLY when the
+  // CONFIGURED renderers do not, on their own, meet the ≥2-distinct-classes /
+  // ≥1-effective-sink floor (e.g. `dashboard` alone — the inert stub can never
+  // be the effective sink). The install-state half (a class whose bundle
+  // didn't load) runs AFTER plugin loading (S6) in `cortex.ts`, since "did the
+  // bundle load?" is not answerable here. Out of scope (→ no-op) for stacks
+  // that declare no system-covering renderer. See `src/renderers/coverage.ts`.
+  assertConfiguredSystemCoverage(configuredRendererCoverage, {
+    principal: cortexConfig.principal.id,
+    stack:
+      cortexConfig.stack !== undefined
+        ? deriveStackId({
+            principal: { id: cortexConfig.principal.id },
+            stack: cortexConfig.stack,
+          }).stack
+        : undefined,
+  });
 
   // CortexConfigSchema guarantees `agents.min(1)`, so [0] is always defined
   // at runtime; noUncheckedIndexedAccess still types it as possibly undefined.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -134,6 +134,7 @@ import {
 } from "./bus/myelin/envelope-validator";
 
 import { resolveRendererPluginAndConfig, UnimplementedRendererKindError, type Renderer } from "./renderers";
+import { assertRuntimeSystemCoverage } from "./renderers/coverage";
 import { createDefaultSurfacePluginRegistry, validateSurfacesAgainstRegistry } from "./adapters/registry";
 import { loadExternalPlugins } from "./adapters/loader";
 import { createSystemPluginLoadFailedEvent, createSystemPluginLoadedEvent } from "./bus/system-events";
@@ -3446,6 +3447,44 @@ export async function startCortex(
       }
     }
   }
+
+  // cortex#1893 (S12b-pre, ADR-0024 §OQ9) — the INSTALL-STATE half of the
+  // G-1111 §4.6 renderer-coverage HARD-FAIL guard. This is the post-S6 seam:
+  // `loadExternalPlugins` (S6, above) has already imported+registered any
+  // arc-installed renderer bundles, and the renderer boot loop just above has
+  // STARTED every renderer whose kind resolved — populating `renderers[]`
+  // (what actually delivers) and `skippedRendererConfigs` (entries whose kind
+  // is unregistered because their bundle isn't loaded → the install-state
+  // signal). Only HERE is "did the bundle load?" answerable, so the
+  // config-vs-install-state distinction (OQ9) is drawn here, not at
+  // config-load. The config-load half (`loadCortexShape`) already asserted the
+  // CONFIGURED set meets the floor, so a shortfall now is attributable to an
+  // absent covering bundle → a loud INSTALL-STATE hard-fail naming the bundle +
+  // `arc install` remedy, rather than the pager silently not paging. pagerduty
+  // is still in-tree today (extraction is cortex#1894), so the current
+  // dashboard+pagerduty pair starts fine and this passes; it only bites once a
+  // covering renderer is a bundle that failed to load.
+  assertRuntimeSystemCoverage(
+    {
+      // `r.subjects` are already placeholder-substituted (the boot loop above
+      // substitutes `subscribe` before construction); re-substituting concrete
+      // subjects in the coverage check is idempotent.
+      started: renderers.map((r) => ({ kind: r.kind, subscribe: r.subjects })),
+      skippedForMissingBundle: [...skippedRendererConfigs.entries()].flatMap(
+        ([kind, rawEntries]) =>
+          rawEntries.map((raw) => ({
+            kind,
+            subscribe: Array.isArray((raw as { subscribe?: unknown }).subscribe)
+              ? ((raw as { subscribe: string[] }).subscribe)
+              : [],
+          })),
+      ),
+    },
+    {
+      principal: principalId,
+      stack: options.stack !== undefined ? derivedStack.stack : undefined,
+    },
+  );
 
   // IAW Phase C.3.1 — build the PolicyEngine from the optional
   // `policy:` block on cortex.yaml. `policyEngineFromConfig` returns

--- a/src/renderers/__tests__/coverage.test.ts
+++ b/src/renderers/__tests__/coverage.test.ts
@@ -1,0 +1,362 @@
+/**
+ * cortex#1893 (S12b-pre, ADR-0024 §OQ9) — renderer-coverage boot HARD-FAIL
+ * guard tests. Security-critical: a degraded/absent pager must produce a LOUD
+ * no-boot, never a silent no-page.
+ *
+ * Each acceptance criterion from the issue is pinned by name below:
+ *   AC1 — one configured system sink → CONFIG error (unchanged behaviour)
+ *   AC2 — two configured, one bundle absent → INSTALL-STATE error (bundle + arc install)
+ *   AC3 — `dashboard` alone never satisfies coverage
+ *   AC4 — error text never leaks `routingKey`/secrets
+ *   AC5 — healthy dashboard + loaded pagerduty BOOTS (no false hard-fail)
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  assertConfiguredSystemCoverage,
+  assertRuntimeSystemCoverage,
+  evaluateSystemCoverage,
+  rendererBundleForKind,
+  rendererCoversSystem,
+  subjectPatternsIntersect,
+  systemProbeSubjects,
+  RendererCoverageConfigError,
+  RendererCoverageInstallStateError,
+  INERT_RENDERER_KINDS,
+  type RendererCoverageInput,
+} from "../coverage";
+
+const CTX = { principal: "andreas" } as const;
+const CTX_STACKFUL = { principal: "andreas", stack: "work" } as const;
+
+// The canonical covering configs, with placeholders as a real config carries them.
+const DASHBOARD: RendererCoverageInput = { kind: "dashboard", subscribe: ["local.{principal}.>"] };
+const PAGERDUTY_SYSTEM: RendererCoverageInput = {
+  kind: "pagerduty",
+  subscribe: ["local.{principal}.system.>"],
+};
+
+// =============================================================================
+// Subject math — the coverage primitive
+// =============================================================================
+
+describe("subjectPatternsIntersect", () => {
+  const tok = (s: string) => s.split(".");
+
+  test("a broad `local.p.>` covers the system probe", () => {
+    expect(subjectPatternsIntersect(tok("local.andreas.>"), tok("local.andreas.system.>"))).toBe(
+      true,
+    );
+  });
+
+  test("a specific system subject covers the probe", () => {
+    expect(
+      subjectPatternsIntersect(
+        tok("local.andreas.system.adapter.degraded"),
+        tok("local.andreas.system.>"),
+      ),
+    ).toBe(true);
+  });
+
+  test("a sibling family (`dispatch.>`) does NOT cover system — no fail-open false positive", () => {
+    expect(
+      subjectPatternsIntersect(tok("local.andreas.dispatch.>"), tok("local.andreas.system.>")),
+    ).toBe(false);
+  });
+
+  test("an exact non-system subject does not cover system", () => {
+    expect(subjectPatternsIntersect(tok("local.andreas"), tok("local.andreas.system.>"))).toBe(
+      false,
+    );
+  });
+
+  test("`*` matches a single token but not a family mismatch", () => {
+    expect(
+      subjectPatternsIntersect(tok("local.andreas.*.>"), tok("local.andreas.system.>")),
+    ).toBe(true);
+    expect(
+      subjectPatternsIntersect(tok("local.*.dispatch.>"), tok("local.andreas.system.>")),
+    ).toBe(false);
+  });
+});
+
+describe("systemProbeSubjects / rendererCoversSystem", () => {
+  test("stack-less deployment → single stack-less probe", () => {
+    expect(systemProbeSubjects(CTX)).toEqual(["local.andreas.system.>"]);
+  });
+
+  test("stack-ful deployment → both stack-ful and stack-less probes (matches observability renderer)", () => {
+    expect(systemProbeSubjects(CTX_STACKFUL)).toEqual([
+      "local.andreas.work.system.>",
+      "local.andreas.system.>",
+    ]);
+  });
+
+  test("dashboard default `local.{principal}.>` covers system (stack-less and stack-ful)", () => {
+    expect(rendererCoversSystem(DASHBOARD.subscribe, CTX)).toBe(true);
+    expect(rendererCoversSystem(DASHBOARD.subscribe, CTX_STACKFUL)).toBe(true);
+  });
+
+  test("a stack-less system pattern covers system even in a stack-ful deployment", () => {
+    expect(rendererCoversSystem(["local.{principal}.system.>"], CTX_STACKFUL)).toBe(true);
+  });
+
+  test("a stack-ful system pattern covers system in a stack-ful deployment", () => {
+    expect(rendererCoversSystem(["local.{principal}.{stack}.system.>"], CTX_STACKFUL)).toBe(true);
+  });
+
+  test("an empty subscribe (pagerduty default) covers nothing", () => {
+    expect(rendererCoversSystem([], CTX)).toBe(false);
+    expect(rendererCoversSystem([], CTX_STACKFUL)).toBe(false);
+  });
+
+  test("a dispatch-only subscribe does not cover system (stack-less or stack-ful)", () => {
+    expect(rendererCoversSystem(["local.{principal}.dispatch.>"], CTX)).toBe(false);
+    expect(rendererCoversSystem(["local.{principal}.dispatch.>"], CTX_STACKFUL)).toBe(false);
+    expect(rendererCoversSystem(["local.{principal}.{stack}.dispatch.>"], CTX_STACKFUL)).toBe(
+      false,
+    );
+  });
+});
+
+// =============================================================================
+// evaluateSystemCoverage — the rule
+// =============================================================================
+
+describe("evaluateSystemCoverage", () => {
+  test("AC5: dashboard + system-covering pagerduty is satisfied", () => {
+    const v = evaluateSystemCoverage([DASHBOARD, PAGERDUTY_SYSTEM], CTX);
+    expect(v.coveringKinds).toEqual(["dashboard", "pagerduty"]);
+    expect(v.effectiveCoveringKinds).toEqual(["pagerduty"]);
+    expect(v.satisfied).toBe(true);
+  });
+
+  test("AC3: dashboard alone is in scope but NOT satisfied (inert, single class)", () => {
+    const v = evaluateSystemCoverage([DASHBOARD], CTX);
+    expect(v.inScope).toBe(true);
+    expect(v.coveringKinds).toEqual(["dashboard"]);
+    expect(v.effectiveCoveringKinds).toEqual([]);
+    expect(v.satisfied).toBe(false);
+  });
+
+  test("AC1: a single effective sink (pagerduty alone) is not satisfied — <2 classes", () => {
+    const v = evaluateSystemCoverage([PAGERDUTY_SYSTEM], CTX);
+    expect(v.satisfied).toBe(false);
+  });
+
+  test("two EFFECTIVE covering classes are satisfied", () => {
+    const v = evaluateSystemCoverage(
+      [PAGERDUTY_SYSTEM, { kind: "webhook-out", subscribe: ["local.{principal}.system.>"] }],
+      CTX,
+    );
+    expect(v.effectiveCoveringKinds).toEqual(["pagerduty", "webhook-out"]);
+    expect(v.satisfied).toBe(true);
+  });
+
+  test("two dashboard INSTANCES are still one class → not satisfied (all-inert)", () => {
+    const v = evaluateSystemCoverage(
+      [DASHBOARD, { kind: "dashboard", subscribe: ["local.{principal}.system.>"] }],
+      CTX,
+    );
+    expect(v.coveringKinds).toEqual(["dashboard"]);
+    expect(v.satisfied).toBe(false);
+  });
+
+  test("out of scope: no system-covering renderer → satisfied (no blast radius on non-system stacks)", () => {
+    const v = evaluateSystemCoverage(
+      [{ kind: "webhook-out", subscribe: ["local.{principal}.dispatch.>"] }],
+      CTX,
+    );
+    expect(v.inScope).toBe(false);
+    expect(v.satisfied).toBe(true);
+  });
+
+  test("out of scope: zero renderers → satisfied", () => {
+    expect(evaluateSystemCoverage([], CTX).satisfied).toBe(true);
+  });
+
+  test("`dashboard` is the inert kind", () => {
+    expect(INERT_RENDERER_KINDS.has("dashboard")).toBe(true);
+    expect(INERT_RENDERER_KINDS.has("pagerduty")).toBe(false);
+  });
+});
+
+// =============================================================================
+// assertConfiguredSystemCoverage — the CONFIG-LOAD guard (AC1, AC3)
+// =============================================================================
+
+describe("assertConfiguredSystemCoverage (config-load)", () => {
+  test("AC5: dashboard + pagerduty passes without throwing", () => {
+    expect(() => assertConfiguredSystemCoverage([DASHBOARD, PAGERDUTY_SYSTEM], CTX)).not.toThrow();
+  });
+
+  test("AC1: a single configured sink throws the CONFIG error", () => {
+    expect(() => assertConfiguredSystemCoverage([PAGERDUTY_SYSTEM], CTX)).toThrow(
+      RendererCoverageConfigError,
+    );
+  });
+
+  test("AC3: dashboard alone throws the CONFIG error", () => {
+    let thrown: unknown;
+    try {
+      assertConfiguredSystemCoverage([DASHBOARD], CTX);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(RendererCoverageConfigError);
+    // It is a CONFIG fault, NOT an install-state fault.
+    expect(thrown).not.toBeInstanceOf(RendererCoverageInstallStateError);
+    expect((thrown as Error).message).toContain("(config)");
+    expect((thrown as Error).message).toContain("[dashboard]");
+  });
+
+  test("out-of-scope / zero-renderer configs never throw", () => {
+    expect(() => assertConfiguredSystemCoverage([], CTX)).not.toThrow();
+    expect(() =>
+      assertConfiguredSystemCoverage(
+        [{ kind: "webhook-out", subscribe: ["local.{principal}.dispatch.>"] }],
+        CTX,
+      ),
+    ).not.toThrow();
+  });
+});
+
+// =============================================================================
+// assertRuntimeSystemCoverage — the POST-S6 install-state guard (AC2, AC5)
+// =============================================================================
+
+describe("assertRuntimeSystemCoverage (post-S6 install-state)", () => {
+  test("AC5: dashboard + started pagerduty BOOTS (no false hard-fail)", () => {
+    expect(() =>
+      assertRuntimeSystemCoverage(
+        {
+          // started renderers carry already-substituted concrete subjects.
+          started: [
+            { kind: "dashboard", subscribe: ["local.andreas.>"] },
+            { kind: "pagerduty", subscribe: ["local.andreas.system.>"] },
+          ],
+          skippedForMissingBundle: [],
+        },
+        CTX,
+      ),
+    ).not.toThrow();
+  });
+
+  test("AC2: dashboard started but pagerduty bundle absent → INSTALL-STATE error naming bundle + arc install", () => {
+    let thrown: unknown;
+    try {
+      assertRuntimeSystemCoverage(
+        {
+          started: [{ kind: "dashboard", subscribe: ["local.andreas.>"] }],
+          // pagerduty's kind never registered → its config landed here.
+          skippedForMissingBundle: [PAGERDUTY_SYSTEM],
+        },
+        CTX,
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(RendererCoverageInstallStateError);
+    // NOT reported as a config error.
+    expect(thrown).not.toBeInstanceOf(RendererCoverageConfigError);
+    const msg = (thrown as Error).message;
+    expect(msg).toContain("(install-state)");
+    expect(msg).toContain("metafactory-cortex-renderer-pagerduty");
+    expect(msg).toContain("arc install metafactory-cortex-renderer-pagerduty");
+    expect((thrown as RendererCoverageInstallStateError).missingKinds).toEqual(["pagerduty"]);
+    expect((thrown as RendererCoverageInstallStateError).missingBundles).toEqual([
+      "metafactory-cortex-renderer-pagerduty",
+    ]);
+  });
+
+  test("AC5 (stack-ful): dashboard + started pagerduty with a stack segment BOOTS", () => {
+    expect(() =>
+      assertRuntimeSystemCoverage(
+        {
+          started: [
+            { kind: "dashboard", subscribe: ["local.andreas.work.>"] },
+            { kind: "pagerduty", subscribe: ["local.andreas.work.system.>"] },
+          ],
+          skippedForMissingBundle: [],
+        },
+        CTX_STACKFUL,
+      ),
+    ).not.toThrow();
+  });
+
+  test("a skipped bundle that does NOT cover system does not trigger install-state (shortfall is config)", () => {
+    // started dashboard alone; the skipped bundle covers only dispatch → the
+    // shortfall isn't explained by a missing SYSTEM sink → config error.
+    let thrown: unknown;
+    try {
+      assertRuntimeSystemCoverage(
+        {
+          started: [{ kind: "dashboard", subscribe: ["local.andreas.>"] }],
+          skippedForMissingBundle: [
+            { kind: "webhook-out", subscribe: ["local.andreas.dispatch.>"] },
+          ],
+        },
+        CTX,
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(RendererCoverageConfigError);
+  });
+
+  test("bundle naming falls back to the compass#115 convention for unknown kinds", () => {
+    expect(rendererBundleForKind("pagerduty")).toBe("metafactory-cortex-renderer-pagerduty");
+    expect(rendererBundleForKind("slacklog")).toBe("metafactory-cortex-renderer-slacklog");
+  });
+});
+
+// =============================================================================
+// AC4 — secrets never leak into error text
+// =============================================================================
+
+describe("AC4: error text never leaks routingKey / secrets", () => {
+  const SECRET = "R0UT1NG-K3Y-SUPER-SECRET-do-not-leak";
+
+  test("CONFIG error carries only kinds — never the routingKey or a principal's subscribe values", () => {
+    // A pagerduty-alone config whose secret must never surface. Use a
+    // DISTINCTIVE subscribe token so we can prove the principal's actual
+    // subject values are never echoed (only the generic rule template is).
+    const distinctive = "local.andreas.system.super-private-family.>";
+    const err = new RendererCoverageConfigError(
+      evaluateSystemCoverage([{ kind: "pagerduty", subscribe: [distinctive] }], CTX),
+    );
+    expect(err.message).not.toContain(SECRET);
+    expect(err.message).not.toContain("routingKey");
+    // The principal's own subscribe patterns are never echoed.
+    expect(err.message).not.toContain("super-private-family");
+  });
+
+  test("INSTALL-STATE error carries only kinds + bundle names — never the routingKey", () => {
+    const err = new RendererCoverageInstallStateError(["pagerduty"]);
+    expect(err.message).not.toContain(SECRET);
+    expect(err.message).not.toContain("routingKey");
+  });
+
+  test("the guard never READS a secret field — passing a routingKey-bearing entry cannot surface it", () => {
+    // Simulate the real raw config entry shape: pagerduty carries `routingKey`.
+    const withSecret: RendererCoverageInput & { routingKey: string } = {
+      kind: "pagerduty",
+      subscribe: ["local.{principal}.system.>"],
+      routingKey: SECRET,
+    };
+    let msg = "";
+    try {
+      assertRuntimeSystemCoverage(
+        {
+          started: [{ kind: "dashboard", subscribe: ["local.andreas.>"] }],
+          skippedForMissingBundle: [withSecret],
+        },
+        CTX,
+      );
+    } catch (err) {
+      msg = (err as Error).message;
+    }
+    expect(msg).toContain("(install-state)");
+    expect(msg).not.toContain(SECRET);
+  });
+});

--- a/src/renderers/coverage.ts
+++ b/src/renderers/coverage.ts
@@ -1,0 +1,362 @@
+/**
+ * cortex#1893 (S12b-pre, epic #1784) — the G-1111 §4.6 renderer-coverage
+ * boot HARD-FAIL guard. ADR-0024 §OQ9 (ratified 2026-07-11).
+ *
+ * ## Why this exists
+ *
+ * G-1111 §4.6 requires **≥2 distinct renderer platform classes** covering
+ * `local.{principal}.system.>` so a single degraded sink cannot blind the
+ * principal to system events (`src/renderers/types.ts:15-21`). Today the pair
+ * is `dashboard` + `pagerduty`, both in-tree. Once `pagerduty` extracts to a
+ * bundle (cortex#1894, S12b), a stack that never ran `arc install` — OR that
+ * left `system.plugins.external` off (the recommended secure default for
+ * ADAPTERS) — is left with ONE sink, the INERT `dashboard`. The pager then
+ * SILENTLY does not page: a default that is *secure* for adapters ("don't load
+ * third-party code") is *fail-OPEN* for a pager ("don't page").
+ *
+ * Ratified decision: move the risk from *silent no-page* → *loud no-boot*. Boot
+ * HARD-FAILS when `system.>` coverage drops below two distinct platform classes
+ * (with at least one EFFECTIVE sink). A stack that cannot page refuses to start
+ * rather than running blind while believing it is monitored.
+ *
+ * ## The inert-`dashboard` interpretation (requirement #3, ADR-0024 §OQ9)
+ *
+ * `DashboardRenderer` is a stub superseded by ADR-0005 §4: it buffers into a
+ * ring nothing reads (`getRecent()` has no production consumer), so it DELIVERS
+ * NOTHING. Coverage counting must not be fooled by it — "dashboard alone" is
+ * the exact fail-open being closed.
+ *
+ * We count it as a **class for diversity, but never as an EFFECTIVE sink**:
+ *
+ *   coverage is SATISFIED  ⇔  (≥2 distinct system-covering classes)
+ *                         AND (≥1 of those classes is EFFECTIVE, i.e. not inert)
+ *
+ * This is the interpretation that makes both required truths hold at once:
+ *   - `dashboard` ALONE → 1 covering class → FAILS the ≥2 clause. ✔ (acc. #3)
+ *   - `dashboard` + a loaded `pagerduty` → 2 classes, `pagerduty` effective →
+ *     BOOTS. ✔ (acc. #5) — this is why `dashboard` must still *count* toward
+ *     diversity rather than being excluded outright: the ratified canonical
+ *     pair is dashboard+pagerduty, and acceptance criterion #5 mandates it boot.
+ *   - `dashboard` + a configured-but-UNLOADED `pagerduty` → at runtime only the
+ *     inert `dashboard` started → FAILS, and the shortfall is attributable to
+ *     an absent bundle → INSTALL-STATE error (acc. #2), not a config error.
+ *
+ * The guard is deliberately the OQ9-scoped rule (close "dashboard alone"), NOT
+ * the stronger "≥2 EFFECTIVE sinks" ideal — the latter would false-fail the
+ * canonical dashboard+pagerduty pair that acceptance #5 requires to boot.
+ *
+ * ## Two distinct failures (requirement #2)
+ *
+ *   - {@link RendererCoverageConfigError} — "you configured one sink." A pure
+ *     CONFIG authoring error. Raised at config-load (`loadCortexShape`).
+ *   - {@link RendererCoverageInstallStateError} — "you configured two, one's
+ *     bundle isn't loaded." A fleet/INSTALL-STATE error naming the missing
+ *     bundle + the exact `arc install` remedy. Raised AFTER plugin loading
+ *     (S6), where "did the bundle load?" is finally answerable. It is NOT a
+ *     config error and must never be reported as one.
+ *
+ * ## Secrets (requirement #4)
+ *
+ * Error text carries only renderer **kinds** (`dashboard`, `pagerduty`) and
+ * **bundle names** (`metafactory-cortex-renderer-pagerduty`). It NEVER echoes a
+ * renderer's `subscribe` patterns, its `routingKey` (the PagerDuty secret), or
+ * any token — none of those are read into a message here.
+ */
+
+/**
+ * Renderer kinds that count toward class-diversity but can NEVER be one of the
+ * ≥2 EFFECTIVE sinks. `dashboard` is inert per ADR-0005 §4 (its ring buffer has
+ * no production reader). If a second inert kind is ever introduced, add it here
+ * with the same justification — an all-inert covering set must always fail.
+ */
+export const INERT_RENDERER_KINDS: ReadonlySet<string> = new Set(["dashboard"]);
+
+/**
+ * Known first-party renderer-bundle names, keyed by `rendererKind`. Used ONLY
+ * to build the install-state remediation message. Follows the compass#115
+ * `metafactory-cortex-renderer-<name>` standard (the renderer twin of the
+ * `metafactory-cortex-adapter-<name>` adapter bundles). A kind absent from this
+ * map falls back to the conventional name via {@link rendererBundleForKind}.
+ */
+export const RENDERER_BUNDLE_BY_KIND: Readonly<Record<string, string>> = {
+  pagerduty: "metafactory-cortex-renderer-pagerduty",
+};
+
+/** The bundle name that provides `rendererKind`, per the compass#115 standard. */
+export function rendererBundleForKind(kind: string): string {
+  return RENDERER_BUNDLE_BY_KIND[kind] ?? `metafactory-cortex-renderer-${kind}`;
+}
+
+/**
+ * Substitute the `{principal}` / `{stack}.` subject placeholders exactly as
+ * {@link makeSubjectPlaceholderSubstituter} (`src/bus/myelin/runtime.ts`) does.
+ *
+ * DUPLICATED (not imported) on purpose: this module runs on the CONFIG-LOAD
+ * path (`loadCortexShape`), and importing `runtime.ts` would drag the whole
+ * NATS client (`import ... from "nats"`) into config validation. The logic is
+ * three lines of pure string work; keeping it local avoids that coupling. If
+ * the canonical helper's grammar changes, mirror it here.
+ */
+function substitutePlaceholders(
+  subjects: readonly string[],
+  ctx: { principal: string; stack?: string },
+): string[] {
+  const stackToken = ctx.stack !== undefined ? `${ctx.stack}.` : "";
+  return subjects.map((s) =>
+    s.replaceAll("{principal}", ctx.principal).replaceAll("{stack}.", stackToken),
+  );
+}
+
+/** Tokenise a NATS subject/pattern on `.`. */
+function tokenize(subject: string): string[] {
+  return subject.split(".");
+}
+
+/**
+ * Do two NATS subject PATTERNS share at least one concrete subject? `*` matches
+ * exactly one token; `>` matches one-or-more trailing tokens. Conservative by
+ * construction — it returns `true` only when a common subject provably exists,
+ * so it never over-claims coverage (over-claiming would be fail-OPEN, the exact
+ * hazard this guard closes).
+ */
+export function subjectPatternsIntersect(a: readonly string[], b: readonly string[]): boolean {
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    const ta = a[i];
+    const tb = b[j];
+    // A `>` here matches the ≥1 tokens the loop guarantees remain on the other
+    // side — a common subject exists from this point on.
+    if (ta === ">" || tb === ">") return true;
+    if (ta === "*" || tb === "*" || ta === tb) {
+      i += 1;
+      j += 1;
+      continue;
+    }
+    // Two distinct literal tokens at the same position — disjoint.
+    return false;
+  }
+  // Both fully consumed with every token reconciled → identical-length match.
+  if (i === a.length && j === b.length) return true;
+  // One side has tokens left while the other ended. `>` needs ≥1 token, but the
+  // exhausted side offers none there — no common subject. (A trailing `>` on
+  // the longer side would already have returned true inside the loop.)
+  return false;
+}
+
+/**
+ * The concrete `system.>` probe subject(s) for a deployment. cortex publishes
+ * system events in BOTH shapes — stack-ful (`local.andreas.work.system.>`) and
+ * stack-less (`local.andreas.system.>`) — depending on whether a `stack:` block
+ * is declared (`src/bus/myelin/runtime.ts:685-687`), and the production
+ * system-event consumer (`observability-renderer.ts`) defensively subscribes to
+ * BOTH forms for every family. A renderer covering EITHER shape is therefore
+ * providing a real, intentional system sink, so coverage is judged against both
+ * probes.
+ *
+ * NON-GOAL (documented residual): this guard checks *class-level* coverage
+ * diversity (is there ≥2 distinct classes intending to catch system events, and
+ * did their bundles load?), NOT fine-grained subject-alignment. A principal who
+ * writes a stack-LESS pagerduty pattern in a stack-FUL deployment whose runtime
+ * only emits stack-ful subjects passes this guard but would not actually page —
+ * a finer misconfiguration than the "a whole sink CLASS silently vanished"
+ * regression this slice targets (ADR-0024 §OQ9). Matching the observability
+ * renderer's both-shapes treatment keeps the guard from false-failing the
+ * documented stack-less pagerduty example (`src/renderers/pagerduty.ts:11-18`).
+ */
+export function systemProbeSubjects(ctx: { principal: string; stack?: string }): string[] {
+  // `{stack}.` collapses to "" when stack is undefined, so this is already the
+  // stack-less probe for a stack-less deployment.
+  const stackful = substitutePlaceholders(["local.{principal}.{stack}.system.>"], ctx)[0] ?? "";
+  if (ctx.stack === undefined) return [stackful];
+  const stackless = substitutePlaceholders(["local.{principal}.system.>"], {
+    principal: ctx.principal,
+  })[0] ?? "";
+  return [stackful, stackless];
+}
+
+/**
+ * Does a renderer's `subscribe` set (raw, with placeholders) overlap the
+ * `local.{principal}.system.>` subtree — in either the stack-ful or stack-less
+ * shape — for this deployment?
+ */
+export function rendererCoversSystem(
+  subscribe: readonly string[],
+  ctx: { principal: string; stack?: string },
+): boolean {
+  const probes = systemProbeSubjects(ctx).map(tokenize);
+  return substitutePlaceholders(subscribe, ctx).some((s) => {
+    const st = tokenize(s);
+    return probes.some((probe) => subjectPatternsIntersect(st, probe));
+  });
+}
+
+/** One renderer's coverage-relevant shape: its class (`kind`) + subscribe set. */
+export interface RendererCoverageInput {
+  kind: string;
+  subscribe: readonly string[];
+}
+
+/** The outcome of evaluating a renderer set against the §4.6 fail-safe rule. */
+export interface CoverageVerdict {
+  /** Distinct classes (kinds) that cover `system.>`, sorted. */
+  coveringKinds: string[];
+  /** Distinct covering classes that are EFFECTIVE (not inert), sorted. */
+  effectiveCoveringKinds: string[];
+  /** Whether ANY renderer covers `system.>` — i.e. the stack opted into system
+   *  alerting. When false the rule does not apply (out of scope → satisfied). */
+  inScope: boolean;
+  /** Whether the fail-safe rule is satisfied. */
+  satisfied: boolean;
+}
+
+/**
+ * Evaluate a renderer set against the G-1111 §4.6 fail-safe rule.
+ *
+ * SCOPE: the rule applies only to stacks that opted into system alerting —
+ * i.e. that configured at least one renderer covering `system.>`. A stack with
+ * NO system-covering renderer (zero renderers, or only non-system sinks) is out
+ * of scope and `satisfied` is `true`. This bounds the guard's blast radius to
+ * stacks that have declared a system sink; it does not newly force every stack
+ * in the fleet to configure paging.
+ */
+export function evaluateSystemCoverage(
+  renderers: readonly RendererCoverageInput[],
+  ctx: { principal: string; stack?: string },
+): CoverageVerdict {
+  const covering = renderers.filter((r) => rendererCoversSystem(r.subscribe, ctx));
+  const coveringKinds = [...new Set(covering.map((r) => r.kind))].sort();
+  const effectiveCoveringKinds = [
+    ...new Set(covering.filter((r) => !INERT_RENDERER_KINDS.has(r.kind)).map((r) => r.kind)),
+  ].sort();
+  const inScope = coveringKinds.length > 0;
+  const satisfied =
+    !inScope || (coveringKinds.length >= 2 && effectiveCoveringKinds.length >= 1);
+  return { coveringKinds, effectiveCoveringKinds, inScope, satisfied };
+}
+
+const RULE_PREAMBLE =
+  "G-1111 §4.6 requires at least two distinct renderer platform classes " +
+  "covering `local.{principal}.system.>`, with at least one EFFECTIVE " +
+  "(delivering) sink, so a single degraded sink cannot blind the principal to " +
+  "system events. The `dashboard` renderer is INERT (ADR-0005 §4: it buffers " +
+  "but delivers nothing), so it counts toward class diversity but can never be " +
+  "the effective sink.";
+
+/**
+ * "You configured one sink." A pure CONFIG authoring error — the declared
+ * renderers do not, on their own, meet the fail-safe floor. Raised at
+ * config-load. Distinct TYPE from {@link RendererCoverageInstallStateError} so
+ * callers/tests can tell a config fault from an install-state fault.
+ */
+export class RendererCoverageConfigError extends Error {
+  readonly verdict: CoverageVerdict;
+  constructor(verdict: CoverageVerdict) {
+    const found =
+      verdict.coveringKinds.length > 0 ? `[${verdict.coveringKinds.join(", ")}]` : "[none]";
+    const effective =
+      verdict.effectiveCoveringKinds.length > 0
+        ? `[${verdict.effectiveCoveringKinds.join(", ")}]`
+        : "[none]";
+    super(
+      `cortex: renderer coverage check FAILED (config). ${RULE_PREAMBLE}\n` +
+        `Configured system-covering classes: ${found} (effective: ${effective}).\n` +
+        `Add an effective system-covering renderer (e.g. a \`pagerduty\` renderer ` +
+        `subscribed to \`local.{principal}.system.>\`) so an operational alert ` +
+        `reliably reaches you. Decision: ADR-0024 §OQ9.`,
+    );
+    this.name = "RendererCoverageConfigError";
+    this.verdict = verdict;
+  }
+}
+
+/**
+ * "You configured two, one's bundle isn't loaded." A fleet/INSTALL-STATE error:
+ * the config declares enough classes, but the bundle(s) providing one or more
+ * of them did not load, so effective runtime coverage dropped below the floor.
+ * Names the missing bundle(s) + the exact `arc install` remedy. Raised AFTER
+ * plugin loading (S6). NOT a config error and must never be reported as one.
+ */
+export class RendererCoverageInstallStateError extends Error {
+  /** Renderer kinds whose bundle is absent/unloaded. */
+  readonly missingKinds: string[];
+  /** Bundle names that would restore coverage. */
+  readonly missingBundles: string[];
+  constructor(missingKinds: string[]) {
+    const kinds = [...new Set(missingKinds)].sort();
+    const bundles = kinds.map(rendererBundleForKind);
+    const installLines = bundles.map((b) => `    arc install ${b}`).join("\n");
+    super(
+      `cortex: renderer coverage check FAILED (install-state). ${RULE_PREAMBLE}\n` +
+        `The config declares enough classes, but the bundle(s) providing ` +
+        `[${kinds.join(", ")}] did not load — effective coverage of ` +
+        `\`local.{principal}.system.>\` dropped below the floor and the pager ` +
+        `would silently not page. This is a fleet/install-state failure, NOT a ` +
+        `config error. Install the missing renderer bundle(s) and restart:\n` +
+        `${installLines}\n` +
+        `Missing bundle(s): ${bundles.join(", ")}. Decision: ADR-0024 §OQ9 ` +
+        `(boot hard-fails rather than run blind).`,
+    );
+    this.name = "RendererCoverageInstallStateError";
+    this.missingKinds = kinds;
+    this.missingBundles = bundles;
+  }
+}
+
+/**
+ * CONFIG-LOAD guard: assert the CONFIGURED renderer set meets the §4.6 floor.
+ * Throws {@link RendererCoverageConfigError} on a pure-config shortfall
+ * (e.g. `dashboard` alone). No-op when the stack is out of scope (no
+ * system-covering renderer declared).
+ */
+export function assertConfiguredSystemCoverage(
+  renderers: readonly RendererCoverageInput[],
+  ctx: { principal: string; stack?: string },
+): void {
+  const verdict = evaluateSystemCoverage(renderers, ctx);
+  if (!verdict.satisfied) throw new RendererCoverageConfigError(verdict);
+}
+
+/**
+ * POST-S6 (install-state) guard: assert the renderers that ACTUALLY STARTED
+ * still meet the §4.6 floor, now that plugin loading has run and "did the
+ * bundle load?" is answerable.
+ *
+ * @param started renderers that started successfully (kind + already-resolved
+ *   subscribe subjects).
+ * @param skippedForMissingBundle renderer config entries that could NOT start
+ *   because their kind is unregistered — i.e. their bundle isn't loaded
+ *   (`UnimplementedRendererKindError`). This is the install-state signal.
+ *
+ * Throws {@link RendererCoverageInstallStateError} when the runtime shortfall is
+ * attributable to an absent covering bundle; falls back to
+ * {@link RendererCoverageConfigError} if the started set is insufficient for a
+ * reason no unloaded bundle explains (normally pre-empted at config-load, but
+ * kept correct for callers that construct `startCortex` inputs directly).
+ */
+export function assertRuntimeSystemCoverage(
+  opts: {
+    started: readonly RendererCoverageInput[];
+    skippedForMissingBundle: readonly RendererCoverageInput[];
+  },
+  ctx: { principal: string; stack?: string },
+): void {
+  const startedVerdict = evaluateSystemCoverage(opts.started, ctx);
+  if (startedVerdict.satisfied) return;
+
+  const absentCoveringKinds = [
+    ...new Set(
+      opts.skippedForMissingBundle
+        .filter((r) => rendererCoversSystem(r.subscribe, ctx))
+        .map((r) => r.kind),
+    ),
+  ];
+
+  if (absentCoveringKinds.length > 0) {
+    throw new RendererCoverageInstallStateError(absentCoveringKinds);
+  }
+  // No unloaded covering bundle explains the shortfall → treat as a config
+  // insufficiency. At boot this is unreachable (config-load already asserted
+  // configured coverage); it stays correct for direct `startCortex` callers.
+  throw new RendererCoverageConfigError(startedVerdict);
+}


### PR DESCRIPTION
Implements the ADR-0024 §OQ9 renderer-coverage boot guard: cortex **hard-fails boot** when `local.{principal}.system.>` coverage drops below two distinct renderer platform classes with ≥1 *effective* (non-inert) sink. Moves risk from **silent no-page → loud no-boot**.

Closes #1893. Epic #1784 (S12b-pre). **Gates the pagerduty extraction (#1894)** — lands first.

## Why (the fail-open being closed)
G-1111 §4.6 requires ≥2 distinct classes covering `system.>` so a degraded sink can't blind the principal. Today `dashboard`+`pagerduty` are that pair, in-tree. Once pagerduty is a bundle (#1894), a stack that never ran `arc install` — or left `system.plugins.external` off (the recommended secure default) — is left with only the **inert** `dashboard` (ADR-0005 §4; nothing reads its `getRecent()`). The pager silently doesn't page. Secure-for-adapters is fail-open-for-a-pager.

## Key discovery
The config-load coverage check the issue said "currently fires" **did not exist** — only comments referenced it as implemented. This slice builds **both halves for the first time**.

## What's built
- New pure module `src/renderers/coverage.ts`.
- **Config-load half** (`loader.ts` `loadCortexShape`, after the renderer registry pass): `assertConfiguredSystemCoverage` → `RendererCoverageConfigError`. Fires ONLY when ≥1 configured renderer covers `system.>` → zero-renderer / non-system stacks unaffected (**the config-split fleet ships no renderers block → zero blast radius**).
- **Install-state half** (`cortex.ts`, after the renderer boot loop — the post-S6 seam where `loadExternalPlugins` results + started `renderers[]` + `skippedRendererConfigs` are all in hand): `assertRuntimeSystemCoverage` → `RendererCoverageInstallStateError`, naming the missing bundle + the exact `arc install …` remedy.
- **Distinct Error subclasses** so an install-state failure can never be mislabeled as a config error.
- **dashboard-alone → FAIL**: coverage satisfied iff (≥2 distinct classes) AND (≥1 effective/non-inert class). `dashboard ∈ INERT_RENDERER_KINDS` — counts for diversity, never as the effective sink. Documented (ADR-0024 §OQ9 / ADR-0005 §4).
- Fixed `cortex.yaml.example` renderers block (dashboard-only + stale `{org}`) → the ratified dashboard+pagerduty pair — it was itself an instance of the fail-open.

## Secrets
Error text carries only kinds + bundle names — **no `routingKey`**, no subscribe subjects. Asserted (AC4).

## Acceptance (each tested)
AC1 one-sink → CONFIG error · AC2 bundle-absent → INSTALL-STATE (names bundle + `arc install`) · AC3 dashboard-alone fails · AC4 no `routingKey` leak · AC5 healthy pair boots + zero-renderer unaffected. In-tree dashboard+pagerduty pair verified booting today (guard only bites once pagerduty is an unloaded bundle).

## Forward note for #1894
The existing config-load renderer-registry validation (`loader.ts` ~L947) will throw on an unknown bundle kind BEFORE this check — **#1894 must relax it to tolerate a not-yet-loaded bundle kind**. The pure helpers here are decoupled and ready.

## Gate
`bun test src/common src/renderers src/adapters src/gateway` 2319/0 · `src/runner` 886/0 · coverage+config-validate 47/0 · CLI config 170/0 · `tsc` 0 · `lint:errors` clean · `check-carveouts.sh` PASS · `check-shippable-hygiene.ts` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)