### PR TITLE
fix(brain): resolve arc pkg-repos dir via XDG-mirror resolver (#1988)

### DIFF
--- a/src/common/config/__tests__/arc-pack-repos-dir.test.ts
+++ b/src/common/config/__tests__/arc-pack-repos-dir.test.ts
@@ -1,0 +1,148 @@
+/**
+ * cortex#1988 — arc package-repos dir resolver tests (EPIC cortex#1867).
+ *
+ * cortex boots exec-brain packs from `{brainPackBaseDir}/{agentId}`, where the
+ * DEFAULT base must MIRROR arc's own `dataRoot/repos` resolution (arc#287), not
+ * the moved pre-#287 legacy path. The resolver must:
+ *   - resolve the XDG-canonical `~/.local/share/metafactory/arc/repos` on a
+ *     default (multi-tree) migrated box;
+ *   - honor `$XDG_DATA_HOME` (→ `<base>/metafactory/arc/repos`);
+ *   - fall back to legacy `~/.config/metafactory/pkg/repos` ONLY if it exists
+ *     (singleTree / `ARC_CONFIG_ROOT` install — existence-gated);
+ *   - target the canonical path (fresh host / default) when neither exists.
+ *
+ * Every case is hermetic: a scratch `$HOME`, an explicit `env` bag, and all
+ * assertions land under the scratch dir — zero real `~/.local`/`~/.config`
+ * access.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  arcCanonicalPackReposDir,
+  legacyArcPackReposDir,
+  resolveArcPackReposDir,
+} from "../arc-pack-repos-dir";
+
+let home: string;
+
+// Canonical multi-tree (no $XDG_DATA_HOME): ~/.local/share/metafactory/arc/repos.
+function canonicalDefault() {
+  return join(home, ".local", "share", "metafactory", "arc", "repos");
+}
+// Legacy pre-#287 singleTree tree: ~/.config/metafactory/pkg/repos.
+function legacyDir() {
+  return join(home, ".config", "metafactory", "pkg", "repos");
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "b1988-home-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("arcCanonicalPackReposDir (pure computation, no fs)", () => {
+  test("no $XDG_DATA_HOME → ~/.local/share/metafactory/arc/repos", () => {
+    expect(arcCanonicalPackReposDir({ home, env: {} })).toBe(canonicalDefault());
+  });
+
+  test("$XDG_DATA_HOME set → <base>/metafactory/arc/repos", () => {
+    const xdg = join(home, "xdg-data");
+    expect(arcCanonicalPackReposDir({ home, env: { XDG_DATA_HOME: xdg } })).toBe(
+      join(xdg, "metafactory", "arc", "repos"),
+    );
+  });
+
+  test("$XDG_DATA_HOME with a leading ~ is home-expanded", () => {
+    expect(
+      arcCanonicalPackReposDir({ home, env: { XDG_DATA_HOME: "~/custom-data" } }),
+    ).toBe(join(home, "custom-data", "metafactory", "arc", "repos"));
+  });
+
+  test("blank / whitespace-only $XDG_DATA_HOME reads as unset (never a relative dir)", () => {
+    expect(arcCanonicalPackReposDir({ home, env: { XDG_DATA_HOME: "   " } })).toBe(
+      canonicalDefault(),
+    );
+  });
+
+  test("a trailing separator on $XDG_DATA_HOME is normalized away", () => {
+    const xdg = join(home, "xdg-data");
+    expect(
+      arcCanonicalPackReposDir({ home, env: { XDG_DATA_HOME: `${xdg}/` } }),
+    ).toBe(join(xdg, "metafactory", "arc", "repos"));
+  });
+});
+
+describe("legacyArcPackReposDir", () => {
+  test("is ~/.config/metafactory/pkg/repos", () => {
+    expect(legacyArcPackReposDir({ home, env: {} })).toBe(legacyDir());
+  });
+});
+
+describe("resolveArcPackReposDir (existence-gated, mirrors arc dataRoot/repos)", () => {
+  // AC1 — default (multi-tree) migrated box: canonical tree present → canonical.
+  test("default multi-tree box → ~/.local/share/metafactory/arc/repos", () => {
+    mkdirSync(canonicalDefault(), { recursive: true });
+    expect(resolveArcPackReposDir({ home, env: {} })).toBe(canonicalDefault());
+  });
+
+  // AC2 — $XDG_DATA_HOME set → resolves under that base.
+  test("$XDG_DATA_HOME set → resolves under that base", () => {
+    const xdg = join(home, "xdg-data");
+    const expected = join(xdg, "metafactory", "arc", "repos");
+    mkdirSync(expected, { recursive: true });
+    expect(resolveArcPackReposDir({ home, env: { XDG_DATA_HOME: xdg } })).toBe(
+      expected,
+    );
+  });
+
+  // AC3 — only legacy present (singleTree / ARC_CONFIG_ROOT install) → legacy.
+  test("only legacy ~/.config/metafactory/pkg/repos present → legacy (existence-gated)", () => {
+    mkdirSync(legacyDir(), { recursive: true });
+    // Canonical does NOT exist.
+    expect(existsSync(canonicalDefault())).toBe(false);
+    expect(resolveArcPackReposDir({ home, env: {} })).toBe(legacyDir());
+  });
+
+  // Canonical wins over legacy when BOTH exist (canonical is authoritative).
+  test("both present → canonical wins over legacy", () => {
+    mkdirSync(canonicalDefault(), { recursive: true });
+    mkdirSync(legacyDir(), { recursive: true });
+    expect(resolveArcPackReposDir({ home, env: {} })).toBe(canonicalDefault());
+  });
+
+  // Fresh host — neither tree exists → canonical (the default write/read target).
+  test("neither present (fresh host) → canonical default", () => {
+    expect(existsSync(canonicalDefault())).toBe(false);
+    expect(existsSync(legacyDir())).toBe(false);
+    expect(resolveArcPackReposDir({ home, env: {} })).toBe(canonicalDefault());
+  });
+
+  // $XDG_DATA_HOME base takes precedence even when the legacy tree also exists,
+  // as long as the XDG-canonical tree exists (mirrors arc's multi-tree layout).
+  test("$XDG_DATA_HOME canonical present wins over legacy", () => {
+    const xdg = join(home, "xdg-data");
+    const expected = join(xdg, "metafactory", "arc", "repos");
+    mkdirSync(expected, { recursive: true });
+    mkdirSync(legacyDir(), { recursive: true });
+    expect(resolveArcPackReposDir({ home, env: { XDG_DATA_HOME: xdg } })).toBe(
+      expected,
+    );
+  });
+});
+
+describe("consumer parity — brain-consumer-boot join shape", () => {
+  // brain-consumer-boot.ts:280 → join(opts.brainPackBaseDir, agent.id). Confirm
+  // the resolved base composes into the exact pack dir cortex boots from.
+  test("resolved base + agentId → the pack dir arc installed", () => {
+    mkdirSync(canonicalDefault(), { recursive: true });
+    const base = resolveArcPackReposDir({ home, env: {} });
+    expect(join(base, "my-exec-brain")).toBe(
+      join(canonicalDefault(), "my-exec-brain"),
+    );
+  });
+});

--- a/src/common/config/arc-pack-repos-dir.ts
+++ b/src/common/config/arc-pack-repos-dir.ts
@@ -1,0 +1,135 @@
+/**
+ * arc-pack-repos-dir — existence-gated resolver for ARC's package-repos
+ * DIRECTORY, mirroring arc's own `dataRoot/repos` resolution (cortex#1988,
+ * EPIC cortex#1867).
+ *
+ * WHY THIS EXISTS — the runtime miss it closes:
+ *
+ * cortex boots exec-brain (Bot Pack) agents from packs that ARC installs on
+ * disk. cortex locates a pack at `{brainPackBaseDir}/{agentId}`
+ * (`src/runner/brain-consumer-boot.ts` → `join(opts.brainPackBaseDir, agent.id)`).
+ * Before this module, `cortex.ts` hardcoded that base as
+ * `~/.config/metafactory/pkg/repos` — arc's PRE-#287 default. arc#287 (arc's
+ * XDG own-dirs wave) moved arc's canonical package-repos dir to the DATA class
+ * root: `$XDG_DATA_HOME ?? ~/.local/share` → `metafactory/arc/repos`
+ * (`arc/src/lib/paths.ts` `reposDir`, multi-tree default layout). The old
+ * `~/.config/metafactory/pkg/repos` now survives ONLY as arc's `singleTree`
+ * fallback (an `ARC_CONFIG_ROOT` / override install). On a default MIGRATED box
+ * cortex was reading an empty/stale legacy tree → exec-brain packs failed to
+ * resolve at boot.
+ *
+ * So cortex MUST resolve arc's package-repos dir the SAME way arc does, and
+ * always read where arc writes. This module is the single source of that
+ * resolution — the REVERSE of `arc/src/lib/hosts/cortex-config-dir.ts` (arc
+ * mirroring cortex's config resolver). It byte-mirrors arc's `dataDir("arc")`
+ * (`arc/src/lib/xdg-paths.ts`) plus the `/repos` tail:
+ *
+ *   canonical = (`$XDG_DATA_HOME` ?? `~/.local/share`) / `metafactory` / `arc` / `repos`
+ *
+ * Precedence (read):
+ *   1. canonical (XDG-honoring) — if it exists (a default / migrated box).
+ *   2. legacy `~/.config/metafactory/pkg/repos` — ONLY if it exists
+ *      (existence-gated, so an `ARC_CONFIG_ROOT` / singleTree install that keeps
+ *      the pre-#287 tree still resolves).
+ *   3. canonical — the default target when neither exists (a fresh host reads
+ *      the XDG-canonical tree, never the legacy one).
+ *
+ * DELIBERATELY existence-gated rather than a bare canonical-string swap: a bare
+ * swap re-drifts on the next arc paths change and silently breaks singleTree
+ * installs. This resolver tracks arc's DATA-class layout AND keeps legacy
+ * installs resolving.
+ *
+ * SCOPE — this only RESOLVES arc's repos dir for READ; it never creates,
+ * migrates, or writes it. arc owns that tree and its migration (#287). cortex
+ * reads it.
+ *
+ * The `{home, env}` seam is injectable for hermetic tests (never touch the real
+ * `~/.local/share` or `~/.config`). It mirrors arc's `XdgSeam` `{home, env}`.
+ */
+
+import { join } from "path";
+import { homedir } from "os";
+import { existsSync } from "fs";
+
+/** The shared metafactory XDG suite namespace (matches arc's `SUITE`). */
+export const METAFACTORY_DIRNAME = "metafactory";
+/** arc's XDG app namespace — every arc XDG root resolves under `metafactory/arc`. */
+export const ARC_APP_DIRNAME = "arc";
+/** The repos-dir tail arc appends under its data root (`dataRoot/repos`). */
+export const ARC_REPOS_DIRNAME = "repos";
+
+/**
+ * Injectable `{home, env}` seam for hermetic tests. Both default to the real
+ * process environment when omitted — mirroring arc's `XdgSeam` `{home, env}`.
+ */
+export interface ArcPackReposDirSeam {
+  /** Injectable `$HOME`. Defaults to `os.homedir()`. */
+  home?: string;
+  /** Injectable environment. Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+function seamHome(seam?: ArcPackReposDirSeam): string {
+  return seam?.home ?? homedir();
+}
+
+function seamEnv(seam?: ArcPackReposDirSeam): Record<string, string | undefined> {
+  return seam?.env ?? process.env;
+}
+
+/**
+ * Expand a leading `~` (and only a leading `~`) to `home`, then strip trailing
+ * separators (but never collapse `/` itself). Mirrors arc's `xdg-paths.ts`
+ * `normalizePath` (Windows-aware superset; identical for POSIX input).
+ */
+function normalizePath(path: string, home: string): string {
+  const expanded = path === "~" ? home : path.replace(/^~(?=[/\\])/, home);
+  return expanded === "/" ? expanded : expanded.replace(/[/\\]+$/, "");
+}
+
+/**
+ * arc's CANONICAL package-repos dir, byte-mirroring `arc/src/lib/paths.ts`
+ * `reposDir` on the default (multi-tree) layout = `dataDir("arc")/repos`:
+ *
+ *   (`$XDG_DATA_HOME` ?? `~/.local/share`) / `metafactory` / `arc` / `repos`
+ *
+ * `$XDG_DATA_HOME` is trimmed; a blank/whitespace-only value reads as unset
+ * (matching arc's `raw?.trim()` truthiness check), never a literal relative dir.
+ */
+export function arcCanonicalPackReposDir(seam?: ArcPackReposDirSeam): string {
+  const home = seamHome(seam);
+  const raw = seamEnv(seam).XDG_DATA_HOME?.trim();
+  const base = raw ? normalizePath(raw, home) : join(home, ".local", "share");
+  return join(base, METAFACTORY_DIRNAME, ARC_APP_DIRNAME, ARC_REPOS_DIRNAME);
+}
+
+/**
+ * arc's LEGACY (pre-#287) package-repos dir `~/.config/metafactory/pkg/repos` —
+ * the path an `ARC_CONFIG_ROOT` / singleTree install still uses. Read-fallback
+ * only, existence-gated in {@link resolveArcPackReposDir}.
+ */
+export function legacyArcPackReposDir(seam?: ArcPackReposDirSeam): string {
+  return join(seamHome(seam), ".config", METAFACTORY_DIRNAME, "pkg", ARC_REPOS_DIRNAME);
+}
+
+/**
+ * Resolve arc's package-repos DIRECTORY, existence-gated, mirroring arc's
+ * `dataRoot/repos` resolution (see file header). The XDG-canonical tree wins if
+ * it exists (a default / migrated box), else the legacy
+ * `~/.config/metafactory/pkg/repos` tree if it exists (singleTree / override
+ * install), else the canonical path as the fresh-host default.
+ *
+ * cortex routes the DEFAULT `brainPackBaseDir` (when no explicit
+ * `options.brainPackBaseDir` override is set) through this so exec-brain packs
+ * resolve where arc actually installed them — canonical on a migrated box,
+ * legacy on a singleTree install.
+ */
+export function resolveArcPackReposDir(seam?: ArcPackReposDirSeam): string {
+  const canonical = arcCanonicalPackReposDir(seam);
+  if (existsSync(canonical)) return canonical;
+
+  const legacy = legacyArcPackReposDir(seam);
+  if (existsSync(legacy)) return legacy;
+
+  return canonical;
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -40,6 +40,7 @@ import {
   AgentsDirectoryWatcher,
   type AgentsChangeEvent,
 } from "./common/config/watcher";
+import { resolveArcPackReposDir } from "./common/config/arc-pack-repos-dir";
 import { type AgentConfig } from "./common/types/config";
 import { migrateStackDbOnTouch } from "./common/migrate-data-dir";
 import { migratePublishedEventsDirValue } from "./common/config/migrate-published-events-value";
@@ -2303,8 +2304,15 @@ export async function startCortex(
   // brainConsumers[] array the shutdown drain + reconcile walk), provisions the
   // per-capability JetStream durables, and binds the consumer. NEVER throws —
   // one brain's wiring failure does not abort boot.
+  // #1988 — the DEFAULT arc package-repos dir must MIRROR arc's own
+  // `dataRoot/repos` resolution (XDG DATA class; arc#287), NOT the moved
+  // pre-#287 legacy path. `resolveArcPackReposDir` honors `$XDG_DATA_HOME`
+  // (→ `<base>/metafactory/arc/repos`) and existence-gates the legacy
+  // `~/.config/metafactory/pkg/repos` fallback (singleTree / `ARC_CONFIG_ROOT`
+  // installs). An explicit `options.brainPackBaseDir` (set only in tests) stays
+  // the highest-precedence override, unchanged.
   const brainPackBaseDir =
-    options.brainPackBaseDir ?? expandTilde("~/.config/metafactory/pkg/repos/");
+    options.brainPackBaseDir ?? resolveArcPackReposDir();
 
   // Bot Packs B-3 (cortex#1021 W-1/W-2) — the adapter inbound reply-bridge +
   // the booted surface gate. Constructed ONCE here (before the per-agent brain


### PR DESCRIPTION
Closes #1988.

## Problem
arc#287 moved arc's canonical package-repos dir to the DATA class root — `$XDG_DATA_HOME ?? ~/.local/share` → `metafactory/arc/repos` (`arc/src/lib/paths.ts` `reposDir`, multi-tree default). cortex's `brainPackBaseDir` fallback (`src/cortex.ts:2307`) still hardcoded the **pre-#287** path `~/.config/metafactory/pkg/repos`. Since `options.brainPackBaseDir` is set only in tests, that fallback **is** the production path — so on a default migrated box cortex read an empty/stale tree and exec-brain packs failed to resolve at boot (`src/runner/brain-consumer-boot.ts:280` → `join(opts.brainPackBaseDir, agent.id)`).

## Fix
New `src/common/config/arc-pack-repos-dir.ts` — an existence-gated resolver that **mirrors arc's `dataRoot/repos` resolution** (the reverse of arc's `src/lib/hosts/cortex-config-dir.ts`, which mirrors cortex's config resolver in arc):

- canonical = (`$XDG_DATA_HOME` ?? `~/.local/share`) / `metafactory` / `arc` / `repos` — byte-mirrors arc's `dataDir("arc")` + `/repos`;
- precedence: canonical if it exists → legacy `~/.config/metafactory/pkg/repos` **only if it exists** (existence-gated, so `ARC_CONFIG_ROOT`/singleTree installs still resolve) → canonical as the fresh-host default;
- injectable `{home, env}` seam for hermetic tests.

`cortex.ts`'s fallback now routes through it; the explicit `options.brainPackBaseDir` override stays highest precedence, unchanged. Not a bare string swap — that would re-drift on the next arc paths change and ignore `$XDG_DATA_HOME`/singleTree.

## Acceptance criteria
- [x] Default (multi-tree) migrated box → `~/.local/share/metafactory/arc/repos`
- [x] `$XDG_DATA_HOME` set → resolves under that base
- [x] Only legacy `~/.config/metafactory/pkg/repos` present → legacy (existence-gated)
- [x] `options.brainPackBaseDir` explicit override still wins
- [x] Hermetic tests (scratch `$HOME`, explicit env bag, zero real `~/.local`/`~/.config` access)
- [x] `brain-consumer-boot` `join(base, agentId)` consumer shape confirmed

## Verification (local)
- `bun test src/common/config/__tests__/arc-pack-repos-dir.test.ts` → **13 pass / 0 fail**
- `bun test src/runner` → **886 pass / 0 fail**
- `bunx tsc --noEmit` → **exit 0**
- Full `bun test` → **9753 pass**, 21 fail — all pre-existing known non-hermetic (1 `plist-render bin-cutover` shell suite + 20 `cortex network secret add/revoke-member` CLI); zero related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)