### PR TITLE
test(surface-sdk): route in-tree Renderer import through the barrel + guard it (#1917)

### DIFF
--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -32,9 +32,8 @@
  * activity-centric, not agent-centric.
  */
 
-import type { Envelope, RenderTarget, RendererPlugin } from "../surface-sdk";
+import type { Envelope, Renderer, RenderTarget, RendererPlugin } from "../surface-sdk";
 import { DashboardRendererSchema, type DashboardRendererConfig } from "../common/types/cortex-config";
-import type { Renderer } from "./types";
 
 export interface DashboardRendererOptions {
   /** Max envelopes retained in the ring buffer. Default 1000 — generous

--- a/src/surface-sdk/__tests__/boundary-guard.test.ts
+++ b/src/surface-sdk/__tests__/boundary-guard.test.ts
@@ -56,12 +56,15 @@ const GUARDED_MODULES: readonly { absPath: string; symbols: readonly string[] }[
       "ContextMessage",
     ],
   },
-  // NOTE: `Renderer` (renderers/types.ts) is deliberately NOT in this list.
-  // Its only in-tree consumers (dashboard.ts, pagerduty.ts, renderers/index.ts)
-  // import it via the intra-directory `./types` relative path, which the
-  // slice's scope explicitly leaves alone ("their own intra-directory
-  // relative imports stay") — there is no adapter-side consumer for it to
-  // guard against drifting from.
+  // `Renderer` (renderers/types.ts): in-tree renderer consumers must import it
+  // via the `../surface-sdk` barrel, not the intra-directory `./types` path —
+  // symmetric with `PlatformAdapter`. Closes the #1917 asymmetry (S5's scope
+  // had left the renderer half unguarded). The defining file (types.ts) and
+  // its re-export barrel (index.ts) are exempt via EXEMPT_ABS_PATHS.
+  {
+    absPath: resolve(SRC_ROOT, "renderers", "types.ts"),
+    symbols: ["Renderer"],
+  },
   {
     absPath: resolve(SRC_ROOT, "bus", "surface-router.ts"),
     symbols: ["SurfaceAdapter"],


### PR DESCRIPTION
Closes #1917 (S5 review nit #2 — boundary-guard asymmetry). The guard routed `PlatformAdapter` + `RenderTarget` through the barrel but not `Renderer` — so an in-tree renderer could silently drift its `Renderer` import off the barrel.

- `dashboard.ts` imports `Renderer` from `../surface-sdk` (barrel), not `./types`.
- Boundary-guard adds `renderers/types.ts → Renderer` to the forbidden-pre-SDK list; `types.ts` (defining) + `index.ts` (re-export) stay exempt via `EXEMPT_ABS_PATHS`.

The guard test itself is the proof: it passes only because the import was repointed. Gate: tsc 0 · 60 renderer/sdk tests pass · lint clean · carveouts PASS · hygiene 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)