### PR TITLE
feat(substrates): API-P0.1 — add `api-agent` substrate to runtime + config enums

### DIFF
--- a/src/common/substrates/__tests__/types.test.ts
+++ b/src/common/substrates/__tests__/types.test.ts
@@ -48,13 +48,14 @@ describe("HarnessId", () => {
     "mistral",
     "pi-dev",
     "agent-team",
+    "api-agent",
   ];
 
-  test("includes all eight known substrates", () => {
-    expect(ALL_HARNESS_IDS).toHaveLength(8);
+  test("includes all nine known substrates", () => {
+    expect(ALL_HARNESS_IDS).toHaveLength(9);
   });
 
-  test("exhaustive switch compiles for all eight values", () => {
+  test("exhaustive switch compiles for all nine values", () => {
     // If a new HarnessId is added without updating this switch, tsc fails
     // (the `never` assignment becomes ill-typed). Compile-time proof that
     // every downstream switch must enumerate the union exhaustively.
@@ -68,6 +69,7 @@ describe("HarnessId", () => {
         case "mistral": return "mistral";
         case "pi-dev": return "pi";
         case "agent-team": return "team";
+        case "api-agent": return "api";
         default: {
           const _exhaustive: never = id;
           return _exhaustive;

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -110,6 +110,8 @@ export type MyelinEnvelope = Envelope;
  *                         used for cortex-co-located agents.
  *   - `"agent-team"`    — meta-harness that coordinates a moderator plus
  *                         multiple participant harnesses for delegate mode.
+ *   - `"api-agent"`     — direct API harness; an agent opts in to run against
+ *                         a model provider via the API rather than a CLI child.
  *
  * **Why not `string`?** Because the runtime needs to refuse the unknown.
  * A new harness must be a typed registration, not a free-form string,
@@ -123,7 +125,8 @@ export type HarnessId =
   | "gemini"
   | "mistral"
   | "pi-dev"
-  | "agent-team";
+  | "agent-team"
+  | "api-agent";
 
 // ---------------------------------------------------------------------------
 // Capability

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -641,7 +641,7 @@ export const AgentRuntimeSchema = z.object({
    *  `engine: sage` agents run through the sage CLI (no HarnessId) and omit it;
    *  the legacy `pi-dev` value is the back-compat shim that `resolveReviewEngine`
    *  maps to `engine: sage`. */
-  substrate: z.enum(["claude-code", "codex", "pi-dev", "cursor", "custom"]).optional(),
+  substrate: z.enum(["claude-code", "codex", "pi-dev", "cursor", "custom", "api-agent"]).optional(),
   /** Dispatch mode. `in-process` = cortex's runner spawns the substrate;
    *  `standalone` = arc-installed daemon connects to the bus directly. */
   mode: z.enum(["in-process", "standalone"]),


### PR DESCRIPTION
Closes #2056 · Part of epic #2055 · Phase 0.

Adds `"api-agent"` to both substrate enums: `HarnessId` (`src/common/substrates/types.ts`) and the config `substrate` z.enum (`cortex-config.ts:644`). Updates the `HarnessId` exhaustiveness-guard test (`substrates/__tests__/types.test.ts`) — that compile-time guard is designed to trip on any new `HarnessId`; updating it is the guard working as intended. No provider/vendor names added to `HarnessId`. The two enums remain intentionally divergent — no reconciliation (explicitly out of scope).

Verification: `bunx tsc --noEmit` exit 0; `bun run lint:errors` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)