### PR TITLE
fix(xdg): route agent-state scripts + confidentiality-scan engine through resolveArcPackReposDir (#2007)

### DIFF
--- a/scripts/__tests__/scan-deploy-surface.test.ts
+++ b/scripts/__tests__/scan-deploy-surface.test.ts
@@ -9,8 +9,11 @@
 // below is obviously-fake and non-sequential; it is not a real platform id.
 //
 // ENGINE DEPENDENCY: this suite shells to the INSTALLED confidentiality-scan
-// engine (~/.config/metafactory/pkg/repos/metafactory-actions/scan/) — an
-// arc-managed local package, not something vendored into this repo or fetched
+// engine, resolved via `DEFAULT_ENGINE_PATH` through the shared arc-pack-repos
+// resolver (cortex#2007: canonical ~/.local/share/metafactory/arc/repos on a
+// migrated box, legacy ~/.config/metafactory/pkg/repos on a singleTree install)
+// under `metafactory-actions/scan/` — an arc-managed local package, not
+// something vendored into this repo or fetched
 // by GitHub Actions' `bun test` job. Mirrors the existing `hasClaude` /
 // `testClaude` self-skip pattern in src/common/test-utils.ts for the same
 // reason (external binary not present on GitHub Actions runners): tests that

--- a/scripts/scan-deploy-surface.ts
+++ b/scripts/scan-deploy-surface.ts
@@ -74,13 +74,20 @@
  */
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { join, relative, resolve } from "node:path";
+// cortex#2007 — the confidentiality-scan engine ships in the arc-installed
+// `metafactory-actions` pack, so its default path MUST resolve the same way
+// every other arc-pack path does (canonical XDG data tree on a migrated box,
+// existence-gated legacy fallback) rather than hardcoding the pre-#287
+// `~/.config/metafactory/pkg/repos`. `scripts/` already imports from
+// `src/common/` (see migrate-config-dir-exec.ts), so route through the shared
+// resolver instead of inlining. `--engine <path>` still overrides.
+import { arcPackScriptPath } from "../src/common/config/arc-pack-repos-dir";
 
-export const DEFAULT_ENGINE_PATH = join(
-  homedir(),
-  ".config/metafactory/pkg/repos/metafactory-actions/scan/confidentiality-scan.ts",
-);
+export const DEFAULT_ENGINE_PATH = arcPackScriptPath("metafactory-actions", [
+  "scan",
+  "confidentiality-scan.ts",
+]);
 
 // Text-scannable extensions for the dashboard build output. Bun's build emits
 // js/css/html/map/json (and any inlined svg); fonts/images are skipped — not

--- a/src/adapters/loader.ts
+++ b/src/adapters/loader.ts
@@ -71,11 +71,11 @@
  */
 
 import { existsSync, readFileSync, realpathSync } from "fs";
-import { homedir } from "os";
 import { join, resolve as resolvePath, sep } from "path";
 import { pathToFileURL } from "url";
 import { parse as parseYaml } from "yaml";
 
+import { resolveArcPackReposDir } from "../common/config/arc-pack-repos-dir";
 import {
   ArcListOutputSchema,
   PluginManifestSchema,
@@ -117,10 +117,15 @@ async function defaultArcListRunner(): Promise<ArcListRunResult> {
   return { stdout, stderr, exitCode };
 }
 
-/** Default trusted install root — arc#289's real on-disk layout. Overridable
- *  (tests point this at a fixtures directory). */
+/** Default trusted install root — arc's package-repos dir. Routed through the
+ *  shared existence-gated resolver (cortex#2007 / #1988) so it mirrors arc's
+ *  post-#287 layout: the canonical `~/.local/share/metafactory/arc/repos` on a
+ *  migrated box, the legacy `~/.config/metafactory/pkg/repos` only on a
+ *  singleTree install. A raw `join(homedir(), ".config"/"metafactory"/"pkg"/"repos")`
+ *  here was a segmented copy of the pre-#287 default that the literal path audit
+ *  could not see. Overridable (tests point this at a fixtures directory). */
 export function defaultPkgRoot(): string {
-  return join(homedir(), ".config", "metafactory", "pkg", "repos");
+  return resolveArcPackReposDir();
 }
 
 // =============================================================================

--- a/src/common/agents/__tests__/agent-state-scripts.test.ts
+++ b/src/common/agents/__tests__/agent-state-scripts.test.ts
@@ -1,0 +1,137 @@
+/**
+ * cortex#2007 — shared AgentState script-path resolvers (EPIC cortex#1867).
+ *
+ * The `scaffold.ts` / `errands.ts` default paths were triplicated across the
+ * agent-state consumers, each hardcoding the pre-#287
+ * `~/.config/metafactory/pkg/repos`. They now route through the ONE shared
+ * `defaultScaffoldScript` / `defaultErrandsScript`, which resolve arc's
+ * package-repos dir via `resolveArcPackReposDir` (arc#287 layout). This suite
+ * pins the resolution matrix the ACs require:
+ *   - default (multi-tree) migrated box → `~/.local/share/metafactory/arc/repos/…`;
+ *   - `$XDG_DATA_HOME` honoured;
+ *   - legacy-only (singleTree) box → `~/.config/metafactory/pkg/repos/…`;
+ *   - env override (`MF_AGENT_STATE_SCRIPT` / `MF_AGENT_STATE_ERRANDS_SCRIPT`) wins.
+ *
+ * Every case is hermetic: a scratch `$HOME`, an explicit `env` bag (both flow
+ * through the injectable `{home, env}` seam), and all assertions land under the
+ * scratch dir — zero real `~/.local`/`~/.config` access, zero `process.env`
+ * mutation.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  defaultScaffoldScript,
+  defaultErrandsScript,
+} from "../agent-state-scripts";
+
+let home: string;
+
+// Canonical multi-tree tree (no $XDG_DATA_HOME): ~/.local/share/metafactory/arc/repos.
+function canonicalRepos() {
+  return join(home, ".local", "share", "metafactory", "arc", "repos");
+}
+// Legacy pre-#287 singleTree tree: ~/.config/metafactory/pkg/repos.
+function legacyRepos() {
+  return join(home, ".config", "metafactory", "pkg", "repos");
+}
+function scaffoldUnder(repos: string) {
+  return join(repos, "agent-state", "skill", "scripts", "scaffold.ts");
+}
+function errandsUnder(repos: string) {
+  return join(repos, "agent-state", "skill", "scripts", "errands.ts");
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "b2007-home-"));
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("defaultScaffoldScript", () => {
+  test("default multi-tree box → ~/.local/share/metafactory/arc/repos/…/scaffold.ts", () => {
+    mkdirSync(canonicalRepos(), { recursive: true });
+    expect(defaultScaffoldScript({ home, env: {} })).toBe(
+      scaffoldUnder(canonicalRepos()),
+    );
+  });
+
+  test("$XDG_DATA_HOME honoured", () => {
+    const xdg = join(home, "xdg-data");
+    const repos = join(xdg, "metafactory", "arc", "repos");
+    mkdirSync(repos, { recursive: true });
+    expect(defaultScaffoldScript({ home, env: { XDG_DATA_HOME: xdg } })).toBe(
+      scaffoldUnder(repos),
+    );
+  });
+
+  test("legacy-only (singleTree) box → ~/.config/metafactory/pkg/repos/…/scaffold.ts", () => {
+    mkdirSync(legacyRepos(), { recursive: true });
+    // Canonical does NOT exist → existence-gated fall back to legacy.
+    expect(defaultScaffoldScript({ home, env: {} })).toBe(
+      scaffoldUnder(legacyRepos()),
+    );
+  });
+
+  test("neither present (fresh host) → canonical default target", () => {
+    expect(defaultScaffoldScript({ home, env: {} })).toBe(
+      scaffoldUnder(canonicalRepos()),
+    );
+  });
+
+  test("MF_AGENT_STATE_SCRIPT override wins over any resolved path", () => {
+    mkdirSync(canonicalRepos(), { recursive: true });
+    const override = join(home, "custom", "scaffold.ts");
+    expect(
+      defaultScaffoldScript({ home, env: { MF_AGENT_STATE_SCRIPT: override } }),
+    ).toBe(override);
+  });
+});
+
+describe("defaultErrandsScript", () => {
+  test("default multi-tree box → ~/.local/share/metafactory/arc/repos/…/errands.ts", () => {
+    mkdirSync(canonicalRepos(), { recursive: true });
+    expect(defaultErrandsScript({ home, env: {} })).toBe(
+      errandsUnder(canonicalRepos()),
+    );
+  });
+
+  test("legacy-only (singleTree) box → ~/.config/metafactory/pkg/repos/…/errands.ts", () => {
+    mkdirSync(legacyRepos(), { recursive: true });
+    expect(defaultErrandsScript({ home, env: {} })).toBe(
+      errandsUnder(legacyRepos()),
+    );
+  });
+
+  test("neither present (fresh host) → canonical default target", () => {
+    expect(defaultErrandsScript({ home, env: {} })).toBe(
+      errandsUnder(canonicalRepos()),
+    );
+  });
+
+  test("MF_AGENT_STATE_ERRANDS_SCRIPT override wins over any resolved path", () => {
+    mkdirSync(canonicalRepos(), { recursive: true });
+    const override = join(home, "custom", "errands.ts");
+    expect(
+      defaultErrandsScript({
+        home,
+        env: { MF_AGENT_STATE_ERRANDS_SCRIPT: override },
+      }),
+    ).toBe(override);
+  });
+
+  test("errands override does NOT leak into scaffold (independent env keys)", () => {
+    mkdirSync(canonicalRepos(), { recursive: true });
+    const errandsOverride = join(home, "custom", "errands.ts");
+    const env = { MF_AGENT_STATE_ERRANDS_SCRIPT: errandsOverride };
+    expect(defaultErrandsScript({ home, env })).toBe(errandsOverride);
+    // scaffold ignores the errands override → still the canonical resolved path.
+    expect(defaultScaffoldScript({ home, env })).toBe(
+      scaffoldUnder(canonicalRepos()),
+    );
+  });
+});

--- a/src/common/agents/agent-state-scaffold.ts
+++ b/src/common/agents/agent-state-scaffold.ts
@@ -30,46 +30,15 @@
 import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-
-/**
- * Canonical AgentState bundle scaffold script.
- *
- * NOTE: this is `skill/scripts/scaffold.ts`, NOT `scripts/errands.ts`. Grove's
- * own default (`grove/src/bot/lib/agent-state-scaffold.ts`) points at the wrong
- * path — it omits the `skill/` segment and names `errands.ts` (a filed grove
- * bug). The bundle installed by arc lays the workflow scripts down under
- * `.../agent-state/skill/scripts/`, and the scaffold entrypoint is
- * `scaffold.ts` (`bun scaffold.ts <instance-dir> --host=<h> --agent=<a>`).
- * `MF_AGENT_STATE_SCRIPT` overrides for non-standard installs.
- */
-function defaultScaffoldScript(): string {
-  return (
-    process.env.MF_AGENT_STATE_SCRIPT ??
-    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/scaffold.ts`
-  );
-}
-
-/**
- * cortex#1720 S2 — canonical AgentState bundle errands script.
- *
- * The `ReplayPending` workflow (`agent-state/skill/Workflows/ReplayPending.md`)
- * lists pending work via `bun <bundle>/skill/scripts/errands.ts pending` — a
- * SIBLING of `scaffold.ts` in the same `skill/scripts/` dir, NOT the scaffold
- * entrypoint. Kept as its own resolver (rather than deriving from
- * `defaultScaffoldScript`) so a principal can install / override the two
- * independently. `MF_AGENT_STATE_ERRANDS_SCRIPT` overrides for non-standard
- * installs.
- *
- * Resolved PER CALL (not frozen at module import) so an env override set after
- * import — e.g. by a test or a late-configured host — is honoured, matching the
- * `opts ?? DEFAULT` pattern used throughout this module.
- */
-function defaultErrandsScript(): string {
-  return (
-    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
-    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`
-  );
-}
+// cortex#2007 — the scaffold/errands default-path resolvers now live in ONE
+// shared module (was triplicated across the agent-state consumers, which is how
+// the pre-#287 `~/.config/metafactory/pkg/repos` default shipped three times).
+// Both route through `resolveArcPackReposDir()`; env overrides + per-call lazy
+// resolution are preserved.
+import {
+  defaultScaffoldScript,
+  defaultErrandsScript,
+} from "./agent-state-scripts";
 
 /** Default host label baked into cortex-scaffolded instance dirs. */
 const DEFAULT_HOST = "cortex";
@@ -158,10 +127,8 @@ export function scaffoldInstance(
   const instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, host);
   // Resolve the bundle script PER CALL (not frozen at module import) so a late
   // env override is honoured — matches the `opts ?? DEFAULT` pattern.
-  const agentStateScript =
-    opts.agentStateScript ??
-    process.env.MF_AGENT_STATE_SCRIPT ??
-    defaultScaffoldScript();
+  // `defaultScaffoldScript()` owns the `MF_AGENT_STATE_SCRIPT` precedence.
+  const agentStateScript = opts.agentStateScript ?? defaultScaffoldScript();
 
   const created: string[] = [];
   const skipped: string[] = [];
@@ -439,10 +406,8 @@ export function replayPending(
   const instanceDir = opts.instanceDir ?? resolveInstanceDir(agent.id, host);
   // Resolve the script path PER CALL (not frozen at module import) so an env
   // override set after import is honoured — matches the `opts ?? DEFAULT` pattern.
-  const errandsScript =
-    opts.errandsScript ??
-    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
-    defaultErrandsScript();
+  // `defaultErrandsScript()` owns the `MF_AGENT_STATE_ERRANDS_SCRIPT` precedence.
+  const errandsScript = opts.errandsScript ?? defaultErrandsScript();
 
   // Bundle not installed → soft-skip (S1 already logged this class of miss on
   // the scaffold side; here we degrade the onStart hook to a no-op).

--- a/src/common/agents/agent-state-scripts.ts
+++ b/src/common/agents/agent-state-scripts.ts
@@ -1,0 +1,65 @@
+/**
+ * cortex#2007 — SHARED resolvers for the AgentState bundle's workflow scripts.
+ *
+ * Before this module the `scaffold.ts` / `errands.ts` default paths were
+ * hand-built at FOUR call sites (agent-state-scaffold ×2, dispatch-state-recorder,
+ * agent-state-dev-session-store) — three of them a byte-identical
+ * `defaultErrandsScript()` copy. That triplication is exactly how the #1988 bug
+ * class (a hardcoded pre-#287 `~/.config/metafactory/pkg/repos`) shipped three
+ * times. Consolidating to ONE definition per script means the arc package-repos
+ * dir is resolved in ONE place ({@link arcPackScriptPath} →
+ * {@link resolveArcPackReposDir}) and can never re-drift per-caller.
+ *
+ * Precedence (highest first), preserved from the original per-call resolvers:
+ *   1. the env override (`MF_AGENT_STATE_SCRIPT` / `MF_AGENT_STATE_ERRANDS_SCRIPT`)
+ *      for a non-standard install;
+ *   2. the arc-canonical pack path, existence-gated (canonical XDG tree on a
+ *      migrated box, legacy `~/.config/metafactory/pkg/repos` on a singleTree
+ *      install, canonical as the fresh-host default).
+ *
+ * Resolved PER CALL (never frozen at import) so a late env / `$HOME` /
+ * `$XDG_DATA_HOME` change — or arc installing the bundle after cortex boot — is
+ * honoured, matching the `opts ?? DEFAULT` pattern the consumers use. The
+ * `{home, env}` seam is injectable for hermetic tests; the env override is read
+ * from the SAME seam bag so a test never has to mutate `process.env`.
+ */
+
+import {
+  arcPackScriptPath,
+  type ArcPackReposDirSeam,
+} from "../config/arc-pack-repos-dir";
+
+/** arc pack that houses the AgentState bundle's workflow scripts. */
+export const AGENT_STATE_PACK = "agent-state";
+/** In-pack directory the bundle lays its workflow scripts under. */
+const SKILL_SCRIPTS_SEGMENTS = ["skill", "scripts"] as const;
+
+function seamEnv(seam?: ArcPackReposDirSeam): Record<string, string | undefined> {
+  return seam?.env ?? process.env;
+}
+
+/**
+ * Canonical AgentState bundle scaffold script — `skill/scripts/scaffold.ts`
+ * (`bun scaffold.ts <instance-dir> --host=<h> --agent=<a>`).
+ * `MF_AGENT_STATE_SCRIPT` overrides for a non-standard install.
+ */
+export function defaultScaffoldScript(seam?: ArcPackReposDirSeam): string {
+  return (
+    seamEnv(seam).MF_AGENT_STATE_SCRIPT ??
+    arcPackScriptPath(AGENT_STATE_PACK, [...SKILL_SCRIPTS_SEGMENTS, "scaffold.ts"], seam)
+  );
+}
+
+/**
+ * Canonical AgentState bundle errands script — `skill/scripts/errands.ts`, a
+ * SIBLING of `scaffold.ts` carrying the `pending` / `enqueue` / `claim` /
+ * `resolve` / `list` / `get` / `annotate` subcommands. Kept as its own resolver
+ * (rather than derived from {@link defaultScaffoldScript}) so a principal can
+ * install / override the two independently via `MF_AGENT_STATE_ERRANDS_SCRIPT`.
+ */
+export function defaultErrandsScript(seam?: ArcPackReposDirSeam): string {
+  return (
+    seamEnv(seam).MF_AGENT_STATE_ERRANDS_SCRIPT ??
+    arcPackScriptPath(AGENT_STATE_PACK, [...SKILL_SCRIPTS_SEGMENTS, "errands.ts"], seam)
+  );
+}

--- a/src/common/agents/dispatch-state-recorder.ts
+++ b/src/common/agents/dispatch-state-recorder.ts
@@ -52,6 +52,11 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { resolveInstanceDir } from "./agent-state-scaffold";
+// cortex#2007 — `defaultErrandsScript()` is now the ONE shared resolver (was
+// triplicated here / in the scaffold lib / in the dev-session store). It routes
+// through `resolveArcPackReposDir()`; `MF_AGENT_STATE_ERRANDS_SCRIPT` override +
+// per-call lazy resolution preserved.
+import { defaultErrandsScript } from "./agent-state-scripts";
 import {
   defaultAgentStateSpawn,
   type AgentStateSpawnResult,
@@ -59,23 +64,6 @@ import {
 
 /** Default host label baked into cortex work_item env. */
 const DEFAULT_HOST = "cortex";
-
-/**
- * cortex#1720 S3 — canonical AgentState bundle errands script (shared shape with
- * S2's replay lib). The `enqueue` / `claim` / `resolve` subcommands live on the
- * SAME `errands.ts` the S2 `pending` path uses. Kept as its own env override so
- * a principal can point the dispatch-wiring at a non-standard install
- * independently. `MF_AGENT_STATE_ERRANDS_SCRIPT` overrides.
- *
- * Resolved PER CALL (not frozen at module import) so a late env override is
- * honoured — matches the `opts ?? DEFAULT` pattern used throughout.
- */
-function defaultErrandsScript(): string {
-  return (
-    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
-    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`
-  );
-}
 
 /** Terminal outcome an accepted dispatch resolves to. */
 export type DispatchResolveStatus = "done" | "failed";

--- a/src/common/config/__tests__/arc-pack-repos-dir.test.ts
+++ b/src/common/config/__tests__/arc-pack-repos-dir.test.ts
@@ -22,6 +22,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   arcCanonicalPackReposDir,
+  arcPackScriptPath,
   legacyArcPackReposDir,
   resolveArcPackReposDir,
 } from "../arc-pack-repos-dir";
@@ -144,5 +145,71 @@ describe("consumer parity — brain-consumer-boot join shape", () => {
     expect(join(base, "my-exec-brain")).toBe(
       join(canonicalDefault(), "my-exec-brain"),
     );
+  });
+});
+
+describe("arcPackScriptPath (cortex#2007 — single arc-pack path construction site)", () => {
+  // Multi-tree box: pack path roots at the canonical XDG data tree.
+  test("default multi-tree box → <canonical>/<pack>/<segments>", () => {
+    mkdirSync(canonicalDefault(), { recursive: true });
+    expect(
+      arcPackScriptPath(
+        "agent-state",
+        ["skill", "scripts", "scaffold.ts"],
+        { home, env: {} },
+      ),
+    ).toBe(join(canonicalDefault(), "agent-state", "skill", "scripts", "scaffold.ts"));
+  });
+
+  // Legacy-only (singleTree) box: existence-gated fall back to the legacy tree.
+  test("legacy-only box → <legacy>/<pack>/<segments>", () => {
+    mkdirSync(legacyDir(), { recursive: true });
+    expect(
+      arcPackScriptPath("agent-state", ["skill", "scripts", "errands.ts"], {
+        home,
+        env: {},
+      }),
+    ).toBe(join(legacyDir(), "agent-state", "skill", "scripts", "errands.ts"));
+  });
+
+  // The deploy confidentiality-scan engine path (scan-deploy-surface.ts
+  // DEFAULT_ENGINE_PATH) resolves through the SAME helper — pin its shape on
+  // both a multi-tree and a legacy box.
+  test("scan engine path (metafactory-actions) → canonical on a multi-tree box", () => {
+    mkdirSync(canonicalDefault(), { recursive: true });
+    expect(
+      arcPackScriptPath(
+        "metafactory-actions",
+        ["scan", "confidentiality-scan.ts"],
+        { home, env: {} },
+      ),
+    ).toBe(
+      join(canonicalDefault(), "metafactory-actions", "scan", "confidentiality-scan.ts"),
+    );
+  });
+
+  test("scan engine path (metafactory-actions) → legacy on a singleTree box", () => {
+    mkdirSync(legacyDir(), { recursive: true });
+    expect(
+      arcPackScriptPath(
+        "metafactory-actions",
+        ["scan", "confidentiality-scan.ts"],
+        { home, env: {} },
+      ),
+    ).toBe(
+      join(legacyDir(), "metafactory-actions", "scan", "confidentiality-scan.ts"),
+    );
+  });
+
+  test("$XDG_DATA_HOME flows through the seam to the pack path", () => {
+    const xdg = join(home, "xdg-data");
+    const repos = join(xdg, "metafactory", "arc", "repos");
+    mkdirSync(repos, { recursive: true });
+    expect(
+      arcPackScriptPath("agent-state", ["skill", "scripts", "scaffold.ts"], {
+        home,
+        env: { XDG_DATA_HOME: xdg },
+      }),
+    ).toBe(join(repos, "agent-state", "skill", "scripts", "scaffold.ts"));
   });
 });

--- a/src/common/config/arc-pack-repos-dir.ts
+++ b/src/common/config/arc-pack-repos-dir.ts
@@ -133,3 +133,32 @@ export function resolveArcPackReposDir(seam?: ArcPackReposDirSeam): string {
 
   return canonical;
 }
+
+/**
+ * Resolve the on-disk path to a file (typically a workflow script) INSIDE an
+ * arc-installed pack, rooted at the existence-gated {@link resolveArcPackReposDir}.
+ * The pack name plus any trailing path `segments` are joined onto the resolved
+ * repos dir:
+ *
+ *   arcPackScriptPath("agent-state", ["skill", "scripts", "scaffold.ts"])
+ *     → <reposDir>/agent-state/skill/scripts/scaffold.ts
+ *
+ * This is the SINGLE construction site for arc-pack script paths across cortex —
+ * the agent-state scaffold/errands resolvers and the deploy confidentiality-scan
+ * engine path all route through it (cortex#2007), so the pre-#287
+ * `~/.config/metafactory/pkg/repos` default can never be re-hardcoded per-caller
+ * (the #1988 bug class — it had already shipped three times via a triplicated
+ * `defaultErrandsScript`).
+ *
+ * Resolved PER CALL (never frozen): a late `$HOME` / `$XDG_DATA_HOME` change — or
+ * arc installing the pack AFTER cortex boot — is honoured, matching the lazy
+ * `opts ?? DEFAULT` semantics of the resolvers that consume it. The `{home, env}`
+ * seam flows straight through to the repos-dir resolver for hermetic tests.
+ */
+export function arcPackScriptPath(
+  pack: string,
+  segments: string[],
+  seam?: ArcPackReposDirSeam,
+): string {
+  return join(resolveArcPackReposDir(seam), pack, ...segments);
+}

--- a/src/runner/agent-state-dev-session-store.ts
+++ b/src/runner/agent-state-dev-session-store.ts
@@ -47,6 +47,9 @@
 
 import { existsSync } from "node:fs";
 import { resolveInstanceDir } from "../common/agents/agent-state-scaffold";
+// cortex#2007 — shared `defaultErrandsScript()` (was triplicated); routes
+// through `resolveArcPackReposDir()`, env override + lazy resolution preserved.
+import { defaultErrandsScript } from "../common/agents/agent-state-scripts";
 import {
   defaultAgentStateSpawn,
   type AgentStateSpawn,
@@ -65,18 +68,6 @@ export const DEV_SESSION_WORK_ITEM_KIND = "dev-session";
 
 /** The host-namespaced notes key carrying the CC session id. */
 const SESSION_ID_NOTE_KEY = "session_id";
-
-/**
- * Canonical AgentState `errands.ts` path (shared shape with the S3 recorder).
- * `MF_AGENT_STATE_ERRANDS_SCRIPT` overrides; resolved lazily so a late env
- * override is honoured.
- */
-function defaultErrandsScript(): string {
-  return (
-    process.env.MF_AGENT_STATE_ERRANDS_SCRIPT ??
-    `${process.env.HOME ?? ""}/.config/metafactory/pkg/repos/agent-state/skill/scripts/errands.ts`
-  );
-}
 
 /** Minimal shape this store needs off an agent — id, plus the opt-in `state`. */
 export interface DevSessionStoreAgent {


### PR DESCRIPTION
Closes #2007.

## What
Five (plus one sweep-found) runtime path defaults still pointed at arc's pre-#287 package-repos dir `~/.config/metafactory/pkg/repos` (the #1988 bug class). arc#287 moved arc's canonical repos dir to `~/.local/share/metafactory/arc/repos`; on a migrated (multi-tree) box each of these resolved to an empty/stale tree.

## Changes
- **New `arcPackScriptPath(pack, segments, seam?)`** in `src/common/config/arc-pack-repos-dir.ts` — the single arc-pack path construction site, rooted at the existence-gated `resolveArcPackReposDir()`.
- **Consolidated the triplicated `defaultErrandsScript()`** (+ `defaultScaffoldScript`) into ONE shared module `src/common/agents/agent-state-scripts.ts`, imported by all three consumers (`agent-state-scaffold.ts`, `dispatch-state-recorder.ts`, `agent-state-dev-session-store.ts`). The triplication is how this bug shipped three times. Env overrides (`MF_AGENT_STATE_SCRIPT` / `MF_AGENT_STATE_ERRANDS_SCRIPT`) stay highest-precedence; per-call lazy resolution preserved.
- **`scripts/scan-deploy-surface.ts` `DEFAULT_ENGINE_PATH`** → routed through the resolver. `scripts/` already imports from `src/common/` (see `migrate-config-dir-exec.ts`), so no inlining needed.
- **Variant-aware negative sweep found a 6th runtime site** the literal-string audit missed: `src/adapters/loader.ts` `defaultPkgRoot()` built the same path via a segmented `join(homedir(), ".config", "metafactory", "pkg", "repos")` (invisible to the literal grep). Routed through `resolveArcPackReposDir()` too; `realpathSync` already handles non-existence gracefully.

## Sweep commands run
```
git grep -nE '\.config/metafactory/pkg/repos' -- 'src/**/*.ts' 'scripts/**/*.ts' ':!**/__tests__/**'
git grep -nE '"pkg",\s*"repos"|join\([^)]*"pkg"' -- 'src/**/*.ts' 'scripts/**/*.ts' ':!**/__tests__/**'
git grep -nE 'metafactory.{0,20}pkg|pkg.{0,20}repos' -- 'src/**/*.ts' 'scripts/**/*.ts' ':!**/__tests__/**'
```
Post-fix, the segmented-join gate returns **zero**; every literal-string survivor is a comment/docstring (resolver internals + explanatory comments + two pre-existing `grep tier …` doc examples that are explicitly out of scope).

## Tests
Hermetic (scratch `$HOME` + env bag, no real-home reads), mirroring `arc-pack-repos-dir.test.ts`:
- `agent-state-scripts.test.ts` (new): multi-tree → canonical, legacy-only → legacy, `$XDG_DATA_HOME` honoured, `MF_AGENT_STATE_*` override wins, override independence.
- `arc-pack-repos-dir.test.ts`: `arcPackScriptPath` matrix incl. the `metafactory-actions` scan-engine path on multi-tree + legacy boxes.

## Verification
- `bunx tsc --noEmit` → 0.
- Full `bun test` → 9795 pass; 21 fail = the known ~20 non-hermetic `network-secret-cli` fails + 1 pre-existing `ConfigWatcher` fs-watch timing flake (4.1s under full-suite load; **passes cleanly in isolation** and imports nothing this diff touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)