### PR TITLE
fix(bus): rename underscore system.* envelope types to hyphens — unbreak silently-dropped events (#1935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,7 +207,7 @@ with new unit coverage added for the extracted seams.
   anything in this PR. The bridge trusts the already-verified fired payload; it
   does not re-authenticate it. A spoofed author on an unverified delivery is an
   upstream concern, out of scope here. A trusted-author drop is an honest policy
-  SKIP, not a failure: it emits the new `system.bus.reflex_activation_skipped`
+  SKIP, not a failure: it emits the new `system.bus.reflex-activation-skipped`
   visibility event (reason `author_trusted`, with the matched `author`) and
   marks the Decision id so a redelivery re-skips silently. Empty/absent list =
   no gate (dispatch everyone). Drives reflex's `@jc/sage-pr-review` target

--- a/src/__tests__/iaw-phase-b-integration.test.ts
+++ b/src/__tests__/iaw-phase-b-integration.test.ts
@@ -282,9 +282,9 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
     await betaListener.stop();
 
     // β's runtime.publish should have been called exactly once with
-    // a `system.bus.peer_dispatch_received` envelope for α's request.
+    // a `system.bus.peer-dispatch-received` envelope for α's request.
     const betaVisibility = beta.runtime.published.filter(
-      (e) => e.type === "system.bus.peer_dispatch_received",
+      (e) => e.type === "system.bus.peer-dispatch-received",
     );
     expect(betaVisibility).toHaveLength(1);
     expect(betaVisibility[0]?.payload.receiving_agent_id).toBe("beta-agent");
@@ -293,7 +293,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
 
     // α symmetrically: one visibility event for β's envelope.
     const alphaVisibility = alpha.runtime.published.filter(
-      (e) => e.type === "system.bus.peer_dispatch_received",
+      (e) => e.type === "system.bus.peer-dispatch-received",
     );
     expect(alphaVisibility).toHaveLength(1);
     expect(alphaVisibility[0]?.payload.receiving_agent_id).toBe("alpha-agent");
@@ -375,7 +375,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
 
     // No visibility event — rejection drops the envelope.
     const betaVisibility = beta.runtime.published.filter(
-      (e) => e.type === "system.bus.peer_dispatch_received",
+      (e) => e.type === "system.bus.peer-dispatch-received",
     );
     expect(betaVisibility).toHaveLength(0);
   });
@@ -436,7 +436,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
     // No visibility event.
     expect(
       beta.runtime.published.filter(
-        (e) => e.type === "system.bus.peer_dispatch_received",
+        (e) => e.type === "system.bus.peer-dispatch-received",
       ),
     ).toHaveLength(0);
   });
@@ -496,7 +496,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
     expect(stderrOutput).toContain("signer_not_trusted");
     expect(
       beta.runtime.published.filter(
-        (e) => e.type === "system.bus.peer_dispatch_received",
+        (e) => e.type === "system.bus.peer-dispatch-received",
       ),
     ).toHaveLength(0);
   });

--- a/src/adapters/loader.ts
+++ b/src/adapters/loader.ts
@@ -57,7 +57,7 @@
  * It does not publish bus envelopes itself — `src/cortex.ts` (which holds
  * the boot's `MyelinRuntime` + `SystemEventSource`) converts this module's
  * structured `loaded`/`skipped`/`failed` results into
- * `system.plugin.loaded` / `system.plugin.load_failed` envelopes
+ * `system.plugin.loaded` / `system.plugin.load-failed` envelopes
  * (`src/bus/system-events.ts`) and a stderr line each, mirroring the
  * existing renderer-boot-loop convention (`cortex.ts`'s `console.error` +
  * loop, upgraded to a `system.*` event per ADR-0024 §3.3). Keeping the

--- a/src/bus/__tests__/bus-dispatch-listener.test.ts
+++ b/src/bus/__tests__/bus-dispatch-listener.test.ts
@@ -8,7 +8,7 @@
  *      our own publishes are ignored.
  *   3. Verify gate — invalid chain (untrusted signer, malformed
  *      principal, etc.) drops with a stderr log; no visibility event.
- *   4. Valid chain emits `system.bus.peer_dispatch_received` carrying
+ *   4. Valid chain emits `system.bus.peer-dispatch-received` carrying
  *      the peer source + envelope id + correlation id.
  *   5. Idempotent start/stop.
  */
@@ -274,7 +274,7 @@ describe("BusDispatchListener — peer-dispatch filter", () => {
 });
 
 describe("BusDispatchListener — verification gate", () => {
-  test("emits system.bus.peer_dispatch_received on valid peer dispatch", async () => {
+  test("emits system.bus.peer-dispatch-received on valid peer dispatch", async () => {
     const luna = agentFixture({ id: "luna", trust: ["echo"] });
     const echo = agentFixture({
       id: "echo",
@@ -305,7 +305,7 @@ describe("BusDispatchListener — verification gate", () => {
     // Exactly one visibility event published.
     expect(published).toHaveLength(1);
     const event = published[0];
-    expect(event?.type).toBe("system.bus.peer_dispatch_received");
+    expect(event?.type).toBe("system.bus.peer-dispatch-received");
     expect(event?.payload.receiving_agent_id).toBe("luna");
     expect(event?.payload.peer_source).toBe("metafactory.echo.local");
     expect(event?.payload.dispatch_envelope_id).toBe(
@@ -406,7 +406,7 @@ describe("BusDispatchListener — verification gate", () => {
     await drain();
 
     expect(published).toHaveLength(1);
-    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+    expect(published[0]?.type).toBe("system.bus.peer-dispatch-received");
 
     await listener.stop();
   });
@@ -521,7 +521,7 @@ describe("BusDispatchListener — signing posture (TC-1d / #210)", () => {
     // Accepted: the unsigned empty-chain envelope falls through, the listener
     // surfaces exactly one visibility event.
     expect(published).toHaveLength(1);
-    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+    expect(published[0]?.type).toBe("system.bus.peer-dispatch-received");
 
     await listener.stop();
   });
@@ -553,7 +553,7 @@ describe("BusDispatchListener — signing posture (TC-1d / #210)", () => {
     await drain();
 
     expect(published).toHaveLength(1);
-    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+    expect(published[0]?.type).toBe("system.bus.peer-dispatch-received");
 
     await listener.stop();
   });
@@ -604,7 +604,7 @@ describe("BusDispatchListener — signing posture (TC-1d / #210)", () => {
 
     // Passed the reject gate despite enforce: re-signed traffic surfaces.
     expect(published).toHaveLength(1);
-    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+    expect(published[0]?.type).toBe("system.bus.peer-dispatch-received");
 
     await listener.stop();
   });

--- a/src/bus/__tests__/envelope-type-no-underscore.test.ts
+++ b/src/bus/__tests__/envelope-type-no-underscore.test.ts
@@ -1,0 +1,157 @@
+/**
+ * cortex#1935 — REGRESSION GATE: no underscore in a bus-envelope `type` literal.
+ *
+ * ## The bug this locks out
+ *
+ * The vendored myelin envelope schema (`src/bus/myelin/vendor/envelope.schema.json`)
+ * pins `/type` to `^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$` — HYPHENS only, no
+ * underscores. `validateEnvelope` runs on the SUBSCRIBER (delivery) side, so an
+ * underscore-typed `system.*` envelope PUBLISHES without error and is then
+ * **silently dropped** by every standard push-mode subscriber. A publisher that
+ * emits `system.bus.peer_dispatch_received` looks healthy in isolation and never
+ * reaches a soul. That is exactly how the F-6 / gateway-observability visibility
+ * events shipped dark until #1935, and how signal's U2.x overlay shipped dead
+ * (cortex#1467). Unit fakes never touch AJV, so nothing catches it.
+ *
+ * ## What this gate scans
+ *
+ * Every NON-TEST source file under `src/`, for string literals that occupy a
+ * `type:` construction slot or a `.type ===` / `.type !==` matcher slot AND look
+ * like a dotted bus-envelope type (`root.segment[.segment…]`). Each such literal
+ * MUST satisfy the vendored schema's `/type` pattern (loaded from the schema file
+ * itself, so the gate can never drift from the real contract).
+ *
+ * ## Why it does not false-positive on non-envelope `type:` fields
+ *
+ *   - Single-token discriminated-union tags (`task_started`, `gate_verdict`,
+ *     `user_message`, `tool_use`, `principal_requeue`, …) have NO `.`, so they
+ *     never match the dotted-literal regex. These are internal runner / brain /
+ *     event-processor / websocket union tags — deliberately underscore-cased and
+ *     out of scope (they never become a bus envelope `type`).
+ *   - `iteration.*` (`iteration.detail_updated`, `iteration.state_changed`) is
+ *     the Mission-Control WebSocket NOTIFICATION namespace — broadcast via
+ *     `wsRegistry.broadcast(...)` in `src/surface/mc/notifications.ts`, never
+ *     `buildBaseEnvelope` / the myelin bus. It is the ONE dotted, underscore-
+ *     bearing namespace that is legitimately non-envelope, so it is the sole
+ *     documented exclusion below. Adding a namespace here is a conscious,
+ *     reviewable act — the safe direction (a real bus family is never silently
+ *     skipped).
+ *   - TEST files are excluded: negative tests intentionally construct
+ *     underscore-typed envelopes to prove `validateEnvelope` REJECTS them
+ *     (e.g. `signal-transport-envelopes.test.ts`, the `toUnderscoreType` flip).
+ *     Enforcing the pattern there would flag the very assertions that protect us.
+ *
+ * If this test fails, a publisher (or a subscriber matcher) is using an
+ * underscore in a bus-envelope type. Rename the leaf to hyphens at EVERY
+ * publisher AND matcher (a publisher-only rename just relocates the silent drop),
+ * or — if the literal is genuinely a non-envelope internal `type` — add its
+ * dotted namespace to `NON_ENVELOPE_DOTTED_NAMESPACES` with a one-line rationale.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Glob } from "bun";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC_ROOT = join(import.meta.dir, "..", "..");
+const SCHEMA_PATH = join(
+  SRC_ROOT,
+  "bus",
+  "myelin",
+  "vendor",
+  "envelope.schema.json",
+);
+
+/**
+ * Dotted `type:` namespaces that are NOT bus envelopes and may legitimately
+ * carry underscores. Keep this list minimal + rationale'd — every entry is an
+ * exemption from the silent-drop gate.
+ */
+const NON_ENVELOPE_DOTTED_NAMESPACES: readonly {
+  prefix: string;
+  why: string;
+}[] = [
+  {
+    prefix: "iteration.",
+    why: "Mission-Control WebSocket notification tags (wsRegistry.broadcast in src/surface/mc/notifications.ts) — never buildBaseEnvelope / the myelin bus.",
+  },
+];
+
+/** The vendored schema's `/type` pattern — the single source of truth. */
+function loadSchemaTypePattern(): RegExp {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8")) as {
+    properties?: { type?: { pattern?: string } };
+  };
+  const pattern = schema.properties?.type?.pattern;
+  if (!pattern) {
+    throw new Error(
+      `envelope.schema.json has no properties.type.pattern — cannot anchor the gate`,
+    );
+  }
+  return new RegExp(pattern);
+}
+
+/**
+ * Matches a dotted lowercase string literal in a `type:` construction slot or a
+ * `.type ===` / `.type !==` matcher slot. Requires at least one `.` so single-
+ * token union tags are excluded. Segments may contain `_`/`-` so we still SEE an
+ * underscore-typed literal (and then reject it against the schema pattern).
+ */
+const DOTTED_TYPE_LITERAL =
+  /(?:\btype:\s*|\.type\s*[!=]==?\s*)"([a-z][a-z0-9_-]*(?:\.[a-z0-9][a-z0-9_-]*)+)"/g;
+
+function isExcluded(literal: string): boolean {
+  return NON_ENVELOPE_DOTTED_NAMESPACES.some((n) => literal.startsWith(n.prefix));
+}
+
+function collectSources(): string[] {
+  const glob = new Glob("**/*.ts");
+  const files: string[] = [];
+  for (const rel of glob.scanSync({ cwd: SRC_ROOT })) {
+    // Exclude test files + fixtures: negative tests intentionally use bad types.
+    if (rel.includes("__tests__/")) continue;
+    if (rel.endsWith(".test.ts") || rel.endsWith(".test.tsx")) continue;
+    files.push(rel);
+  }
+  return files.sort();
+}
+
+describe("cortex#1935 — no underscore in a bus-envelope type literal", () => {
+  const typePattern = loadSchemaTypePattern();
+
+  it("the vendored schema still forbids underscores in a type segment", () => {
+    // Guards the guard: if the schema is ever relaxed to allow `_`, this gate
+    // silently becomes a no-op. Pin the property we depend on.
+    expect(typePattern.test("system.bus.peer-dispatch-received")).toBe(true);
+    expect(typePattern.test("system.bus.peer_dispatch_received")).toBe(false);
+  });
+
+  it("every dotted `type:` / `.type ===` literal in non-test src is schema-valid", () => {
+    const offenders: string[] = [];
+
+    for (const rel of collectSources()) {
+      const text = readFileSync(join(SRC_ROOT, rel), "utf8");
+      const lines = text.split("\n");
+      lines.forEach((line, i) => {
+        for (const m of line.matchAll(DOTTED_TYPE_LITERAL)) {
+          const literal = m[1]!;
+          if (isExcluded(literal)) continue;
+          if (!typePattern.test(literal)) {
+            offenders.push(`  ${rel}:${i + 1}  "${literal}"`);
+          }
+        }
+      });
+    }
+
+    if (offenders.length > 0) {
+      throw new Error(
+        `Found ${offenders.length} envelope-type literal(s) violating the vendored ` +
+          `schema /type pattern (underscores are silently dropped on delivery — ` +
+          `cortex#1935). Rename the leaf to hyphens at EVERY publisher AND matcher, ` +
+          `or exempt a genuinely non-envelope namespace in ` +
+          `NON_ENVELOPE_DOTTED_NAMESPACES:\n${offenders.join("\n")}`,
+      );
+    }
+    expect(offenders.length).toBe(0);
+  });
+});

--- a/src/bus/__tests__/notify-discord.test.ts
+++ b/src/bus/__tests__/notify-discord.test.ts
@@ -73,7 +73,7 @@ async function flush() {
 }
 
 const lastNotify = (published: Envelope[]) =>
-  published.find((e) => e.type === "system.bus.notify_discord")?.payload;
+  published.find((e) => e.type === "system.bus.notify-discord")?.payload;
 
 // ===========================================================================
 

--- a/src/bus/__tests__/reflex-activation-listener.test.ts
+++ b/src/bus/__tests__/reflex-activation-listener.test.ts
@@ -332,7 +332,7 @@ describe("ReflexActivationListener.handleFired", () => {
     expect(await dedup.seen("decision-123")).toBe(true);
 
     const vis = ctrl.published.find(
-      (e) => e.type === "system.bus.reflex_activation_dispatched",
+      (e) => e.type === "system.bus.reflex-activation-dispatched",
     );
     expect(vis).toBeDefined();
     const vp = vis!.payload;
@@ -366,7 +366,7 @@ describe("ReflexActivationListener.handleFired", () => {
     expect(decision).toEqual({ kind: "ack" });
     expect(ctrl.onSubject).toHaveLength(0);
     const fail = ctrl.published.find(
-      (e) => e.type === "system.bus.reflex_activation_failed",
+      (e) => e.type === "system.bus.reflex-activation-failed",
     );
     expect(fail).toBeDefined();
     expect((fail!.payload).reason).toBe("unknown_target");
@@ -383,7 +383,7 @@ describe("ReflexActivationListener.handleFired", () => {
     expect(decision.kind).toBe("term");
     expect(ctrl.onSubject).toHaveLength(0);
     expect(
-      ctrl.published.some((e) => e.type === "system.bus.reflex_activation_failed"),
+      ctrl.published.some((e) => e.type === "system.bus.reflex-activation-failed"),
     ).toBe(true);
   });
 
@@ -410,7 +410,7 @@ describe("ReflexActivationListener.handleFired", () => {
     expect(decision).toEqual({ kind: "ack" });
     expect(await dedup.seen("decision-123")).toBe(false);
     const fail = ctrl.published.find(
-      (e) => e.type === "system.bus.reflex_activation_failed",
+      (e) => e.type === "system.bus.reflex-activation-failed",
     );
     expect(fail).toBeDefined();
     expect((fail!.payload).reason as string).toContain(
@@ -456,7 +456,7 @@ describe("ReflexActivationListener.handleFired", () => {
     expect(ctrl.onSubject).toHaveLength(0); // no bus re-emit
     expect(await dedup.seen("decision-123")).toBe(true);
     const vis = ctrl.published.find(
-      (e) => e.type === "system.bus.reflex_activation_dispatched",
+      (e) => e.type === "system.bus.reflex-activation-dispatched",
     );
     expect((vis!.payload).via).toBe("handler");
   });
@@ -472,7 +472,7 @@ describe("ReflexActivationListener.handleFired", () => {
     expect(decision).toEqual({ kind: "ack" });
     expect(await dedup.seen("decision-123")).toBe(false);
     const fail = ctrl.published.find(
-      (e) => e.type === "system.bus.reflex_activation_failed",
+      (e) => e.type === "system.bus.reflex-activation-failed",
     );
     expect((fail!.payload).reason as string).toContain("handler:");
   });
@@ -500,7 +500,7 @@ describe("ReflexActivationListener.handleFired", () => {
     expect(decision).toEqual({ kind: "ack" });
     expect(ctrl.onSubject).toHaveLength(0);
     const fail = ctrl.published.find(
-      (e) => e.type === "system.bus.reflex_activation_failed",
+      (e) => e.type === "system.bus.reflex-activation-failed",
     );
     expect((fail!.payload).reason as string).toContain(
       "unknown_handler",
@@ -574,7 +574,7 @@ describe("ReflexActivationListener.handleFired — author trust gate", () => {
     expect(ctrl.onSubject).toHaveLength(0); // no CC dispatch
     expect(await dedup.seen("decision-123")).toBe(true); // marked → redelivery re-skips
 
-    const vis = ctrl.published.find((e) => e.type === "system.bus.reflex_activation_skipped");
+    const vis = ctrl.published.find((e) => e.type === "system.bus.reflex-activation-skipped");
     expect(vis).toBeDefined();
     const vp = vis!.payload;
     expect(vp.reason).toBe("author_trusted");
@@ -582,7 +582,7 @@ describe("ReflexActivationListener.handleFired — author trust gate", () => {
     expect(vp.target).toBe("@jc/sage-pr-review");
     expect(vp.capability).toBe("code-review.generic");
     // It must NOT look like a failure.
-    expect(ctrl.published.some((e) => e.type === "system.bus.reflex_activation_failed")).toBe(false);
+    expect(ctrl.published.some((e) => e.type === "system.bus.reflex-activation-failed")).toBe(false);
   });
 
   test("untrusted author → dispatches the review normally", async () => {
@@ -595,8 +595,8 @@ describe("ReflexActivationListener.handleFired — author trust gate", () => {
 
     expect(decision).toEqual({ kind: "ack" });
     expect(ctrl.onSubject).toHaveLength(1); // CC review dispatched
-    expect(ctrl.published.some((e) => e.type === "system.bus.reflex_activation_skipped")).toBe(false);
-    expect(ctrl.published.some((e) => e.type === "system.bus.reflex_activation_dispatched")).toBe(true);
+    expect(ctrl.published.some((e) => e.type === "system.bus.reflex-activation-skipped")).toBe(false);
+    expect(ctrl.published.some((e) => e.type === "system.bus.reflex-activation-dispatched")).toBe(true);
   });
 
   test("audit publish fails AFTER author match → dedup NOT marked, re-fireable", async () => {
@@ -624,7 +624,7 @@ describe("ReflexActivationListener.handleFired — author trust gate", () => {
     await listener.handleFired(firedPrEnvelope("MELLANON"), "subj");
 
     expect(ctrl.onSubject).toHaveLength(0);
-    expect(ctrl.published.some((e) => e.type === "system.bus.reflex_activation_skipped")).toBe(true);
+    expect(ctrl.published.some((e) => e.type === "system.bus.reflex-activation-skipped")).toBe(true);
   });
 });
 
@@ -723,7 +723,7 @@ describe("ReflexActivationListener.handleFired — review dispatch (engine:sage)
       title: "Fix bug",
     });
     expect(await dedup.seen("decision-123")).toBe(true);
-    expect(ctrl.published.some((e) => e.type === "system.bus.reflex_activation_dispatched")).toBe(true);
+    expect(ctrl.published.some((e) => e.type === "system.bus.reflex-activation-dispatched")).toBe(true);
   });
 
   test("trusted author → skipped BEFORE any review publish", async () => {
@@ -733,7 +733,7 @@ describe("ReflexActivationListener.handleFired — review dispatch (engine:sage)
     await listener.handleFired(firedReviewablePr({ author: "jcfischer" }), "subj");
 
     expect(ctrl.onSubject).toHaveLength(0);
-    expect(ctrl.published.some((e) => e.type === "system.bus.reflex_activation_skipped")).toBe(true);
+    expect(ctrl.published.some((e) => e.type === "system.bus.reflex-activation-skipped")).toBe(true);
   });
 
   test("non-PR payload → _failed (not-a-reviewable-pr), dedup marked, no publish", async () => {
@@ -746,7 +746,7 @@ describe("ReflexActivationListener.handleFired — review dispatch (engine:sage)
     );
 
     expect(ctrl.onSubject).toHaveLength(0);
-    const fail = ctrl.published.find((e) => e.type === "system.bus.reflex_activation_failed");
+    const fail = ctrl.published.find((e) => e.type === "system.bus.reflex-activation-failed");
     expect(fail).toBeDefined();
     expect((fail!.payload).reason).toBe("review-payload-not-a-reviewable-pr");
     expect(await dedup.seen("decision-123")).toBe(true);
@@ -759,7 +759,7 @@ describe("ReflexActivationListener.handleFired — review dispatch (engine:sage)
     await listener.handleFired(firedReviewablePr({}), "subj");
 
     expect(await dedup.seen("decision-123")).toBe(false);
-    expect(ctrl.published.some((e) => e.type === "system.bus.reflex_activation_failed")).toBe(true);
+    expect(ctrl.published.some((e) => e.type === "system.bus.reflex-activation-failed")).toBe(true);
   });
 
   test("non-reviewable payload + audit publish fails → dedup NOT marked (re-fireable)", async () => {

--- a/src/bus/__tests__/renamed-envelope-types-roundtrip.test.ts
+++ b/src/bus/__tests__/renamed-envelope-types-roundtrip.test.ts
@@ -1,0 +1,185 @@
+/**
+ * cortex#1935 — REAL-SCHEMA round-trip for the renamed `system.*` families.
+ *
+ * ## Why this test exists
+ *
+ * The underscore-typed-envelope bug survived every existing unit test because
+ * those tests assert on FAKE runtimes whose `published[]` arrays are captured
+ * BEFORE the schema is applied — they never call `validateEnvelope`. But
+ * `validateEnvelope` is the SUBSCRIBER-side gate: a real subscriber runs it on
+ * delivery, and an underscore-typed envelope fails the vendored `/type` pattern
+ * and is **silently dropped**. So a green fake-based suite proved nothing about
+ * whether the event would actually be RECEIVED.
+ *
+ * This suite closes that hole for the families #1935 renamed: it drives each
+ * real builder's OUTPUT through the REAL vendored schema (`validateEnvelope`,
+ * `src/bus/myelin/vendor/envelope.schema.json`) and asserts:
+ *
+ *   1. the hyphen-typed envelope PASSES `validateEnvelope` → a subscriber
+ *      receives it (this is the delivery gate; passing it == not dropped);
+ *   2. flipping its type back to the OLD underscore spelling is REJECTED →
+ *      proves the pre-#1935 form was genuinely un-deliverable (the silent drop),
+ *      i.e. the rename is what makes the event reach a subscriber at all.
+ *
+ * One representative per renamed family. If a builder ever regresses its `type`
+ * to an underscore, assertion (1) fails here — not silently in production.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { validateEnvelope } from "../myelin/envelope-validator";
+import type { Envelope } from "../myelin/envelope-validator";
+import {
+  createSystemBusNotifyDiscordEvent,
+  createSystemBusPeerDispatchReceivedEvent,
+  createSystemBusReflexActivationDispatchedEvent,
+  createSystemBusReflexActivationFailedEvent,
+  createSystemBusReflexActivationSkippedEvent,
+  createSystemGatewayRoutingDecisionEvent,
+  createSystemPluginLoadFailedEvent,
+} from "../system-events";
+
+const SOURCE = { principal: "andreas", agent: "cortex", instance: "local" };
+const UUID = "11111111-1111-4111-8111-111111111111";
+
+/** Return a copy of `env` whose `type` has hyphens flipped back to underscores. */
+function toUnderscoreType(env: Envelope): Envelope {
+  return {
+    ...env,
+    type: env.type.replace(/-/g, "_"),
+  };
+}
+
+/**
+ * The renamed families, one representative envelope each. The verifier
+ * self-check (`system.verifier.self-check`) is built inline below because its
+ * only builder (`runVerifierSelfCheck`) needs live signing infrastructure; the
+ * base envelope shape is reproduced field-for-field from `verifier-self-check.ts`.
+ */
+const RENAMED_FAMILIES: readonly { family: string; envelope: Envelope }[] = [
+  {
+    family: "system.bus.peer-dispatch-received",
+    envelope: createSystemBusPeerDispatchReceivedEvent({
+      source: SOURCE,
+      receivingAgentId: "luna",
+      peerSource: "metafactory.echo.local",
+      dispatchEnvelopeId: UUID,
+      receivedAt: new Date("2026-07-14T00:00:00.000Z"),
+    }),
+  },
+  {
+    family: "system.bus.reflex-activation-dispatched",
+    envelope: createSystemBusReflexActivationDispatchedEvent({
+      source: SOURCE,
+      decisionId: "decision-1",
+      target: "@jc/notify-discord",
+      capability: "notify.discord",
+      via: "handler",
+    }),
+  },
+  {
+    family: "system.bus.reflex-activation-failed",
+    envelope: createSystemBusReflexActivationFailedEvent({
+      source: SOURCE,
+      reason: "unknown_target",
+      firedEnvelopeId: UUID,
+    }),
+  },
+  {
+    family: "system.bus.reflex-activation-skipped",
+    envelope: createSystemBusReflexActivationSkippedEvent({
+      source: SOURCE,
+      decisionId: "decision-1",
+      target: "@jc/sage-pr-review",
+      capability: "code-review",
+      reason: "author_trusted",
+      author: "dependabot",
+      firedEnvelopeId: UUID,
+    }),
+  },
+  {
+    family: "system.bus.notify-discord",
+    envelope: createSystemBusNotifyDiscordEvent({
+      source: SOURCE,
+      outcome: "posted",
+      repo: "the-metafactory/cortex",
+    }),
+  },
+  {
+    family: "system.gateway.routing-decision",
+    envelope: createSystemGatewayRoutingDecisionEvent({
+      source: SOURCE,
+      outcome: "routed",
+      platform: "discord",
+      instanceId: "disc-1",
+      agent: "luna",
+      subject: "local.andreas.meta-factory.tasks.@luna.chat",
+    }),
+  },
+  {
+    family: "system.plugin.load-failed",
+    envelope: createSystemPluginLoadFailedEvent({
+      source: SOURCE,
+      bundleName: "metafactory-cortex-renderer-pagerduty",
+      stage: "import",
+      reason: "module not found",
+    }),
+  },
+  {
+    // Reproduces the base shape built in src/bus/verifier-self-check.ts (it
+    // does NOT use the production builders on purpose — self-contained audit).
+    family: "system.verifier.self-check",
+    envelope: {
+      id: UUID,
+      source: "andreas.cortex.self-check",
+      type: "system.verifier.self-check",
+      timestamp: "2026-07-14T00:00:00.000Z",
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 0,
+        frontier_ok: false,
+        model_class: "any",
+      },
+      payload: { note: "cortex#480 boot-time self-check" },
+    } as unknown as Envelope,
+  },
+];
+
+describe("cortex#1935 — renamed system.* families round-trip the real schema", () => {
+  it("covers every family the #1935 rename touched", () => {
+    // Belt against a family being dropped from the table during a future edit.
+    expect(RENAMED_FAMILIES.map((f) => f.family).sort()).toEqual([
+      "system.bus.notify-discord",
+      "system.bus.peer-dispatch-received",
+      "system.bus.reflex-activation-dispatched",
+      "system.bus.reflex-activation-failed",
+      "system.bus.reflex-activation-skipped",
+      "system.gateway.routing-decision",
+      "system.plugin.load-failed",
+      "system.verifier.self-check",
+    ]);
+  });
+
+  for (const { family, envelope } of RENAMED_FAMILIES) {
+    it(`${family}: the builder output has the hyphen type and PASSES validateEnvelope (received, not dropped)`, () => {
+      expect(envelope.type).toBe(family);
+      expect(envelope.type).not.toContain("_");
+
+      const result = validateEnvelope(envelope);
+      if (!result.ok) {
+        // Surface AJV errors so any drift is diagnosable.
+        throw new Error(
+          `validateEnvelope REJECTED canonical ${family}: ${JSON.stringify(result.errors)}`,
+        );
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    it(`${family}: the OLD underscore spelling is REJECTED (proves the pre-#1935 silent drop)`, () => {
+      const bad = toUnderscoreType(envelope);
+      expect(bad.type).toContain("_");
+      expect(validateEnvelope(bad).ok).toBe(false);
+    });
+  }
+});

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -992,9 +992,9 @@ describe("createSystemPluginReloadFailedEvent (cortex#1793, S8)", () => {
     // — no underscores) publishes without error but is SILENTLY DROPPED by
     // every standard push-mode subscriber (`runtime.subscribe()` +
     // `onEnvelope`, via `myelin/subscriber.ts`'s schema check). The
-    // already-shipped sibling `system.plugin.load_failed` (S6, on `main`)
-    // and several older `system.*` families (`system.bus.notify_discord`,
-    // `system.bus.reflex_activation_failed`, `system.gateway.routing_decision`,
+    // already-shipped sibling `system.plugin.load-failed` (S6, on `main`)
+    // and several older `system.*` families (`system.bus.notify-discord`,
+    // `system.bus.reflex-activation-failed`, `system.gateway.routing-decision`,
     // …) still carry this bug — out of scope to mass-fix here (separate,
     // coordinated change), but `reload-failed` is spelled correctly since
     // it ships in THIS slice.

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -6,7 +6,7 @@
  * this cortex's own publish path). Verifies each envelope's
  * `signed_by[]` chain via `verifySignedByChain` (cryptoVerify-gated by
  * whether the receiving agent has an `nkey_pub` declared), then surfaces
- * the receipt as a `system.bus.peer_dispatch_received` visibility event.
+ * the receipt as a `system.bus.peer-dispatch-received` visibility event.
  *
  * **What this slice delivers (B.2a — inbound listener half of B.2):**
  *   - Subscribes via `runtime.onEnvelope` and filters for
@@ -14,7 +14,7 @@
  *     our own publish).
  *   - Verifies the chain (structural always; cryptographic when the
  *     receiving agent has an `nkey_pub`).
- *   - Emits a structured `system.bus.peer_dispatch_received` envelope
+ *   - Emits a structured `system.bus.peer-dispatch-received` envelope
  *     on every valid arrival — principals see "peer X dispatched a task
  *     to us at <time>" on the dashboard / audit trail.
  *   - Drops invalid envelopes with a stderr log carrying the structured

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1826,23 +1826,25 @@ export function createSystemPluginLoadedEvent(
  * **Leaf segment is `reload-failed` (hyphen), NOT `reload_failed`.** The
  * vendored envelope schema's `/type` pattern
  * (`^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`, `envelope.schema.json`)
- * forbids underscores in a type segment. `system.plugin.load-failed` (S6,
- * already on `main`) and several older `system.*` families
- * (`system.bus.notify-discord`, `system.bus.reflex-activation-failed`,
- * `system.gateway.routing-decision`, …) violate this pattern — the schema
- * check only runs on the SUBSCRIBER side (`myelin/subscriber.ts`), so a
- * violating envelope publishes without error and is then **silently
- * dropped by every standard push-mode subscriber** (`runtime.subscribe()` +
- * `onEnvelope`) — confirmed via a live NATS round-trip while building S8's
- * `system.plugin.control-request`/`-response` pair (the exact bug this
- * comment documents: the first draft used `control_request`/`control_response`
- * and every response silently vanished). `unloaded` has no segment needing
- * a separator fix; `reload-failed` is spelled correctly here rather than
- * inheriting the sibling's already-broken convention. `load_failed` is left
- * as-is — it already shipped on `main` via S6/#1927, and renaming a shipped
- * wire type is a separate, coordinated fix (flagged, not bundled into this
- * unrelated slice); every OTHER pre-existing underscore violation across
- * `system.*` is the same systemic gap and is out of scope here too.
+ * forbids underscores in a type segment. The schema check only runs on the
+ * SUBSCRIBER side (`myelin/subscriber.ts`), so an underscore-typed envelope
+ * publishes without error and is then **silently dropped by every standard
+ * push-mode subscriber** (`runtime.subscribe()` + `onEnvelope`) — confirmed via
+ * a live NATS round-trip while building S8's
+ * `system.plugin.control-request`/`-response` pair (the exact bug: the first
+ * draft used `control_request`/`control_response` and every response silently
+ * vanished). `unloaded` has no segment needing a separator fix; `reload-failed`
+ * is spelled correctly here.
+ *
+ * A cohort of earlier `system.*` families shipped with the underscore bug —
+ * `system.plugin.load_failed` (S6/#1927), `system.bus.notify_discord`,
+ * `system.bus.peer_dispatch_received`, `system.bus.reflex_activation_*`,
+ * `system.gateway.routing_decision`, `system.verifier.self_check`. cortex#1935
+ * was the coordinated fix that renamed every one of those leaves to hyphens
+ * (this file now emits `system.plugin.load-failed`, `system.bus.notify-discord`,
+ * …), and added the `envelope-type-no-underscore` regression gate +
+ * `renamed-envelope-types-roundtrip` real-schema test so the class cannot
+ * silently recur. Any new `system.*` leaf MUST use hyphens.
  *
  * `createSystemPluginUnloadedEvent` fires on a SUCCESSFUL runtime detach
  * (`cortex plugin unload`, or a reconcile-driven detach of a bundle removed

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -479,7 +479,7 @@ export function createSystemAccessFilteredEvent(
 }
 
 // ---------------------------------------------------------------------------
-// system.bus.peer_dispatch_received — IAW Phase B.2a visibility event
+// system.bus.peer-dispatch-received — IAW Phase B.2a visibility event
 // ---------------------------------------------------------------------------
 
 export interface SystemBusPeerDispatchReceivedOpts {
@@ -490,7 +490,7 @@ export interface SystemBusPeerDispatchReceivedOpts {
    * Multi-agent stacks may run one listener per agent (the JSDoc on
    * `BusDispatchListener.receivingAgentId` explicitly contemplates
    * `peer-router` agents and per-agent listeners). Without this
-   * field, a dashboard subscribed to `system.bus.peer_dispatch_received`
+   * field, a dashboard subscribed to `system.bus.peer-dispatch-received`
    * can't answer "who in our stack received this" (Echo cortex#203
    * round 1).
    */
@@ -539,7 +539,7 @@ export function createSystemBusPeerDispatchReceivedEvent(
   opts: SystemBusPeerDispatchReceivedOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.bus.peer_dispatch_received",
+    type: "system.bus.peer-dispatch-received",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -555,7 +555,7 @@ export function createSystemBusPeerDispatchReceivedEvent(
 }
 
 // ---------------------------------------------------------------------------
-// system.bus.reflex_activation_dispatched / _failed — F-6 visibility events
+// system.bus.reflex-activation-dispatched / -failed — F-6 visibility events
 // ---------------------------------------------------------------------------
 
 interface SystemBusReflexActivationDispatchedBase {
@@ -601,7 +601,7 @@ export type SystemBusReflexActivationDispatchedOpts =
  * F-6 — visibility event emitted when `ReflexActivationListener` resolves a
  * reflex `reflex.activation.fired` event and re-emits it as a `tasks.*`
  * dispatch the existing executor runs. Parity with
- * `system.bus.peer_dispatch_received`: bookkeeping about our own stack,
+ * `system.bus.peer-dispatch-received`: bookkeeping about our own stack,
  * sovereignty defaults to local even when the underlying activation carries
  * a different classification (which is preserved on the dispatch itself).
  */
@@ -609,7 +609,7 @@ export function createSystemBusReflexActivationDispatchedEvent(
   opts: SystemBusReflexActivationDispatchedOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.bus.reflex_activation_dispatched",
+    type: "system.bus.reflex-activation-dispatched",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -663,7 +663,7 @@ export function createSystemBusReflexActivationFailedEvent(
   opts: SystemBusReflexActivationFailedOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.bus.reflex_activation_failed",
+    type: "system.bus.reflex-activation-failed",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -708,7 +708,7 @@ export interface SystemBusReflexActivationSkippedOpts {
  * DROPS a fired activation because its author is trusted (in the target's
  * configurable `skip_authors`). This is an honest policy SKIP, not a failure:
  * no dispatch, no error, the Decision id is marked (a redelivery re-skips
- * silently). Distinct from `_failed` (which means the bridge could not
+ * silently). Distinct from `-failed` (which means the bridge could not
  * dispatch) so the audit trail distinguishes "we chose not to" from "we
  * could not".
  */
@@ -716,7 +716,7 @@ export function createSystemBusReflexActivationSkippedEvent(
   opts: SystemBusReflexActivationSkippedOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.bus.reflex_activation_skipped",
+    type: "system.bus.reflex-activation-skipped",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -734,7 +734,7 @@ export function createSystemBusReflexActivationSkippedEvent(
 }
 
 // ---------------------------------------------------------------------------
-// system.bus.notify_discord — F-6 downstream code-capability visibility
+// system.bus.notify-discord — F-6 downstream code-capability visibility
 // ---------------------------------------------------------------------------
 
 export interface SystemBusNotifyDiscordOpts {
@@ -763,7 +763,7 @@ export function createSystemBusNotifyDiscordEvent(
   opts: SystemBusNotifyDiscordOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.bus.notify_discord",
+    type: "system.bus.notify-discord",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -1599,7 +1599,7 @@ export function createSystemDispatchStageEvent(
 }
 
 // ---------------------------------------------------------------------------
-// system.gateway.routing_decision — cortex#596 gateway inbound observability
+// system.gateway.routing-decision — cortex#596 gateway inbound observability
 // ---------------------------------------------------------------------------
 
 /**
@@ -1624,7 +1624,7 @@ export function createSystemDispatchStageEvent(
  *
  * Two outcomes of ONE decision, so they share a single envelope type
  * discriminated on `outcome` — the same shape the sibling
- * `system.bus.notify_discord` (`posted`/`failed`/`skipped`) and
+ * `system.bus.notify-discord` (`posted`/`failed`/`skipped`) and
  * `system.bus.process` (`started`/`completed`/`failed`) visibility events use,
  * rather than two near-identical `.routed` / `.unroutable` types.
  */
@@ -1666,7 +1666,7 @@ export interface SystemGatewayRoutingDecisionOpts {
 }
 
 /**
- * Construct a `system.gateway.routing_decision` envelope (cortex#596).
+ * Construct a `system.gateway.routing-decision` envelope (cortex#596).
  *
  * The SurfaceGateway is a thin demux in front of the per-stack runners; it
  * carries its own source identity `{principal}.gateway.{instance}` (see
@@ -1684,14 +1684,14 @@ export interface SystemGatewayRoutingDecisionOpts {
  * takes its own `gateway` leaf. `git grep system.gateway` was empty before this
  * event: an unclaimed, natural namespace.
  *
- * Subject convention: `local.{principal}.system.gateway.routing_decision` —
+ * Subject convention: `local.{principal}.system.gateway.routing-decision` —
  * surfaces subscribe to `system.gateway.>` (or the broader `system.>`).
  */
 export function createSystemGatewayRoutingDecisionEvent(
   opts: SystemGatewayRoutingDecisionOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.gateway.routing_decision",
+    type: "system.gateway.routing-decision",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -1708,7 +1708,7 @@ export function createSystemGatewayRoutingDecisionEvent(
 }
 
 // ---------------------------------------------------------------------------
-// system.plugin.load_failed / system.plugin.loaded — cortex#1792 (S6,
+// system.plugin.load-failed / system.plugin.loaded — cortex#1792 (S6,
 // ADR-0024 D1/D3/D5)
 // ---------------------------------------------------------------------------
 
@@ -1756,15 +1756,15 @@ export interface SystemPluginLoadFailedOpts {
 }
 
 /**
- * Construct a `system.plugin.load_failed` envelope. Subject convention:
- * `local.{principal}.system.plugin.load_failed` — surfaces subscribe to
+ * Construct a `system.plugin.load-failed` envelope. Subject convention:
+ * `local.{principal}.system.plugin.load-failed` — surfaces subscribe to
  * `system.plugin.>` (or the broader `system.>`).
  */
 export function createSystemPluginLoadFailedEvent(
   opts: SystemPluginLoadFailedOpts,
 ): Envelope {
   return buildBaseEnvelope({
-    type: "system.plugin.load_failed",
+    type: "system.plugin.load-failed",
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
@@ -1816,7 +1816,7 @@ export function createSystemPluginLoadedEvent(
 
 /**
  * S8's runtime-lifecycle twins of the S6 boot-time `system.plugin.loaded` /
- * `system.plugin.load_failed` pair, above. Same `system.plugin.*` family
+ * `system.plugin.load-failed` pair, above. Same `system.plugin.*` family
  * (never a separate `system.adapter.*`/`system.renderer.*` namespace — the
  * SCOPE AMENDED comment on cortex#1793 is explicit that S8 stays consistent
  * with S6's naming rather than forking one), same secret-free reason-string
@@ -1826,10 +1826,10 @@ export function createSystemPluginLoadedEvent(
  * **Leaf segment is `reload-failed` (hyphen), NOT `reload_failed`.** The
  * vendored envelope schema's `/type` pattern
  * (`^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$`, `envelope.schema.json`)
- * forbids underscores in a type segment. `system.plugin.load_failed` (S6,
+ * forbids underscores in a type segment. `system.plugin.load-failed` (S6,
  * already on `main`) and several older `system.*` families
- * (`system.bus.notify_discord`, `system.bus.reflex_activation_failed`,
- * `system.gateway.routing_decision`, …) violate this pattern — the schema
+ * (`system.bus.notify-discord`, `system.bus.reflex-activation-failed`,
+ * `system.gateway.routing-decision`, …) violate this pattern — the schema
  * check only runs on the SUBSCRIBER side (`myelin/subscriber.ts`), so a
  * violating envelope publishes without error and is then **silently
  * dropped by every standard push-mode subscriber** (`runtime.subscribe()` +

--- a/src/bus/verifier-self-check.ts
+++ b/src/bus/verifier-self-check.ts
@@ -81,7 +81,7 @@ export async function runVerifierSelfCheck(
   const base = {
     id: crypto.randomUUID(),
     source: `${opts.principalId}.cortex.self-check`,
-    type: "system.verifier.self_check" as const,
+    type: "system.verifier.self-check" as const,
     timestamp: new Date().toISOString(),
     sovereignty: {
       classification: "local" as const,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2794,7 +2794,7 @@ export async function startCortex(
   // IAW Phase B.2a (refs cortex#114) — inbound peer-dispatch listener.
   // Subscribes via the runtime's onEnvelope fan-out, filters for
   // `dispatch.task.dispatched` envelopes from non-self sources, runs
-  // verifySignedByChain, emits `system.bus.peer_dispatch_received`
+  // verifySignedByChain, emits `system.bus.peer-dispatch-received`
   // visibility envelopes on valid arrivals. Listener is bound to the
   // FIRST registered agent today — multi-agent stacks may eventually
   // want one listener per agent (each receiver's `trust:` list is
@@ -3158,7 +3158,7 @@ export async function startCortex(
   // `loadExternalPlugins` does the same for discovery issues). Boot used to
   // ALSO `console.error`/`console.log` the same failed/loaded outcomes here,
   // duplicating every plugin outcome in boot logs. This loop's job is only
-  // the structured bus event (`system.plugin.load_failed`/`.loaded`) —
+  // the structured bus event (`system.plugin.load-failed`/`.loaded`) —
   // logging stays the loader's job. `skipped` is the one outcome the loader
   // never logs (an off-by-default gate skip isn't a failure worth a stderr
   // line), so its `console.log` here remains the single site for it.
@@ -3182,7 +3182,7 @@ export async function startCortex(
       );
     } catch (err) {
       process.stderr.write(
-        `cortex: failed to publish system.plugin.load_failed for "${failure.bundleName}": ${err instanceof Error ? err.message : String(err)}\n`,
+        `cortex: failed to publish system.plugin.load-failed for "${failure.bundleName}": ${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
   }

--- a/src/gateway/__tests__/bus-inbound-sink.test.ts
+++ b/src/gateway/__tests__/bus-inbound-sink.test.ts
@@ -426,7 +426,7 @@ describe("BusInboundSink", () => {
     expect(calls[0]?.subjectPrincipal).toBeUndefined();
   });
 
-  // ── cortex#596: system.gateway.routing_decision bus events ──────────────────
+  // ── cortex#596: system.gateway.routing-decision bus events ──────────────────
   //
   // The sink emits a structured routing-decision event on both branches so
   // signal + Mission Control observe the gateway's demux decision instead of
@@ -448,7 +448,7 @@ describe("BusInboundSink", () => {
     return { runtime, published };
   }
 
-  test("routed publish → emits system.gateway.routing_decision { outcome: routed, stack, subject }", async () => {
+  test("routed publish → emits system.gateway.routing-decision { outcome: routed, stack, subject }", async () => {
     const { runtime, published } = makeCapturingRuntime();
     const { sink } = makeSink(
       [{ published: true, subject: "local.andreas.meta-factory.tasks.@luna.chat" }],
@@ -458,7 +458,7 @@ describe("BusInboundSink", () => {
     await sink.publish(makeDecision(), makeMsg());
 
     const evt = published.find(
-      (e) => e.type === "system.gateway.routing_decision",
+      (e) => e.type === "system.gateway.routing-decision",
     );
     expect(evt).toBeDefined();
     const payload = evt!.payload;
@@ -472,7 +472,7 @@ describe("BusInboundSink", () => {
     expect(payload.reason).toBeUndefined();
   });
 
-  test("refused publish → emits system.gateway.routing_decision { outcome: unroutable, reason }", async () => {
+  test("refused publish → emits system.gateway.routing-decision { outcome: unroutable, reason }", async () => {
     const { runtime, published } = makeCapturingRuntime();
     // Silence the expected stderr refusal breadcrumb.
     const originalWrite = process.stderr.write.bind(process.stderr);
@@ -495,7 +495,7 @@ describe("BusInboundSink", () => {
     }
 
     const evt = published.find(
-      (e) => e.type === "system.gateway.routing_decision",
+      (e) => e.type === "system.gateway.routing-decision",
     );
     expect(evt).toBeDefined();
     const payload = evt!.payload;

--- a/src/gateway/__tests__/gateway-unroutable-emit.test.ts
+++ b/src/gateway/__tests__/gateway-unroutable-emit.test.ts
@@ -1,12 +1,12 @@
 /**
- * cortex#596 — no-binding-match routing_decision emit tests (TDD Red→Green).
+ * cortex#596 — no-binding-match routing-decision emit tests (TDD Red→Green).
  *
  * Covers the UPSTREAM unroutable case PR #1667 left as stdout-only: an inbound
  * that matches NO binding. Mirrors the emit-assertion shape of
  * `bus-inbound-sink.test.ts` (the publish-refusal twin).
  *
  * Tests:
- *   1. no-binding inbound → emits system.gateway.routing_decision
+ *   1. no-binding inbound → emits system.gateway.routing-decision
  *      { outcome: "unroutable", reason, platform, instanceId } and NO agent.
  *   2. source undefined → no emit, no throw (optional-dep guard).
  *   3. runtime undefined → no emit, no throw.
@@ -74,7 +74,7 @@ const REASON = 'no binding for discord guildId "111222333"';
 // =============================================================================
 
 describe("emitUnroutableRoutingDecision", () => {
-  test("no-binding inbound → emits system.gateway.routing_decision { unroutable, reason }, no agent", () => {
+  test("no-binding inbound → emits system.gateway.routing-decision { unroutable, reason }, no agent", () => {
     const { runtime, published } = makeCapturingRuntime();
 
     emitUnroutableRoutingDecision(
@@ -84,7 +84,7 @@ describe("emitUnroutableRoutingDecision", () => {
     );
 
     const evt = published.find(
-      (e) => e.type === "system.gateway.routing_decision",
+      (e) => e.type === "system.gateway.routing-decision",
     );
     expect(evt).toBeDefined();
     const payload = evt!.payload;
@@ -154,7 +154,7 @@ describe("makeEmittingUnroutable", () => {
     expect(baseCalls[0]?.reason).toBe(REASON);
     // …and the event was emitted.
     const evt = published.find(
-      (e) => e.type === "system.gateway.routing_decision",
+      (e) => e.type === "system.gateway.routing-decision",
     );
     expect(evt).toBeDefined();
     expect(evt!.payload.outcome).toBe("unroutable");

--- a/src/gateway/bus-inbound-sink.ts
+++ b/src/gateway/bus-inbound-sink.ts
@@ -104,7 +104,7 @@ export interface BusInboundSinkDeps {
  * `SurfaceGateway.handleInbound` catch-swallow loop) are free to rely on this.
  *
  * cortex#596 — on BOTH branches the sink also emits a structured
- * `system.gateway.routing_decision` bus event (`outcome: "routed"` on success,
+ * `system.gateway.routing-decision` bus event (`outcome: "routed"` on success,
  * `"unroutable"` on refusal) via {@link source}, so signal + Mission Control
  * observe the gateway's demux decision instead of tailing stdout. The emit is
  * fire-and-forget and guarded on the optional runtime/source deps (see
@@ -253,7 +253,7 @@ export class BusInboundSink implements GatewayInboundSink {
   }
 
   /**
-   * cortex#596 — emit a `system.gateway.routing_decision` bus event, the
+   * cortex#596 — emit a `system.gateway.routing-decision` bus event, the
    * structured replacement for the gateway's interim stdout routing hunt-line.
    *
    * Fire-and-forget and guarded on BOTH optional deps: the gateway may run
@@ -281,7 +281,7 @@ export class BusInboundSink implements GatewayInboundSink {
     // defence-in-depth so a runtime contract change can't crash the sink.
     void runtime.publish(env).catch((err: unknown) => {
       process.stderr.write(
-        `[bus-inbound-sink] publish(system.gateway.routing_decision) failed — ` +
+        `[bus-inbound-sink] publish(system.gateway.routing-decision) failed — ` +
           `${err instanceof Error ? err.message : String(err)}\n`,
       );
     });

--- a/src/gateway/gateway-unroutable-emit.ts
+++ b/src/gateway/gateway-unroutable-emit.ts
@@ -1,5 +1,5 @@
 /**
- * cortex#596 — no-binding-match `system.gateway.routing_decision` emit.
+ * cortex#596 — no-binding-match `system.gateway.routing-decision` emit.
  *
  * PR #1667 added the routed / publish-refusal routing-decision event, emitted
  * from {@link BusInboundSink} once an inbound has MATCHED a binding. The OTHER
@@ -13,7 +13,7 @@
  * gateway boot path (`start-gateway.ts`) already holds the `runtime` + `source`
  * it uses to build {@link BusInboundSink}, so it injects an `onUnroutable` that
  * (1) preserves the existing `console.warn` breadcrumb (the fallback when the
- * bus is down) and (2) fire-and-forget emits a `system.gateway.routing_decision`
+ * bus is down) and (2) fire-and-forget emits a `system.gateway.routing-decision`
  * with `outcome: "unroutable"` and `reason` = the `unroutableReason()` string.
  * `SurfaceGateway` itself stays free of any bus/system-event coupling — it keeps
  * its injected-interface design; the bus knowledge lives only here + at the boot
@@ -61,7 +61,7 @@ export interface GatewayUnroutableEmitDeps {
 }
 
 /**
- * Fire-and-forget emit a `system.gateway.routing_decision` for a NO-BINDING
+ * Fire-and-forget emit a `system.gateway.routing-decision` for a NO-BINDING
  * unroutable inbound. Guarded on both optional deps and on the runtime actually
  * exposing `publish`; on any miss it returns without emitting. Never throws —
  * the caller runs inside `SurfaceGateway`'s never-throw `onUnroutable` contract.
@@ -95,7 +95,7 @@ export function emitUnroutableRoutingDecision(
   // defence-in-depth so a runtime contract change can't crash the caller.
   void runtime.publish(env).catch((err: unknown) => {
     process.stderr.write(
-      `[surface-gateway] publish(system.gateway.routing_decision) failed — ` +
+      `[surface-gateway] publish(system.gateway.routing-decision) failed — ` +
         `${err instanceof Error ? err.message : String(err)}\n`,
     );
   });

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -274,7 +274,7 @@ export async function startGatewayIfEnabled(
     : undefined;
 
   // cortex#596 — on the LIVE path, decorate `onUnroutable` so a NO-BINDING-match
-  // inbound emits a `system.gateway.routing_decision { outcome: "unroutable" }`
+  // inbound emits a `system.gateway.routing-decision { outcome: "unroutable" }`
   // bus event (the signal/MC-consumable replacement for the stdout hunt-line),
   // NOT just the `console.warn` breadcrumb. This is the upstream twin of the
   // publish-refusal emit `BusInboundSink` already does (that case matched a

--- a/src/gateway/surface-gateway.ts
+++ b/src/gateway/surface-gateway.ts
@@ -642,7 +642,7 @@ export class LoggingInboundSink implements GatewayInboundSink {
  * so the composition-root's bus-emitting `onUnroutable` (see
  * `makeEmittingUnroutable` in `gateway-unroutable-emit.ts`) can PRESERVE the
  * exact stdout breadcrumb — it stays the fallback when the bus is down — while
- * ALSO emitting the structured `system.gateway.routing_decision` event. Reusing
+ * ALSO emitting the structured `system.gateway.routing-decision` event. Reusing
  * this function keeps the two in lockstep instead of duplicating the format.
  *
  * `onUnroutable` must never throw; `console.warn` does not.

--- a/src/surface/mc/__tests__/observability-renderer.test.ts
+++ b/src/surface/mc/__tests__/observability-renderer.test.ts
@@ -377,8 +377,8 @@ describe("#1661 — familyForType routes the cortex-local families", () => {
 
   it("EXCLUDES high-volume siblings by design (narrow type set, not a prefix)", () => {
     expect(familyForType("system.access.allowed")).toBeNull();
-    expect(familyForType("system.bus.peer_dispatch_received")).toBeNull();
-    expect(familyForType("system.bus.notify_discord")).toBeNull();
+    expect(familyForType("system.bus.peer-dispatch-received")).toBeNull();
+    expect(familyForType("system.bus.notify-discord")).toBeNull();
     expect(familyForType("system.dispatch.dead_letter")).toBeNull();
   });
 });

--- a/src/surface/mc/projection/observability-renderer.ts
+++ b/src/surface/mc/projection/observability-renderer.ts
@@ -96,7 +96,7 @@ export const OBSERVABILITY_PROJECTION_SUBJECTS: string[] = [
   // #1661 (MC folds) — the cortex-LOCAL families. Subscribed to the EXACT
   // subjects the folded types publish on (`local.{principal}[.{stack}].{type}`),
   // NOT broad `system.access.>` / `system.bus.>` prefixes — so high-volume
-  // sibling types (`system.access.allowed`, `system.bus.peer_dispatch_received`)
+  // sibling types (`system.access.allowed`, `system.bus.peer-dispatch-received`)
   // never reach the renderer's dispatch loop at all. `familyForType` remains the
   // authoritative belt-filter for anything that does arrive.
   // access:
@@ -143,7 +143,7 @@ export function familyForType(type: string): ObservabilityFamily | null {
   // this renderer READS these system envelopes; the producer emit sites in
   // bus/system-events.ts are OUT of scope and untouched. Routed by EXACT type,
   // not broad prefix — sibling types like `system.access.allowed` (high-volume)
-  // or `system.bus.peer_dispatch_received` stay OUT of the fold by design
+  // or `system.bus.peer-dispatch-received` stay OUT of the fold by design
   // (decision B is 3 SECTIONS, not "everything under the prefix"). Widening a
   // family's type set is a deliberate follow-up, never an accidental default.
   //   access   = system.access.{denied,filtered} + system.admission.{throttled,degraded}


### PR DESCRIPTION
Fixes #1935 (bug). The vendored envelope `type` schema allows hyphens only per dot-segment, and `validateEnvelope` runs on **delivery** — so several merged `system.*` families that used underscores **published cleanly but were silently dropped by every compliant subscriber**. Found during S8 (#1793) against a real `nats-server`.

## Renamed families (underscore leaf → hyphen), publisher + every matcher in one change
`peer_dispatch_received`, `reflex_activation_dispatched/_failed/_skipped`, `notify_discord`, `routing_decision`, `load_failed`, `self_check`. The enum of all 25 emitted envelope `type:` literals in non-test src is now **100% hyphen-only**.

## Correctly NOT touched (verified non-envelope)
NATS **subjects** (`…leaf_connect` — legal in subjects; the envelope body type is already `…leaf-connect`), an HTTP JSON error string, MC WebSocket tags (`iteration.*`), a never-emitted hypothetical, and single-token union discriminants.

## Regression gate (new)
`envelope-type-no-underscore.test.ts` — scans non-test src for dotted `type:`/`.type ===` literals, asserts each matches the vendored schema `/type` pattern (loaded FROM the schema, can't drift). False-positive-safe (requires `.`, exempts documented `iteration.*`, excludes tests). Proven to bite.

## Real-schema round-trip (new)
`renamed-envelope-types-roundtrip.test.ts` — one per family through the REAL `validateEnvelope`: hyphen received, underscore-flip rejected. Unit fakes skipped `validateEnvelope` — why this wasn't caught.

## Residual risk: LOW
Underscore forms were never delivered → no working consumer of old names → renaming can only add delivery, never regress.

## Gate
`bun test src/bus src/common src/runner src/surface src/adapters` **6950/0** · tsc 0 · lint:errors clean · carveouts PASS · hygiene 0 · new gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)