### PR TITLE
docs(xdg): update stale legacy-path references to canonical XDG paths — design docs (#1867)

### DIFF
--- a/docs/design-arc-agent-bots.md
+++ b/docs/design-arc-agent-bots.md
@@ -33,7 +33,7 @@ The pi.dev design doc's central insight: **presence and substrate are independen
 
 | Axis | Values | Where it persists | Who owns it |
 |---|---|---|---|
-| **Identity** | `id`, `displayName`, `roles`, `trust` | Fragment in `~/.config/cortex/agents.d/<id>.yaml` | Bot package (Q1 answer) |
+| **Identity** | `id`, `displayName`, `roles`, `trust` | Fragment in `~/.config/metafactory/cortex/agents.d/<id>.yaml` | Bot package (Q1 answer) |
 | **Capabilities** | `[code-review]`, `[research]`, `[copy-edit]`, ... | NATS KV `local.{org}.agents.capabilities.{id}` on start | Bot daemon |
 | **Substrate** | `claude-code` / `codex` / `pi-dev` / `custom-binary` | Fragment + bot's arc-manifest | Bot package |
 | **Presence** | `discord` / `mattermost` / `slack` / none | Fragment under `presence:` (optional) | Bot package |
@@ -54,8 +54,8 @@ Cortex's runner (after MIG-7.1 lands `src/cortex.ts`) spawns Claude Code subproc
 
 ```
 arc install foo-review-bot
-  → drops persona.md   → ~/.config/cortex/personas/foo.md
-  → drops fragment     → ~/.config/cortex/agents.d/foo.yaml
+  → drops persona.md   → ~/.config/metafactory/cortex/personas/foo.md
+  → drops fragment     → ~/.config/metafactory/cortex/agents.d/foo.yaml
   → signals cortex     → SIGHUP or `cortex agents reload`
                          (loader+watcher, extended per §6.1, pick up the fragment;
                           daemon registers foo BEFORE creds issue so it can scope
@@ -65,7 +65,7 @@ arc install foo-review-bot
                           writes ~/.config/nats/creds/foo.creds)
 ```
 
-**No new process. No new launchd plist.** The watcher (`src/common/config/watcher.ts`) hot-reloads `cortex.yaml` today and is extended in §6.1 to also watch `~/.config/cortex/agents.d/`. Cortex's runner spawns CC for foo on the next dispatch matching foo's capability.
+**No new process. No new launchd plist.** The watcher (`src/common/config/watcher.ts`) hot-reloads `cortex.yaml` today and is extended in §6.1 to also watch `~/.config/metafactory/cortex/agents.d/`. Cortex's runner spawns CC for foo on the next dispatch matching foo's capability.
 
 Use this shape for: simple persona-based agents on the cortex's Claude-Code substrate.
 
@@ -88,15 +88,15 @@ runtime:
 ```
 arc install foo-codex-review-bot
   → cortex target:
-      drops persona.md   → ~/.config/cortex/personas/foo.md
-      drops fragment     → ~/.config/cortex/agents.d/foo.yaml
+      drops persona.md   → ~/.config/metafactory/cortex/personas/foo.md
+      drops fragment     → ~/.config/metafactory/cortex/agents.d/foo.yaml
       signals cortex     → SIGHUP or `cortex agents reload`
                             (daemon registers foo from agents.d/ before creds issue)
       mints NATS creds   → cortex creds issue foo
                             (now scoped to foo's runtime.capabilities)
                             → ~/.config/nats/creds/foo.creds (cortex daemon-signed)
   → darwin-launchd target:
-      installs binary    → ~/bin/foo-bot   (symlink to package)
+      installs binary    → ~/.local/bin/foo-bot   (symlink to package)
       installs plist     → ~/Library/LaunchAgents/ai.meta-factory.foo.plist
       launchctl load     → daemon starts LAST — connects bus with the creds,
                             publishes capability registration to NATS KV
@@ -162,11 +162,11 @@ presence:
 
 provides:
   files:
-    persona.md: ~/.config/cortex/personas/foo.md
-    agent.yaml: ~/.config/cortex/agents.d/foo.yaml
+    persona.md: ~/.config/metafactory/cortex/personas/foo.md
+    agent.yaml: ~/.config/metafactory/cortex/agents.d/foo.yaml
 
   # standalone-only — omitted for in-process
-  binary: foo-bot                 # → ~/bin/foo-bot
+  binary: foo-bot                 # → ~/.local/bin/foo-bot
   plist: services/ai.meta-factory.foo.plist
 
 lifecycle:
@@ -182,7 +182,7 @@ lifecycle:
 
 **Schema decisions (locked):**
 
-- **Q1 — persona ownership:** the bot package ships its own `persona.md` under `provides.files`. Bot author edits the persona in the bot's source repo; arc upgrades carry persona updates. Cortex's `~/.config/cortex/personas/` is rendered output, not source of truth.
+- **Q1 — persona ownership:** the bot package ships its own `persona.md` under `provides.files`. Bot author edits the persona in the bot's source repo; arc upgrades carry persona updates. Cortex's `~/.config/metafactory/cortex/personas/` is rendered output, not source of truth.
 - **Q3 — substrate + mode in fragment:** the rendered `agent.yaml` fragment (next section) includes `runtime.substrate` and `runtime.mode` so cortex's dashboard renders accurate provenance ("foo (in-process / claude-code)") without inferring from capability registry.
 
 **`roles:` semantics** (per `docs/architecture.md` §9 + cortex's role-resolution model): roles declare the **maximum** capability bundle an agent is allowed to exercise. The agent's effective capability set at dispatch time is the **intersection** of `runtime.capabilities` (declared by the bot package) and the bundle implied by `roles:`. Declaring a capability that the role doesn't grant is a load-time warning, not an error — the role wins. An empty `roles: []` means no capability is granted regardless of `runtime.capabilities`; agents must declare at least one role to be dispatched against. The role → capability bundle mapping is owned by cortex (G-121 family) and is out of scope for this design — bots reference role names, cortex resolves them.
@@ -194,10 +194,10 @@ lifecycle:
 `provides.files.agent.yaml` is rendered by arc at install time. Example for the manifest above:
 
 ```yaml
-# ~/.config/cortex/agents.d/foo.yaml
+# ~/.config/metafactory/cortex/agents.d/foo.yaml
 id: foo
 displayName: Foo
-persona: ~/.config/cortex/personas/foo.md
+persona: ~/.config/metafactory/cortex/personas/foo.md
 roles: [agent-restricted]
 trust: [luna, holly, ivy]
 
@@ -236,7 +236,7 @@ These are the prerequisites for `arc install <bot>` to work end-to-end. None of 
 
 **Scope:** `src/common/config/loader.ts` + `watcher.ts`.
 
-- Loader walks `~/.config/cortex/agents.d/*.yaml` after parsing `cortex.yaml`, merges into `agents[]`.
+- Loader walks `~/.config/metafactory/cortex/agents.d/*.yaml` after parsing `cortex.yaml`, merges into `agents[]`.
 - Watcher watches the directory; emits the same reload event as `cortex.yaml` does today.
 - New CLI: `cortex agents reload` — manual trigger for principals / lifecycle scripts. Calls into the same reload code path. SIGHUP also routes here.
 - Fragment schema = subset of `CortexConfigAgent` (no `principal:` block; cortex.yaml stays the source of truth for principal identity).
@@ -261,12 +261,12 @@ export class CortexHostAdapter implements HostAdapter {
 
   paths: HostPaths & CortexPaths = {
     skillsDir:    "",                                  // n/a — cortex isn't a skills host
-    agentsDir:    "~/.config/cortex/agents.d/",        // arc#117 HostPaths field — identity fragments
-    binDir:       "~/bin/",                            // arc#117 HostPaths field — standalone bot binaries
-    settingsPath: "~/.config/cortex/cortex.yaml",      // arc#117 HostPaths field — principal-edited core config
+    agentsDir:    "~/.config/metafactory/cortex/agents.d/",        // arc#117 HostPaths field — identity fragments
+    binDir:       "~/.local/bin/",                            // arc#117 HostPaths field — standalone bot binaries
+    settingsPath: "~/.config/metafactory/cortex/cortex.yaml",      // arc#117 HostPaths field — principal-edited core config
     hooksFormat:  "none",                              // arc#117 HostPaths field — no claude-code-style hooks
     // Cortex-internal extensions (not in arc#117 HostPaths today):
-    personasDir:  "~/.config/cortex/personas/",        // persona markdown files
+    personasDir:  "~/.config/metafactory/cortex/personas/",        // persona markdown files
     credsDir:     "~/.config/nats/creds/",             // per-agent NATS creds (daemon-written)
   };
 
@@ -365,8 +365,8 @@ identity:
   trust: [luna, holly]
 provides:
   files:
-    persona.md: ~/.config/cortex/personas/rev.md
-    agent.yaml: ~/.config/cortex/agents.d/rev.yaml
+    persona.md: ~/.config/metafactory/cortex/personas/rev.md
+    agent.yaml: ~/.config/metafactory/cortex/agents.d/rev.yaml
 lifecycle:
   postinstall:
     - scripts/signal-cortex-reload.sh    # FIRST — daemon registers rev
@@ -394,8 +394,8 @@ identity:
   trust: [luna, holly]
 provides:
   files:
-    persona.md: ~/.config/cortex/personas/codex-rev.md
-    agent.yaml: ~/.config/cortex/agents.d/codex-rev.yaml
+    persona.md: ~/.config/metafactory/cortex/personas/codex-rev.md
+    agent.yaml: ~/.config/metafactory/cortex/agents.d/codex-rev.yaml
   binary: codex-rev-bot
   plist: services/ai.meta-factory.codex-rev.plist
 lifecycle:
@@ -435,8 +435,8 @@ Principal interacts with Scout indirectly: another agent (Luna) dispatches a res
 ```
 principal: arc install foo-review-bot
 arc:      preinstall: scripts/check-cortex-version.sh        [verify cortex target compat via CortexHostAdapter.detect()]
-arc:      drop persona.md   → ~/.config/cortex/personas/foo.md
-arc:      drop agent.yaml   → ~/.config/cortex/agents.d/foo.yaml
+arc:      drop persona.md   → ~/.config/metafactory/cortex/personas/foo.md
+arc:      drop agent.yaml   → ~/.config/metafactory/cortex/agents.d/foo.yaml
 arc:      postinstall: scripts/signal-cortex-reload.sh        [signal BEFORE creds]
             → SIGHUP cortex bot pid (or `cortex agents reload`)
             → config-watcher.ts re-reads agents.d/
@@ -455,7 +455,7 @@ principal: foo appears in dashboard, can take tasks
 ```
 principal: arc install codex-review-bot
 arc:      preinstall: scripts/check-cortex-version.sh         [via CortexHostAdapter.detect()]
-arc:      drop persona, agent.yaml, binary (~/bin/codex-rev-bot)
+arc:      drop persona, agent.yaml, binary (~/.local/bin/codex-rev-bot)
 arc:      drop plist → ~/Library/LaunchAgents/ai.meta-factory.codex-rev.plist
 arc:      postinstall: scripts/signal-cortex-reload.sh        [signal FIRST so daemon learns about agent]
             → cortex re-reads agents.d/, registers codex-rev

--- a/docs/design-bot-packs.md
+++ b/docs/design-bot-packs.md
@@ -82,8 +82,8 @@ An arc package, `type: agent` (extends the cortex#60 manifest):
 ```
 yarrow/
   arc-manifest.yaml        # type: agent, targets: [cortex]
-  agent.yaml               # → installed to ~/.config/cortex/agents.d/yarrow.yaml
-  persona.md               # → ~/.config/cortex/personas/yarrow.md
+  agent.yaml               # → installed to ~/.config/metafactory/cortex/agents.d/yarrow.yaml
+  persona.md               # → ~/.config/metafactory/cortex/personas/yarrow.md
   brain/
     main.ts                # the behavior — any language, any framework
   README.md

--- a/docs/design-bus-addressing.md
+++ b/docs/design-bus-addressing.md
@@ -161,7 +161,7 @@ A principal may peer into more than one network — `andreas` in `metafactory` a
 
 ## 11. The per-stack descriptor
 
-A convenience artefact (not the source of truth — `cortex.{stack}.yaml` is): a rendered, human- and agent-readable card declaring a stack's bus-addressing identity — "where am I, what subjects do I own." One per stack, at `~/.config/cortex/stack-{name}.md`.
+A convenience artefact (not the source of truth — `cortex.{stack}.yaml` is): a rendered, human- and agent-readable card declaring a stack's bus-addressing identity — "where am I, what subjects do I own." One per stack, at `~/.config/metafactory/cortex/stack-{name}.md`.
 
 > **Distinct from `CONTEXT.md`.** `CONTEXT.md` (repo root, uppercase) is the bounded-context *glossary*. The per-stack descriptor is a *runtime identity card* for one deployment. Different artefacts; do not conflate.
 

--- a/docs/design-discord-bundle-decoupling.md
+++ b/docs/design-discord-bundle-decoupling.md
@@ -30,7 +30,7 @@ metafactory-discord/
   skills/
     discord/SKILL.md       # the existing CLI-wrapping skill (post/read/role/threads)
     fleet-admit/SKILL.md   # NEW — the two-tier admission procedure
-  bin/discord              # the PATH shim arc installs (replaces cortex's ~/bin/discord)
+  bin/discord              # the PATH shim arc installs (replaces cortex's ~/.local/bin/discord)
   README.md  CLAUDE.md  package.json  tests
 ```
 
@@ -65,7 +65,7 @@ Skills provided:
 - **S1** — create `the-metafactory/metafactory-discord`; extract `src/cli/discord/` (CLI +
   existing skill) into it; vendor `config-path`; arc-manifest; tests pass standalone;
   `arc install` from repo works.
-- **S2** — cortex consumes the bundle: remove `src/cli/discord/` from cortex; `~/bin/discord`
+- **S2** — cortex consumes the bundle: remove `src/cli/discord/` from cortex; `~/.local/bin/discord`
   comes from the bundle; cortex `arc-manifest` declares the dependency; cortex build + tests
   green without the CLI. *(the decoupling)*
 - **S3** — add `fleet-admit` + `discord-role` / `discord-post` skills to the bundle.

--- a/docs/design-gh-repo-recon-agent.md
+++ b/docs/design-gh-repo-recon-agent.md
@@ -374,7 +374,7 @@ The judgment-free property of the deterministic class is enforced by the workflo
 
 ## 7. Cortex Config Block
 
-Registered as a fragment under `~/.config/cortex/agents.d/gh-repo-recon-agent.yaml`. Loaded by cortex's existing fragment loader. Discriminator: `runtime.harness: deterministic-agent` (the new `HarnessId` entry).
+Registered as a fragment under `~/.config/metafactory/cortex/agents.d/gh-repo-recon-agent.yaml`. Loaded by cortex's existing fragment loader. Discriminator: `runtime.harness: deterministic-agent` (the new `HarnessId` entry).
 
 ```yaml
 agents:
@@ -698,7 +698,7 @@ For any well-formed input that passes `ReconInputSchema`, the output passes `Rec
 
 ### Principal-side
 
-- [ ] Fragment at `~/.config/cortex/agents.d/gh-repo-recon-agent.yaml` loaded by cortex without rejection
+- [ ] Fragment at `~/.config/metafactory/cortex/agents.d/gh-repo-recon-agent.yaml` loaded by cortex without rejection
 - [ ] Manual smoke: Luna in `#cortex` channel emits `dispatch.recon.cortex`, receives verdict within 5s, summarizes "what's in flight for cortex" without making any gh calls herself
 - [ ] Verdict envelope is renderable in the Mission Control dashboard (existing envelope-viewer surfaces it)
 
@@ -772,7 +772,7 @@ Independent of cortex#92 — can land in parallel.
 ### Step 3 — Principal side
 
 - `arc install github:the-metafactory/arc-skill-recon` — drops skill + slash command
-- `cp <fragment-example> ~/.config/cortex/agents.d/gh-repo-recon-agent.yaml`
+- `cp <fragment-example> ~/.config/metafactory/cortex/agents.d/gh-repo-recon-agent.yaml`
 - Restart cortex so the new agent loads. Restart command is principal-deployment-specific:
   - On macOS (Andreas' deployment): `launchctl kickstart -k gui/$(id -u)/ai.meta-factory.cortex.meta-factory` (or `.work` for the parallel work stack)
   - On Linux / containers: per the principal's process manager (systemd unit, docker restart, etc.)

--- a/docs/design-internet-of-agentic-work.md
+++ b/docs/design-internet-of-agentic-work.md
@@ -436,7 +436,7 @@ The orchestrator pattern is what gives principals the "main digital assistant th
 
 ### §3.7 Config split — layering cortex.yaml by blast radius (foundation)
 
-Everything above assumes one config file per stack. Today that file — `~/.config/cortex/cortex.yaml` — is **~911 lines** and has quietly grown into the *whole-environment* config. It mixes, in one document:
+Everything above assumes one config file per stack. Today that file — `~/.config/metafactory/cortex/cortex.yaml` — is **~911 lines** and has quietly grown into the *whole-environment* config. It mixes, in one document:
 
 - **principal + stack identity** (`operator:` block / `stack:` block — names pending cortex#448),
 - the **capability catalog** (Q2's `capabilities:` schema),

--- a/docs/design-multi-network-bridge.md
+++ b/docs/design-multi-network-bridge.md
@@ -143,10 +143,10 @@ Per `plan-internet-of-agentic-work.md` §E.1 (lines 426–433) and Phase E accep
 leaf_nodes:
   nats-leaf-research:
     url: nats://research-mesh.example:4222
-    creds_path: ~/.config/cortex/creds/research.creds   # chmod 600, NatsLink loader (connection.ts)
+    creds_path: ~/.config/metafactory/cortex/creds/research.creds   # chmod 600, NatsLink loader (connection.ts)
   nats-leaf-jv:
     url: nats://jv-mesh.example:4222
-    creds_path: ~/.config/cortex/creds/jv.creds
+    creds_path: ~/.config/metafactory/cortex/creds/jv.creds
 
 policy:
   federated:

--- a/docs/design-multi-network.md
+++ b/docs/design-multi-network.md
@@ -86,7 +86,7 @@ resolved before any code lands.
 
 ```yaml
 leaf_nodes:
-  nats-leaf-research: { url: nats://research:4222, creds_path: ~/.config/cortex/creds/research.creds }
+  nats-leaf-research: { url: nats://research:4222, creds_path: ~/.config/metafactory/cortex/creds/research.creds }
 policy:
   federated:
     networks:
@@ -107,7 +107,7 @@ policy:
     networks:
       - id: research-collab
         leaf_node: nats-leaf-research      # retained as the routing label / pool key
-        nats: { url: nats://research:4222, credsPath: ~/.config/cortex/creds/research.creds }
+        nats: { url: nats://research:4222, credsPath: ~/.config/metafactory/cortex/creds/research.creds }
 ```
 
 The `nats:` block sits directly on each network; `leaf_node` survives purely as the pool key /

--- a/docs/design-pilot-restructure.md
+++ b/docs/design-pilot-restructure.md
@@ -54,7 +54,7 @@ These are inputs to this spec, NOT open for re-litigation:
 ```
 ~/.config/metafactory/pkg/repos/pilot/
 ├── arc-manifest.yaml            # skill manifest (`pilot-review-loop` v0.3.0)
-├── package.json                 # bun package, ships `~/bin/pilot`
+├── package.json                 # bun package, ships `~/.local/bin/pilot`
 ├── bun.lock
 ├── agent/                       # AgentManifest (Pilot as proactive agent, Phase 1)
 ├── bin/                         # `bin/pilot` entrypoint shim
@@ -94,7 +94,7 @@ Below: every file, one-line responsibility, line count, primary concern.
 | `config.ts` | 194 | W | `validateClaimLoopConfig` (identity-collapse guard) + `loadRepoCommandConfigs` (per-repo install/test env). Pure. |
 | `dashboard.ts` | 66 | P | Renders `~/.metafactory/agents/pilot/dashboard.md` from `db.ts` errands. |
 | `db.ts` | 456 | P | SQLite errand + finding store; the `pilot fetch`/`triage`/`dispatch` persistence backbone. |
-| `discord.ts` | 64 | B (transition) | `channelForRepo` + `threadNameForPR` + `postMessage` shelling `~/bin/discord`. Lives at `bus/legacy/discord.ts` post-restructure — the bot-mention transport that retires when cortex#237 ships. |
+| `discord.ts` | 64 | B (transition) | `channelForRepo` + `threadNameForPR` + `postMessage` shelling `~/.local/bin/discord`. Lives at `bus/legacy/discord.ts` post-restructure — the bot-mention transport that retires when cortex#237 ships. |
 | `discord-veto.ts` | 382 | B (transition) | Discord REST API client for the claim-veto window: announce → reactions → defensive-veto. Same transition shell as `discord.ts`. |
 | `dispatch.ts` | 321 | W | `pilot dispatch` — parses triage, applies decisions, posts re-review request + ping. Touches discord + gh. |
 | `drive-review.ts` | 120 | W | `driveReview` — pure outer loop over `runReviewCycle` with fix-and-push + escalation. |
@@ -175,7 +175,7 @@ These bear special attention during the move (decide retire-vs-keep):
 | File | Status | Recommendation |
 |---|---|---|
 | `mention-dispatch.ts` | Spec 0003 surface; tests exist; no `cli.ts` import references it as of 2026-05-16. **Looks unwired.** | Keep — Phase 3 §F-9 wires it (audited in `agent-state.ts:142-148`'s `claim.requested-by-mention` event). Move into `workflow/mention/` and document the wiring gap as a known-TODO. |
-| `discord.ts` + `discord-veto.ts` + `reviewers.ts` | Three Discord-coupled files. `discord-veto.ts` talks Discord REST directly (bypasses `~/bin/discord` CLI). `discord.ts` shells the CLI. `reviewers.ts` hardcodes IDs. | Cluster into `bus/legacy/` — see §3.2. Retires module-by-module as cortex#237 lands. |
+| `discord.ts` + `discord-veto.ts` + `reviewers.ts` | Three Discord-coupled files. `discord-veto.ts` talks Discord REST directly (bypasses `~/.local/bin/discord` CLI). `discord.ts` shells the CLI. `reviewers.ts` hardcodes IDs. | Cluster into `bus/legacy/` — see §3.2. Retires module-by-module as cortex#237 lands. |
 | `nats-review-io.ts` | Subscribes to `mf.{network}.review.completed` — **legacy subject namespace**. | Retire when `wait-for-verdict` ships. Keep in `bus/legacy/` until the cutover (Phase C in the migration plan). |
 | `nats-publish.ts` | Publishes to `local.{org}.tasks.code-review.<specialization>` — **canonical subject**. | Promote to `bus/publish-review-request.ts` (renamed for clarity; legacy name preserved as re-export). |
 | `gh.ts` | Re-export shim of `github-backend.ts`. Comment says "back-compat." | Keep across MIG-1; delete after MIG-3 once all importers consume `forge/github-backend.ts` directly. |
@@ -239,7 +239,7 @@ src/
 │   │   ├── verdict.ts                # match review.verdict.* by (repo, pr_number, correlation_id)
 │   │   └── github-review.ts          # match local.{org}.github.> for (repo, pr_number, reviewer login)
 │   └── legacy/                       # retires post-cortex#237
-│       ├── discord.ts                # (was src/discord.ts) ~/bin/discord shell
+│       ├── discord.ts                # (was src/discord.ts) ~/.local/bin/discord shell
 │       ├── discord-veto.ts           # (was src/discord-veto.ts) claim-veto window
 │       ├── reviewers.ts              # (was src/reviewers.ts) — REVIEWERS registry
 │       ├── mention-dispatch.ts       # (was src/mention-dispatch.ts) — @pilot verb dispatch
@@ -614,7 +614,7 @@ pilot request-review --pr <owner/repo#N> --capability code-review.<flavor>
 **Behaviour:**
 
 1. Validate args (PR ref, capability grammar — `code-review.<segment>` matching `VALID_SPECIALIZATION`).
-2. Load cortex config (`~/.config/cortex/cortex.yaml` by default, `--config` override). Required: `nats.url`, `agent.operatorId` (becomes `<org>`). Optional: `nats.token` / `nats.credsPath`.
+2. Load cortex config (`~/.config/metafactory/cortex/cortex.yaml` by default, `--config` override). Required: `nats.url`, `agent.operatorId` (becomes `<org>`). Optional: `nats.token` / `nats.credsPath`.
 3. Build and publish the capability-dispatch envelope via `bus/publish-review-request.ts`. **Always publishes** — bus publish is fire-and-forget, independent of `--wait`.
 4. If `--wait`:
    a. Subscribe to `local.{org}.review.verdict.>` AND `local.{org}.dispatch.task.completed` AND `local.{org}.dispatch.task.failed`.
@@ -637,7 +637,7 @@ pilot request-review --pr <owner/repo#N> --capability code-review.<flavor>
 | `--note` | string | no | Free-form note in envelope payload. |
 | `--wait` | bool | no | Block until verdict, lifecycle-completed, or timeout. |
 | `--timeout` | duration | no | `<n>(s\|m\|h)`. Default `30m`. Only used with `--wait`. |
-| `--config` | path | no | cortex.yaml path. Default `~/.config/cortex/cortex.yaml`. |
+| `--config` | path | no | cortex.yaml path. Default `~/.config/metafactory/cortex/cortex.yaml`. |
 | `--json` | bool | no | Emit `CliJsonEnvelope<RequestResult>` on stdout. Default: text. |
 
 **Exit codes:**
@@ -944,7 +944,7 @@ The plan is **phase-by-phase**, each phase shipping a discrete PR (or PR cluster
 |---|---|
 | **Schema versioning** | The envelope shape is myelin-defined; pilot pins to `@the-metafactory/cortex@<sha>` (see §7) which transitively pins myelin. Any schema-flip is a coordinated update across cortex + pilot. |
 | **OTLP spans** | Phase C.4 adds them. Pre-Phase C, pilot emits no traces — only stderr logs. |
-| **Principal config** | `pilot request-review` reads cortex.yaml. The skill's `--config` defaults to `~/.config/cortex/cortex.yaml`. No new principal-visible config file in pilot. |
+| **Principal config** | `pilot request-review` reads cortex.yaml. The skill's `--config` defaults to `~/.config/metafactory/cortex/cortex.yaml`. No new principal-visible config file in pilot. |
 | **Rollback** | Each phase is reversible: Phase B can be reverted to A by removing the new verbs; Phase C can be reverted to B by reinstating the env-var gate; Phase D is a deletion phase — reverting it requires recovering the legacy files from git history. By Phase D the new path is proven, so rollback is not anticipated. |
 
 ---
@@ -973,7 +973,7 @@ Pilot's `bus/` subtree imports `NatsLink`, `MyelinSubscriber`, `Envelope`, `vali
 
 - Assumes cortex repo is at `../cortex` relative to pilot checkout. **False for the standard `~/Developer/cortex` + `~/.config/metafactory/pkg/repos/pilot` layout.** Principals would have to manually symlink.
 - CI configuration would need to clone cortex before `bun install`.
-- arc-manifest distribution (the `arc upgrade Pilot` story): `arc` does NOT install path-relative deps. The pilot binary at `~/bin/pilot` would silently break on principal machines that don't have cortex checked out alongside.
+- arc-manifest distribution (the `arc upgrade Pilot` story): `arc` does NOT install path-relative deps. The pilot binary at `~/.local/bin/pilot` would silently break on principal machines that don't have cortex checked out alongside.
 
 ### §7.2 Option B — Git-URL with pinned ref
 

--- a/docs/design-pluggable-adapters.md
+++ b/docs/design-pluggable-adapters.md
@@ -60,7 +60,7 @@ The epic's stocktake was captured @ origin/main `83e73ec2`; re-verified here aga
 | 8 | Platform npm deps live in cortex `package.json` | ❌ blocker | `package.json:47,48,55` |
 | 9 | arc bundles + `dependencies:` ranges + repo-first install proven | ✅ | ADR-0017, `metafactory-discord` installed under `~/.config/metafactory/pkg/repos/` |
 | 10 | arc semver-range *enforcement* between installed packages + bundle `bun install` | ⚠️ likely missing | arc-side slice (arc#284 / S7) |
-| 11 | Daemon runs TS via bun → dynamic `import()` of installed bundle source is feasible | ✅ | `src/cortex.ts:1` shebang; plists run `~/bin/cortex start` |
+| 11 | Daemon runs TS via bun → dynamic `import()` of installed bundle source is feasible | ✅ | `src/cortex.ts:1` shebang; plists run `~/.local/bin/cortex start` |
 | 12 | Config hot-reload machinery exists (`applied` vs `requiresRestart`) | ✅ | `src/common/config/watcher.ts:12-16,101-106` |
 | 13 | Gateway lifecycle is all-or-nothing `start()/stop()`; no per-adapter runtime attach/detach | ❌ missing | `src/gateway/surface-gateway.ts:167,191` |
 | 14 | No existing ADR/issue covers adapter extraction/hot-loading | ✅ gap | ADR-0001..0023 checked; this fills it |

--- a/docs/design-policy-cutover.md
+++ b/docs/design-policy-cutover.md
@@ -328,7 +328,7 @@ The cutover is a config-schema and adapter-internal change. The bus, federation,
 
 ## 11. Reality-check — what Andreas's current cortex.yaml actually contains
 
-Anchoring the design in operational config. Two files: `~/.config/cortex/cortex.yaml` (meta-factory stack) and `~/.config/cortex/cortex.work.yaml` (work stack).
+Anchoring the design in operational config. Two files: `~/.config/metafactory/cortex/cortex.yaml` (meta-factory stack) and `~/.config/metafactory/cortex/cortex.work.yaml` (work stack).
 
 ### 11.1 meta-factory stack (the one this migration targets)
 

--- a/docs/design-soma-integration.md
+++ b/docs/design-soma-integration.md
@@ -391,7 +391,7 @@ Note the `id: luna` / `id: luna-codex` / `id: luna-daemon` are *presence handles
 The first concrete deliverable, once this design ratifies:
 
 1. **`SomaCortexAdapter`** (Soma-side, new) — implements Soma's adapter contract for the Cortex/Myelin substrate. Two projection shapes per `docs/substrate-adapters.md`:
-   - **In-process** (`home` mode): projects a Soma assistant into `~/.config/cortex/agents.d/<name>.md` as the thin frontmatter+pointer fragment shown in §7.
+   - **In-process** (`home` mode): projects a Soma assistant into `~/.config/metafactory/cortex/agents.d/<name>.md` as the thin frontmatter+pointer fragment shown in §7.
    - **Daemon** (`daemon` mode): arc-installs a standalone bot from the Soma package; bot subscribes to Myelin subjects via the existing `MyelinRuntime` interface (no SessionHarness, no in-process spawn — pattern matches sage today).
 2. **Schema additions on the cortex side** — add `body: soma://...` to **both** `AgentSchema` (around line 421, for projection) and `PolicyPrincipalSchema` (around line 1124, for federation join) in `src/common/types/cortex-config.ts`. Optional string field at first (back-compat with pre-Soma agents that carry inline persona); cross-field validation enforces that when both are present they agree per id. Becomes the only path at v3.0.0 cutover.
 3. **`migrate-config` extension** — when an agent fragment carries inline persona + capabilities + trust, offer to lift those into a new Soma assistant scaffold under `~/.soma/profile/<id>/` and rewrite the fragment to `body: soma://...`. Idempotent. Principal pre-flight via `--check`.


### PR DESCRIPTION
Design-docs slice of the XDG epic (cortex#1867) doc-sweep. **DOCS ONLY** — no `src/**`, tests, or resolvers. Verified against `scripts/xdg-audit.ts` patterns.

## Mapping applied (genuine stale "lives-here-now" refs only)
- `~/.config/cortex/{cortex.yaml,agents.d/,personas/,creds/,stack-*}` → `~/.config/metafactory/cortex/…`
- `~/bin/<x>` → `~/.local/bin/<x>`

## Audit impact (this branch vs main, xdg-audit regexes)
- `config-tree`: 435 → 398 (**−37**)
- `bin-home`: 84 → 72 (**−12**)
- No new legacy refs introduced.

## Files updated: 12
design-arc-agent-bots, design-pilot-restructure, design-gh-repo-recon-agent, design-discord-bundle-decoupling, design-multi-network, design-multi-network-bridge, design-bot-packs, design-soma-integration, design-policy-cutover, design-pluggable-adapters, design-internet-of-agentic-work, design-bus-addressing.

## Left verbatim
- **9 grove-v2 provenance-frozen design docs** (explicit `⚠️ Historical — lifted from grove-v2 … not as current reference` / `do not modernise` banners): design-test-rig, design-cloud-api, design-github-visibility, design-mission-control, design-mc-f20-observe, design-mc-f12-task-curation, design-mc-f11-discord-notifications, design-dm-operator-channel, design-collaboration-surface.
- `~/.claude/events/raw` (hook substrate); nats / pkg-repos / systemd / Apple / soma / Developer paths (out of scope).
- **Per-agent INSTANCE-STATE dir** `~/.config/cortex/agents/<id>/{state.sqlite,dashboard,retros}` (design-agentic-dev-pipeline.md) — state-class, excluded from the config move (#1869), cortex hardcodes it at runtime. **Left verbatim.** (Note: `agents.d/` config fragments ARE swept.)

## SKIPPED-AMBIGUOUS: 1
- `design-discord-bundle-decoupling.md:20` — prose describing a "`~/.config/cortex` path resolver" helper, not a fixed file location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)