### PR TITLE
feat(systemd): XDG Linux systemd re-render/restart + $XDG_CONFIG_HOME-aware unit dir (#1909)

### DIFF
--- a/src/__tests__/xdg-migration-guard.e2e.test.ts
+++ b/src/__tests__/xdg-migration-guard.e2e.test.ts
@@ -164,6 +164,37 @@ function verifyPlistPaths(xml: string): PathVerdict[] {
   return out;
 }
 
+/**
+ * cortex#1909 (G-09) — the invariant-(iii) verifier over a systemd `.service`
+ * unit: the Linux parallel of {@link verifyPlistPaths}. Collect every filesystem
+ * path the unit's `ExecStart=` names and classify extant-ness:
+ *   - ExecStart absolute-path args (minus the `--config` value) → the exec /
+ *     script FILE must exist (the relay.ts / cortex-bin class G-03/G-09).
+ *   - the `--config` value → the config FILE must exist (the Linux parallel of
+ *     the plist `--config` check — this is what invariant (iii) previously only
+ *     asserted for launchd plists).
+ *   - WorkingDirectory=… → the DIR must exist.
+ */
+function verifyUnitPaths(unitText: string): PathVerdict[] {
+  const args = parseUnitExecStartArgs(unitText);
+  const config = configArgValue(args);
+  const out: PathVerdict[] = [];
+
+  for (const a of args) {
+    if (!a.startsWith("/")) continue; // "start", "--config", flags
+    if (a === config) continue; // handled as config below
+    out.push({ path: a, kind: "exec", extant: existsSync(a) });
+  }
+  if (config !== undefined) {
+    out.push({ path: config, kind: "config", extant: existsSync(config) });
+  }
+  const workdir = /^\s*WorkingDirectory\s*=\s*(.+)$/m.exec(unitText)?.[1]?.trim();
+  if (workdir !== undefined && workdir !== "") {
+    out.push({ path: workdir, kind: "workdir", extant: existsSync(workdir) });
+  }
+  return out;
+}
+
 /** Build a fully-populated scratch fleet layout + the two rendered plists. */
 function renderFleet(): {
   home: string;
@@ -365,30 +396,68 @@ describe("(iii) installed plist ProgramArguments + WorkingDirectory + Std*Path +
     expect(missing.some((v) => v.path.endsWith("relay.ts"))).toBe(true);
   });
 
-  test("(Linux) a .service ExecStart path is verified extant (G-09)", () => {
-    const { cortexDir } = renderFleet();
+  test("(Linux) a correctly-installed .service has its ExecStart exec + --config + WorkingDirectory extant (G-09)", () => {
+    const { cortexDir, configPath } = renderFleet();
     const relayTs = join(cortexDir, "src", "taps", "cc-events", "relay.ts");
+    // cortex#1909 — a daemon unit carries BOTH an exec AND `--config <path>`;
+    // invariant (iii) now asserts the config value extant too (the Linux
+    // parallel of the plist `--config` check), not just the exec.
     const unit = [
+      "[Unit]",
+      "Description=cortex daemon",
       "[Service]",
-      `ExecStart=/usr/bin/bun ${relayTs} start`,
-      "WorkingDirectory=" + cortexDir,
+      `ExecStart=/usr/bin/bun ${relayTs} start --config ${configPath}`,
+      `WorkingDirectory=${cortexDir}`,
       "[Install]",
       "WantedBy=default.target",
     ].join("\n");
-    const args = parseUnitExecStartArgs(unit);
-    const execPaths = args.filter((a) => a.startsWith("/"));
-    expect(execPaths).toContain(relayTs);
-    for (const p of execPaths) {
-      // /usr/bin/bun may be absent on CI; assert the CORTEX-owned exec is extant
-      // (the migration-relevant path). The system interpreter is out of scope.
-      if (p.startsWith(cortexDir)) expect(existsSync(p)).toBe(true);
-    }
 
-    const staleUnit = unit.replace(relayTs, "/nonexistent/pkg/repos/relay.ts");
-    const staleArgs = parseUnitExecStartArgs(staleUnit);
-    const staleCortexExec = staleArgs.find((a) => a.includes("/pkg/repos/"));
-    expect(staleCortexExec).toBeDefined();
-    expect(existsSync(staleCortexExec!)).toBe(false); // FLAGGED
+    const verdicts = verifyUnitPaths(unit);
+    // sanity: we actually exercised exec + config + workdir kinds.
+    expect(new Set(verdicts.map((v) => v.kind))).toEqual(
+      new Set(["exec", "config", "workdir"]),
+    );
+    // The CORTEX-owned exec, the config file, and the workdir are all extant.
+    // (/usr/bin/bun may be absent on CI, but it is not under cortexDir so it is
+    // not among the cortex-owned exec verdicts we hard-assert.)
+    const cortexOwned = verdicts.filter(
+      (v) => v.kind !== "exec" || v.path.startsWith(cortexDir),
+    );
+    expect(cortexOwned.filter((v) => !v.extant)).toEqual([]);
+    // Explicitly: the --config value is verified (the G-09 addition).
+    const configVerdict = verdicts.find((v) => v.kind === "config");
+    expect(configVerdict).toBeDefined();
+    expect(configVerdict!.path).toBe(configPath);
+    expect(configVerdict!.extant).toBe(true);
+  });
+
+  test("(Linux) NEGATIVE: a .service whose exec moved out from under it is FLAGGED (G-09)", () => {
+    const { cortexDir, configPath } = renderFleet();
+    const relayTs = join(cortexDir, "src", "taps", "cc-events", "relay.ts");
+    const stale = [
+      "[Service]",
+      `ExecStart=/usr/bin/bun /nonexistent/pkg/repos/cortex/relay.ts start --config ${configPath}`,
+      `WorkingDirectory=${cortexDir}`,
+    ].join("\n");
+    const verdicts = verifyUnitPaths(stale);
+    const missing = verdicts.filter((v) => !v.extant);
+    expect(missing.length).toBeGreaterThan(0);
+    expect(missing.some((v) => v.kind === "exec" && v.path.includes("/pkg/repos/"))).toBe(true);
+    // control: relay.ts under the real cortexDir would have been extant.
+    expect(existsSync(relayTs)).toBe(true);
+  });
+
+  test("(Linux) NEGATIVE: a .service whose --config points at a moved/absent path is FLAGGED (the T17 split-brain, G-09)", () => {
+    const { cortexDir } = renderFleet();
+    const relayTs = join(cortexDir, "src", "taps", "cc-events", "relay.ts");
+    const stale = [
+      "[Service]",
+      `ExecStart=/usr/bin/bun ${relayTs} start --config /home/ghost/.config/cortex/gone.yaml`,
+    ].join("\n");
+    const verdicts = verifyUnitPaths(stale);
+    const configVerdict = verdicts.find((v) => v.kind === "config");
+    expect(configVerdict).toBeDefined();
+    expect(configVerdict!.extant).toBe(false); // FLAGGED — the config-cutover regression
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/daemon-locator.test.ts
+++ b/src/cli/cortex/commands/__tests__/daemon-locator.test.ts
@@ -260,4 +260,26 @@ describe("#800 findCortexDaemonDescriptor (linux/systemd)", () => {
     });
     expect(found).toBe(`${SD}/cortex-bot.service`);
   });
+
+  // cortex#1909 G-39 — NAMING DECISION: GRANDFATHER. Discovery matches by the
+  // ExecStart `--config` value, NEVER by unit name, so a unit named under EITHER
+  // convention is found: the frozen-doc `cortex-<slug>.service` (plain) AND the
+  // shipped `ai.meta-factory.cortex.*` label style. Nothing is deployed on Linux
+  // yet, so a forced rename would only risk orphaning a hand-authored unit for
+  // zero benefit; config-match discovery is name-agnostic by construction.
+  test.each([
+    ["cortex-work.service", "frozen-doc plain `cortex-<slug>.service`"],
+    ["ai.meta-factory.cortex.work.service", "shipped `ai.meta-factory.cortex.*` label style"],
+    ["totally-hand-authored.service", "an arbitrary hand-authored name"],
+  ])("G-39 GRANDFATHER: discovers %p (%s) purely by --config match", (name) => {
+    const io = fakeIO({ [SD]: { [name]: unit, "other.service": otherUnit } });
+    const found = findCortexDaemonDescriptor({
+      platform: "linux",
+      cortexConfigPath: LXCFG,
+      launchAgentsDir: "/unused",
+      systemdUserDir: SD,
+      io,
+    });
+    expect(found).toBe(`${SD}/${name}`);
+  });
 });

--- a/src/cli/cortex/commands/daemon-locator.ts
+++ b/src/cli/cortex/commands/daemon-locator.ts
@@ -125,6 +125,16 @@ export function findCortexDaemonDescriptor(opts: {
   }
   // Linux (systemd user units). The clawbox daemon is `cortex-bot.service`; match
   // by the ExecStart `--config` rather than a hard-coded unit name.
+  //
+  // cortex#1909 G-39 (NAMING DECISION — GRANDFATHER): the name pattern is the
+  // maximally-permissive `/\.service$/`, NEVER a specific label. This is a
+  // deliberate grandfather: a cortex daemon unit named under EITHER the frozen
+  // doc convention (`cortex-<slug>.service`, plain) OR the shipped
+  // `ai.meta-factory.cortex.*` label style is discovered identically, purely by
+  // the ExecStart `--config` match. No forced rename/disable migration is done —
+  // nothing is deployed on Linux yet, so forcing a rename would only risk
+  // orphaning a hand-authored unit for no gain. `--config` uniqueness (the relay/
+  // mc siblings carry no `--config`) keeps the match unambiguous regardless of name.
   return scanDir(opts.systemdUserDir, /\.service$/, io, (text) =>
     configMatches(parseUnitExecStartArgs(text), cortexConfigPath),
   );

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -37,6 +37,7 @@ import { parse as parseYaml, parseDocument } from "yaml";
 
 import { expandTilde } from "../../../common/config/loader";
 import { resolveConfigDir } from "../../../common/config/config-path";
+import { systemdUserDir } from "../../../common/xdg";
 import {
   ensureLeafInclude,
   leafIncludeDirectivePresent,
@@ -1049,7 +1050,9 @@ function assertDaemonLoadsConfig(cfg: LivePortsConfig): void {
     platform,
     cortexConfigPath: cfg.cortexConfigPath,
     launchAgentsDir: override?.launchAgentsDir ?? expandTilde("~/Library/LaunchAgents"),
-    systemdUserDir: override?.systemdUserDir ?? expandTilde("~/.config/systemd/user"),
+    // cortex#1909 (G-38) — honor $XDG_CONFIG_HOME instead of hardcoding
+    // ~/.config/systemd/user (the override seam still wins for tests).
+    systemdUserDir: override?.systemdUserDir ?? systemdUserDir(),
     io: override?.io ?? liveDaemonLocatorIO,
   });
   if (descriptorPath === undefined) {
@@ -1141,11 +1144,12 @@ function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
         platform,
         cortexConfigPath: cfg.cortexConfigPath,
         launchAgentsDir: expandTilde("~/Library/LaunchAgents"),
-        systemdUserDir: expandTilde("~/.config/systemd/user"),
+        // cortex#1909 (G-38) — $XDG_CONFIG_HOME-aware systemd user unit dir.
+        systemdUserDir: systemdUserDir(),
         io: liveDaemonLocatorIO,
       });
       if (descriptorPath === undefined) {
-        const where = platform === "darwin" ? "~/Library/LaunchAgents" : "~/.config/systemd/user";
+        const where = platform === "darwin" ? "~/Library/LaunchAgents" : systemdUserDir();
         return {
           ok: false,
           reason:

--- a/src/cli/cortex/commands/network-make-live-adapters.ts
+++ b/src/cli/cortex/commands/network-make-live-adapters.ts
@@ -17,6 +17,7 @@ import { Socket } from "net";
 import { parseDocument } from "yaml";
 
 import { expandTilde } from "../../../common/config/loader";
+import { systemdUserDir } from "../../../common/xdg";
 import {
   renderOperatorModeBlocks,
   renderBaseIsolatedConfig,
@@ -296,7 +297,6 @@ export function buildResolverPreloadAdapter(): ResolverPreloadPort {
 // =============================================================================
 
 const LAUNCH_AGENTS_DIR = join(homedir(), "Library", "LaunchAgents");
-const SYSTEMD_USER_DIR = join(homedir(), ".config", "systemd", "user");
 
 const realLocatorIO: DaemonLocatorIO = {
   listDir: (dir) => {
@@ -352,6 +352,10 @@ export function findNatsServerDescriptor(opts: {
 /** Live {@link ServiceRestartPort}. Discovers descriptors, restarts via launchd/systemd. */
 export function buildServiceRestartAdapter(mutate: boolean): ServiceRestartPort {
   const platform = currentServicePlatform();
+  // cortex#1909 (G-38) — resolve the systemd user unit dir at call time so
+  // $XDG_CONFIG_HOME is honored (was a module-level hardcoded ~/.config/systemd/
+  // user, blind to a relocated config home — the exact var this epic honors).
+  const SYSTEMD_USER_DIR = systemdUserDir();
   return {
     // BLOCK 2 — read-only descriptor resolution for the dry-run preview. Reuses
     // the SAME finders the restarts use, so the previewed target is exactly the

--- a/src/common/__tests__/xdg.test.ts
+++ b/src/common/__tests__/xdg.test.ts
@@ -13,10 +13,18 @@ import {
   XDG_FALLBACK_PREFIX,
   noteXdgFallback,
   readDirEnv,
+  systemdUserDir,
   xdgStrict,
 } from "../xdg";
 
-const VARS = ["CORTEX_CONFIG_DIR", "CORTEX_EVENTS_DIR", "CORTEX_XDG_STRICT", "X_DIR_TEST"] as const;
+const VARS = [
+  "CORTEX_CONFIG_DIR",
+  "CORTEX_EVENTS_DIR",
+  "CORTEX_XDG_STRICT",
+  "X_DIR_TEST",
+  "XDG_CONFIG_HOME",
+  "HOME",
+] as const;
 const saved: Record<string, string | undefined> = {};
 
 beforeEach(() => {
@@ -61,6 +69,42 @@ describe("xdgStrict — CORTEX_XDG_STRICT parse", () => {
   test.each(["0", "false", "no", ""])("%p ⇒ false", (v) => {
     process.env.CORTEX_XDG_STRICT = v;
     expect(xdgStrict()).toBe(false);
+  });
+});
+
+describe("systemdUserDir — $XDG_CONFIG_HOME-aware user unit dir (cortex#1909, G-38)", () => {
+  test("UNSET $XDG_CONFIG_HOME ⇒ $HOME/.config/systemd/user (systemd default)", () => {
+    process.env.HOME = "/home/clawbox";
+    expect(systemdUserDir()).toBe("/home/clawbox/.config/systemd/user");
+  });
+
+  test("SET $XDG_CONFIG_HOME ⇒ $XDG_CONFIG_HOME/systemd/user (honored)", () => {
+    process.env.HOME = "/home/clawbox";
+    process.env.XDG_CONFIG_HOME = "/opt/xdg";
+    expect(systemdUserDir()).toBe("/opt/xdg/systemd/user");
+  });
+
+  test("BLANK $XDG_CONFIG_HOME ⇒ falls back to $HOME/.config (never /systemd/user at root)", () => {
+    process.env.HOME = "/home/clawbox";
+    process.env.XDG_CONFIG_HOME = "";
+    expect(systemdUserDir()).toBe("/home/clawbox/.config/systemd/user");
+  });
+
+  test("WHITESPACE-only $XDG_CONFIG_HOME ⇒ unset (never a literal relative dir)", () => {
+    process.env.HOME = "/home/clawbox";
+    process.env.XDG_CONFIG_HOME = "   ";
+    expect(systemdUserDir()).toBe("/home/clawbox/.config/systemd/user");
+  });
+
+  test("injected xdgConfigHome WINS over the process env (hermetic seam)", () => {
+    process.env.HOME = "/home/clawbox";
+    process.env.XDG_CONFIG_HOME = "/opt/env-xdg";
+    expect(systemdUserDir({ xdgConfigHome: "/scratch/xdg" })).toBe("/scratch/xdg/systemd/user");
+  });
+
+  test("injected home is used for the default when $XDG_CONFIG_HOME is unset", () => {
+    process.env.HOME = "/home/real";
+    expect(systemdUserDir({ home: "/scratch/home" })).toBe("/scratch/home/.config/systemd/user");
   });
 });
 

--- a/src/common/nats/__tests__/nats-service-manager.test.ts
+++ b/src/common/nats/__tests__/nats-service-manager.test.ts
@@ -148,7 +148,7 @@ describe("systemd manager — ExecStart ensure-config-arg (live)", () => {
     expect(after).not.toContain(`-c ${NATS_CONFIG}`);
   });
 
-  test("restart runs `systemctl --user restart <unit>` for a user-scope unit", async () => {
+  test("restart runs `systemctl --user daemon-reload` THEN `restart <unit>` for a user-scope unit (cortex#1909)", async () => {
     const dir = freshDir();
     // A path under a `systemd/user/` dir → user scope.
     const userDir = join(dir, "systemd", "user");
@@ -167,11 +167,15 @@ describe("systemd manager — ExecStart ensure-config-arg (live)", () => {
     });
     const res = await mgr.restart();
     expect(res.ok).toBe(true);
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual(["systemctl", "--user", "restart", "nats-server.service"]);
+    // cortex#1909 — daemon-reload MUST precede restart so a rewritten ExecStart
+    // is reloaded from disk (systemd caches units; restart alone runs stale argv).
+    expect(calls).toEqual([
+      ["systemctl", "--user", "daemon-reload"],
+      ["systemctl", "--user", "restart", "nats-server.service"],
+    ]);
   });
 
-  test("restart runs system-scope `systemctl restart <unit>` for a /etc/systemd/system unit", async () => {
+  test("restart runs system-scope `systemctl daemon-reload` THEN `restart <unit>` for a /etc/systemd/system unit", async () => {
     const dir = freshDir();
     const sysDir = join(dir, "etc", "systemd", "system");
     const fs = await import("fs");
@@ -187,7 +191,86 @@ describe("systemd manager — ExecStart ensure-config-arg (live)", () => {
       exec: runner,
     });
     await mgr.restart();
-    expect(calls[0]).toEqual(["systemctl", "restart", "nats-server.service"]);
+    // System scope: NO `--user` flag on either command.
+    expect(calls).toEqual([
+      ["systemctl", "daemon-reload"],
+      ["systemctl", "restart", "nats-server.service"],
+    ]);
+  });
+
+  test("cortex#1909 config-cutover ROUND-TRIP: repoint ExecStart --config then reload+restart (the Linux T17 fix)", async () => {
+    const dir = freshDir();
+    const userDir = join(dir, "systemd", "user");
+    const fs = await import("fs");
+    fs.mkdirSync(userDir, { recursive: true });
+    const unitPath = join(userDir, "cortex-bot.service");
+    // A unit still pointing at the PRE-move config path.
+    const OLD_CONFIG = "/home/jc/.config/cortex/cortex.yaml";
+    const NEW_CONFIG = "/home/jc/.config/metafactory/cortex/cortex.yaml";
+    const before = [
+      "[Unit]",
+      "Description=cortex daemon",
+      "",
+      "[Service]",
+      `ExecStart=/usr/bin/bun /opt/cortex/cli.ts start --config ${OLD_CONFIG}`,
+      "",
+      "[Install]",
+      "WantedBy=default.target",
+      "",
+    ].join("\n");
+    writeFileSync(unitPath, before, "utf-8");
+
+    const { runner, calls } = capturingExec();
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: runner,
+    });
+
+    // (1) re-render: the stale config flag is repointed to the canonical path.
+    // The arg normalizer collapses any `--config X` to the canonical `-c <path>`
+    // form (single source of truth: nats-plist-loader `ensureConfigArg`).
+    mgr.ensureConfigLoaded(NEW_CONFIG);
+    const after = readFileSync(unitPath, "utf-8");
+    expect(after).toContain(`-c ${NEW_CONFIG}`);
+    expect(after).not.toContain(OLD_CONFIG);
+
+    // (2) reload+restart: the rewritten unit is reloaded, then the service bounced.
+    const res = await mgr.restart();
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([
+      ["systemctl", "--user", "daemon-reload"],
+      ["systemctl", "--user", "restart", "cortex-bot.service"],
+    ]);
+  });
+
+  test("cortex#1909: a FAILED daemon-reload aborts BEFORE restart (fail-closed)", async () => {
+    const dir = freshDir();
+    const userDir = join(dir, "systemd", "user");
+    const fs = await import("fs");
+    fs.mkdirSync(userDir, { recursive: true });
+    const unitPath = join(userDir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+
+    const calls: string[][] = [];
+    // daemon-reload fails; restart must NOT be attempted.
+    const failingReload: ExecRunner = async (argv) => {
+      calls.push(argv);
+      if (argv.includes("daemon-reload")) return { code: 1, stderr: "reload boom" };
+      return { code: 0, stderr: "" };
+    };
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: failingReload,
+    });
+    const res = await mgr.restart();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("daemon-reload");
+    // Only daemon-reload ran — restart was never attempted.
+    expect(calls).toEqual([["systemctl", "--user", "daemon-reload"]]);
   });
 
   test("restart surfaces a non-zero systemctl exit as { ok: false }", async () => {

--- a/src/common/nats/nats-service-manager.ts
+++ b/src/common/nats/nats-service-manager.ts
@@ -20,10 +20,13 @@
  *     via `launchctl kickstart -k gui/<uid>/<label>` reading the plist
  *     `<key>Label</key>`. This is the EXISTING behavior, lifted here verbatim.
  *   - **systemd (Linux):** ensure the unit `[Service] ExecStart=` carries
- *     `-c <config>` (S3-sibling `ensureUnitConfigArg`), restart via
- *     `systemctl [--user] restart <unit>` reading the unit's `.service` id
- *     (the systemd analogue of the plist Label). `--user` vs system scope is
- *     chosen from the unit's on-disk location.
+ *     `-c <config>` (S3-sibling `ensureUnitConfigArg`), then `systemctl
+ *     [--user] daemon-reload` + `systemctl [--user] restart <unit>` reading the
+ *     unit's `.service` id (the systemd analogue of the plist Label). The
+ *     `daemon-reload` is REQUIRED (cortex#1909): systemd caches unit files, so a
+ *     rewritten `ExecStart=` does not take effect on `restart` alone — unlike
+ *     `launchctl kickstart -k`, which re-reads the plist implicitly. `--user`
+ *     vs system scope is chosen from the unit's on-disk location.
  *
  * {@link selectNatsServiceManager} picks the implementation by the descriptor
  * type (plist XML vs systemd unit — detected from path extension, falling back
@@ -311,12 +314,38 @@ class SystemdServiceManager implements NatsServiceManager {
     const unitText = readFileSync(this.unitPath, "utf-8");
     const serviceId = systemdUnitServiceId(this.unitPath, unitText);
     const scope = systemdScope(this.unitPath);
-    const argv =
-      scope === "user"
-        ? ["systemctl", "--user", "restart", serviceId]
-        : ["systemctl", "restart", serviceId];
+    const scopeFlag = scope === "user" ? ["--user"] : [];
+    const scopeLabel = scope === "user" ? "--user " : "";
+
+    // cortex#1909 (config-cutover re-render, G-09) — `daemon-reload` BEFORE
+    // `restart`. Unlike `launchctl kickstart -k`, which re-reads the plist on
+    // every kick, systemd caches the unit file: a rewritten `ExecStart=`
+    // (`ensureConfigLoaded` repointing `--config` to the moved canonical path)
+    // does NOT take effect on `restart` alone — the manager keeps running the
+    // OLD argv until `daemon-reload` reloads the unit from disk. Without this
+    // the Linux config split-brain the macOS leg fixes (#763/T17) stays live:
+    // the daemon restarts still pointing at the pre-move config. `daemon-reload`
+    // is idempotent + cheap, so we always run it (mirroring kickstart's implicit
+    // re-read) rather than tracking whether THIS call mutated the unit.
+    const reloadArgv = ["systemctl", ...scopeFlag, "daemon-reload"];
     // #821 item-2 — `exec` (Bun.spawn) THROWS SYNCHRONOUSLY on ENOENT (systemctl
     // not on PATH). Honour the "never throws" contract → { ok: false }.
+    try {
+      const { code, stderr } = await this.exec(reloadArgv);
+      if (code !== 0) {
+        return {
+          ok: false,
+          reason: `systemctl ${scopeLabel}daemon-reload exited ${code.toString()}: ${stderr.trim()}`,
+        };
+      }
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `systemctl ${scopeLabel}daemon-reload could not run: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const argv = ["systemctl", ...scopeFlag, "restart", serviceId];
     let code: number;
     let stderr: string;
     try {
@@ -324,13 +353,13 @@ class SystemdServiceManager implements NatsServiceManager {
     } catch (err) {
       return {
         ok: false,
-        reason: `systemctl ${scope === "user" ? "--user " : ""}restart ${serviceId} could not run: ${err instanceof Error ? err.message : String(err)}`,
+        reason: `systemctl ${scopeLabel}restart ${serviceId} could not run: ${err instanceof Error ? err.message : String(err)}`,
       };
     }
     if (code !== 0) {
       return {
         ok: false,
-        reason: `systemctl ${scope === "user" ? "--user " : ""}restart ${serviceId} exited ${code.toString()}: ${stderr.trim()}`,
+        reason: `systemctl ${scopeLabel}restart ${serviceId} exited ${code.toString()}: ${stderr.trim()}`,
       };
     }
     return { ok: true };

--- a/src/common/xdg.ts
+++ b/src/common/xdg.ts
@@ -28,6 +28,8 @@
  *      every classified site) is later-wave work.
  */
 
+import { join } from "path";
+
 /** Structured prefix every fallback diagnostic carries (the guard greps this). */
 export const XDG_FALLBACK_PREFIX = "xdg-fallback:";
 
@@ -43,6 +45,35 @@ export function readDirEnv(name: string): string | undefined {
   if (raw === undefined) return undefined;
   const v = raw.trim();
   return v.length > 0 ? v : undefined;
+}
+
+/**
+ * cortex#1909 (G-38, EPIC cortex#1867) — the single resolver for the systemd
+ * *user* unit directory, honoring `$XDG_CONFIG_HOME` exactly as systemd itself
+ * does (`man systemd.unit` → "Table 1: Load paths"): the per-user unit dir is
+ * `$XDG_CONFIG_HOME/systemd/user`, and `$XDG_CONFIG_HOME` defaults to
+ * `$HOME/.config` when unset/empty. Three sites hardcoded `~/.config/systemd/user`
+ * and so silently ignored a relocated `$XDG_CONFIG_HOME` — the very variable this
+ * epic honors — pointing daemon discovery / restart at the WRONG dir on any box
+ * that moved its config home. Route all three through this.
+ *
+ * Precedence (highest first):
+ *   1. explicit `env.xdgConfigHome` — the injectable test/caller seam;
+ *   2. the `$XDG_CONFIG_HOME` process env (blank/whitespace-only ⇒ unset, via
+ *      {@link readDirEnv}, so `XDG_CONFIG_HOME=` keeps the `$HOME/.config`
+ *      default rather than resolving to `/systemd/user`);
+ *   3. `$HOME/.config` (systemd's documented default), where `$HOME` is
+ *      `env.home` when injected, else the process `$HOME`.
+ *
+ * Pure over its injected inputs — no fs, no side effects — so callers can pin a
+ * scratch `$HOME`/`$XDG_CONFIG_HOME` in a hermetic test without touching a real
+ * `~/.config`.
+ */
+export function systemdUserDir(env: { home?: string; xdgConfigHome?: string } = {}): string {
+  const xdgConfigHome = env.xdgConfigHome ?? readDirEnv("XDG_CONFIG_HOME");
+  const home = env.home ?? process.env.HOME ?? "~";
+  const configHome = xdgConfigHome ?? join(home, ".config");
+  return join(configHome, "systemd", "user");
 }
 
 /**


### PR DESCRIPTION
Closes #1909. Part of the XDG epic (#1867), wave-4 prerequisite (G-09 critical / G-38 / G-39). The epic exists for a Linux user, yet the config-cutover re-render/restart was effectively launchd-only. This adds the systemd leg and makes the systemd user-unit dir honor `$XDG_CONFIG_HOME`.

## How I mirrored the launchd leg
The launchd/systemd split already lived behind the `NatsServiceManager` seam (`src/common/nats/nats-service-manager.ts`), selected per-platform by `selectNatsServiceManager` and threaded into the `PlistPort` (config-arg ensure) + daemon/nats restart ports. The `SystemdServiceManager` already:
- rewrote a stale `ExecStart` `--config` to the canonical path via the **shared** `ensureUnitConfigArg` → `ensureConfigArg` arg algorithm (same source of truth as the plist path), and
- discovered the real unit by ExecStart `--config` match (`daemon-locator.ts`), never by a guessed name.

The **one missing half** was reload. `launchctl kickstart -k` re-reads the plist on every kick; systemd **caches** unit files, so a rewritten `ExecStart` never took effect on `restart` alone — the Linux parallel of the macOS T17 config split-brain stayed live (daemon restarts still pointing at the pre-move config).

## AC1 — systemd re-render/restart leg (config cutover)
`SystemdServiceManager.restart()` now runs `systemctl [--user] daemon-reload` **before** `systemctl [--user] restart <unit>`, scope-matched (`--user` for user units, plain for system units), and **fail-closed**: a failed `daemon-reload` aborts before restart. The `systemctl` runner remains the injected `ExecRunner` seam — tests assert the exact rendered unit bytes **and** the `[daemon-reload, restart]` command sequence via a fake runner. No real `systemctl` runs.

## AC2 — `systemdUserDir` resolver + 3 routed sites
Single resolver in `src/common/xdg.ts`:
`systemdUserDir = ($XDG_CONFIG_HOME ?? $HOME/.config)/systemd/user`, with blank/whitespace-only `$XDG_CONFIG_HOME` treated as unset (via `readDirEnv`), and an injectable `{home, xdgConfigHome}` seam. Mirrors systemd's own load-path spec. Routed at all three previously-hardcoded sites:
- `network-adapters.ts` — `assertDaemonLoadsConfig` (fallback behind the existing `daemonLocatorOverride` seam) and `buildDaemonPort.restart`,
- `network-make-live-adapters.ts` — resolved at call time inside `buildServiceRestartAdapter` (was a module-level `const` blind to env).

## AC3 — #1870 invariant (iii) extended to `.service`
New `verifyUnitPaths()` mirrors `verifyPlistPaths()`: asserts every `ExecStart` exec path **and** the `--config` value is extant (plus `WorkingDirectory`). Positive test + two negatives (moved exec; moved/absent `--config` — the config-cutover regression, the Linux parallel of the plist check).

## AC4 — G-39 naming decision: **GRANDFATHER**
Daemon discovery matches units by the ExecStart `--config` value, **never** by name, so a unit under **either** `cortex-<slug>.service` (frozen-doc plain) **or** `ai.meta-factory.cortex.*` (shipped label style) is discovered identically. **Why grandfather, not forced rename:** nothing is deployed on Linux yet, so a forced rename/disable migration would only risk orphaning a hand-authored unit for zero benefit; `--config` uniqueness (relay/mc siblings carry no `--config`) keeps the match unambiguous regardless of name. Decision encoded in `daemon-locator.ts` and pinned by a parametrized test (plain / label / arbitrary name all resolve).

## Tests (hermetic, Linux-CI-runnable, no real systemctl)
- `nats-service-manager.test.ts` — daemon-reload+restart sequence (user + system scope), config-cutover round-trip (repoint `--config` → reload+restart), fail-closed daemon-reload.
- `xdg.test.ts` — `$XDG_CONFIG_HOME` set / unset / blank / whitespace / injected-override matrix.
- `xdg-migration-guard.e2e.test.ts` — invariant (iii) `.service` exec + `--config` extant (positive + 2 negatives).
- `daemon-locator.test.ts` — G-39 grandfather (either name resolves by `--config`).

## Verification
- `bunx tsc --noEmit` → 0.
- Full `bun test`: two consecutive runs → only the **20 known non-hermetic `network-secret-cli`** fails (pre-existing; fail identically in isolation; untouched by this change). Zero others. (A transient `plist-render` shell-suite flake appeared once under full-suite concurrency and passed in isolation + on the second full run — the known "stagger concurrent suites" flake, unrelated to this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)