### PR TITLE
docs(xdg): update stale legacy-path references to canonical XDG paths — ops SOPs (#1867)

### DIFF
--- a/docs/sop-enable-dev-loop.md
+++ b/docs/sop-enable-dev-loop.md
@@ -55,15 +55,15 @@ when the config-split dir holds more than one stack):
 
 ```bash
 # dev agent — implement a slice (internal only)
-cortex offer dev.implement  --scope local --config ~/.config/cortex/<slug>
+cortex offer dev.implement  --scope local --config ~/.config/metafactory/cortex/<slug>
 
 # release agent — cut a release (internal only, principal-gated)
-cortex offer release.cut    --scope local --config ~/.config/cortex/<slug>
+cortex offer release.cut    --scope local --config ~/.config/metafactory/cortex/<slug>
 
 # review lane — scope is the principal's call:
 #   local      → review only your own stack's PRs
 #   public     → the PR-review marketplace (CO-5; requires CO-7 hardening)
-cortex offer code-review.typescript --scope local --config ~/.config/cortex/<slug>
+cortex offer code-review.typescript --scope local --config ~/.config/metafactory/cortex/<slug>
 ```
 
 Each command is **dry-run by default** — it prints the offerings edit + the
@@ -126,12 +126,12 @@ offering makes the intent explicit without changing a single subscribed subject.
 
 ```bash
 # 1. Apply each offering (writes stacks/<slug>.yaml + a timestamped .bak)
-cortex offer dev.implement  --scope local --config ~/.config/cortex/<slug> --apply
-cortex offer release.cut    --scope local --config ~/.config/cortex/<slug> --apply
-cortex offer code-review.typescript --scope local --config ~/.config/cortex/<slug> --apply
+cortex offer dev.implement  --scope local --config ~/.config/metafactory/cortex/<slug> --apply
+cortex offer release.cut    --scope local --config ~/.config/metafactory/cortex/<slug> --apply
+cortex offer code-review.typescript --scope local --config ~/.config/metafactory/cortex/<slug> --apply
 
 # 2. Confirm the exposure surface
-cortex offer list --config ~/.config/cortex/<slug>
+cortex offer list --config ~/.config/metafactory/cortex/<slug>
 
 # 3. Restart the stack so the daemon re-composes config + re-binds consumers
 arc upgrade cortex     # or reload the stack's launchd plist

--- a/docs/sop-network-join.md
+++ b/docs/sop-network-join.md
@@ -104,7 +104,7 @@ To join a **second or later** stack, pass `--principal-seed <root-seed>` — the
 
 ```bash
 cortex network join <network> \
-  --config ~/.config/cortex/<slug>/<slug>.yaml \
+  --config ~/.config/metafactory/cortex/<slug>/<slug>.yaml \
   --principal-seed ~/.config/nats/cortex.nk \
   --apply
 ```

--- a/docs/sop-onboard-peer-principal.md
+++ b/docs/sop-onboard-peer-principal.md
@@ -198,10 +198,10 @@ This is the same sealed channel that later carries the network **payload key** `
 
 ```bash
 # Dry-run first — inspect what will be written before touching the live deployment:
-cortex network join <network> --config ~/.config/cortex/<slug>/<slug>.yaml
+cortex network join <network> --config ~/.config/metafactory/cortex/<slug>/<slug>.yaml
 
 # Then apply:
-cortex network join <network> --config ~/.config/cortex/<slug>/<slug>.yaml --apply
+cortex network join <network> --config ~/.config/metafactory/cortex/<slug>/<slug>.yaml --apply
 ```
 
 The join command performs the full sequence idempotently:

--- a/docs/sop-stack-onboarding.md
+++ b/docs/sop-stack-onboarding.md
@@ -111,16 +111,16 @@ launchctl load ~/Library/LaunchAgents/ai.meta-factory.nats.<slug>.plist
 lsof -nP -iTCP:<port> -sTCP:LISTEN | grep nats   # verify up
 ```
 
-### Step 3 — Write the cortex config (`~/.config/cortex/<slug>/`)
+### Step 3 — Write the cortex config (`~/.config/metafactory/cortex/<slug>/`)
 
 **Start from the canonical template.** [`docs/config-layout/`](config-layout/) is
 the self-documenting config-split template — copy it and fill the `<REPLACE_ME>`
 markers rather than hand-rolling the directory:
 
 ```bash
-cp -R docs/config-layout ~/.config/cortex/<slug>
+cp -R docs/config-layout ~/.config/metafactory/cortex/<slug>
 # rename the pointer file after your slug, then fill the <REPLACE_ME> markers
-mv ~/.config/cortex/<slug>/research.yaml ~/.config/cortex/<slug>/<slug>.yaml
+mv ~/.config/metafactory/cortex/<slug>/research.yaml ~/.config/metafactory/cortex/<slug>/<slug>.yaml
 ```
 
 Multi-file layout (`composer` reads `system/` + `stacks/`):
@@ -175,12 +175,12 @@ presence:
 
 ### Step 4 — Write + load the cortex plist
 
-`~/Library/LaunchAgents/ai.meta-factory.cortex.<slug>.plist` → `/Users/<you>/.local/bin/cortex start --config ~/.config/cortex/<slug>/<slug>.yaml`, `WorkingDirectory` = the installed pkg, `CORTEX_CHANNEL=<slug>`, logs to `~/.config/cortex/logs/cortex-<slug>.{log,error.log}`. Then `launchctl load …`.
+`~/Library/LaunchAgents/ai.meta-factory.cortex.<slug>.plist` → `/Users/<you>/.local/bin/cortex start --config ~/.config/metafactory/cortex/<slug>/<slug>.yaml`, `WorkingDirectory` = the installed pkg, `CORTEX_CHANNEL=<slug>`, logs to `~/.local/state/metafactory/cortex/logs/cortex-<slug>.{log,error.log}`. Then `launchctl load …`.
 
 ### Step 5 — Verify
 
 ```bash
-grep -E "Stack:|connected to nats|policy-engine active|connected as|Guild:" ~/.config/cortex/logs/cortex-<slug>.log | tail
+grep -E "Stack:|connected to nats|policy-engine active|connected as|Guild:" ~/.local/state/metafactory/cortex/logs/cortex-<slug>.log | tail
 ```
 
 A healthy boot shows `Stack: <principal>/<slug>`, `connected to nats://…:<port>`, `policy-engine active — principals=N`, `discord adapter started (… guild: <guildId>)`, and `connected as <Bot>#NNNN`. Then:
@@ -334,7 +334,7 @@ policy:
 ```bash
 cortex provision-stack register <principal> --seed-path <seed> \
   --registry-url https://network.meta-factory.ai --stack-id <principal>/<slug>
-cortex network join <network> --config ~/.config/cortex/<slug>/<slug>.yaml --apply
+cortex network join <network> --config ~/.config/metafactory/cortex/<slug>/<slug>.yaml --apply
 ```
 
 Dry-run first (omit `--apply`). The join pulls the signature-verified descriptor → renders a `leafnodes` include into the stack's nats config → writes `policy.federated.networks[]` with registry-resolved peers → restarts. If the B2 config blocks are absent, pass `--registry-pubkey / --creds / --account / --nats-config / --plist` overrides instead.
@@ -342,7 +342,7 @@ Dry-run first (omit `--apply`). The join pulls the signature-verified descriptor
 **If this is the principal's 2nd+ stack** (e.g. you already federated `andreas/meta-factory` and are now adding `andreas/community`), the register step needs the principal **root** seed to authorize the add-stack — pass `--principal-seed <root-seed>` (#791):
 
 ```bash
-cortex network join <network> --config ~/.config/cortex/<slug>/<slug>.yaml \
+cortex network join <network> --config ~/.config/metafactory/cortex/<slug>/<slug>.yaml \
   --principal-seed ~/.config/nats/cortex.nk --apply
 ```
 


### PR DESCRIPTION
Ops slice of the XDG epic (cortex#1867) doc-sweep. **DOCS ONLY**. Deliberately **conservative**: only *living operational SOPs* got path updates; migration/history docs were left verbatim per sweep rules, and genuinely-borderline cases are listed below as **SKIPPED-AMBIGUOUS for your adjudication** rather than force-edited.

## Updated: 4 files, 17 refs
| File | Change |
|------|--------|
| `sop-onboard-peer-principal.md` | `--config ~/.config/cortex/<slug>/<slug>.yaml` → metafactory (×2) |
| `sop-enable-dev-loop.md` | `--config ~/.config/cortex/<slug>` → metafactory (×7) |
| `sop-network-join.md` | `--config` path → metafactory (×1) |
| `sop-stack-onboarding.md` | config-root copy/move/heading + logs → `~/.local/state/metafactory/cortex/logs` (×7) |

## Audit impact
- `config-tree`: 435 → 418 (**−17**). No new legacy refs. All changed files are `.md`.

## Left verbatim (migration/history — per sweep rules)
- **Named migration-procedure docs** — `plan-cortex-migration.md`, `migrations/0003-config-split-layout.md`, `sop-migrate-config.md`, `archive/v1-to-v2-cutover.md`: their `~/.config/cortex/…` refs ARE the migration subject / before→after / rollback anchors.
- grove-provenance-frozen iteration docs (`iteration-cloud-api`, `iteration-github-visibility`, `iteration-mission-control-pane-of-glass`, `iteration-policy-cutover`, `stock-take-v3-to-v4.5`); superseded `runbook-federation-peering` ("do not follow"); worklogs.
- `~/.claude/events/raw`; nats / Apple / systemd / worktree paths (out of scope).

## SKIPPED-AMBIGUOUS (need your call)
- **`.specify/specs/F-2-agents-d-*` + `F-3-cortex-agents-reload-cli` (spec.md + plan.md)** — draft specs mirror the CLI's *code* default paths (`~/.config/cortex/agents.d/`, `~/.config/cortex/cortex.yaml`). A docs-only edit here would drift from unmodified code. `agents.d/` is config-class and *should* sweep — but only alongside the code default. Recommend a follow-up that moves spec + code together.
- **`plan-bot-packs-completion.md:105-106`** — `~/.config/cortex/agents.d/` (config-class, normally swept) but inside a dated point-in-time handoff artifact.
- **`sop-migrate-config.md:135-151`** — in-place live-config refs, but it's the named migrate-config procedure doc (its whole subject is the legacy→canonical move).
- **`adr/0017-surface-tooling-arc-bundles.md:20`** — `~/bin/discord` shim in an append-only ADR record.
- **`migrations/0003:34`** — `~/.config/grove/state/…pid` pidfile inside the executed-migration record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)