### PR TITLE
chore: bump to v6.8.0 — pluggable surface plugins (epic #1784)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.7.2"
+version: "6.8.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Minor version bump for the pluggable-surface-plugins capability (epic #1784). No breaking change — transparent upgrade via first-party arc bundles.

Release cut follows on merge. Deploy (`arc upgrade cortex`) is NOT part of this — held per Andreas (production machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)