### PR TITLE
feat(xdg-audit): machine-domain positive-layout checks + repos-gate CI lane (#2033)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,39 @@ jobs:
 
       - name: check-shippable-hygiene (whole-tree)
         run: bun scripts/check-shippable-hygiene.ts
+
+  # ──────────────────────────────────────────────────────────────────
+  # XDG gate — runs the xdg-audit REPO GATE against THIS checkout only
+  # (cortex#2033). The self-test (scripts/__tests__/xdg-audit.test.ts) already
+  # runs under the `test` job and proves the gate MECHANISM works; this job runs
+  # the gate itself over the PR's tree so a stale-XDG-path regression can't land
+  # the way it did in PR#2026 (2 gated findings + 9 dead allow-entries reached
+  # main because the full scan ran only manually — b2030 had to clean it up).
+  #
+  # Scope is SELF-REPO ONLY: the positional root `.` REPLACES the tool's default
+  # cross-repo roots (cortex/arc/metafactory-discord), so CI scans just the
+  # cortex checkout. arc + metafactory-discord are not checked out here and
+  # cross-repo state is not a cortex PR's fault — each repo enforces its own tree
+  # in its own CI.
+  #
+  # Exit contract (verified in scripts/xdg-audit.ts): the exit code is the count
+  # of GATED findings; unused/unknown allowlist ENTRIES are WARNINGS that do NOT
+  # affect the exit code. On a cortex-only scan the shared allowlist's arc/discord
+  # entries read "unused" by design (the cross-repo NOTE b2030 added documents
+  # this) — so those warnings inform without failing the job. Only gated findings
+  # in the PR's tree turn this red.
+  # ──────────────────────────────────────────────────────────────────
+  xdg-gate:
+    name: XDG gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: xdg-audit --repos (self-repo scope)
+        run: bun scripts/xdg-audit.ts --repos .

--- a/scripts/__tests__/xdg-audit.test.ts
+++ b/scripts/__tests__/xdg-audit.test.ts
@@ -42,15 +42,22 @@ function runGate(root: string, allowlistPath?: string) {
  * dev/CI environment can't relocate the canonical roots out from under the
  * fixture — the seam honors those verbatim, so the test must pin them to unset.
  */
-function runMachine(home: string) {
+function runMachine(home: string, extraEnv: Record<string, string> = {}) {
   const env: Record<string, string | undefined> = { ...process.env };
   for (const k of ["CORTEX_STATE_DIR", "XDG_STATE_HOME", "XDG_CONFIG_HOME"]) delete env[k];
+  Object.assign(env, extraEnv);
   const r = spawnSync("bun", [AUDIT, "--machine", "--home", home, "--json"], { encoding: "utf8", env });
   let json: any = {};
   try { json = JSON.parse(r.stdout); } catch { /* leave empty; assertions below will surface it */ }
   return { status: r.status ?? -1, json, stderr: r.stderr, stdout: r.stdout };
 }
 const gatedPatterns = (json: any) => (json.gated ?? []).map((f: any) => f.pattern);
+// A pid guaranteed ALIVE for the child's real `process.kill(pid,0)` probe: this
+// test-runner's own pid (it is blocked in spawnSync while the child runs).
+const ALIVE_PID = process.pid;
+// A pid guaranteed DEAD: above any Linux/macOS pid_max (2^31-1 > 2^30 ceiling) →
+// kill() returns ESRCH → classified dead, deterministically, on any runner.
+const DEAD_PID = 2147483647;
 
 beforeAll(() => {
   scratch = mkdtempSync(join(tmpdir(), "xdg-audit-selftest-"));
@@ -167,12 +174,27 @@ describe("xdg-audit machine domain — positive-layout checks (cortex#2033)", ()
     rmSync(box, { recursive: true, force: true });
   });
 
-  test("canonical state root WITHOUT completion marker → NONZERO (wedge class)", () => {
+  test("NON-override canonical state root WITHOUT completion marker → NONZERO (wedge class)", () => {
     const box = freshBox();
     mkdirSync(join(box, ".local", "state", "metafactory", "cortex"), { recursive: true });
     const { status, json } = runMachine(box);
     expect(status).toBeGreaterThan(0);
     expect(gatedPatterns(json)).toContain("canonical-state-without-marker");
+    rmSync(box, { recursive: true, force: true });
+  });
+
+  // A $CORTEX_STATE_DIR override box resolves canonical by rule 1 and never runs
+  // the gated migration, so "canonical present, no marker" is its NORMAL state —
+  // must NOT gate. (Flips the pre-fix over-detection: check 2 fired here.)
+  test("OVERRIDE box ($CORTEX_STATE_DIR set, state present, no marker) → PASS", () => {
+    const box = freshBox();
+    const override = mkdtempSync(join(tmpdir(), "xdg-audit-override-"));
+    // state present under the override root, deliberately WITHOUT the marker.
+    mkdirSync(join(override, "network-cache"), { recursive: true });
+    const { status, json } = runMachine(box, { CORTEX_STATE_DIR: override });
+    expect(status).toBe(0);
+    expect(json.summary.gated).toBe(0);
+    rmSync(override, { recursive: true, force: true });
     rmSync(box, { recursive: true, force: true });
   });
 
@@ -187,13 +209,47 @@ describe("xdg-audit machine domain — positive-layout checks (cortex#2033)", ()
     rmSync(box, { recursive: true, force: true });
   });
 
-  test("marker present + pidfile in a LEGACY state dir → NONZERO (split identity)", () => {
+  // The migration is COPY-KEEP-SOURCE (#1904 prunes later), so a healthy migrated
+  // box keeps DEAD legacy pid copies + a LIVE canonical pid. Must NOT gate.
+  // (Flips the pre-fix BLOCKER: check 3 fired on filename presence alone.)
+  test("migrated box: marker + LIVE canonical pid + DEAD legacy copies → PASS", () => {
     const box = freshBox();
     const canon = join(box, ".local", "state", "metafactory", "cortex");
     mkdirSync(canon, { recursive: true });
     writeFileSync(join(canon, ".xdg-state-migration.json"), "{}\n");
-    mkdirSync(join(box, ".config", "grove", "state"), { recursive: true });
-    writeFileSync(join(box, ".config", "grove", "state", "cortex.pid"), "424242\n");
+    writeFileSync(join(canon, "cortex.pid"), `${ALIVE_PID}\n`); // live daemon, canonical-side
+    const legacy = join(box, ".config", "grove", "state");
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, "cortex.pid"), `${DEAD_PID}\n`); // kept dead source copy
+    const { status, json } = runMachine(box);
+    expect(status).toBe(0);
+    expect(json.summary.gated).toBe(0);
+    rmSync(box, { recursive: true, force: true });
+  });
+
+  test("genuine split identity: LIVE legacy pid ≠ canonical pid → NONZERO", () => {
+    const box = freshBox();
+    const canon = join(box, ".local", "state", "metafactory", "cortex");
+    mkdirSync(canon, { recursive: true });
+    writeFileSync(join(canon, ".xdg-state-migration.json"), "{}\n");
+    writeFileSync(join(canon, "cortex.pid"), `${DEAD_PID}\n`); // canonical tracks a DIFFERENT pid
+    const legacy = join(box, ".config", "grove", "state");
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, "cortex.pid"), `${ALIVE_PID}\n`); // a LIVE daemon off the legacy path
+    const { status, json } = runMachine(box);
+    expect(status).toBeGreaterThan(0);
+    expect(gatedPatterns(json)).toContain("split-identity-legacy-pidfile");
+    rmSync(box, { recursive: true, force: true });
+  });
+
+  test("fail-safe: UNPARSEABLE legacy pidfile (post-marker) → NONZERO (can't prove dead)", () => {
+    const box = freshBox();
+    const canon = join(box, ".local", "state", "metafactory", "cortex");
+    mkdirSync(canon, { recursive: true });
+    writeFileSync(join(canon, ".xdg-state-migration.json"), "{}\n");
+    const legacy = join(box, ".config", "grove", "state");
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, "cortex.pid"), "not-a-pid\n");
     const { status, json } = runMachine(box);
     expect(status).toBeGreaterThan(0);
     expect(gatedPatterns(json)).toContain("split-identity-legacy-pidfile");

--- a/scripts/__tests__/xdg-audit.test.ts
+++ b/scripts/__tests__/xdg-audit.test.ts
@@ -36,6 +36,22 @@ function runGate(root: string, allowlistPath?: string) {
   return { status: r.status ?? -1, json, stderr: r.stderr, stdout: r.stdout };
 }
 
+/**
+ * Run the MACHINE domain against a scratch `$HOME` (`--home`), never the real
+ * home. The `$XDG_*` / `$CORTEX_*` dir-override env is SCRUBBED so a value in the
+ * dev/CI environment can't relocate the canonical roots out from under the
+ * fixture — the seam honors those verbatim, so the test must pin them to unset.
+ */
+function runMachine(home: string) {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const k of ["CORTEX_STATE_DIR", "XDG_STATE_HOME", "XDG_CONFIG_HOME"]) delete env[k];
+  const r = spawnSync("bun", [AUDIT, "--machine", "--home", home, "--json"], { encoding: "utf8", env });
+  let json: any = {};
+  try { json = JSON.parse(r.stdout); } catch { /* leave empty; assertions below will surface it */ }
+  return { status: r.status ?? -1, json, stderr: r.stderr, stdout: r.stdout };
+}
+const gatedPatterns = (json: any) => (json.gated ?? []).map((f: any) => f.pattern);
+
 beforeAll(() => {
   scratch = mkdtempSync(join(tmpdir(), "xdg-audit-selftest-"));
   git(scratch, "init", "-q");
@@ -116,5 +132,71 @@ describe("xdg-audit gate — self-test (cortex#1867)", () => {
     expect(gatedRuntime.length).toBe(1);
     expect(gatedRuntime[0].content).toContain("grove/other.yaml");
     expect(status).toBeGreaterThan(0); // the un-allowed line keeps the gate red
+  });
+});
+
+// ── machine-domain positive-layout checks (cortex#2033) ─────────────────────
+// Vincent's blind spot: the machine scan only fired on KNOWN-BAD legacy paths,
+// so a box wrong-by-CLASS (state dirs under the config root, or a half-migrated
+// canonical state tree) passed with all-zeros. These pin the positive-layout
+// assertions. Every fixture runs against a scratch $HOME (`--home`) with the
+// XDG/CORTEX dir-override env scrubbed — ZERO real-home access.
+describe("xdg-audit machine domain — positive-layout checks (cortex#2033)", () => {
+  let mhome: string;
+  beforeAll(() => { mhome = mkdtempSync(join(tmpdir(), "xdg-audit-machine-")); });
+  afterAll(() => { if (mhome) rmSync(mhome, { recursive: true, force: true }); });
+
+  const freshBox = () => mkdtempSync(join(tmpdir(), "xdg-audit-machine-box-"));
+
+  test("clean fresh box → PASS with zeros (legitimately)", () => {
+    const box = freshBox();
+    const { status, json } = runMachine(box);
+    expect(status).toBe(0);
+    expect(json.summary.gated).toBe(0);
+    rmSync(box, { recursive: true, force: true });
+  });
+
+  test("state-class dir under the CONFIG root → NONZERO naming the misplacement", () => {
+    const box = freshBox();
+    mkdirSync(join(box, ".config", "metafactory", "cortex", "state"), { recursive: true });
+    const { status, json } = runMachine(box);
+    expect(status).toBeGreaterThan(0);
+    expect(gatedPatterns(json)).toContain("config-root-state-misplacement");
+    const f = (json.gated ?? []).find((x: any) => x.pattern === "config-root-state-misplacement");
+    expect(f.location).toContain(".config/metafactory/cortex/state");
+    rmSync(box, { recursive: true, force: true });
+  });
+
+  test("canonical state root WITHOUT completion marker → NONZERO (wedge class)", () => {
+    const box = freshBox();
+    mkdirSync(join(box, ".local", "state", "metafactory", "cortex"), { recursive: true });
+    const { status, json } = runMachine(box);
+    expect(status).toBeGreaterThan(0);
+    expect(gatedPatterns(json)).toContain("canonical-state-without-marker");
+    rmSync(box, { recursive: true, force: true });
+  });
+
+  test("coherent canonical state root + completion marker → PASS", () => {
+    const box = freshBox();
+    const canon = join(box, ".local", "state", "metafactory", "cortex");
+    mkdirSync(canon, { recursive: true });
+    writeFileSync(join(canon, ".xdg-state-migration.json"), "{}\n");
+    const { status, json } = runMachine(box);
+    expect(status).toBe(0);
+    expect(json.summary.gated).toBe(0);
+    rmSync(box, { recursive: true, force: true });
+  });
+
+  test("marker present + pidfile in a LEGACY state dir → NONZERO (split identity)", () => {
+    const box = freshBox();
+    const canon = join(box, ".local", "state", "metafactory", "cortex");
+    mkdirSync(canon, { recursive: true });
+    writeFileSync(join(canon, ".xdg-state-migration.json"), "{}\n");
+    mkdirSync(join(box, ".config", "grove", "state"), { recursive: true });
+    writeFileSync(join(box, ".config", "grove", "state", "cortex.pid"), "424242\n");
+    const { status, json } = runMachine(box);
+    expect(status).toBeGreaterThan(0);
+    expect(gatedPatterns(json)).toContain("split-identity-legacy-pidfile");
+    rmSync(box, { recursive: true, force: true });
   });
 });

--- a/scripts/xdg-audit.ts
+++ b/scripts/xdg-audit.ts
@@ -12,7 +12,10 @@
  *   --machine  live inventory: dangling symlinks, plist exec paths,
  *              settings.json hooks, packages.db rows, WAL sidecars,
  *              occupied cutover destinations, grove-vs-cortex divergence,
- *              pidfile liveness
+ *              pidfile liveness, and positive-layout checks (cortex#2033):
+ *              state-class dirs misplaced under the canonical CONFIG root, and
+ *              STATE-tree coherence (stray canonical without marker / split
+ *              identity). Testable against a scratch $HOME via `--home <dir>`.
  *
  * ── THE REPO GATE ──────────────────────────────────────────────────────────
  * `bun xdg-audit.ts --repos` is a DETERMINISTIC gate. Exit code = number of
@@ -57,10 +60,24 @@ import { homedir } from "os";
 import { Database } from "bun:sqlite";
 import { parse as parseYaml } from "yaml";
 
-const HOME = homedir();
+import {
+  cortexStateDir,
+  legacyPidStateDir,
+  stateMigrationCompleted,
+  STATE_MIGRATION_JOURNAL_NAME,
+} from "../src/common/state-path";
+import { readDirEnv } from "../src/common/xdg";
+
 const args = process.argv.slice(2);
 const flag = (f: string) => args.includes(f);
 const opt = (f: string) => { const i = args.indexOf(f); return i >= 0 ? args[i + 1] : undefined; };
+// HOME is the machine-scan root. `--home <dir>` overrides it so the machine
+// domain is testable against a scratch $HOME with ZERO real-home access (the
+// same escape hatch the repo scan gets from positional roots). The state/config
+// coherence checks below thread this HOME into the state-path resolvers, which
+// still honor `$XDG_*` / `$CORTEX_*` verbatim — env wins over the injected home,
+// exactly as the resolvers behave in production.
+const HOME = opt("--home") ?? homedir();
 const JSON_OUT = flag("--json");
 const VERBOSE = flag("--verbose");
 const WAVE = opt("--wave");
@@ -440,6 +457,77 @@ function scanPidfiles() {
   }
 }
 
+// ─────────────────────────────────── positive-layout checks (cortex#2033)
+// The legacy scans above only fire on KNOWN-BAD legacy paths, so a box that is
+// wrong-by-CLASS — state-class content living under the canonical CONFIG root,
+// or a half-migrated canonical STATE tree — passes with all-zeros (Vincent's
+// blind spot, #2033). These assert the layout POSITIVELY. All GATE.
+
+/** The canonical config home, honoring `$XDG_CONFIG_HOME` (blank ⇒ unset) the
+ *  same way the resolvers do; default `$HOME/.config`. */
+function xdgConfigHomeDir(): string {
+  return readDirEnv("XDG_CONFIG_HOME") ?? join(HOME, ".config");
+}
+
+/**
+ * (1) Class-misplacement: state-class dirs living under the canonical CONFIG
+ * root (`…/metafactory/cortex/{logs,state,relay,network-cache}`) — the #2030
+ * postinstall bug shape. These four are STATE classes (they belong under
+ * `~/.local/state/metafactory/cortex`); their presence under the CONFIG root is
+ * a layout error the legacy-path scan can't see (it's a canonical path, not a
+ * legacy one). Catches already-scaffolded-wrong boxes + any future regression.
+ */
+function scanConfigRootMisplacement() {
+  const cortexConfig = join(xdgConfigHomeDir(), "metafactory", "cortex");
+  for (const name of ["logs", "state", "relay", "network-cache"]) {
+    const p = join(cortexConfig, name);
+    if (!existsSync(p)) continue;
+    pushMachine({
+      domain: "machine", pattern: "config-root-state-misplacement", clazz: "state", wave: 5, issue: "cortex#2030/#2033",
+      location: p.replace(HOME, "~"),
+      excerpt: `state-class '${name}' under CONFIG root — belongs in ~/.local/state/metafactory/cortex (#2030 bug shape)`,
+    });
+  }
+}
+
+/**
+ * (2) State-tree coherence of the canonical STATE root:
+ *   • canonical root EXISTS but the completion marker does NOT → partial/stray
+ *     canonical (the "wedge" class): a bare/half-migrated canonical dir that the
+ *     resolvers must NOT prefer, and which shouldn't exist without a completed,
+ *     marker-writing migration.
+ *   • marker PRESENT (migration completed) yet a cortex pidfile still sits in a
+ *     LEGACY state dir → split identity: a daemon whose pidfile lives in the old
+ *     tree while the box has flipped canonical.
+ * Both honor `$CORTEX_STATE_DIR` / `$XDG_STATE_HOME` via the state-path seam.
+ */
+function scanStateTreeCoherence() {
+  const canonical = cortexStateDir(HOME);
+  const migrated = stateMigrationCompleted(HOME);
+
+  if (existsSync(canonical) && !migrated) {
+    pushMachine({
+      domain: "machine", pattern: "canonical-state-without-marker", clazz: "state", wave: 5, issue: "cortex#1903/#2033",
+      location: canonical.replace(HOME, "~"),
+      excerpt: `canonical state root exists WITHOUT completion marker ${STATE_MIGRATION_JOURNAL_NAME} (partial/stray — wedge class)`,
+    });
+  }
+
+  if (migrated) {
+    const legacy = legacyPidStateDir(HOME);
+    let names: string[] = [];
+    try { if (existsSync(legacy)) names = readdirSync(legacy); } catch { names = []; }
+    for (const name of names) {
+      if (!name.endsWith(".pid")) continue;
+      pushMachine({
+        domain: "machine", pattern: "split-identity-legacy-pidfile", clazz: "state", wave: 5, issue: "cortex#1903/#2033",
+        location: join(legacy, name).replace(HOME, "~"),
+        excerpt: `pidfile in LEGACY state dir while canonical marker present (split identity)`,
+      });
+    }
+  }
+}
+
 // -------------------------------------------------------------------- main
 if (DO_REPOS) {
   const extra = args.filter(a => !a.startsWith("--") && a !== WAVE && a !== REF && existsSync(a));
@@ -458,6 +546,7 @@ if (DO_MACHINE) {
   for (const d of ["skills", "bin", "agents", "commands", "hooks"]) scanSymlinks(join(HOME, ".claude", d), 5, "arc#287");
   scanPlists(); scanSettingsHooks(); scanPackagesDb(); scanWalSidecars();
   scanOccupiedDestinations(); scanTreeDivergence(); scanPidfiles();
+  scanConfigRootMisplacement(); scanStateTreeCoherence();
 }
 
 // ------------------------------------------------------------------ report

--- a/scripts/xdg-audit.ts
+++ b/scripts/xdg-audit.ts
@@ -61,7 +61,9 @@ import { Database } from "bun:sqlite";
 import { parse as parseYaml } from "yaml";
 
 import {
+  canonicalPidStateDir,
   cortexStateDir,
+  cortexStateDirOverride,
   legacyPidStateDir,
   stateMigrationCompleted,
   STATE_MIGRATION_JOURNAL_NAME,
@@ -444,13 +446,25 @@ function scanTreeDivergence() {
 }
 
 function scanPidfiles() {
-  for (const dir of [join(HOME, ".config", "grove", "state"), join(HOME, ".local", "share", "cortex")]) {
+  // Post-migration, the legacy pid state dir keeps DEAD copies by design (the
+  // migration is copy-keep-source; the legacy prune is #1904). So once the marker
+  // is set, a STALE pidfile in the LEGACY dir is expected cruft — an info, not a
+  // gate. LIVE ones still gate (a daemon that must be booted out first), and the
+  // genuinely-split case (live legacy pid ≠ canonical) is caught by
+  // scanStateTreeCoherence. Pre-migration behavior is unchanged (byte-identical).
+  const legacyPidDir = legacyPidStateDir(HOME);
+  const migrated = stateMigrationCompleted(HOME);
+  for (const dir of [legacyPidDir, join(HOME, ".local", "share", "cortex")]) {
     if (!existsSync(dir)) continue;
     for (const name of readdirSync(dir)) {
       if (!name.endsWith(".pid")) continue;
       const p = join(dir, name);
       let pid = 0; try { pid = parseInt(readFileSync(p, "utf8").trim(), 10); } catch { continue; }
       let alive = false; try { process.kill(pid, 0); alive = true; } catch {}
+      if (!alive && migrated && dir === legacyPidDir) {
+        infos.push(`kept legacy pid source (post-migration, #1904 prunes): ${p.replace(HOME, "~")} — pid ${pid} stale`);
+        continue;
+      }
       pushMachine({ domain: "machine", pattern: alive ? "live-pidfile" : "stale-pidfile", clazz: "state", wave: 5, issue: "cortex#1903",
         location: p.replace(HOME, "~"), excerpt: `pid ${pid} ${alive ? "ALIVE (gate must bootout first)" : "stale"}` });
     }
@@ -469,6 +483,32 @@ function xdgConfigHomeDir(): string {
   return readDirEnv("XDG_CONFIG_HOME") ?? join(HOME, ".config");
 }
 
+/** EPERM-as-alive / ESRCH-as-dead liveness probe — the SAME semantics as
+ *  `migrate-state-dir.ts`'s `defaultProcAlive`, so this gate and the migrator's
+ *  occupancy precondition classify a pidfile identically. */
+function procAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (err) { return (err as { code?: string }).code !== "ESRCH"; }
+}
+
+/** The set of pid VALUES written in the `*.pid` files of `dir` (unreadable /
+ *  unparseable entries are skipped — membership is by value, liveness-agnostic).
+ *  Used to decide whether a live LEGACY pid is the SAME daemon the box already
+ *  tracks canonically (coherent) or a DIFFERENT one (split identity). */
+function readPidSet(dir: string): Set<number> {
+  const out = new Set<number>();
+  if (!existsSync(dir)) return out;
+  let names: string[]; try { names = readdirSync(dir); } catch { return out; }
+  for (const name of names) {
+    if (!name.endsWith(".pid")) continue;
+    let text: string; try { text = readFileSync(join(dir, name), "utf8"); } catch { continue; }
+    const pid = parseInt(text.trim(), 10);
+    if (Number.isInteger(pid) && pid > 0) out.add(pid);
+  }
+  return out;
+}
+
 /**
  * (1) Class-misplacement: state-class dirs living under the canonical CONFIG
  * root (`…/metafactory/cortex/{logs,state,relay,network-cache}`) — the #2030
@@ -476,6 +516,11 @@ function xdgConfigHomeDir(): string {
  * `~/.local/state/metafactory/cortex`); their presence under the CONFIG root is
  * a layout error the legacy-path scan can't see (it's a canonical path, not a
  * legacy one). Catches already-scaffolded-wrong boxes + any future regression.
+ *
+ * NOTE: this is an unconditional class assertion — a deliberate operator that
+ * pins `paths.logDir` under the config root (e.g. `~/.config/metafactory/cortex/
+ * logs`) is UNSUPPORTED and will flag here; state classes belong under the state
+ * root, and the gate does not carve out a hand-pinned exception.
  */
 function scanConfigRootMisplacement() {
   const cortexConfig = join(xdgConfigHomeDir(), "metafactory", "cortex");
@@ -492,39 +537,74 @@ function scanConfigRootMisplacement() {
 
 /**
  * (2) State-tree coherence of the canonical STATE root:
+ *
  *   • canonical root EXISTS but the completion marker does NOT → partial/stray
  *     canonical (the "wedge" class): a bare/half-migrated canonical dir that the
  *     resolvers must NOT prefer, and which shouldn't exist without a completed,
- *     marker-writing migration.
- *   • marker PRESENT (migration completed) yet a cortex pidfile still sits in a
- *     LEGACY state dir → split identity: a daemon whose pidfile lives in the old
- *     tree while the box has flipped canonical.
+ *     marker-writing migration. SKIPPED under an explicit `$CORTEX_STATE_DIR`:
+ *     an override box resolves canonical by rule 1 (the override IS the root,
+ *     VERBATIM), never runs the gated migration, and so never writes the marker
+ *     — "canonical without marker" is the NORMAL steady state there, not a wedge.
+ *
+ *   • split identity: the state migration is COPY-KEEP-SOURCE (the legacy prune
+ *     is the separate #1904 job), so a healthy migrated box legitimately keeps
+ *     DEAD `*.pid` copies at the legacy dir alongside the marker. Gate ONLY a
+ *     genuinely split identity — a LEGACY pidfile whose pid is ALIVE and is NOT
+ *     the pid the box tracks canonically — OR one we cannot prove dead
+ *     (unreadable / unparseable → fail-safe PRESENT, mirroring
+ *     `migrate-state-dir.ts`'s `stateDirOccupancyCheck`). A dead legacy copy is
+ *     the kept migration source (#1904 cleanup), never a finding.
+ *
  * Both honor `$CORTEX_STATE_DIR` / `$XDG_STATE_HOME` via the state-path seam.
  */
 function scanStateTreeCoherence() {
-  const canonical = cortexStateDir(HOME);
   const migrated = stateMigrationCompleted(HOME);
 
-  if (existsSync(canonical) && !migrated) {
-    pushMachine({
-      domain: "machine", pattern: "canonical-state-without-marker", clazz: "state", wave: 5, issue: "cortex#1903/#2033",
-      location: canonical.replace(HOME, "~"),
-      excerpt: `canonical state root exists WITHOUT completion marker ${STATE_MIGRATION_JOURNAL_NAME} (partial/stray — wedge class)`,
-    });
-  }
-
-  if (migrated) {
-    const legacy = legacyPidStateDir(HOME);
-    let names: string[] = [];
-    try { if (existsSync(legacy)) names = readdirSync(legacy); } catch { names = []; }
-    for (const name of names) {
-      if (!name.endsWith(".pid")) continue;
+  // (2a) stray/partial canonical — genuine only for a NON-override box (an
+  // override box legitimately has no marker; see doc above).
+  if (cortexStateDirOverride() === undefined) {
+    const canonical = cortexStateDir(HOME);
+    if (existsSync(canonical) && !migrated) {
       pushMachine({
-        domain: "machine", pattern: "split-identity-legacy-pidfile", clazz: "state", wave: 5, issue: "cortex#1903/#2033",
-        location: join(legacy, name).replace(HOME, "~"),
-        excerpt: `pidfile in LEGACY state dir while canonical marker present (split identity)`,
+        domain: "machine", pattern: "canonical-state-without-marker", clazz: "state", wave: 5, issue: "cortex#1903/#2033",
+        location: canonical.replace(HOME, "~"),
+        excerpt: `canonical state root exists WITHOUT completion marker ${STATE_MIGRATION_JOURNAL_NAME} (partial/stray — wedge class)`,
       });
     }
+  }
+
+  // (2b) split identity — liveness-aware. Only fires post-migration (marker set).
+  if (!migrated) return;
+  const legacy = legacyPidStateDir(HOME);
+  if (!existsSync(legacy)) return;
+  const flagSplit = (where: string, why: string) => pushMachine({
+    domain: "machine", pattern: "split-identity-legacy-pidfile", clazz: "state", wave: 5, issue: "cortex#1903/#2033",
+    location: where.replace(HOME, "~"), excerpt: why,
+  });
+
+  let names: string[];
+  try { names = readdirSync(legacy); }
+  catch {
+    // present-but-unreadable legacy dir hides an unknown pidfile set — fail-safe
+    // gate (cannot prove there is no live split identity).
+    flagSplit(join(legacy, "*.pid"), "legacy state dir unreadable — cannot prove no live split identity");
+    return;
+  }
+  const canonicalPids = readPidSet(canonicalPidStateDir(HOME));
+  for (const name of names) {
+    if (!name.endsWith(".pid")) continue;
+    const p = join(legacy, name);
+    let text: string;
+    try { text = readFileSync(p, "utf8"); }
+    catch { flagSplit(p, "legacy pidfile unreadable — cannot prove dead (fail-safe gate)"); continue; }
+    const pid = parseInt(text.trim(), 10);
+    if (!Number.isInteger(pid) || pid <= 0) {
+      flagSplit(p, `unparseable pid "${text.trim().slice(0, 24)}" — cannot prove dead (fail-safe gate)`);
+      continue;
+    }
+    if (!procAlive(pid)) continue;              // dead copy = the kept migration source (#1904 prunes it)
+    if (canonicalPids.has(pid)) continue;       // same live daemon also tracked canonically → coherent
+    flagSplit(p, `pid ${pid} ALIVE and ≠ canonical pid (split identity)`);
   }
 }
 


### PR DESCRIPTION
closes #2033

## What & why

Two hardening pieces for the xdg-audit gate, both proven-needed by real events.

### Piece 1 — machine-domain positive-layout checks (Vincent's blind spot)
The `--machine` scan only fired on **known-bad LEGACY paths**, so a box wrong-by-**class** passed with all-zeros — exactly why Vincent's repro (`~/.config/metafactory/cortex/{logs,state}` from the #2030 bug) reported GATE PASS. Added three **gated** positive-layout assertions (additive; legacy checks untouched):

| pattern | fires when |
|---|---|
| `config-root-state-misplacement` | any of `{logs,state,relay,network-cache}` exist under the canonical **CONFIG** root `~/.config/metafactory/cortex` (state-class dirs in the wrong tree — the #2030 shape) |
| `canonical-state-without-marker` | canonical state root (`~/.local/state/metafactory/cortex`) exists **without** the completion marker `.xdg-state-migration.json` (partial/stray canonical — the wedge class) |
| `split-identity-legacy-pidfile` | marker present, yet a cortex `*.pid` still sits in a legacy state dir (`~/.config/grove/state`) — split identity |

All honor `$XDG_CONFIG_HOME` / `$XDG_STATE_HOME` / `$CORTEX_STATE_DIR` verbatim by importing the `state-path.ts` seam (`cortexStateDir`, `stateMigrationCompleted`, `STATE_MIGRATION_JOURNAL_NAME`, `legacyPidStateDir`) — the constants are imported, never duplicated.

**HOME seam:** the machine scan read the real `$HOME`. Added a `--home <dir>` option (the machine analogue of the repo scan's positional roots) so `HOME` is injectable; env still wins over it, matching production. Self-tests run against a scratch `$HOME` with the XDG/CORTEX overrides scrubbed — zero real-home access.

### Piece 2 — repos-gate as a CI lane (the #2026 regression proof)
The self-test ran in CI but the **full scan** did not, so PR#2026 landed 2 gated findings + 9 dead allow-entries on main unnoticed. Added an `XDG gate` job running `bun scripts/xdg-audit.ts --repos .` — **self-repo scope only** (positional `.` replaces the tool's cross-repo defaults; arc/discord enforce their own trees in their own CI). Unused cross-repo allowlist entries stay **warnings** (verified: they don't affect exit code); only **gated findings** in the PR's tree turn it red.

## Proof
- **Machine checks (scratch-HOME):** clean fresh box → PASS(0); misplaced `.config/metafactory/cortex/state` → FAIL naming it; canonical-without-marker → FAIL; canonical+marker → PASS(0); split-identity → FAIL. Env-respect verified for `$XDG_CONFIG_HOME` and `$CORTEX_STATE_DIR`.
- **CI lane:** exact command on this branch → exit 0 (PASS); planted stale runtime literal (`~/.config/cortex/bot.yaml`) → exit 1 naming the file (FAIL).
- Full `bun test`: 9853 pass / 0 fail. `tsc --noEmit`: 0 errors. New self-tests: 5 machine-domain fixtures, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)