### PR TITLE
fix(stack-create): system.yaml ships no per-stack identity block — 6.8.4 (cortex#2052)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.8.3"
+version: "6.8.4"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin layer model"

--- a/docs/config-layout/system/system.yaml
+++ b/docs/config-layout/system/system.yaml
@@ -139,11 +139,18 @@ nats:
   #     - local.{principal}.{stack}.tasks.*.>
   subjects: []
 
-  # NKey identity for envelope signing (paths point at on-disk key material;
-  # the loader enforces chmod 600 on the creds/account-signing files).
-  identity:
-    seedPath: ~/.config/nats/cortex.nk
-    publicKey: UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV
+  # NKey identity for envelope signing is PER-STACK and lives in
+  # stacks/<slug>.yaml — `stack.nkey_seed_path` + `stack.nkey_pub`, which
+  # `arc upgrade cortex` auto-provisions on first install (seed at
+  # ~/.config/nats/cortex-<slug>.nk, chmod 600) and which the runtime signer
+  # actually reads. This machine-wide layer ships NO active `identity:` block by
+  # default: a per-stack key does not belong in the shared substrate file, and a
+  # placeholder here is never reconciled by provisioning (cortex#2052). This
+  # `nats.identity` field remains schema-optional purely as a machine-wide
+  # OVERRIDE — uncomment only if you fully understand it, with a REAL pubkey:
+  # identity:
+  #   seedPath: ~/.config/nats/cortex-<slug>.nk
+  #   publicKey: U...   # the real U-prefixed pubkey (56 chars), NOT a placeholder
 
 # -----------------------------------------------------------------------------
 # bus — application-level JetStream stream / consumer provisioning

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -165,6 +165,37 @@ describe("renderScaffold", () => {
     // No SU… seed ever appears in scaffolded output.
     expect(all).not.toMatch(/\bSU[A-Z0-9]{20,}/);
   });
+
+  // cortex#2052: the machine-wide system.yaml must NOT ship a per-stack
+  // `identity:` block. It previously carried a non-slug seedPath
+  // (~/.config/nats/cortex.nk) and a placeholder publicKey the provisioner
+  // never reconciled — per-stack identity is authoritative in stacks/<slug>.yaml.
+  test("system/system.yaml ships NO active identity block (cortex#2052 — #3/#4)", () => {
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    // No active (uncommented) `identity:` key, and no active seedPath/publicKey.
+    expect(system?.contents).not.toMatch(/^\s*identity:\s*$/m);
+    expect(system?.contents).not.toMatch(/^\s*seedPath:/m);
+    expect(system?.contents).not.toMatch(/^\s*publicKey:/m);
+    // #3: the old non-slug seed path must not appear anywhere in the file.
+    expect(system?.contents).not.toContain("cortex.nk");
+  });
+
+  test("system/system.yaml's commented identity reference is slug-aware + points at stacks/ (cortex#2052)", () => {
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    // The commented reference documents the slug-aware seed path…
+    expect(system?.contents).toContain("~/.config/nats/cortex-demo.nk");
+    // …and redirects to the authoritative per-stack identity source.
+    expect(system?.contents).toContain("stacks/demo.yaml");
+    expect(system?.contents).toMatch(/#\s*identity:/);
+  });
+
+  test("system/system.yaml's nats.url carries a review-the-port note (cortex#2052 — #2)", () => {
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    expect(system?.contents).toMatch(/url:\s*nats:\/\/127\.0\.0\.1:4222\s+#.*port/i);
+  });
 });
 
 // =============================================================================

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -360,7 +360,7 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   const Display = displayName;
 
   return [
-    { relPath: "system/system.yaml", contents: systemYaml(slug) },
+    { relPath: "system/system.yaml", contents: systemYaml(slug, seedPath) },
     { relPath: "surfaces/surfaces.yaml", contents: surfacesYaml(agentId, stackId) },
     { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath) },
     { relPath: `${slug}.yaml`, contents: pointerYaml(slug) },
@@ -368,10 +368,13 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   ];
 }
 
-function systemYaml(slug: string): string {
+function systemYaml(slug: string, seedPath: string): string {
   // The cross-cutting substrate layer — substituted from
-  // docs/config-layout/system/system.yaml. Identity is left at the safe
-  // conventional default; `arc upgrade cortex` auto-provisions the seed.
+  // docs/config-layout/system/system.yaml. NO active `identity:` block: the
+  // authoritative, auto-provisioned signing identity is per-stack and lives in
+  // stacks/<slug>.yaml (`stack.nkey_seed_path`/`nkey_pub`), not in this shared
+  // machine-wide file. Shipping a per-stack key here left a non-slug seedPath
+  // and a placeholder pubkey the provisioner never reconciled (cortex#2052).
   return `# =============================================================================
 # system.yaml — the cross-cutting machine / substrate layer (IAW CFG.b)
 # =============================================================================
@@ -408,7 +411,7 @@ paths:
 # pattern double-binds the boot subscriber (the double-message problem,
 # cortex#491). The dispatch-listener self-subscribes its own interest at start.
 nats:
-  url: nats://127.0.0.1:4222
+  url: nats://127.0.0.1:4222   # review host:port for your NATS server (default: local 4222)
   name: cortex
   subjects: []
   # credsPath — the daemon's OWN bus/bot creds, minted under the \`agents\` account
@@ -419,13 +422,18 @@ nats:
   # \`~/.config/nats/${slug}.creds\`). Two different NATS accounts MUST be two
   # different files — a shared path would clobber on the second mint.
   credsPath: ~/.config/nats/${slug}-bot.creds
-  # NKey identity for envelope signing. The seedPath is the conventional path
-  # \`arc upgrade cortex\` auto-provisions on first install; publicKey is pinned
-  # after first boot (paste from the cortex log \`stack signing key staged …\`).
-  identity:
-    seedPath: ~/.config/nats/cortex.nk
-    # Valid-FORMAT placeholder so this file loads; REPLACE after first boot.
-    publicKey: ${NKEY_PUB_PLACEHOLDER}   # <REPLACE_ME>: U-prefixed pubkey
+  # NKey identity for envelope signing is PER-STACK and lives in
+  # stacks/${slug}.yaml — \`stack.nkey_seed_path\` + \`stack.nkey_pub\`, which
+  # \`arc upgrade cortex\` auto-provisions on first install (seed at
+  # ${seedPath}, chmod 600) and which the runtime signer actually reads.
+  # This machine-wide layer intentionally ships NO \`identity:\` block: a
+  # per-stack key does not belong in the shared substrate file, and a
+  # placeholder here is never reconciled by provisioning (cortex#2052).
+  # Uncomment ONLY to force a machine-wide override you fully understand —
+  # and paste a REAL U-prefixed pubkey, never a placeholder:
+  # identity:
+  #   seedPath: ${seedPath}
+  #   publicKey: U...   # the real U-prefixed pubkey (56 chars), NOT a placeholder
 
 bus:
   review:


### PR DESCRIPTION
Closes #2052. Found by Vincent on a clean-slate **6.8.3** Linux bring-up (the two 6.8.3 regressions did **not** recur ✅ — this is a new, separate surface).

## What & why

The machine-wide `system/system.yaml` carried a **per-stack** `nats.identity` block that shipped broken:

- **#3** `identity.seedPath` hardcoded `~/.config/nats/cortex.nk` (non-slug) while the sibling `credsPath` and the provisioner's real seed are slug-aware (`cortex-<slug>.nk`) → pointed at a nonexistent file, collides across stacks.
- **#4** `identity.publicKey` shipped an all-A placeholder the provisioner never reconciled (`stack-identity-provision.sh` only patches snake_case `nkey_pub` in `stacks/<slug>.yaml`; `postupgrade.sh` never targets system.yaml) → orphaned forever.

`nats.identity` is **not read by the runtime signer** — `verifier-self-check.ts` / `stack-provisioning.ts` authoritatively use `stack.nkey_seed_path`/`stack.nkey_pub` from `stacks/<slug>.yaml` (why Vincent's boot logged `signed_by chain verified`), and it's Zod-`optional()` with an absent block explicitly supported (`migrate-config.test.ts:323`).

## Fix

Stop emitting an active `identity:` block in the generated machine-wide `system.yaml` — replace with a slug-aware **commented** reference that redirects to the authoritative per-stack identity in `stacks/<slug>.yaml`. Resolves #3 (no dangling seedPath) and #4 (no orphaned placeholder) **at the source** — no change to the bash provisioner in the "dangerous transport knobs" subsystem.

- **#2** `nats.url` now carries an inline "review host:port" note.
- **#1** `publishedEventsDir` was **not a bug** — it's the correct XDG data path (matches `logDir` + arc's own `~/.local/share/metafactory/`); unchanged. Reporter's `~/.claude/...` suggestion would regress XDG; the dir is created lazily on first publish.

## Verification

- 3 new `renderScaffold` assertions — **verified fail-on-old / pass-on-new** (20 pass / 3 fail on origin/main's generator; 23/23 with the fix).
- Generated `system.yaml` **parses cleanly**; `nats.identity` absent by construction.
- `tsc --noEmit`: exit 0. Lint: 0 errors (22 pre-existing warnings). Full scaffold-consumer suite (config loader, provisioning, migrate-config, stack/network CLI — 1862 tests): **0 fail**.

## Design note (review welcome)

Alternative considered + rejected: keep the block and teach `stack-identity-provision.sh` to reconcile system.yaml's camelCase identity too — higher-risk (delicate awk in the most dangerous config subsystem) for a field the runtime doesn't read. Pushback welcome if maintainers prefer the machine-wide layer retain an identity block.

Ships in **v6.8.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)