### PR TITLE
feat(xdg-audit): precision gate — class rules + allow mechanisms + raw-exception + doc-accuracy sweep (#1867)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ this template), and
 
 **CLAUDE.md is fully generated — NEVER hand-edit it.** It is produced by `arc upgrade compass` from:
 
-- **Template:** `compass/templates/CLAUDE.md.template` (shared ecosystem template; the installed copy lives at `~/.config/metafactory/pkg/repos/compass/templates/CLAUDE.md.template`)
+- **Template:** `compass/templates/CLAUDE.md.template` (shared ecosystem template; the installed copy lives at `~/.local/share/metafactory/arc/repos/compass/templates/CLAUDE.md.template`)
 - **Config:** `agents-md.yaml` (repo-specific placeholders and section list)
 - **Section files:** `docs/agents-md/*.md` (repo-specific content injected at marked positions)
 

--- a/docs/agents-md/critical-rules.md
+++ b/docs/agents-md/critical-rules.md
@@ -12,7 +12,7 @@
 
 **CLAUDE.md is fully generated — NEVER hand-edit it.** It is produced by `arc upgrade compass` from:
 
-- **Template:** `compass/templates/CLAUDE.md.template` (shared ecosystem template; the installed copy lives at `~/.config/metafactory/pkg/repos/compass/templates/CLAUDE.md.template`)
+- **Template:** `compass/templates/CLAUDE.md.template` (shared ecosystem template; the installed copy lives at `~/.local/share/metafactory/arc/repos/compass/templates/CLAUDE.md.template`)
 - **Config:** `agents-md.yaml` (repo-specific placeholders and section list)
 - **Section files:** `docs/agents-md/*.md` (repo-specific content injected at marked positions)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -390,7 +390,7 @@ Reference: `the-metafactory/arc` — the metafactory package manager. Like compa
 | Cortex consumes other bundles indirectly | Principals install `myelin` (via arc) for the bus protocol; `signal` (via arc) for the observability tap; `cortex` (via arc) for the surface. Each is independently rolled out. |
 | Cortex does NOT runtime-import arc | arc is a build/install-time tool. At runtime cortex doesn't know it was installed by arc — it just finds its config at the configured path and runs. |
 | Cross-bundle dependencies | Declared via the `arc-manifest.yaml` `dependsOn:` field. Cortex declares `myelin` (the schema is vendored, but principals need myelin's CLI for identity-key provisioning per MIG-7's `nats.identity` config). signal is *recommended* but not required (cortex tolerates absent collector). |
-| Existing examples | `~/.config/metafactory/pkg/repos/` shows installed bundles today: `grove` (legacy bot), `compass` (SOPs + validators), `pilot`, etc. The same directory will hold `cortex` post-MIG-7. |
+| Existing examples | `~/.local/share/metafactory/arc/repos/` shows installed bundles today: `grove` (legacy bot), `compass` (SOPs + validators), `pilot`, etc. The same directory will hold `cortex` post-MIG-7. |
 
 **Why this matters for the design:**
 
@@ -404,7 +404,7 @@ Reference: `the-metafactory/arc` — the metafactory package manager. Like compa
 - Cortex's `arc-manifest.yaml` MUST be valid against arc's published manifest schema. Manifest validation runs in cortex's CI.
 - Cortex MAY shell out to `arc` for one-shot install-time steps (e.g. `arc identity provision` per JC's E2E NATS work) but never as a runtime dependency.
 
-**Reading order:** `~/Developer/arc/README.md` for the install model → `arc list` / `arc upgrade --help` for the principal-facing CLI → existing manifests in `~/.config/metafactory/pkg/repos/*/arc-manifest.yaml` as concrete examples.
+**Reading order:** `~/Developer/arc/README.md` for the install model → `arc list` / `arc upgrade --help` for the principal-facing CLI → existing manifests in `~/.local/share/metafactory/arc/repos/*/arc-manifest.yaml` as concrete examples.
 
 ---
 
@@ -766,7 +766,7 @@ Skip on first pass: signal collector internals (still design), pilot's internals
 - **Lineage docs** — `docs/design-collaboration-surface.md` (PR #58 + #83 — includes the event architecture diagram), `docs/design-event-taxonomy.md` (PR #81), `docs/iteration-collaboration-surface.md` (PR #79).
 - **M7 sibling apps** — `~/Developer/pilot/README.md`, `~/Developer/signal/README.md` + `~/Developer/signal/docs/design-signal-bundle-migration.md`.
 - **Knowledge artefacts** — `~/Developer/compass/sops/*.md`, `~/Developer/blueprint/README.md`, `~/Developer/blueprint/docs/design-event-sync.md`.
-- **Distribution layer** — `~/Developer/arc/README.md`, existing manifests at `~/.config/metafactory/pkg/repos/*/arc-manifest.yaml` (concrete examples).
+- **Distribution layer** — `~/Developer/arc/README.md`, existing manifests at `~/.local/share/metafactory/arc/repos/*/arc-manifest.yaml` (concrete examples).
 - **Process** — `~/Developer/compass/sops/dev-pipeline.md`, `worktree-discipline.md`, `pr-review.md`, `design-process.md`, `versioning.md`, `new-repo-pattern.md`.
 - **Working migration plan** — `docs/plan-cortex-migration.md`.
 

--- a/docs/design-bot-packs.md
+++ b/docs/design-bot-packs.md
@@ -235,7 +235,7 @@ wont_do` failure vocabulary maps 1:1 onto brain exit codes / error events.
 The process boundary makes this almost boring — no module-cache exorcism:
 
 1. **Install/upgrade:** `arc install yarrow` drops the pack into
-   `~/.config/metafactory/pkg/repos/yarrow/`, writes `agent.yaml` into
+   `~/.local/share/metafactory/arc/repos/yarrow/`, writes `agent.yaml` into
    `agents.d/`, runs `cortex creds issue yarrow` (A.2) when
    `lifecycle: daemon`.
 2. **Detect:** the cortex#60 A.1 watcher on `agents.d/` (plus

--- a/docs/design-pilot-restructure.md
+++ b/docs/design-pilot-restructure.md
@@ -10,7 +10,7 @@
 - `docs/architecture.md` — §3 (four subject classes, hot/cold path), §7 (capability-driven dispatch, three distribution modes, nak taxonomy, sovereignty modes).
 - `docs/plan-internet-of-agentic-work.md` — Phase D §D.4 (capability registry / federation handshake).
 - Reverted source (still readable in git history) — `git show 3a88dd8:src/cli/cortex/commands/wait-for-review.ts` (the cortex#234 CLI; PR #236 reverts it). The new `pilot wait-for-review` CLI lifts shape from here.
-- Source under restructure — `~/.config/metafactory/pkg/repos/pilot/` (the pilot repo, root commit `ff2fe2a` extracted from `the-metafactory/meta-factory` on 2026-04-24).
+- Source under restructure — `~/.local/share/metafactory/arc/repos/pilot/` (the pilot repo, root commit `ff2fe2a` extracted from `the-metafactory/meta-factory` on 2026-04-24).
 
 **Tracking issues:** cortex#232 (umbrella — review-bundle migration to pilot), cortex#237 (Echo's bus-side consumer: subscribe to `tasks.code-review.*`, emit `review.verdict.*`).
 
@@ -52,7 +52,7 @@ These are inputs to this spec, NOT open for re-litigation:
 ### §2.1 Top-level layout
 
 ```
-~/.config/metafactory/pkg/repos/pilot/
+~/.local/share/metafactory/arc/repos/pilot/
 ├── arc-manifest.yaml            # skill manifest (`pilot-review-loop` v0.3.0)
 ├── package.json                 # bun package, ships `~/.local/bin/pilot`
 ├── bun.lock
@@ -971,7 +971,7 @@ Pilot's `bus/` subtree imports `NatsLink`, `MyelinSubscriber`, `Envelope`, `vali
 
 **Cons:**
 
-- Assumes cortex repo is at `../cortex` relative to pilot checkout. **False for the standard `~/Developer/cortex` + `~/.config/metafactory/pkg/repos/pilot` layout.** Principals would have to manually symlink.
+- Assumes cortex repo is at `../cortex` relative to pilot checkout. **False for the standard `~/Developer/cortex` + `~/.local/share/metafactory/arc/repos/pilot` layout.** Principals would have to manually symlink.
 - CI configuration would need to clone cortex before `bun install`.
 - arc-manifest distribution (the `arc upgrade Pilot` story): `arc` does NOT install path-relative deps. The pilot binary at `~/.local/bin/pilot` would silently break on principal machines that don't have cortex checked out alongside.
 
@@ -1133,7 +1133,7 @@ cortex#232 is closed when Phase A merges (the design lands as a tracked artefact
 - `~/Developer/cortex/docs/design-internet-of-agentic-work.md` — multi-network framing (Phase D context).
 - `~/Developer/cortex/docs/architecture.md` — §3, §7 (bus structure, capability dispatch).
 - `~/Developer/cortex/docs/plan-internet-of-agentic-work.md` — Phase D detail (out of this spec's immediate scope).
-- `~/.config/metafactory/pkg/repos/pilot/` — source under restructure.
+- `~/.local/share/metafactory/arc/repos/pilot/` — source under restructure.
 - `git show 3a88dd8:src/cli/cortex/commands/wait-for-review.ts` — reverted CLI; the shape template for §5's three new CLIs.
 - cortex PR #236 — reverts the cortex#234 CLI; surfaces this restructure as the follow-up.
 - cortex#232 — review-bundle migration umbrella.

--- a/docs/design-pluggable-adapters.md
+++ b/docs/design-pluggable-adapters.md
@@ -58,7 +58,7 @@ The epic's stocktake was captured @ origin/main `83e73ec2`; re-verified here aga
 | 6 | Legacy worklog reaches through `DiscordAdapter` — static import + `getClient()` + `formatEventForDiscord` | ❌ blocker | `src/cortex.ts:134` (import), `:335` (`formatEventForDiscord`), `:5882,5889` (`getClient`), `:5936` (format call) |
 | 7 | `SurfacesSchema` is `.strict()` with 4 hardcoded platform keys — no out-of-tree platform validates | ❌ blocker | `src/common/types/surfaces.ts:327-341` |
 | 8 | Platform npm deps live in cortex `package.json` | ❌ blocker | `package.json:47,48,55` |
-| 9 | arc bundles + `dependencies:` ranges + repo-first install proven | ✅ | ADR-0017, `metafactory-bundle-discord` installed under `~/.config/metafactory/pkg/repos/` |
+| 9 | arc bundles + `dependencies:` ranges + repo-first install proven | ✅ | ADR-0017, `metafactory-bundle-discord` installed under `~/.local/share/metafactory/arc/repos/` |
 | 10 | arc semver-range *enforcement* between installed packages + bundle `bun install` | ⚠️ likely missing | arc-side slice (arc#284 / S7) |
 | 11 | Daemon runs TS via bun → dynamic `import()` of installed bundle source is feasible | ✅ | `src/cortex.ts:1` shebang; plists run `~/.local/bin/cortex start` |
 | 12 | Config hot-reload machinery exists (`applied` vs `requiresRestart`) | ✅ | `src/common/config/watcher.ts:12-16,101-106` |
@@ -167,7 +167,7 @@ metafactory-slack/
   src/index.ts             # default-exports a SurfacePlugin
 ```
 
-`arc install metafactory-slack` lands it under `~/.config/metafactory/pkg/repos/metafactory-slack/` and runs its `bun install` (arc#284 / S7). Distribution is **repo-first** (ADR-0017's decision) — registry-by-name publication is later and gated on a principal sign-off (HOLD).
+`arc install metafactory-slack` lands it under `~/.local/share/metafactory/arc/repos/metafactory-slack/` and runs its `bun install` (arc#284 / S7). Distribution is **repo-first** (ADR-0017's decision) — registry-by-name publication is later and gated on a principal sign-off (HOLD).
 
 The manifest is **one file for both kinds** — `cortex-plugin.yaml` (not `cortex-adapter.yaml`; the draft's name predates the fold-in). It carries `kind: adapter | renderer`; `entry`; `sdkRange`; and the advisory `cortex` range. A renderer bundle (`metafactory-pagerduty`) has the identical shape with `kind: renderer` and, typically, no `package.json` deps at all (R10).
 

--- a/scripts/__tests__/xdg-audit.test.ts
+++ b/scripts/__tests__/xdg-audit.test.ts
@@ -1,0 +1,120 @@
+// Hermetic self-test for the xdg-audit REPO GATE (cortex#1867).
+//
+// Pins the gate's core contract so it can't silently rot into a no-op:
+//   (a) a planted stale RUNTIME literal makes the gate exit NONZERO and report it;
+//   (b) the same line carrying `xdg-audit:allow(reason)` exits 0;
+//   (c) an allowlist entry whose content-regex does NOT match a line must NOT
+//       suppress a DIFFERENT line in the same file (narrow-match guarantee);
+//   plus: bare `xdg-audit:allow` (no reason) is a hard gate error, and the
+//   class rules (test files / code comments) are advisory, not gated.
+//
+// Runs entirely in a scratch git repo under a temp dir — never touches the real
+// dev checkouts. The allowlist is supplied via $XDG_AUDIT_ALLOWLIST so the test
+// is independent of the shipped scripts/xdg-audit-allow.yaml.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const AUDIT = join(REPO_ROOT, "scripts", "xdg-audit.ts");
+
+let scratch: string;
+
+function git(cwd: string, ...args: string[]) {
+  const r = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+}
+
+/** Run the gate against `root` with an optional scratch allowlist. */
+function runGate(root: string, allowlistPath?: string) {
+  const env = { ...process.env, XDG_AUDIT_ALLOWLIST: allowlistPath ?? "/nonexistent-allowlist.yaml" };
+  const r = spawnSync("bun", [AUDIT, "--repos", root, "--json"], { encoding: "utf8", env });
+  let json: any = {};
+  try { json = JSON.parse(r.stdout); } catch { /* leave empty; assertions below will surface it */ }
+  return { status: r.status ?? -1, json, stderr: r.stderr, stdout: r.stdout };
+}
+
+beforeAll(() => {
+  scratch = mkdtempSync(join(tmpdir(), "xdg-audit-selftest-"));
+  git(scratch, "init", "-q");
+  git(scratch, "config", "user.email", "t@t");
+  git(scratch, "config", "user.name", "t");
+  // A RUNTIME literal (non-comment, non-test) — the kind the gate must catch.
+  writeFileSync(join(scratch, "runtime.ts"), [
+    'export const CONFIG = "~/.config/cortex/bot.yaml";  // planted stale runtime literal',
+    'export const OTHER = "~/.config/grove/other.yaml";  // a DIFFERENT line, same file',
+  ].join("\n") + "\n");
+  // A code COMMENT line (advisory) + a TEST-file line (advisory).
+  writeFileSync(join(scratch, "commented.ts"), '// legacy note: ~/.config/cortex/legacy.yaml\n');
+  mkdirSync(join(scratch, "__tests__"), { recursive: true });
+  writeFileSync(join(scratch, "__tests__", "fixture.test.ts"), 'const p = "~/.config/cortex/x";\n');
+  git(scratch, "add", "-A");
+});
+
+afterAll(() => { if (scratch) rmSync(scratch, { recursive: true, force: true }); });
+
+describe("xdg-audit gate — self-test (cortex#1867)", () => {
+  test("(a) planted stale runtime literal → NONZERO exit + reported", () => {
+    const { status, json } = runGate(scratch);
+    expect(status).toBeGreaterThan(0);
+    const runtimeGated = (json.gated ?? []).filter((f: any) => f.relPath === "runtime.ts");
+    expect(runtimeGated.length).toBe(2); // both runtime.ts literals are gated
+    // the comment line and the test-file line are advisory, NOT gated
+    expect((json.gated ?? []).some((f: any) => f.relPath === "commented.ts")).toBe(false);
+    expect((json.gated ?? []).some((f: any) => f.relPath.includes("__tests__"))).toBe(false);
+    expect(json.summary.advisory.comment).toBeGreaterThanOrEqual(1);
+    expect(json.summary.advisory.test).toBeGreaterThanOrEqual(1);
+  });
+
+  test("(b) same line with xdg-audit:allow(reason) → exit 0", () => {
+    const allowed = mkdtempSync(join(tmpdir(), "xdg-audit-selftest-b-"));
+    git(allowed, "init", "-q");
+    git(allowed, "config", "user.email", "t@t");
+    git(allowed, "config", "user.name", "t");
+    writeFileSync(join(allowed, "runtime.ts"),
+      'export const CONFIG = "~/.config/cortex/bot.yaml"; // xdg-audit:allow(test — deliberate legacy literal)\n');
+    git(allowed, "add", "-A");
+    const { status, json } = runGate(allowed);
+    expect(status).toBe(0);
+    expect(json.summary.gated).toBe(0);
+    expect(json.summary.allowed.inline).toBe(1);
+    rmSync(allowed, { recursive: true, force: true });
+  });
+
+  test("(b') bare xdg-audit:allow (no reason) is a hard gate error", () => {
+    const bare = mkdtempSync(join(tmpdir(), "xdg-audit-selftest-bare-"));
+    git(bare, "init", "-q");
+    git(bare, "config", "user.email", "t@t");
+    git(bare, "config", "user.name", "t");
+    writeFileSync(join(bare, "runtime.ts"),
+      'export const CONFIG = "~/.config/cortex/bot.yaml"; // xdg-audit:allow\n');
+    git(bare, "add", "-A");
+    const { status, json } = runGate(bare);
+    expect(status).toBeGreaterThan(0);
+    expect(json.summary.errors.some((e: string) => /bare 'xdg-audit:allow'/.test(e))).toBe(true);
+    rmSync(bare, { recursive: true, force: true });
+  });
+
+  test("(c) allowlist entry with a non-matching regex does NOT suppress a different line", () => {
+    // Entry matches ONLY the `cortex/bot.yaml` line; the sibling `grove/other.yaml`
+    // line must stay gated.
+    const allowFile = join(scratch, "scratch-allow.yaml");
+    writeFileSync(allowFile, [
+      "allow:",
+      "  - pattern: config-tree",
+      "    path: runtime.ts",
+      "    match: cortex/bot\\.yaml",
+      "    reason: only the bot.yaml line is by-design",
+      "    owner: self-test",
+    ].join("\n") + "\n");
+    const { status, json } = runGate(scratch, allowFile);
+    // one line suppressed (bot.yaml), the other (grove/other.yaml) still gated
+    expect(json.summary.allowed.list).toBe(1);
+    const gatedRuntime = (json.gated ?? []).filter((f: any) => f.relPath === "runtime.ts");
+    expect(gatedRuntime.length).toBe(1);
+    expect(gatedRuntime[0].content).toContain("grove/other.yaml");
+    expect(status).toBeGreaterThan(0); // the un-allowed line keeps the gate red
+  });
+});

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -67,8 +67,8 @@ resolve_config_dir() {
   fi
   local canonical="${HOME}/.config/metafactory/cortex"
   if [ -d "${canonical}" ]; then printf '%s' "${canonical}"; return 0; fi
-  if [ -d "${HOME}/.config/cortex" ]; then printf '%s' "${HOME}/.config/cortex"; return 0; fi
-  if [ -d "${HOME}/.config/grove" ]; then printf '%s' "${HOME}/.config/grove"; return 0; fi
+  if [ -d "${HOME}/.config/cortex" ]; then printf '%s' "${HOME}/.config/cortex"; return 0; fi  # xdg-audit:allow(XDG-aware config resolver — legacy fallback candidate, by design)
+  if [ -d "${HOME}/.config/grove" ]; then printf '%s' "${HOME}/.config/grove"; return 0; fi  # xdg-audit:allow(XDG-aware config resolver — legacy fallback candidate, by design)
   printf '%s' "${canonical}"
 }
 
@@ -463,7 +463,7 @@ render_cortex_plists() {
 forward_link_legacy_bin() {
   local name="$1"
   local target="${HOME}/.local/bin/${name}"
-  local link="${HOME}/bin/${name}"
+  local link="${HOME}/bin/${name}"  # xdg-audit:allow(legacy ~/bin→~/.local/bin forward-compat bridge — by design (cortex#1866))
 
   # Nothing to point at → do not create a dangling forward-symlink.
   [ -e "${target}" ] || return 0

--- a/scripts/xdg-audit-allow.yaml
+++ b/scripts/xdg-audit-allow.yaml
@@ -1,0 +1,463 @@
+# xdg-audit allowlist — every entry suppresses a BY-DESIGN legacy-path reference
+# the class rules can't (docs/yaml stay gated by default). Five fields required:
+#   pattern : a pattern-id from xdg-audit.ts's registry
+#   path    : glob (repo-relative) selecting the file(s)
+#   match   : NARROW content regex — a bare path glob must not silently allow
+#             future new lines in the file
+#   reason  : why this reference is correct / by-design
+#   owner   : tracking issue, or "by-design" for a permanent exception
+#
+# The gate warns on unknown pattern-ids and unused entries so dead allows get
+# pruned. Run `bun scripts/xdg-audit.ts --repos --verbose` to see what each
+# entry currently suppresses. Resolver-internal legacy fallbacks are suppressed
+# INLINE (xdg-audit:allow(...) at the site), not here.
+allow:
+  # ── cortex: migration / cleanup scripts (must name the legacy path) ──────
+  - pattern: bin-home
+    path: scripts/preupgrade.sh
+    match: grove-bot
+    reason: legacy grove-bot cleanup — kills processes + removes the pre-migration ~/bin/grove-bot symlink; must name the legacy path
+    owner: cortex#1866
+  - pattern: grove-state
+    path: scripts/federation-selftest.sh
+    match: rm -f .*/\.config/grove/state/
+    reason: selftest teardown — removes legacy grove-state pidfiles it created
+    owner: by-design
+  - pattern: config-tree
+    path: scripts/federation-selftest.sh
+    match: rm -f .*/\.config/grove/state/
+    reason: selftest teardown — removes legacy grove-state pidfiles it created
+    owner: by-design
+
+  # ── cortex: postinstall physical creation + status echoes ────────────────
+  - pattern: claude-events
+    path: scripts/postinstall.sh
+    match: \.claude/(events|relay)
+    reason: postinstall creates + describes the permanent ~/.claude events/relay buffer (standard §6; relay dir is pre-migration correct, resolver-gated)
+    owner: by-design
+  - pattern: config-tree
+    path: scripts/postinstall.sh
+    match: Runtime directories created
+    reason: postinstall status echo — the real dir is the resolved CONFIG_DIR; the message shows the transition-active path
+    owner: cortex#1869
+
+  # ── cortex: GV-1 cortex-first / grove-fallback bot.yaml readers ──────────
+  - pattern: config-tree
+    path: src/cli/cldyo-live
+    match: \.config/(cortex|grove)/bot\.yaml
+    reason: cldyo-live GV-1 cortex-first/grove-fallback bot.yaml resolver — reads the XDG-default flat config path
+    owner: cortex#1076
+  - pattern: config-tree
+    path: src/statusline/cortex-status.sh
+    match: \.config/(cortex|grove)/bot\.yaml
+    reason: statusline GV-1 cortex-first/grove-fallback bot.yaml resolver — reads the XDG-default flat config path
+    owner: cortex#1076
+
+  # ── cortex: developer-facing hygiene / CLI help text ─────────────────────
+  - pattern: config-tree
+    path: scripts/check-shippable-hygiene.ts
+    match: keep real ids in ~/\.config/cortex/|move this deployment fragment to ~/\.config/cortex/
+    reason: hygiene remediation text — points devs to the local (never-shipped) config tree
+    owner: by-design
+  - pattern: config-tree
+    path: src/cli/cortex/commands/agents.ts
+    match: ~/\.config/cortex/(agents\.d|cortex\.yaml)
+    reason: CLI --help text — shows the transition-active config path (canonicalizes at the wave-4 cutover)
+    owner: cortex#1869
+  - pattern: config-tree
+    path: src/cli/cortex/commands/cloud.ts
+    match: ~/\.config/cortex/(bot\.yaml|cloud-credentials)
+    reason: CLI --help text — shows the transition-active config path (canonicalizes at the wave-4 cutover)
+    owner: cortex#1869
+  - pattern: config-tree
+    path: src/cli/cortex/commands/network.ts
+    match: ~/\.config/cortex/cortex\.yaml
+    reason: CLI --help text — shows the transition-active config path (canonicalizes at the wave-4 cutover)
+    owner: cortex#1869
+  - pattern: config-tree
+    path: src/cli/cortex/commands/network-adapters.ts
+    match: ~/\.config/cortex/<stack>/<stack>\.yaml
+    reason: CLI --help text — shows the transition-active stack config path (canonicalizes at the wave-4 cutover)
+    owner: cortex#1869
+  - pattern: config-tree
+    path: src/cli/cortex/commands/stack-lib.ts
+    match: cortex start --config ~/\.config/cortex/
+    reason: generated stack.yaml header comment — shows the transition-active start command (canonicalizes at the wave-4 cutover)
+    owner: cortex#1869
+
+  # ── cortex: pier install-script hints ────────────────────────────────────
+  - pattern: config-tree
+    path: scripts/pier/*.sh
+    match: ~/\.config/cortex/(\.env|agents\.d)
+    reason: pier install-script hint text — transition-active config path shown to the operator
+    owner: cortex#1869
+  - pattern: legacy-share
+    path: scripts/pier/signal-cortex-reload.sh
+    match: \.local/share/cortex/cortex\.pid
+    reason: best-effort SIGHUP pidfile fallback (comment acknowledges non-default configs need a manual reload) — see PR note, verify against the pidfile convention
+    owner: cortex#1903
+
+  # ── cortex: STACK logDir cluster (differs from canonical XDG state) ───────
+  # NOTE: canonical logDir default is ~/.local/state/metafactory/cortex/logs
+  # (config.ts / cortex-config.ts), but the stack subsystem generates + logs to
+  # ~/.config/cortex/logs. It WORKS at every migration stage (co-located with
+  # the stack config), so allowed here + flagged in the PR for a product call on
+  # whether stack logs should move to the XDG state dir. publishedEventsDir is
+  # already canonical.
+  - pattern: config-tree
+    path: src/cli/cortex/commands/stack-lib.ts
+    match: logDir:\s*~/\.config/cortex/logs
+    reason: generated stack system.yaml logDir — stack-log co-location, differs from canonical XDG state default (see PR note; needs product decision)
+    owner: cortex#1869
+  - pattern: config-tree
+    path: src/services/*.plist
+    match: \.config/cortex/logs/cortex-
+    reason: stack launchd plist StandardOut/Err path — matches the generated stack logDir (see stack logDir note)
+    owner: cortex#1869
+  - pattern: config-tree
+    path: scripts/federation-selftest.sh
+    match: s\|~/\.config/cortex/logs\|
+    reason: selftest rewrites the default stack logDir literal to a test-isolated dir (see stack logDir note)
+    owner: cortex#1869
+
+  # ═══ DOCS (generated 2026-07-15 sweep) ═══════════════════════════════
+  - pattern: bin-home
+    path: docs/plan-cortex-migration.md
+    match: (~|\$\{HOME\})/bin/
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1866
+  - pattern: config-tree
+    path: docs/plan-cortex-migration.md
+    match: \.config/(cortex|grove)
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: config-tree
+    path: docs/migrations/0002-vocabulary-finish-2026-05.md
+    match: \.config/(cortex|grove)
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: config-tree
+    path: docs/migrations/0003-config-split-layout.md
+    match: ~/\.config/(cortex|grove)
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: grove-state
+    path: docs/migrations/0003-config-split-layout.md
+    match: \.config/grove/state
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1903
+  - pattern: config-tree
+    path: docs/sop-migrate-config.md
+    match: ~/\.config/cortex
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: bin-home
+    path: docs/archive/v1-to-v2-cutover.md
+    match: ~/bin/
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1866
+  - pattern: config-tree
+    path: docs/archive/v1-to-v2-cutover.md
+    match: ~/\.config/grove
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: claude-events
+    path: docs/archive/v1-to-v2-cutover.md
+    match: \.claude/events
+    reason: permanent ~/.claude events/relay buffer (standard §6) — accurate runtime dir
+    owner: by-design
+  - pattern: config-tree
+    path: docs/iteration-cloud-api.md
+    match: ~/\.config/grove
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: config-tree
+    path: docs/iteration-github-visibility.md
+    match: \.config/grove/state
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1903
+  - pattern: grove-state
+    path: docs/iteration-github-visibility.md
+    match: \.config/grove/state
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1903
+  - pattern: legacy-share
+    path: docs/iteration-mission-control-pane-of-glass.md
+    match: \.local/share/cortex/mc
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1902
+  - pattern: config-tree
+    path: docs/iteration-policy-cutover.md
+    match: ~/\.config/cortex
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: config-tree
+    path: docs/stock-take-v3-to-v4.5.md
+    match: ~/\.config/cortex/<stack>
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: bin-home
+    path: docs/federation-1598-admit-mint-worklog.md
+    match: federation-selftest
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1866
+  - pattern: config-tree
+    path: docs/plan-bot-packs-completion.md
+    match: ~/\.config/cortex
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: config-tree
+    path: docs/migration-examples/after-single-adapter.yaml
+    match: logDir:\s*~/\.config/cortex/logs
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: claude-events
+    path: docs/migration-examples/after-single-adapter.yaml
+    match: publishedEventsDir:\s*~/\.claude/events/published
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1902
+  - pattern: bin-home
+    path: CHANGELOG.md
+    match: ~/bin/
+    reason: historical changelog/release entry — frozen
+    owner: cortex#1866
+  - pattern: config-tree
+    path: CHANGELOG.md
+    match: ~/\.config/cortex
+    reason: historical changelog/release entry — frozen
+    owner: cortex#1869
+  - pattern: config-tree
+    path: RELEASE-HISTORY.md
+    match: ~/\.config/cortex
+    reason: historical changelog/release entry — frozen
+    owner: cortex#1869
+  - pattern: config-tree
+    path: .specify/specs/F-2-agents-d-fragment-loader-and-watcher/plan.md
+    match: ~/\.config/cortex
+    reason: archived feature spec — config path as of authoring
+    owner: cortex#1869
+  - pattern: config-tree
+    path: .specify/specs/F-2-agents-d-fragment-loader-and-watcher/spec.md
+    match: ~/\.config/cortex
+    reason: archived feature spec — config path as of authoring
+    owner: cortex#1869
+  - pattern: config-tree
+    path: .specify/specs/F-3-cortex-agents-reload-cli/plan.md
+    match: ~/\.config/cortex
+    reason: archived feature spec — config path as of authoring
+    owner: cortex#1869
+  - pattern: config-tree
+    path: .specify/specs/F-3-cortex-agents-reload-cli/spec.md
+    match: ~/\.config/cortex
+    reason: archived feature spec — config path as of authoring
+    owner: cortex#1869
+  - pattern: config-tree
+    path: .specify/specs/f-6-reflex-activation-bridge/HANDOFF.md
+    match: \.config/cortex
+    reason: archived feature spec — config path as of authoring
+    owner: cortex#1869
+  - pattern: config-tree
+    path: CLAUDE.md
+    match: migrated from grove-v2 `~/\.config/grove
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: config-tree
+    path: docs/agents-md/architecture.md
+    match: migrated from grove-v2 `~/\.config/grove
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: claude-events
+    path: README-AGENTS.md
+    match: \.claude/(events|relay)
+    reason: permanent ~/.claude events/relay buffer (standard §6) — accurate runtime dir
+    owner: by-design
+  - pattern: config-tree
+    path: docs/getting-started.md
+    match: ~/\.config/grove/bot\.yaml
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1869
+  - pattern: claude-events
+    path: docs/getting-started.md
+    match: \.claude/events/\{raw,published\}
+    reason: permanent ~/.claude events/relay buffer (standard §6) — accurate runtime dir
+    owner: by-design
+  - pattern: config-tree
+    path: docs/runbook-federation-peering.md
+    match: ~/\.config/cortex
+    reason: transition-active config path (~/.config/cortex) — canonicalizes at the wave-4 cutover
+    owner: cortex#1869
+  - pattern: bin-home
+    path: docs/adr/0017-surface-tooling-arc-bundles.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: docs/design-agentic-dev-pipeline.md
+    match: ~/\.config/cortex/agents
+    reason: agent instance-state path — future agent-instance-state wave
+    owner: agent-instance-state
+  - pattern: systemd-userdir
+    path: docs/design-arc-agent-bots.md
+    match: \.config/systemd/user
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: G-38
+  - pattern: config-tree
+    path: docs/design-cloud-api.md
+    match: ~/\.config/grove
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: claude-events
+    path: docs/design-cloud-api.md
+    match: \.claude/events/published
+    reason: permanent ~/.claude events/relay buffer (standard §6) — accurate runtime dir
+    owner: by-design
+  - pattern: bin-home
+    path: docs/design-collaboration-surface.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: docs/design-dm-operator-channel.md
+    match: ~/\.config/grove/bot\.yaml
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: config-tree
+    path: docs/design-github-visibility.md
+    match: ~/\.config/grove
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: grove-state
+    path: docs/design-github-visibility.md
+    match: \.config/grove/state
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: bin-home
+    path: docs/design-mc-f11-discord-notifications.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: bin-home
+    path: docs/design-mc-f12-task-curation.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: docs/design-mission-control.md
+    match: ~/\.config/grove/mission-control
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: legacy-share
+    path: docs/design-mission-control.md
+    match: \.local/share/grove
+    reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
+    owner: cortex#436
+  - pattern: bin-home
+    path: docs/design-test-rig.md
+    match: ~/bin/
+    reason: migration/cutover history — frozen doc describing the grove→cortex / XDG migration
+    owner: cortex#1866
+  - pattern: config-tree
+    path: examples/processes/build-journal.yaml
+    match: ~/\.config/cortex/processes
+    reason: transition-active config path (~/.config/cortex) — canonicalizes at the wave-4 cutover
+    owner: cortex#1869
+  - pattern: bin-home
+    path: arc-manifest.yaml
+    match: ~/bin/
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: arc-manifest.yaml
+    match: ~/\.config/cortex/cortex\.yaml
+    reason: transition-active config path (~/.config/cortex) — canonicalizes at the wave-4 cutover
+    owner: cortex#1869
+  - pattern: claude-events
+    path: arc-manifest.yaml
+    match: target:\s*~/\.claude/relay/cortex
+    reason: provides.files symlink target; relay dir is pre-cutover correct, relay cutover owned by wave 5
+    owner: cortex#1903
+  - pattern: config-tree
+    path: arc-manifest-pier.yaml
+    match: ~/\.config/cortex/(personas|agents\.d|\.env)
+    reason: transition-active config path (~/.config/cortex) — canonicalizes at the wave-4 cutover
+    owner: cortex#1869
+  - pattern: config-tree
+    path: agents.d/pier.yaml
+    match: ~/\.config/cortex/(agents\.d|personas)
+    reason: transition-active config path (~/.config/cortex) — canonicalizes at the wave-4 cutover
+    owner: cortex#1869
+  - pattern: pkg-repos
+    path: CLAUDE.md
+    match: \.config/metafactory/pkg/repos
+    reason: arc install-location doc — stale vs arc#287 canonical (~/.local/share/metafactory/arc/repos); companion arc doc fix needed
+    owner: arc#287
+  - pattern: pkg-repos
+    path: QUICKSTART.md
+    match: \.config/metafactory/pkg/repos
+    reason: arc install-location doc — stale vs arc#287 canonical (~/.local/share/metafactory/arc/repos); companion arc doc fix needed
+    owner: arc#287
+  - pattern: pkg-repos
+    path: README.md
+    match: \.config/metafactory/pkg/repos
+    reason: arc install-location doc — stale vs arc#287 canonical (~/.local/share/metafactory/arc/repos); companion arc doc fix needed
+    owner: arc#287
+  - pattern: pkg-repos
+    path: design/library-support.md
+    match: \.config/metafactory/pkg/repos
+    reason: arc install-location doc — stale vs arc#287 canonical (~/.local/share/metafactory/arc/repos); companion arc doc fix needed
+    owner: arc#287
+  - pattern: pkg-repos
+    path: docs/agents-md/architecture.md
+    match: \.config/metafactory/pkg/repos
+    reason: arc install-location doc — stale vs arc#287 canonical (~/.local/share/metafactory/arc/repos); companion arc doc fix needed
+    owner: arc#287
+  - pattern: pkg-repos
+    path: skill/SKILL.md
+    match: \.config/metafactory/pkg/repos
+    reason: arc install-location doc — stale vs arc#287 canonical (~/.local/share/metafactory/arc/repos); companion arc doc fix needed
+    owner: arc#287
+  - pattern: config-tree
+    path: docs/agent-identity-provisioning.md
+    match: ~/\.config/cortex/agents
+    reason: agent instance-state path — future agent-instance-state wave
+    owner: agent-instance-state
+  - pattern: bin-home
+    path: CLAUDE.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: CLAUDE.md
+    match: ~/\.config/cortex/cli\.yaml
+    reason: cli.yaml XDG resolution — canonical-first with legacy read-fallback; accurate
+    owner: by-design
+  - pattern: bin-home
+    path: README.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: README.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: arc-manifest.yaml
+    match: ~/\.config/(cortex|grove)/cli\.yaml
+    reason: declared XDG read-fallback (canonical-first + two legacy reads) — matches the resolver contract
+    owner: by-design
+  - pattern: config-tree
+    path: cli.yaml.example
+    match: ~/\.config/cortex/cli\.yaml
+    reason: example/schema-reference header naming the config file — never a live config
+    owner: by-design
+  - pattern: bin-home
+    path: skill/SKILL.md
+    match: ~/bin/discord
+    reason: discord CLI shim location (~/bin/discord) — legacy-bin bridge, cutover owned by wave 3
+    owner: cortex#1866
+  - pattern: config-tree
+    path: skill/SKILL.md
+    match: ~/\.config/cortex/cli\.yaml
+    reason: cli.yaml XDG resolution — canonical-first with legacy read-fallback; accurate
+    owner: by-design

--- a/scripts/xdg-audit.ts
+++ b/scripts/xdg-audit.ts
@@ -8,31 +8,61 @@
  *
  * Two scan domains:
  *   --repos    pattern-registry scan over git-tracked files (default: cortex,
- *              arc, metafactory-bundle-discord; add more roots as positional args)
+ *              arc, metafactory-discord; override the roots with positional args)
  *   --machine  live inventory: dangling symlinks, plist exec paths,
  *              settings.json hooks, packages.db rows, WAL sidecars,
  *              occupied cutover destinations, grove-vs-cortex divergence,
  *              pidfile liveness
  *
- * Every finding carries {pattern, class, wave, issue, location, excerpt}.
- * Exit code = min(unresolved finding count, 99) → usable as a wave gate:
- *   preflight:      bun xdg-audit.ts --machine            (must be clean-enough)
- *   postcondition:  bun xdg-audit.ts --repos --wave 4     (must be 0 after wave 4)
+ * ── THE REPO GATE ──────────────────────────────────────────────────────────
+ * `bun xdg-audit.ts --repos` is a DETERMINISTIC gate. Exit code = number of
+ * *gated* findings (capped at 99). A raw pattern hit is gated UNLESS it is:
  *
- * Suppression: a source line containing `xdg-audit:allow` is skipped
- * (use for migration code that must reference legacy paths by design).
+ *   1. ADVISORY by a deterministic class rule (never counts toward the gate):
+ *        • a test file (`__tests__/` or `*.test.ts`) — fixtures that exercise
+ *          the migration are by design;
+ *        • a comment-only line in a CODE file (trimmed line starts with `//`,
+ *          `*`, `/*`, or — in a `.sh` file — `#`). Comments cannot break runtime.
+ *      `.md` / `.yaml` / `.yml` / `.example` lines are NEVER advisory — docs
+ *      stay fully gated so stale instructions get fixed, not hidden.
+ *
+ *   2. INLINE-ALLOWED: the matched line (or the line immediately above it)
+ *      carries `xdg-audit:allow(<reason>)`. The reason text is REQUIRED; a bare
+ *      `xdg-audit:allow` with no `(reason)` is a hard gate error. Use this for
+ *      the rare RUNTIME line that legitimately names a legacy path (a resolver
+ *      legacy-fallback constant, a migration/cleanup step).
+ *
+ *   3. ALLOWLIST-ALLOWED: it matches an entry in the checked-in
+ *      `scripts/xdg-audit-allow.yaml`. Each entry needs ALL of
+ *      {pattern, path, match, reason, owner}; `match` is a narrow content
+ *      regex so a bare path glob cannot silently allow future new lines in the
+ *      same file. Unknown pattern-ids and unused entries are surfaced as
+ *      warnings so dead allows get pruned.
+ *
+ * Every suppression is therefore explicit and reviewable, and the gate keeps
+ * biting on any NEW stale reference outside those three escape hatches.
+ *
+ * Usage:
+ *   bun xdg-audit.ts --repos                 # the gate (exit 0 == clean)
+ *   bun xdg-audit.ts --repos --verbose       # + list the advisory findings
+ *   bun xdg-audit.ts --repos <root>...       # gate specific checkouts
+ *   bun xdg-audit.ts --machine               # live-machine preflight
+ *   bun xdg-audit.ts --repos --wave 4        # postcondition for one wave
+ *   bun xdg-audit.ts --repos --json          # machine-readable
  */
 
 import { existsSync, lstatSync, readlinkSync, readdirSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { Database } from "bun:sqlite";
+import { parse as parseYaml } from "yaml";
 
 const HOME = homedir();
 const args = process.argv.slice(2);
 const flag = (f: string) => args.includes(f);
 const opt = (f: string) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : undefined; };
 const JSON_OUT = flag("--json");
+const VERBOSE = flag("--verbose");
 const WAVE = opt("--wave");
 const REF = opt("--ref"); // e.g. origin/main; default = working tree (tracked files)
 const DO_REPOS = flag("--repos") || (!flag("--machine"));
@@ -48,23 +78,42 @@ interface Pattern {
   wave: number;             // wave whose completion zeroes this pattern
   issue: string;
   note?: string;
+  // Optional post-match content filter: a finding is DROPPED (never a hit)
+  // when the matched line still matches `re` only via the excluded sub-path.
+  // Used to carve out a by-design sibling of a legacy path (e.g. events/raw,
+  // which stays under ~/.claude permanently — standard §6) without weakening
+  // what the pattern otherwise catches.
+  exclude?: string;
 }
 const PATTERNS: Pattern[] = [
   { id: "bin-home",        re: '(\\$HOME|\\$\\{HOME\\}|~|__HOME__)/bin/',                clazz: "bin",    wave: 3, issue: "cortex#1866",  note: "legacy ~/bin exec/target" },
   { id: "config-tree",     re: '\\.config/(cortex|grove)([/"\x27]|$)',                   clazz: "config", wave: 4, issue: "cortex#1869",  note: "legacy config tree literal" },
   { id: "grove-state",     re: '\\.config/grove/state',                                  clazz: "state",  wave: 5, issue: "cortex#1903",  note: "legacy pidfile/state dir" },
   { id: "legacy-share",    re: '\\.local/share/(cortex|grove)([/"\x27]|$)',              clazz: "data",   wave: 5, issue: "cortex#1902",  note: "pre-suite data tree" },
-  { id: "claude-events",   re: '\\.claude/(events|relay)',                               clazz: "data",   wave: 5, issue: "cortex#1902/#1903", note: "events/relay under ~/.claude" },
+  // events/raw stays under ~/.claude permanently (standard §6) → excluded.
+  // events/published, bare .claude/events, and .claude/relay still gated.
+  { id: "claude-events",   re: '\\.claude/(events|relay)',                               clazz: "data",   wave: 5, issue: "cortex#1902/#1903", note: "events/relay under ~/.claude", exclude: '\\.claude/events/raw' },
   { id: "pkg-repos",       re: '\\.config/metafactory/pkg/repos',                        clazz: "repos",  wave: 5, issue: "arc#287",      note: "hardcoded package-repos path (G-02/G-04)" },
   { id: "systemd-userdir", re: '\\.config/systemd/user',                                 clazz: "config", wave: 4, issue: "G-38 (new)",   note: "must honor $XDG_CONFIG_HOME" },
   { id: "stale-pai-root",  re: '\\.config/(pai|arc)/pkg',                                clazz: "repos",  wave: 5, issue: "arc#287",      note: "dead roots from prior migrations (G-58)" },
 ];
+const PATTERN_IDS = new Set(PATTERNS.map(p => p.id));
 const EXCLUDES = [":!node_modules", ":!*.lock", ":!dist", ":!build", ":!.git"];
+// The gate never scans its own tool/allowlist/self-test — they name legacy
+// paths and carry example allow-markers by nature (any path with "xdg-audit").
+const isSelfFile = (relPath: string) => relPath.includes("xdg-audit");
 const DEFAULT_REPOS = [
   join(HOME, "Developer", "cortex"),
   join(HOME, "Developer", "arc"),
-  join(HOME, "Developer", "metafactory-bundle-discord"),
+  join(HOME, "Developer", "metafactory-discord"),
 ];
+
+type FindingClass =
+  | "gated"
+  | "advisory:test"
+  | "advisory:comment"
+  | "allow:inline"
+  | "allow:list";
 
 interface Finding {
   domain: "repos" | "machine";
@@ -72,15 +121,93 @@ interface Finding {
   clazz: string;
   wave: number;
   issue: string;
-  location: string;
-  excerpt: string;
+  location: string;        // repoName/relPath:line
+  relPath: string;         // repo-relative path (for allowlist glob matching)
+  content: string;         // full matched line (untruncated)
+  excerpt: string;         // trimmed + capped for display
+  klass: FindingClass;     // gate disposition
+  allowRef?: string;       // which inline reason / allowlist entry suppressed it
 }
 const findings: Finding[] = [];
 const infos: string[] = [];
+const gateErrors: string[] = [];   // structural errors → force a nonzero exit
+const gateWarnings: string[] = []; // non-fatal (unused / unknown allowlist entries)
+let rawExceptionCount = 0;         // findings dropped by a pattern `exclude` rule
+
+// ---------------------------------------------------------------- allowlist
+interface AllowEntry {
+  pattern: string;
+  path: string;
+  match: string;
+  reason: string;
+  owner: string;
+  _glob?: Bun.Glob;
+  _re?: RegExp;
+  _used?: boolean;
+  _idx: number;
+}
+// The allowlist is CENTRAL: it lives beside the tool (cortex/scripts/) and
+// applies to EVERY scanned repo. That keeps the gate + its policy one unit, so
+// a single cortex PR can adjudicate cross-repo (arc/discord) findings. Path
+// globs are repo-relative; scope cross-repo collisions with the `match` regex.
+function loadAllowlist(file: string): AllowEntry[] {
+  if (!existsSync(file)) return [];
+  let doc: unknown;
+  try { doc = parseYaml(readFileSync(file, "utf8")); }
+  catch (e) { gateErrors.push(`allowlist parse error: ${(e as Error).message.slice(0, 80)}`); return []; }
+  const raw = (doc as { allow?: unknown })?.allow;
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) { gateErrors.push(`allowlist: top-level 'allow:' must be a list`); return []; }
+  const out: AllowEntry[] = [];
+  raw.forEach((e: Record<string, unknown>, i: number) => {
+    const missing = (["pattern", "path", "match", "reason", "owner"] as const).filter(k => typeof e?.[k] !== "string" || (e[k] as string).trim() === "");
+    if (missing.length) { gateErrors.push(`allowlist entry #${i}: missing/empty field(s): ${missing.join(", ")}`); return; }
+    const entry: AllowEntry = {
+      pattern: e.pattern as string, path: e.path as string, match: e.match as string,
+      reason: e.reason as string, owner: e.owner as string, _idx: i,
+    };
+    if (!PATTERN_IDS.has(entry.pattern)) gateWarnings.push(`allowlist entry #${i}: unknown pattern-id "${entry.pattern}" (inert — prune or fix)`);
+    try { entry._re = new RegExp(entry.match); }
+    catch (err) { gateErrors.push(`allowlist entry #${i}: invalid match regex /${entry.match}/: ${(err as Error).message.slice(0, 60)}`); return; }
+    try { entry._glob = new Bun.Glob(entry.path); }
+    catch { gateErrors.push(`allowlist entry #${i}: invalid path glob "${entry.path}"`); return; }
+    out.push(entry);
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------- classify
+const fileLineCache = new Map<string, string[]>();
+function fileLines(root: string, relPath: string): string[] {
+  const abs = join(root, relPath);
+  let v = fileLineCache.get(abs);
+  if (v) return v;
+  try { v = readFileSync(abs, "utf8").split("\n"); } catch { v = []; }
+  fileLineCache.set(abs, v);
+  return v;
+}
+function ext(relPath: string): string {
+  const m = relPath.match(/\.([a-z0-9]+)$/i);
+  return m?.[1] ? m[1].toLowerCase() : "";
+}
+const ALLOW_RE = /xdg-audit:allow/;
+const ALLOW_REASON_RE = /xdg-audit:allow\(\s*([^)]+?)\s*\)/;
+
+/** Detect + validate an inline allow on a specific physical line. */
+function inlineAllowOn(line: string | undefined, where: string): { allowed: boolean; reason?: string } {
+  if (line === undefined || !ALLOW_RE.test(line)) return { allowed: false };
+  const m = line.match(ALLOW_REASON_RE);
+  if (!m || !m[1] || m[1].trim() === "") {
+    gateErrors.push(`invalid inline allow at ${where}: bare 'xdg-audit:allow' with no (reason) — reason text is required`);
+    return { allowed: false };
+  }
+  return { allowed: true, reason: m[1].trim() };
+}
 
 // ---------------------------------------------------------------- repo scan
-function repoScan(root: string) {
+function repoScan(root: string, allowlist: AllowEntry[]) {
   if (!existsSync(join(root, ".git"))) { infos.push(`skip (not a git repo): ${root}`); return; }
+  const repoName = root.split("/").pop() ?? root;
   for (const p of PATTERNS) {
     const refArgs = REF ? [REF] : [];
     const proc = Bun.spawnSync(
@@ -89,18 +216,62 @@ function repoScan(root: string) {
     );
     const out = proc.stdout.toString();
     if (!out) continue;
+    const excludeRe = p.exclude ? new RegExp(p.exclude, "g") : null;
+    const baseRe = new RegExp(p.re);
     for (const line of out.split("\n")) {
       if (!line) continue;
-      if (line.includes("xdg-audit:allow")) continue;
-      if (line.includes("xdg-audit.ts")) continue; // self
-      const [loc, ...rest] = REF
-        ? [line.split(":").slice(0, 3).join(":"), line.split(":").slice(3).join(":")]
-        : [line.split(":").slice(0, 2).join(":"), line.split(":").slice(2).join(":")];
-      findings.push({
+      // parse `file:line:content` (or `ref:file:line:content` under --ref)
+      const parts = line.split(":");
+      const relPath = REF ? parts[1]! : parts[0]!;
+      const lineNo = Number(REF ? parts[2] : parts[1]);
+      const content = (REF ? parts.slice(3) : parts.slice(2)).join(":");
+      if (isSelfFile(relPath)) continue; // never gate the gate
+
+      // pattern-level exclusion (e.g. events/raw): drop if the ONLY reason the
+      // line matched is the excluded sub-path.
+      if (excludeRe) {
+        const stripped = content.replace(excludeRe, "");
+        if (!baseRe.test(stripped)) { rawExceptionCount++; continue; }
+      }
+
+      const f: Finding = {
         domain: "repos", pattern: p.id, clazz: p.clazz, wave: p.wave, issue: p.issue,
-        location: `${root.split("/").pop()}/${loc}`,
-        excerpt: rest.join(":").trim().slice(0, 120),
-      });
+        location: `${repoName}/${relPath}:${lineNo}`, relPath,
+        content, excerpt: content.trim().slice(0, 120), klass: "gated",
+      };
+
+      // (2) inline allow — on the matched line, or the line immediately above.
+      // Line-above lookup needs the working tree; under --ref only the matched
+      // line (from grep output) is checked.
+      const self = inlineAllowOn(content, f.location);
+      let above: { allowed: boolean; reason?: string } = { allowed: false };
+      if (!self.allowed && !REF && Number.isFinite(lineNo) && lineNo > 1) {
+        above = inlineAllowOn(fileLines(root, relPath)[lineNo - 2], `${repoName}/${relPath}:${lineNo - 1}`);
+      }
+      if (self.allowed || above.allowed) {
+        f.klass = "allow:inline";
+        f.allowRef = (self.reason ?? above.reason)!;
+        findings.push(f);
+        continue;
+      }
+
+      // (1) advisory class rules — test files, then code comments.
+      const e = ext(relPath);
+      const isTest = /(^|\/)__tests__\//.test(relPath) || /\.test\.ts$/.test(relPath);
+      if (isTest) { f.klass = "advisory:test"; findings.push(f); continue; }
+      const neverAdvisory = e === "md" || e === "yaml" || e === "yml" || relPath.endsWith(".example");
+      if (!neverAdvisory) {
+        const t = content.trim();
+        const isComment = t.startsWith("//") || t.startsWith("*") || t.startsWith("/*") || (e === "sh" && t.startsWith("#"));
+        if (isComment) { f.klass = "advisory:comment"; findings.push(f); continue; }
+      }
+
+      // (3) allowlist
+      const hit = allowlist.find(a => a.pattern === p.id && a._glob!.match(relPath) && a._re!.test(content));
+      if (hit) { hit._used = true; f.klass = "allow:list"; f.allowRef = `#${hit._idx} ${hit.reason}`; findings.push(f); continue; }
+
+      // otherwise: gated
+      findings.push(f);
     }
   }
 }
@@ -113,6 +284,10 @@ function treeOf(p: string): string | null {
   return null;
 }
 
+function pushMachine(f: Omit<Finding, "relPath" | "content" | "excerpt" | "klass"> & { excerpt: string }) {
+  findings.push({ ...f, relPath: "", content: f.excerpt, klass: "gated" });
+}
+
 function scanSymlinks(dir: string, wave: number, issue: string) {
   if (!existsSync(dir)) return;
   for (const name of readdirSync(dir)) {
@@ -122,10 +297,10 @@ function scanSymlinks(dir: string, wave: number, issue: string) {
     let target = ""; try { target = readlinkSync(p); } catch { continue; }
     const abs = target.startsWith("/") ? target : join(dir, target);
     if (!existsSync(abs)) {
-      findings.push({ domain: "machine", pattern: "dangling-symlink", clazz: "symlink", wave, issue,
+      pushMachine({ domain: "machine", pattern: "dangling-symlink", clazz: "symlink", wave, issue,
         location: p.replace(HOME, "~"), excerpt: `→ ${target.replace(HOME, "~")} (MISSING)` });
     } else if (abs.includes("/pkg/repos/")) {
-      findings.push({ domain: "machine", pattern: "pkg-repos-symlink", clazz: "repos", wave: 5, issue: "arc#287",
+      pushMachine({ domain: "machine", pattern: "pkg-repos-symlink", clazz: "repos", wave: 5, issue: "arc#287",
         location: p.replace(HOME, "~"), excerpt: `→ pkg/repos (needs re-link on repos move)` });
     }
   }
@@ -144,11 +319,9 @@ function scanPlists() {
       .filter((x): x is string => typeof x === "string");
     for (const path of paths) {
       if (!path.startsWith("/Users/") && !path.startsWith(HOME)) continue;
-      // colon-joined values are PATH lists, not file paths: flag only if a
-      // segment sits under a legacy tree, and never as "missing"
       if (path.includes(":")) {
         const seg = path.split(":").find(s => treeOf(s));
-        if (seg) findings.push({ domain: "machine", pattern: "plist-PATH-legacy-segment", clazz: "plist",
+        if (seg) pushMachine({ domain: "machine", pattern: "plist-PATH-legacy-segment", clazz: "plist",
           wave: 3, issue: "cortex#1866", location: `~/Library/LaunchAgents/${name}`,
           excerpt: `PATH includes ${seg.replace(HOME, "~")}` });
         continue;
@@ -156,7 +329,7 @@ function scanPlists() {
       const tree = treeOf(path);
       const missing = !existsSync(path.split(" ")[0] ?? path);
       if (tree || missing) {
-        findings.push({ domain: "machine", pattern: missing ? "plist-missing-path" : "plist-legacy-path",
+        pushMachine({ domain: "machine", pattern: missing ? "plist-missing-path" : "plist-legacy-path",
           clazz: "plist", wave: tree === "~/bin" ? 3 : tree === "pkg/repos" ? 5 : 4,
           issue: tree === "~/bin" ? "cortex#1866" : tree === "pkg/repos" ? "arc#287+G-03" : "cortex#1869",
           location: `~/Library/LaunchAgents/${name}`,
@@ -177,7 +350,7 @@ function scanSettingsHooks() {
     const abs = c.replace(/^~/, HOME);
     if (abs.includes("/pkg/repos/")) repos++;
     if (!existsSync(abs)) {
-      findings.push({ domain: "machine", pattern: "settings-hook-missing", clazz: "hooks", wave: 5, issue: "arc#287",
+      pushMachine({ domain: "machine", pattern: "settings-hook-missing", clazz: "hooks", wave: 5, issue: "arc#287",
         location: "~/.claude/settings.json", excerpt: `${c.replace(HOME, "~").slice(0, 100)} (MISSING)` });
     }
   }
@@ -188,12 +361,11 @@ function scanPackagesDb() {
   const p = join(HOME, ".config", "metafactory", "packages.db");
   if (!existsSync(p)) return;
   try {
-    // immutable=1: read-only open that tolerates a WAL db without -shm access
     const db = new Database(`file://${p}?immutable=1`, { readonly: true });
     const rows = db.query("SELECT name, install_path FROM skills").all() as { name: string; install_path: string }[];
     for (const r of rows) {
       if (!existsSync(r.install_path)) {
-        findings.push({ domain: "machine", pattern: "db-stale-install-path", clazz: "db", wave: 5, issue: "arc#287",
+        pushMachine({ domain: "machine", pattern: "db-stale-install-path", clazz: "db", wave: 5, issue: "arc#287",
           location: `packages.db:${r.name}`, excerpt: `${r.install_path.replace(HOME, "~")} (MISSING)` });
       }
     }
@@ -212,7 +384,7 @@ function scanWalSidecars() {
       if (e.isDirectory()) walk(p, depth + 1);
       else if (/\.(db|sqlite)-wal$/.test(e.name)) {
         let size = 0; try { size = statSync(p).size; } catch {}
-        findings.push({ domain: "machine", pattern: "hot-wal-sidecar", clazz: "db", wave: 5, issue: "cortex#1902/G-54",
+        pushMachine({ domain: "machine", pattern: "hot-wal-sidecar", clazz: "db", wave: 5, issue: "cortex#1902/G-54",
           location: p.replace(HOME, "~"), excerpt: `-wal ${size}B (checkpoint before any copy)` });
       }
     }
@@ -234,7 +406,7 @@ function scanOccupiedDestinations() {
       let dst; try { dst = lstatSync(dest); } catch { continue; }
       let dtgt = ""; if (dst.isSymbolicLink()) { try { dtgt = readlinkSync(dest); } catch {} }
       if (dtgt !== tgt) {
-        findings.push({ domain: "machine", pattern: "occupied-destination", clazz: "bin", wave: 3, issue: "cortex#1866/G-41",
+        pushMachine({ domain: "machine", pattern: "occupied-destination", clazz: "bin", wave: 3, issue: "cortex#1866/G-41",
           location: dest.replace(HOME, "~"),
           excerpt: dst.isSymbolicLink() ? `≠ ~/bin target (→ ${dtgt.replace(HOME, "~").slice(0, 60)})` : `regular file blocks cutover (SymlinkConflictError)` });
       }
@@ -248,7 +420,7 @@ function scanTreeDivergence() {
   const la = new Set(readdirSync(a)), lb = new Set(readdirSync(b));
   const onlyA = [...la].filter(x => !lb.has(x)), onlyB = [...lb].filter(x => !la.has(x));
   if (onlyA.length || onlyB.length) {
-    findings.push({ domain: "machine", pattern: "dual-tree-divergence", clazz: "config", wave: 4, issue: "cortex#1869/G-42",
+    pushMachine({ domain: "machine", pattern: "dual-tree-divergence", clazz: "config", wave: 4, issue: "cortex#1869/G-42",
       location: "~/.config/{grove,cortex}",
       excerpt: `grove-only: [${onlyA.join(", ").slice(0, 60)}] cortex-only: [${onlyB.join(", ").slice(0, 60)}] — merge policy required` });
   }
@@ -262,7 +434,7 @@ function scanPidfiles() {
       const p = join(dir, name);
       let pid = 0; try { pid = parseInt(readFileSync(p, "utf8").trim(), 10); } catch { continue; }
       let alive = false; try { process.kill(pid, 0); alive = true; } catch {}
-      findings.push({ domain: "machine", pattern: alive ? "live-pidfile" : "stale-pidfile", clazz: "state", wave: 5, issue: "cortex#1903",
+      pushMachine({ domain: "machine", pattern: alive ? "live-pidfile" : "stale-pidfile", clazz: "state", wave: 5, issue: "cortex#1903",
         location: p.replace(HOME, "~"), excerpt: `pid ${pid} ${alive ? "ALIVE (gate must bootout first)" : "stale"}` });
     }
   }
@@ -271,7 +443,14 @@ function scanPidfiles() {
 // -------------------------------------------------------------------- main
 if (DO_REPOS) {
   const extra = args.filter(a => !a.startsWith("--") && a !== WAVE && a !== REF && existsSync(a));
-  for (const r of [...DEFAULT_REPOS, ...extra]) repoScan(r);
+  // positional repo roots REPLACE the defaults (point the gate at fresh
+  // checkouts / worktrees); with none given, scan the canonical dev checkouts.
+  const roots = extra.length ? extra : DEFAULT_REPOS;
+  // The allowlist is co-located with the tool; $XDG_AUDIT_ALLOWLIST overrides
+  // it (hermetic self-tests supply their own).
+  const allowlist = loadAllowlist(process.env.XDG_AUDIT_ALLOWLIST || join(import.meta.dir, "xdg-audit-allow.yaml"));
+  for (const r of roots) repoScan(r, allowlist);
+  for (const a of allowlist) if (!a._used) gateWarnings.push(`unused allowlist entry #${a._idx}: {pattern:${a.pattern}, path:${a.path}} — prune it`);
 }
 if (DO_MACHINE) {
   scanSymlinks(join(HOME, "bin"), 3, "cortex#1866");
@@ -281,24 +460,73 @@ if (DO_MACHINE) {
   scanOccupiedDestinations(); scanTreeDivergence(); scanPidfiles();
 }
 
-const filtered = WAVE ? findings.filter(f => f.wave === Number(WAVE)) : findings;
+// ------------------------------------------------------------------ report
+const waveFilter = (f: Finding) => (WAVE ? f.wave === Number(WAVE) : true);
+const scoped = findings.filter(waveFilter);
+const gated = scoped.filter(f => f.klass === "gated");
+const advisoryTest = scoped.filter(f => f.klass === "advisory:test");
+const advisoryComment = scoped.filter(f => f.klass === "advisory:comment");
+const allowInline = scoped.filter(f => f.klass === "allow:inline");
+const allowList = scoped.filter(f => f.klass === "allow:list");
+const allowListEntries = new Set(allowList.map(f => f.allowRef?.split(" ")[0])).size;
+
 if (JSON_OUT) {
-  console.log(JSON.stringify({ findings: filtered, infos, total: filtered.length }, null, 1));
+  console.log(JSON.stringify({
+    // `findings` + `total` are the gate-relevant (gated) inventory and the
+    // exit-code basis — kept stable for the --machine doctor-preflight contract
+    // (src/__tests__/xdg-migration-guard.e2e.test.ts). `gated` is an explicit
+    // alias; `summary` + `allFindings` carry the richer repo-gate breakdown.
+    findings: gated,
+    total: gated.length,
+    gated,
+    summary: {
+      gated: gated.length,
+      advisory: { test: advisoryTest.length, comment: advisoryComment.length },
+      allowed: { inline: allowInline.length, list: allowList.length, listEntries: allowListEntries, rawException: rawExceptionCount },
+      errors: gateErrors, warnings: gateWarnings,
+    },
+    allFindings: VERBOSE ? scoped : undefined,
+    infos,
+  }, null, 1));
 } else {
   const byWave = new Map<number, Finding[]>();
-  for (const f of filtered) { if (!byWave.has(f.wave)) byWave.set(f.wave, []); byWave.get(f.wave)!.push(f); }
+  for (const f of gated) { if (!byWave.has(f.wave)) byWave.set(f.wave, []); byWave.get(f.wave)!.push(f); }
   for (const w of [...byWave.keys()].sort((a, b) => a - b)) {
     const fs = byWave.get(w)!;
-    console.log(`\n━━ WAVE ${w} — ${fs.length} site(s) ━━━━━━━━━━━━━━━━━━━━━━━`);
+    console.log(`\n━━ WAVE ${w} — ${fs.length} GATED site(s) ━━━━━━━━━━━━━━━━━━━━━━━`);
     const byPat = new Map<string, Finding[]>();
     for (const f of fs) { if (!byPat.has(f.pattern)) byPat.set(f.pattern, []); byPat.get(f.pattern)!.push(f); }
     for (const [pat, group] of byPat) {
       console.log(`  ${pat} (${group.length}) → ${group[0]?.issue}`);
-      for (const f of group.slice(0, 8)) console.log(`    ${f.location}  ${f.excerpt}`);
-      if (group.length > 8) console.log(`    … +${group.length - 8} more (use --json for full list)`);
+      for (const f of group.slice(0, 12)) console.log(`    ${f.location}  ${f.excerpt}`);
+      if (group.length > 12) console.log(`    … +${group.length - 12} more (use --json for full list)`);
     }
   }
+  if (VERBOSE) {
+    const dump = (title: string, fs: Finding[]) => {
+      if (!fs.length) return;
+      console.log(`\n┄┄ ${title} (${fs.length}) ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄`);
+      for (const f of fs) console.log(`    ${f.location}  ${f.excerpt}${f.allowRef ? `  ⟨${f.allowRef.slice(0, 60)}⟩` : ""}`);
+    };
+    dump("ADVISORY — test files", advisoryTest);
+    dump("ADVISORY — code comments", advisoryComment);
+    dump("ALLOWED — inline", allowInline);
+    dump("ALLOWED — allowlist", allowList);
+  }
   for (const i of infos) console.log(`\nℹ ${i}`);
-  console.log(`\nTOTAL: ${filtered.length} unresolved site(s)${WAVE ? ` in wave ${WAVE}` : ""}`);
+
+  console.log(`\n━━ SUMMARY${WAVE ? ` (wave ${WAVE})` : ""} ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);
+  console.log(`  GATED (counts toward exit): ${gated.length}`);
+  console.log(`  advisory  · test files:    ${advisoryTest.length}`);
+  console.log(`  advisory  · code comments: ${advisoryComment.length}`);
+  console.log(`  allowed   · inline:        ${allowInline.length}`);
+  console.log(`  allowed   · allowlist:     ${allowList.length} (across ${allowListEntries} entr${allowListEntries === 1 ? "y" : "ies"})`);
+  console.log(`  allowed   · raw-exception: ${rawExceptionCount} (.claude/events/raw — permanent, standard §6)`);
+  for (const w of gateWarnings) console.log(`  ⚠ ${w}`);
+  for (const e of gateErrors) console.log(`  ✖ GATE ERROR: ${e}`);
+  console.log(`\n  GATE: ${gated.length === 0 && gateErrors.length === 0 ? "PASS ✓ (exit 0)" : `FAIL ✗ (exit ${Math.min(99, Math.max(1, gated.length + gateErrors.length))})`}`);
 }
-process.exit(Math.min(filtered.length, 99));
+
+// exit code = gated count; structural errors force a nonzero exit even at gated=0.
+const exitCode = gateErrors.length ? Math.min(99, Math.max(1, gated.length + gateErrors.length)) : Math.min(99, gated.length);
+process.exit(exitCode);

--- a/src/common/config/config-path.ts
+++ b/src/common/config/config-path.ts
@@ -202,12 +202,12 @@ export function resolveConfigDir(home?: string): string {
 
   const legacyCortex = legacyCortexConfigDir(home);
   if (existsSync(legacyCortex)) {
-    noteXdgFallback("config", "config dir resolved from legacy ~/.config/cortex");
+    noteXdgFallback("config", "config dir resolved from legacy ~/.config/cortex");  // xdg-audit:allow(resolver legacy-fallback note — by design)
     return legacyCortex;
   }
   const grove = dirname(groveConfigPath("_", home));
   if (existsSync(grove)) {
-    noteXdgFallback("config", "config dir resolved from legacy ~/.config/grove");
+    noteXdgFallback("config", "config dir resolved from legacy ~/.config/grove");  // xdg-audit:allow(resolver legacy-fallback note — by design)
     return grove;
   }
   return canonical;
@@ -248,9 +248,9 @@ export function migrateGroveConfigFile(filename: string, home?: string): boolean
   const legacyCortex = legacyCortexConfigPath(filename, home);
   const grove = groveConfigPath(filename, home);
   const src = existsSync(legacyCortex)
-    ? { path: legacyCortex, tree: "~/.config/cortex" }
+    ? { path: legacyCortex, tree: "~/.config/cortex" }  // xdg-audit:allow(resolver legacy-fallback candidate — by design)
     : existsSync(grove)
-      ? { path: grove, tree: "~/.config/grove" }
+      ? { path: grove, tree: "~/.config/grove" }  // xdg-audit:allow(resolver legacy-fallback candidate — by design)
       : undefined;
   if (src === undefined) return false; // nothing to migrate
 

--- a/src/common/data-path.ts
+++ b/src/common/data-path.ts
@@ -133,7 +133,7 @@ export function resolveStackDbPath(stack: string, home?: string): string {
   if (existsSync(canonical)) return canonical;
   const legacy = legacyStackDbPath(stack, home);
   if (existsSync(legacy)) {
-    noteXdgFallback("data", `mc db for "${stack}" resolved from legacy ~/.local/share/cortex/mc`);
+    noteXdgFallback("data", `mc db for "${stack}" resolved from legacy ~/.local/share/cortex/mc`);  // xdg-audit:allow(resolver legacy-fallback note — by design)
     return legacy;
   }
   return canonical;
@@ -162,7 +162,7 @@ export function resolveStandaloneDbPath(home?: string): string {
   if (existsSync(canonical)) return canonical;
   const legacy = legacyStandaloneDbPath(home);
   if (existsSync(legacy)) {
-    noteXdgFallback("data", "mission-control.db resolved from legacy ~/.local/share/grove");
+    noteXdgFallback("data", "mission-control.db resolved from legacy ~/.local/share/grove");  // xdg-audit:allow(resolver legacy-fallback note — by design)
     return legacy;
   }
   return canonical;
@@ -190,7 +190,7 @@ export function resolveCursorPath(home?: string): string {
   if (existsSync(canonical)) return canonical;
   const legacy = legacyCursorPath(home);
   if (existsSync(legacy)) {
-    noteXdgFallback("data", "mc-hook-cursor.json resolved from legacy ~/.local/share/grove");
+    noteXdgFallback("data", "mc-hook-cursor.json resolved from legacy ~/.local/share/grove");  // xdg-audit:allow(resolver legacy-fallback note — by design)
     return legacy;
   }
   return canonical;
@@ -227,7 +227,7 @@ export function resolvePublishedEventsDir(home?: string): string {
   if (existsSync(canonical)) return canonical;
   const legacy = legacyPublishedEventsDir(home);
   if (existsSync(legacy)) {
-    noteXdgFallback("data", "published events resolved from legacy ~/.claude/events/published");
+    noteXdgFallback("data", "published events resolved from legacy ~/.claude/events/published");  // xdg-audit:allow(resolver legacy-fallback note — by design)
     return legacy;
   }
   return canonical;
@@ -244,4 +244,4 @@ export const PUBLISHED_EVENTS_DIR_DEFAULT =
   "~/.local/share/metafactory/cortex/events/published";
 
 /** The pre-move default literal for `paths.publishedEventsDir` (value-migrator source). */
-export const LEGACY_PUBLISHED_EVENTS_DIR_DEFAULT = "~/.claude/events/published";
+export const LEGACY_PUBLISHED_EVENTS_DIR_DEFAULT = "~/.claude/events/published";  // xdg-audit:allow(resolver legacy-fallback constant — by design)

--- a/src/common/state-path.ts
+++ b/src/common/state-path.ts
@@ -235,7 +235,7 @@ function resolveStateSubdir(
 export function resolvePidStateDir(home?: string): string {
   return resolveStateSubdir(
     home,
-    [{ dir: legacyPidStateDir(home), note: "pidfile dir resolved from legacy ~/.config/grove/state" }],
+    [{ dir: legacyPidStateDir(home), note: "pidfile dir resolved from legacy ~/.config/grove/state" }],  // xdg-audit:allow(resolver legacy-fallback candidate — by design)
     canonicalPidStateDir,
   );
 }
@@ -246,8 +246,8 @@ export function resolveLogsDir(home?: string): string {
   return resolveStateSubdir(
     home,
     [
-      { dir: legacyGroveLogsDir(home), note: "logs dir resolved from legacy ~/.config/grove/logs" },
-      { dir: legacyCortexLogsDir(home), note: "logs dir resolved from legacy ~/.config/cortex/logs" },
+      { dir: legacyGroveLogsDir(home), note: "logs dir resolved from legacy ~/.config/grove/logs" },  // xdg-audit:allow(resolver legacy-fallback candidate — by design)
+      { dir: legacyCortexLogsDir(home), note: "logs dir resolved from legacy ~/.config/cortex/logs" },  // xdg-audit:allow(resolver legacy-fallback candidate — by design)
     ],
     canonicalLogsDir,
   );
@@ -259,7 +259,7 @@ export function resolveLogsDir(home?: string): string {
 export function resolveRelayDir(home?: string): string {
   return resolveStateSubdir(
     home,
-    [{ dir: legacyRelayDir(home), note: "relay pidfile dir resolved from legacy ~/.claude/relay" }],
+    [{ dir: legacyRelayDir(home), note: "relay pidfile dir resolved from legacy ~/.claude/relay" }],  // xdg-audit:allow(resolver legacy-fallback candidate — by design)
     canonicalRelayDir,
   );
 }
@@ -274,7 +274,7 @@ export function resolveNetworkCacheDir(home?: string): string {
     [
       {
         dir: legacyNetworkCacheDir(home),
-        note: "network-cache resolved from legacy ~/.config/cortex/network-cache",
+        note: "network-cache resolved from legacy ~/.config/cortex/network-cache",  // xdg-audit:allow(resolver legacy-fallback note — by design)
       },
     ],
     canonicalNetworkCacheDir,
@@ -294,6 +294,6 @@ export function resolveNetworkCacheDir(home?: string): string {
 export const LOG_DIR_DEFAULT = "~/.local/state/metafactory/cortex/logs";
 
 /** Pre-move grove logDir default (value-migration / test source). */
-export const LEGACY_LOG_DIR_DEFAULT_GROVE = "~/.config/grove/logs";
+export const LEGACY_LOG_DIR_DEFAULT_GROVE = "~/.config/grove/logs";  // xdg-audit:allow(resolver legacy-fallback constant — by design)
 /** Pre-move cortex logDir default (value-migration / test source). */
-export const LEGACY_LOG_DIR_DEFAULT_CORTEX = "~/.config/cortex/logs";
+export const LEGACY_LOG_DIR_DEFAULT_CORTEX = "~/.config/cortex/logs";  // xdg-audit:allow(resolver legacy-fallback constant — by design)


### PR DESCRIPTION
## What

Turns `bun scripts/xdg-audit.ts --repos` into a **real deterministic gate** for the XDG epic (#1867): **exit 0 = nothing missed**, with every suppression an explicit, reviewable decision. On fully-migrated origin/main checkouts the old blunt string-grep reported **683 findings** (cortex 598 · arc 66 · discord 19); the gate now reports **0 gated**, and every one of those 683 raw hits is accounted for by a deterministic class rule, a raw-exception, an inline allow, an allowlist entry, or a doc-accuracy fix.

This is precision tooling + a final doc sweep. **No runtime behaviour changed** (all runtime misses were already fixed by #1988, #2007/#2011). The set of patterns the gate *catches* is unchanged — nothing was weakened.

## Gate semantics (implemented exactly as specced)

Exit code = count of **gated** findings. A raw pattern hit is gated unless it is:

1. **Advisory by class rule** (excluded from the exit code, shown in `--verbose`):
   - test files (`__tests__/` or `*.test.ts`);
   - comment-only lines in code files (`//`, `*`, `/*`, or `#` in `.sh`).
   - `.md` / `.yaml` / `.yml` / `.example` are **never** advisory — docs stay fully gated.
2. **Inline-allowed** — the matched line (or the line immediately above) carries `xdg-audit:allow(<reason>)`. Reason is required; a bare `xdg-audit:allow` is a **hard gate error**.
3. **Allowlist-allowed** — matches an entry in the new checked-in `scripts/xdg-audit-allow.yaml`: `{pattern, path, match, reason, owner}` (all five required; `match` is a narrow content regex, unknown pattern-ids and unused entries → warnings).

The allowlist is **central** (co-located with the tool) and applies to every scanned repo, so one cortex PR can adjudicate cross-repo (arc/discord) findings. `$XDG_AUDIT_ALLOWLIST` overrides it for hermetic tests. Positional repo roots now **replace** the defaults (point the gate at fresh worktrees), and the default discord root was fixed (`metafactory-bundle-discord` → `metafactory-discord`, which never existed so was silently skipped).

## Pattern fix

`claude-events` now excludes `~/.claude/events/raw` (stays under `~/.claude` permanently — standard §6) via a post-match `exclude` filter, while still matching `events/published`, bare `.claude/events`, and `.claude/relay`. **20** raw-exception hits carved out. No other pattern touched — `pkg-repos` (caught the 6 real bugs in #2007) is intact.

## Disposition of the 683 (final: 0 gated)

| Disposition | Count | Notes |
|---|---|---|
| advisory · test files | 214 | migration fixtures — by design |
| advisory · code comments | 213 | comments can't break runtime |
| raw-exception (`events/raw`) | 20 | permanent, standard §6 |
| inline allow | 20 | resolver legacy-fallback constants/notes + `~/bin` forward-bridge |
| allowlist | 206 (86 entries) | migration/historical/design prose, live manifests, GV-1 resolvers |
| **doc-accuracy fixes** | **12** | cortex `pkg-repos` "where bundles live now" docs |
| **gated** | **0** | ✅ |

### Sweep vs allow, per bucket
- **`pkg-repos` docs** — cortex: **fixed** 12 occurrences across 6 files (`~/.config/metafactory/pkg/repos` → `~/.local/share/metafactory/arc/repos`, the arc#287 canonical) where docs describe the *current* bundle location. arc's own install-location docs (CLAUDE/README/QUICKSTART/SKILL/library-support/agents-md, 13 hits) are **allowlisted** with `owner: arc#287` — they should be fixed *in arc* (companion PR); allowlisting them here is the interim so the gate is green from one PR. See "Cross-repo" below.
- **Resolver `LEGACY_*` constants + fallback notes** (`state-path.ts`, `data-path.ts`, `config-path.ts`, `plist-render.sh` resolver) — **inline** `xdg-audit:allow(resolver legacy-fallback …)` at each site.
- **Migration/plan/SOP/spec/changelog/iteration/archive prose** — allowlisted per-file (frozen history).
- **GV-1 cortex-first/grove-fallback readers** (`cldyo-live`, `cortex-status.sh`) + CLI `--help` text + pier hints + postinstall echoes — allowlisted (transition-active / permanent buffer).
- **grove-namespace design docs** — allowlisted; the paths are *accurate current state* (design-mission-control.md:388 explicitly documents the grove namespace is deliberately retained until a separate rename, cortex#436).
- **`systemd-userdir`** — post-#1909, the one remaining hit is the `$XDG_CONFIG_HOME`-aware Linux path in a design doc → allowlisted.

## Relay arc-manifest verdict (investigated per brief)

`arc-manifest.yaml:99 target: ~/.claude/relay/cortex` — **works at every stage → allowlisted (owner cortex#1903), NOT a stop-and-report break.** The relay is exec'd from the repo checkout (`ai.meta-factory.cortex.relay.plist` → `__CORTEX_DIR__/src/taps/cc-events/relay.ts`), not through this symlink; the runtime relay dir + policy are resolver-gated (`resolveRelayDir`, completion-gated). Nothing consumes `~/.claude/relay/cortex` as a runtime path. The relay dir cutover is wave-5 work (cortex#1903), which owns re-pointing this target. Same logic applied to discord's `arc-manifest.yaml:31 target: ~/bin/discord` (in PATH, works pre-cutover; bin cutover owned by wave 3).

## ⚠️ Flagged for a product decision (not fixed here)

**Stack `logDir` differs from the canonical XDG state default.** `stack-lib.ts:404` generates `logDir: ~/.config/cortex/logs` into new stack `system.yaml` (and the stack plist + federation-selftest match it), but the canonical zod default is `~/.local/state/metafactory/cortex/logs` (config.ts / cortex-config.ts). It *works* at every stage (stack logs co-located with the stack config), so it's allowlisted (owner cortex#1869) + flagged here rather than changed — deciding whether stack logs should move to the XDG state dir is a runtime behaviour call. `publishedEventsDir` is already canonical. Also worth a second look: `signal-cortex-reload.sh:37`'s best-effort `~/.local/share/cortex/cortex.pid` SIGHUP fallback (allowlisted, owner cortex#1903).

## Cross-repo note

The gate scans cortex + arc + discord. arc/discord findings are all by-design/historical/stale-docs, suppressed via the central allowlist so the gate is green from this single cortex PR. The genuinely-stale **arc install-location docs** (owner `arc#287`) are the one bucket that ideally gets *fixed at source* in a companion arc PR rather than allowlisted — happy to do that if preferred.

## Self-test

New hermetic `scripts/__tests__/xdg-audit.test.ts` (scratch git repo, no real checkouts touched):
- **(a)** planted stale runtime literal → gate exits nonzero + reports it; comment/test-file siblings are advisory, not gated.
- **(b)** same line with `xdg-audit:allow(reason)` → exit 0.
- **(b')** bare `xdg-audit:allow` (no reason) → hard gate error.
- **(c)** an allowlist entry whose content-regex doesn't match a line does **not** suppress a different line in the same file (narrow-match guarantee).

## Verification

- `bun scripts/xdg-audit.ts --repos <cortex> <arc> <discord>` (all fresh at origin/main) → **exit 0**, gated=0, errors=0, warnings=0.
- Full `bun test`: **9831 pass / 0 fail** (586 files). #2017 made the former non-hermetic network-secret-cli tests hermetic; they pass.
- `tsc --noEmit`: my files add **0 errors** (19 pre-existing CSS-module side-effect-import errors in `src/surface/mc/dashboard-v2/` exist identically on origin/main, untouched here).
- Modified shell scripts pass `bash -n`; the stack plist passes `xmllint`.

Rebased onto current origin/main (`89f6e2c7`, #2017).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
