### PR TITLE
feat(arc-manifest): auto-install the 5 first-party surface bundles (#2028)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -247,6 +247,48 @@ dependencies:
   # https://github.com/the-metafactory/metafactory-cortex-renderer-pagerduty.
   - name: "metafactory-cortex-renderer-pagerduty"
     version: ">=0.1.0"
+
+# depends_on.packages — the arc AUTO-INSTALL contract (cortex#2028).
+#
+# WHY THIS EXISTS SEPARATELY FROM `dependencies:` ABOVE. cortex's own dep
+# graph is read by TWO consumers that key off DIFFERENT fields:
+#
+#   1. cortex's plugin loader (src/adapters/loader.ts,
+#      readCortexDeclaredAdapterRepos / readCortexDeclaredRendererRepos) reads
+#      the TOP-LEVEL `dependencies:` array BY NAME to compute the first-party
+#      load exemption. It derives each repo URL from the dependency NAME
+#      (github.com/the-metafactory/<name>) and never looks at a `repo:` field.
+#      → the `dependencies:` block above is authoritative for that path and is
+#        left exactly as-is.
+#
+#   2. arc's installer (arc/src/commands/install.ts) reads `depends_on.packages`
+#      (PackageDependency = { name, repo }) to CLONE + install each dependency
+#      when you run `arc install cortex` / `arc upgrade cortex`. It IGNORES the
+#      top-level `dependencies:` key entirely (ArcManifest has no such field),
+#      and SKIPS any package with no `repo:`.
+#      → this block is authoritative for that path.
+#
+# Before cortex#2028 only (1) existed, so arc auto-installed NONE of the five
+# first-party surface-plugin bundles — the "arc auto-installs first-party
+# bundles" story (release notes v6.8.0, sop-stack-onboarding.md) was untrue.
+# Declaring the SAME five bundles here (name + repo) closes that gap. The two
+# blocks list the same bundles by design; keep them in sync when a bundle is
+# added or removed. `arc` (no repo) and metafactory-bundle-discord (ADR-0017
+# CLI bundle) stay in `dependencies:` only — out of scope for this auto-install
+# lane.
+depends_on:
+  packages:
+    - name: "metafactory-cortex-adapter-web"
+      repo: "https://github.com/the-metafactory/metafactory-cortex-adapter-web"
+    - name: "metafactory-cortex-adapter-slack"
+      repo: "https://github.com/the-metafactory/metafactory-cortex-adapter-slack"
+    - name: "metafactory-cortex-adapter-mattermost"
+      repo: "https://github.com/the-metafactory/metafactory-cortex-adapter-mattermost"
+    - name: "metafactory-cortex-adapter-discord"
+      repo: "https://github.com/the-metafactory/metafactory-cortex-adapter-discord"
+    - name: "metafactory-cortex-renderer-pagerduty"
+      repo: "https://github.com/the-metafactory/metafactory-cortex-renderer-pagerduty"
+
 # myelin deps still pending — declared once cortex's runtime depends on
 # myelin-side identity primitives.
 # dependencies:


### PR DESCRIPTION
## Summary
Closes **gap 2** of #2028: `arc install cortex` / `arc upgrade cortex` now auto-installs all five first-party surface-plugin bundles (web/slack/mattermost/discord adapters + pagerduty renderer). Previously it installed **none**.

## Root cause (corrected from the issue)
The issue said arc skips the bundle deps because they lack a `repo:` field under `dependencies:`. Verified deeper: arc's installer reads **`depends_on.packages`** (`install.ts:347-348`, `PackageDependency = { name, repo }`), and `ArcManifest` has **no top-level `dependencies` field at all** — so the entire `dependencies:` block was invisible to the installer regardless of `repo:`. Adding `repo:` under `dependencies:` would still have been skipped.

## Why the fix is additive (not a move)
The `dependencies:` block is **not** dead — cortex's own plugin loader (`readCortexDeclaredAdapterRepos` / `readCortexDeclaredRendererRepos`, `loader.ts:610-673`) reads **top-level `dependencies:` by name** to compute the first-party load exemption (it derives the repo URL from the name; never reads `repo:`). Two consumers, two different keys:

| Consumer | Field read | Needs |
|---|---|---|
| cortex loader (first-party exemption) | top-level `dependencies:` (by name) | unchanged |
| arc installer (clone + install) | `depends_on.packages` (name + repo) | **added here** |

So this PR **keeps `dependencies:` exactly as-is** and **adds** a `depends_on.packages` block naming the same five bundles with their repo URLs. `arc` (no repo) and `metafactory-bundle-discord` (ADR-0017 CLI bundle) intentionally stay in `dependencies:` only.

## Paired bundle-side PRs (gap 1 — must merge first)
Each bundle also needs its own `arc-manifest.yaml` (arc install requires one; only discord had it). Merge these **before** this PR, else `arc install cortex` fails on a bundle whose default branch lacks the manifest:
- the-metafactory/metafactory-cortex-adapter-web#1
- the-metafactory/metafactory-cortex-adapter-slack#1
- the-metafactory/metafactory-cortex-adapter-mattermost#1
- the-metafactory/metafactory-cortex-renderer-pagerduty#1

## Verification
- `arc`'s `readManifest` validates the edited manifest (type component, `depends_on.packages` = 5).
- Adapter loader suite: 68 pass / 0 fail — first-party exemption still works off the untouched `dependencies:` block.
- End-to-end scratch `arc install cortex` proof to be appended once the 4 bundle PRs merge.

Refs #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)