### PR TITLE
chore: bump to v6.8.2 — deliver surface-bundle auto-install

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.8.1"
+version: "6.8.2"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Patch bump so `arc upgrade cortex` delivers the #2037 surface-bundle auto-install (and post-6.8.1 commits). Without a version bump, repo-first `arc upgrade` git-pulls the code but short-circuits on the unchanged version — skipping the depends_on.packages bundle install + postinstall. Release cut on merge; no deploy from me.