### PR TITLE
chore: bump to v6.8.1 — pluggable-adapters follow-ups

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.8.0"
+version: "6.8.1"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Patch bump. Additive/backward-compatible follow-ups since v6.8.0 (#2002 upload ceiling, #1909 systemd XDG, #1917/#2017 test-hardening, #1905 rename refs). Release cut on merge. No deploy (Andreas's production machine).