### PR TITLE
feat(inference): API-P0.3 — ModelProvider contract + normalized request/event/error types

### DIFF
--- a/src/bus/__tests__/envelope-type-no-underscore.test.ts
+++ b/src/bus/__tests__/envelope-type-no-underscore.test.ts
@@ -75,6 +75,10 @@ const NON_ENVELOPE_DOTTED_NAMESPACES: readonly {
     prefix: "iteration.",
     why: "Mission-Control WebSocket notification tags (wsRegistry.broadcast in src/surface/mc/notifications.ts) — never buildBaseEnvelope / the myelin bus.",
   },
+  {
+    prefix: "tool_call.",
+    why: "ApiAgentHarness ModelProvider streaming-event discriminants (src/common/inference/types.ts, API-P0.3 #2058) — provider inference-stream tags, never buildBaseEnvelope / the myelin bus; translated to valid bus envelopes before any publish.",
+  },
 ];
 
 /** The vendored schema's `/type` pattern — the single source of truth. */

--- a/src/common/inference/errors.ts
+++ b/src/common/inference/errors.ts
@@ -1,0 +1,48 @@
+// API-P0.3 (epic #2055, Phase 0, decisions D1/D2) — normalized provider error
+// contract. Design §"Error normalization": provider failures collapse to a
+// small closed set of stable kinds while retaining a SAFE native diagnostic.
+// Dispatch lifecycle publishing (→ API-P1.4) maps these kinds onto existing
+// `failed`/`aborted` semantics and back-pressure hints.
+//
+// Types only — no runtime code, no provider implementations.
+
+/**
+ * The stable, provider-neutral classification of a model-provider failure.
+ * Deliberately small: every provider's native error taxonomy normalizes onto
+ * exactly one of these kinds so the harness reasons about failures without
+ * vendor branches.
+ */
+export type ProviderErrorKind =
+  | "authentication"
+  | "authorization"
+  | "rate_limit"
+  | "overloaded"
+  | "invalid_request"
+  | "unsupported_capability"
+  | "content_filter"
+  | "timeout"
+  | "unavailable"
+  | "malformed_response";
+
+/**
+ * A normalized provider failure. Carries retryability, an optional
+ * `retryAfterMs` back-pressure hint when the provider supplied one, the
+ * provider's own request id for correlation, and a redacted diagnostic summary.
+ */
+export interface ProviderError {
+  /** Stable, provider-neutral failure classification. */
+  kind: ProviderErrorKind;
+  /** Whether retrying the same request could plausibly succeed. */
+  retryable: boolean;
+  /** Provider-advised delay before retrying, in milliseconds, when known. */
+  retryAfterMs?: number;
+  /** The provider's own request identifier, for cross-system correlation. */
+  providerRequestId?: string;
+  /**
+   * REDACTED — a safe, human-readable diagnostic only. MUST NEVER carry
+   * secrets, API keys, authorization headers, or raw request/response bodies.
+   * Anything placed here may be logged, published onto the bus, and surfaced
+   * on the dashboard.
+   */
+  summary: string;
+}

--- a/src/common/inference/types.ts
+++ b/src/common/inference/types.ts
@@ -1,0 +1,165 @@
+// API-P0.3 (epic #2055, Phase 0, decisions D1/D2) — the KEYSTONE: the
+// normalized, provider-neutral model-provider contract that every provider
+// adapter implements and the harness consumes. Design §"Model-provider
+// contract": deliberately SMALLER than any provider's full API. Provider-only
+// knobs live under the single namespaced `options` escape hatch (open Q5);
+// no vendor wire fields leak onto these core types.
+//
+// Types only — no runtime code, no provider implementations, no registry
+// (→ API-P0.4), no dispatch-envelope mapping (→ API-P1.4).
+
+import type { ProviderError } from "./errors";
+
+// ── Content model ───────────────────────────────────────────────────────────
+// Text, image references, tool calls, and tool results. Phase 1 sends text
+// ONLY, but the content types must already support the others so Phase 3 does
+// not have to reshape them.
+
+/** A plain-text span of message content. */
+export interface TextContent {
+  type: "text";
+  text: string;
+}
+
+/**
+ * A reference to an image — a pointer (url or opaque provider-side id / handle),
+ * NOT inlined bytes. The core model carries the reference; providers that
+ * support images resolve it. `mediaType` is the MIME type when known.
+ */
+export interface ImageRefContent {
+  type: "image_ref";
+  /** How to locate the image: a URL, or a provider/store-scoped handle. */
+  source: { kind: "url"; url: string } | { kind: "handle"; id: string };
+  /** MIME type (e.g. "image/png"), when known. */
+  mediaType?: string;
+}
+
+/**
+ * A model-issued request to invoke a tool. `input` is the fully-assembled tool
+ * arguments (streamed deltas arrive separately as `tool_call.delta` events).
+ */
+export interface ToolCallContent {
+  type: "tool_call";
+  /** Correlates the call with its later result. */
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+/**
+ * The result of executing a tool, fed back to the model. `toolCallId` matches
+ * the originating {@link ToolCallContent.id}.
+ */
+export interface ToolResultContent {
+  type: "tool_result";
+  toolCallId: string;
+  /** The tool's output as normalized content (typically text). */
+  content: readonly MessageContent[];
+  /** Whether the tool execution failed. */
+  isError?: boolean;
+}
+
+/** A single unit of normalized message content. */
+export type MessageContent =
+  | TextContent
+  | ImageRefContent
+  | ToolCallContent
+  | ToolResultContent;
+
+/** The author of a message in the normalized request. */
+export type MessageRole = "user" | "assistant" | "tool";
+
+/** One normalized message: an author plus an ordered list of content parts. */
+export interface ModelMessage {
+  role: MessageRole;
+  content: readonly MessageContent[];
+}
+
+// ── Request ─────────────────────────────────────────────────────────────────
+
+/**
+ * The single namespaced escape hatch for provider-only knobs. Keyed by an
+ * opaque provider namespace (e.g. `"anthropic"`); the value is an opaque bag
+ * the harness never inspects. This is the ONLY place vendor-specific options
+ * may appear — never as fields on the core request/content/event types.
+ */
+export type ProviderOptions = Readonly<Record<string, Record<string, unknown>>>;
+
+/**
+ * A normalized inference request. Provider-neutral by construction: no provider
+ * wire fields appear here; anything vendor-specific goes under {@link options}.
+ */
+export interface ModelRequest {
+  /** The target model id (provider-neutral identifier). */
+  model: string;
+  /**
+   * System / persona instructions applied to the whole request, separate from
+   * the conversational message list.
+   */
+  instructions?: string;
+  /** The ordered conversation history. */
+  messages: readonly ModelMessage[];
+  /** Upper bound on generated tokens. */
+  maxOutputTokens?: number;
+  /**
+   * Namespaced, opaque provider-only options. The harness passes these through
+   * untouched; portable behaviour must NOT depend on them.
+   */
+  options?: ProviderOptions;
+}
+
+// ── Streaming events ────────────────────────────────────────────────────────
+
+/**
+ * The reason a response finished. A small closed union; every provider's native
+ * stop reason normalizes onto one of these.
+ */
+export type FinishReason =
+  | "stop"
+  | "length"
+  | "tool_use"
+  | "content_filter"
+  | "error";
+
+/**
+ * The normalized streaming event union yielded by {@link ModelProvider.stream}.
+ * Every provider's server-sent stream maps onto these events.
+ */
+export type ModelEvent =
+  | { type: "response.started"; providerRequestId?: string }
+  | { type: "text.delta"; text: string }
+  | { type: "tool_call.delta"; id: string; name?: string; json: string }
+  | { type: "tool_call.completed"; id: string; name: string; input: unknown }
+  | {
+      type: "usage";
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens?: number;
+    }
+  | { type: "response.completed"; finishReason: FinishReason }
+  | { type: "error"; error: ProviderError };
+
+// ── Provider ────────────────────────────────────────────────────────────────
+
+/** The feature matrix a provider advertises up front. */
+export interface ProviderCapabilities {
+  streaming: boolean;
+  tools: boolean;
+  parallelTools: boolean;
+  images: boolean;
+  documents: boolean;
+  structuredOutput: boolean;
+  serverContinuation: boolean;
+  promptCaching: boolean;
+}
+
+/**
+ * The normalized model-provider contract. Every provider adapter implements
+ * this; the harness consumes only this. Deliberately smaller than any
+ * provider's full API.
+ */
+export interface ModelProvider {
+  readonly id: string;
+  readonly capabilities: ProviderCapabilities;
+  stream(request: ModelRequest): AsyncIterable<ModelEvent>;
+}


### PR DESCRIPTION
Closes #2058 · Part of epic #2055 · Phase 0 keystone.

Types-only. Adds `src/common/inference/{types,errors}.ts`: `ModelProvider`, `ProviderCapabilities`, `ModelEvent` union, `ModelRequest` + content model (text/image-ref/tool-call/tool-result), `FinishReason`, `ProviderErrorKind` (10 kinds), `ProviderError`. No runtime code, no `HarnessId` additions. Verbatim blocks copied exactly from the design; `ModelRequest`/content-model shapes designed per the design's prose.

Verification: `bunx tsc --noEmit` exit 0, `bunx eslint src/common/inference/` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)