### PR TITLE
fix(stack-create,dispatch): 0600 scaffold perms + slug nats.name + actionable auth-failure DX — 6.8.5 (cortex#2068)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.8.4"
+version: "6.8.5"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin layer model"

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -20,6 +20,7 @@ import type {
   CCSessionLike,
 } from "../../substrates/claude-code/harness";
 import type { CCSessionResult, CCSessionOpts } from "../../runner/cc-session";
+import { CC_AUTH_FAILURE_MESSAGE } from "../../runner/cc-failure-classifier";
 import { ORCHESTRATOR_CAPABILITY } from "../../runner/orchestrator-command";
 import { CLAUDE_TOOL_INVENTORY } from "../../common/policy/tool-inventory";
 import { readLogicalRouting } from "../../adapters/response-routing-delivery";
@@ -998,6 +999,44 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
     expect(env.correlation_id?.length ?? 0).toBeGreaterThan(0);
     // Schema-valid envelope (drift-detection against vendored myelin schema).
     expect(validateEnvelope(env).ok).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  test("auth failure is terminal (no retry) and surfaces the actionable re-login message (cortex#2055)", async () => {
+    const runtime = makeRecordingRuntime();
+    // A single expired-auth result: exit 1, no stdout response, auth error on
+    // stderr. If retried it would just re-fail, so the loop must NOT retry.
+    const { factory, spawnCount } = makeStubFactory([
+      { success: false, response: "", exitCode: 1, durationMs: 700, stderr: '{"error":"authentication_failed"}' },
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    // Exactly ONE spawn — auth failure short-circuits the retry loop.
+    expect(spawnCount()).toBe(1);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    // No "Still working…" retry status, no opaque exit-code apology — just the
+    // actionable message that names the fix.
+    expect(texts).toEqual([CC_AUTH_FAILURE_MESSAGE]);
+    expect(texts.some((t) => t.startsWith("Sorry, I couldn't process"))).toBe(false);
+
+    // Terminal failure envelope, kind=cant_do, detail carries the actionable text.
+    const failed = runtime.publishes.filter((e) => e.type === "dispatch.task.failed");
+    expect(failed.length).toBe(1);
+    const payload = failed[0]!.payload as { reason: { kind: string; detail?: string } };
+    expect(payload.reason.kind).toBe("cant_do");
+    expect(payload.reason.detail).toBe(CC_AUTH_FAILURE_MESSAGE);
 
     await handler.shutdown();
   });

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -35,6 +35,8 @@ import type {
 import {
   classifyCcFailure,
   classifyCcSpawnError,
+  isCcAuthFailure,
+  CC_AUTH_FAILURE_MESSAGE,
 } from "../runner/cc-failure-classifier";
 import {
   createDispatchTaskFailedEvent,
@@ -1272,6 +1274,19 @@ export class DispatchHandler extends EventEmitter {
           break;
         }
 
+        // cortex#2055 — auth failure is TERMINAL: the host's `claude` login has
+        // expired, so retrying is futile (all attempts re-fail the same way) and
+        // the principal needs to re-login. Classify as `cant_do` and break out
+        // of the retry loop; the post-loop apology swaps in the actionable
+        // CC_AUTH_FAILURE_MESSAGE for this case (detected via `finalResult`).
+        if (isCcAuthFailure(result)) {
+          console.warn(
+            `dispatch-handler: Claude Code auth failure on attempt ${attempt}/${this.retryMaxAttempts} (correlation_id=${correlationId}) — host re-login required; not retrying`,
+          );
+          finalReason = { kind: "cant_do", detail: CC_AUTH_FAILURE_MESSAGE };
+          break;
+        }
+
         // Classify the failure. `null` from the classifier means "no
         // substrate failure detected" — e.g. `success && !response`
         // or `!success && response.trim() !== ""`. Treat as terminal
@@ -1342,9 +1357,15 @@ export class DispatchHandler extends EventEmitter {
       return;
     }
 
-    // Terminal failure — post apology + emit dispatch.task.failed.
+    // Terminal failure — post apology + emit dispatch.task.failed. cortex#2055:
+    // when the failure is an expired-auth on the host, replace the opaque
+    // "couldn't process that (exit code: 1)" with an actionable re-login message
+    // so the principal isn't left digging through the session JSONL.
     const exitCode = finalResult?.exitCode ?? 1;
-    await adapter.postResponse(target, `Sorry, I couldn't process that. (exit code: ${exitCode})`);
+    const apology = finalResult && isCcAuthFailure(finalResult)
+      ? CC_AUTH_FAILURE_MESSAGE
+      : `Sorry, I couldn't process that. (exit code: ${exitCode})`;
+    await adapter.postResponse(target, apology);
 
     // Build a reason if we have none (defensive — every loop exit sets
     // finalReason on a failure path, but TypeScript can't prove it).

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, readdirSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -199,6 +199,36 @@ describe("create uniqueness", () => {
     const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
     expect(res.exitCode).toBe(1);
     expect(res.stderr).toContain("already exists");
+  });
+});
+
+// =============================================================================
+// create --apply permissions (cortex#2055)
+// =============================================================================
+// The scaffold's secret-bearing file is surfaces/surfaces.yaml (Discord bot
+// token). Before this fix it was born 0644 (world-readable) while
+// stacks/<slug>.yaml was only incidentally 0600 (provisioner mktemp+mv) — the
+// file WITH the secret was the readable one. Every scaffold file must be 0600.
+describe("create --apply permissions", () => {
+  test("the bot-token file (surfaces.yaml) is 0600, not world-readable", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(0);
+    const surfaces = join(cfg, "research", "surfaces", "surfaces.yaml");
+    expect(statSync(surfaces).mode & 0o777).toBe(0o600);
+  });
+
+  test("every generated file is 0600", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(0);
+    const base = join(cfg, "research");
+    const entries = readdirSync(base, { recursive: true }) as string[];
+    const files = entries.filter((rel) => statSync(join(base, rel)).isFile());
+    expect(files.length).toBeGreaterThan(0);
+    for (const rel of files) {
+      expect(statSync(join(base, rel)).mode & 0o777).toBe(0o600);
+    }
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -196,6 +196,15 @@ describe("renderScaffold", () => {
     const system = files.find((f) => f.relPath === "system/system.yaml");
     expect(system?.contents).toMatch(/url:\s*nats:\/\/127\.0\.0\.1:4222\s+#.*port/i);
   });
+
+  test("system/system.yaml's nats.name is slug-scoped, not the generic 'cortex' (cortex#2055)", () => {
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    // Slug-scoped client connection label so multi-stack hosts are distinguishable.
+    expect(system?.contents).toMatch(/^\s*name:\s*cortex-demo\s*$/m);
+    // Must NOT ship the old generic non-slug default.
+    expect(system?.contents).not.toMatch(/^\s*name:\s*cortex\s*$/m);
+  });
 });
 
 // =============================================================================

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -412,7 +412,12 @@ paths:
 # cortex#491). The dispatch-listener self-subscribes its own interest at start.
 nats:
   url: nats://127.0.0.1:4222   # review host:port for your NATS server (default: local 4222)
-  name: cortex
+  # NATS *client* connection label (how this daemon identifies itself to the
+  # server — visible in \`nats server report connections\`). Slug-scoped so
+  # multiple stacks on one host are distinguishable (cortex#2055). This is NOT
+  # the nats-server's own \`server_name\` in ~/.config/nats/<slug>.conf — that
+  # names the server process; the two play different roles and needn't match.
+  name: cortex-${slug}
   subjects: []
   # credsPath — the daemon's OWN bus/bot creds, minted under the \`agents\` account
   # by \`cortex network make-live\` (via add-bot). The \`-bot\` suffix is LOAD-BEARING:

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -33,7 +33,7 @@
  * Exit codes: 0 success · 1 operational failure (conflict / write error) · 2 usage.
  */
 
-import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "fs";
 import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 
@@ -320,6 +320,15 @@ function runCreate(
       const dest = join(targetDir, f.relPath);
       mkdirSync(dirname(dest), { recursive: true });
       writeFileSync(dest, f.contents);
+      // cortex#2055 — born 0600. The scaffold's secret-bearing file is
+      // surfaces/surfaces.yaml (the Discord bot token the principal pastes in
+      // later); stacks/<slug>.yaml carries signing identity. `writeFileSync`
+      // defaults to 0644 (world-readable), and only stacks/<slug>.yaml was
+      // *incidentally* tightened later by the provisioner's mktemp+mv rewrite —
+      // so the file with the actual secret was left readable. chmod every
+      // scaffold file to 0600 at birth: it's the principal's private config
+      // tree, and the token is protected before it is ever written.
+      chmodSync(dest, 0o600);
     }
   } catch (err) {
     // Roll back the partial scaffold so a mid-write failure (ENOSPC, EACCES on

--- a/src/runner/__tests__/cc-failure-classifier.test.ts
+++ b/src/runner/__tests__/cc-failure-classifier.test.ts
@@ -3,6 +3,8 @@ import {
   classifyCcFailure,
   classifyCcSpawnError,
   isTransientFailure,
+  isCcAuthFailure,
+  CC_AUTH_FAILURE_MESSAGE,
 } from "../cc-failure-classifier";
 import type { CCSessionResult } from "../cc-session";
 
@@ -174,5 +176,44 @@ describe("classification stability", () => {
     // classifyCcSpawnError always returns not_now → the helper agrees.
     const reason = classifyCcSpawnError(new Error("CC binary missing"));
     expect(isTransientFailure(reason)).toBe(true);
+  });
+});
+
+// =============================================================================
+// cortex#2055 — auth-failure detection (isCcAuthFailure)
+// =============================================================================
+// An expired host login exits non-zero with the auth error on stderr and no
+// stdout response. Without detection the generic classifier buckets it as
+// not_now → 3 futile retries → opaque "exit code: 1". isCcAuthFailure lets the
+// chat path treat it as terminal and surface an actionable re-login message.
+describe("isCcAuthFailure", () => {
+  function failed(overrides: Partial<CCSessionResult> = {}): CCSessionResult {
+    return { success: false, response: "", exitCode: 1, durationMs: 800, ...overrides };
+  }
+
+  test("detects authentication_failed on stderr (the canonical signal)", () => {
+    expect(isCcAuthFailure(failed({ stderr: '{"type":"result","error":"authentication_failed"}' }))).toBe(true);
+  });
+
+  test("detects common auth wordings (expired OAuth / invalid key / re-login)", () => {
+    expect(isCcAuthFailure(failed({ stderr: "Error: OAuth token has expired" }))).toBe(true);
+    expect(isCcAuthFailure(failed({ stderr: "Invalid API key provided" }))).toBe(true);
+    expect(isCcAuthFailure(failed({ stderr: "Please run `claude login` to authenticate" }))).toBe(true);
+    expect(isCcAuthFailure(failed({ response: "You are not logged in." }))).toBe(true);
+  });
+
+  test("does NOT fire on a clean success", () => {
+    expect(isCcAuthFailure(successResult())).toBe(false);
+  });
+
+  test("does NOT fire on an ordinary non-auth failure (no false positives)", () => {
+    expect(isCcAuthFailure(failed({ stderr: "TypeError: cannot read property 'x' of undefined" }))).toBe(false);
+    expect(isCcAuthFailure(failed({ stderr: "" }))).toBe(false);
+    expect(isCcAuthFailure(failed({ response: "partial answer then crash" }))).toBe(false);
+  });
+
+  test("CC_AUTH_FAILURE_MESSAGE is actionable (names the fix: run claude to re-login)", () => {
+    expect(CC_AUTH_FAILURE_MESSAGE).toMatch(/claude/i);
+    expect(CC_AUTH_FAILURE_MESSAGE).toMatch(/log ?in|login/i);
   });
 });

--- a/src/runner/cc-failure-classifier.ts
+++ b/src/runner/cc-failure-classifier.ts
@@ -135,3 +135,48 @@ export function isTransientFailure(
 ): boolean {
   return reason.kind === "not_now";
 }
+
+/**
+ * cortex#2055 — Signatures of a Claude Code **authentication** failure. When
+ * the host's `claude` login has expired, the CLI exits non-zero with the auth
+ * error on stderr (and no stdout response), so the generic classifier buckets
+ * it as `not_now` → the chat path retries 3× (all futile — auth won't self-heal)
+ * and then surfaces the opaque "couldn't process that (exit code: 1)". These
+ * patterns let the chat path detect it, skip the retries, and tell the
+ * principal what to actually do.
+ *
+ * Matched case-insensitively against `response + stderr`. Kept broad because
+ * the exact wording varies by CLI version (OAuth vs API-key, login-expired vs
+ * invalid-key), but every variant is principal-recoverable the same way.
+ */
+const CC_AUTH_FAILURE_SIGNATURES: readonly RegExp[] = [
+  /authentication_failed/i,
+  /invalid api key/i,
+  /oauth token (?:has )?expired/i,
+  /(?:please|run) .*\bclaude\b.*\b(?:login|log ?in)\b/i,
+  /\/login\b/i,
+  /not (?:logged|signed) in/i,
+  /session (?:has )?expired/i,
+];
+
+/**
+ * cortex#2055 — Actionable message shown to the principal (in place of the
+ * generic apology) when a dispatch fails because Claude Code auth expired on
+ * the host. Names the fix so they don't have to dig through session JSONL.
+ */
+export const CC_AUTH_FAILURE_MESSAGE =
+  "⚠️ I couldn't reach Claude Code — the host's authentication has expired. " +
+  "On the host, run `claude` in a terminal and complete the login, then try again.";
+
+/**
+ * cortex#2055 — True when a `CCSessionResult` bears the fingerprint of an auth
+ * failure (checks the captured stderr and any partial response). The chat path
+ * uses this to classify the failure as terminal (no retry) and to swap the
+ * opaque apology for `CC_AUTH_FAILURE_MESSAGE`.
+ */
+export function isCcAuthFailure(result: CCSessionResult): boolean {
+  if (result.success) return false;
+  const haystack = `${result.response}\n${result.stderr ?? ""}`;
+  if (!haystack.trim()) return false;
+  return CC_AUTH_FAILURE_SIGNATURES.some((re) => re.test(haystack));
+}

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -117,6 +117,12 @@ export interface CCSessionResult {
    * shutdown) can populate it without a breaking change.
    */
   abortReason?: "timeout";
+  /**
+   * cortex#2055 — accumulated stderr from the CC process (empty string when
+   * none). Surfaced so failure classifiers can spot substrate-level errors
+   * (e.g. `authentication_failed`) that exit non-zero with no stdout response.
+   */
+  stderr?: string;
 }
 
 /**
@@ -169,6 +175,11 @@ export class CCSession extends EventEmitter {
   private lineBuffer = new StreamLineBuffer();
   private startTime = 0;
   private stdoutDone: Promise<void> = Promise.resolve();
+  private stderrDone: Promise<void> = Promise.resolve();
+  /** cortex#2055 — accumulated stderr text, surfaced on the result so callers
+   *  can detect substrate-level failures (e.g. `authentication_failed`) that
+   *  never reach the stdout stream. */
+  private stderrText = "";
   /** cortex#701 — materialised curated-settings file for this session; cleaned up on exit. */
   private isolatedSettings: IsolatedSettings | null = null;
 
@@ -301,8 +312,10 @@ export class CCSession extends EventEmitter {
       // Wire stdout streaming (track promise so wireExit can await drain)
       this.stdoutDone = this.pipeStdout();
 
-      // Wire stderr (for error detection)
-      void this.pipeStderr();
+      // Wire stderr (for error detection). Tracked so wireExit can await the
+      // drain before settling — an auth failure's message must be captured
+      // before the result resolves (cortex#2055).
+      this.stderrDone = this.pipeStderr();
 
       // Wire exit (waits for stdout drain before emitting "exit")
       void this.wireExit();
@@ -376,6 +389,7 @@ export class CCSession extends EventEmitter {
           exitCode: 1,
           durationMs,
           usage: this.usage,
+          ...(this.stderrText && { stderr: this.stderrText }),
           ...(this.timedOut && { aborted: true, abortReason: "timeout" as const }),
         });
       });
@@ -389,6 +403,7 @@ export class CCSession extends EventEmitter {
           exitCode: code,
           durationMs,
           usage: this.usage,
+          ...(this.stderrText && { stderr: this.stderrText }),
           // The exit path can also be reached on inactivity timeout —
           // wireExit() races with the error listener and may win when CC
           // exits in response to SIGINT before the error has been emitted.
@@ -470,6 +485,9 @@ export class CCSession extends EventEmitter {
     }
 
     const stderrText = chunks.join("");
+    // cortex#2055 — retain the raw stderr on the session so the result can
+    // carry it (auth failures print here and never reach the stdout stream).
+    this.stderrText = stderrText;
     if (stderrText.trim()) {
       // Only emit if there's meaningful stderr (not just progress indicators)
       const meaningful = stderrText.trim().split("\n").filter(
@@ -491,6 +509,9 @@ export class CCSession extends EventEmitter {
     // Wait for stdout to fully drain before firing exit — prevents race
     // where clearProgress runs before late tool-use events are processed.
     await this.stdoutDone;
+    // cortex#2055 — also drain stderr so `this.stderrText` is complete before
+    // the result settles (auth-failure detection reads it).
+    await this.stderrDone;
 
     if (this.timeoutId) {
       clearTimeout(this.timeoutId);


### PR DESCRIPTION
Closes #2068. Three items from Vincent's clean **6.8.4** Linux bring-up (6.8.4 ran clean — prior regressions did not recur ✅).

## C — bot-token file world-readable → **0600** (security)
`stack create --apply` wrote every scaffold file with a bare `writeFileSync` (`stack.ts:322`) → 0644. `stacks/<slug>.yaml` only *looked* protected (incidental 0600 from the provisioner's `mktemp`+`mv`); `surfaces/surfaces.yaml`, which holds the Discord bot **token** (`stack-lib.ts:466`), was never rewritten and stayed world-readable. Now every generated file is chmod 0600 at write time — the token is protected before it's ever pasted in.

## B — slug-scoped `nats.name` (observability + Vincent's question)
`nats.name` was the hardcoded generic `cortex`, so every stack on a host connects with the same client label. Slug-scoped to `cortex-<slug>` + a comment explaining this is the **client connection label** (`runtime.ts:801`), distinct from the nats-server's own `server_name` — different roles, needn't match (answering Vincent directly).

## A — actionable auth-failure DX
Expired host `claude` login exits non-zero with the auth error on **stderr** and no stdout; `cc-session` discarded stderr, so the chat path bucketed it as `not_now` → **3 futile retries** → the opaque `Sorry, I couldn't process that. (exit code: 1)` (hardcoded at `dispatch-handler.ts:1347`, ignores `reason.detail`). Now:
- `CCSessionResult` carries `stderr` (drained before settle);
- `isCcAuthFailure()` matches auth signatures across stderr+response;
- the chat path classifies it **terminal** (no retries) and swaps in an actionable *"run `claude` on the host to re-login"* message.

The shared `classifyCcFailure` is untouched — the review-consumer path keeps its behavior (auth detection is chat-path only).

## Verification
- **Fail-on-old confirmed**: perms tests + slug-`nats.name` test fail on origin/main, pass with the fix.
- New tests: `isCcAuthFailure` unit matrix (auth signals true; clean/ordinary-failure false) + a dispatch-handler **end-to-end** (1 spawn, no "Still working…", actionable message, `cant_do` envelope).
- `tsc --noEmit`: 0. Lint: 0 errors. Blast-radius suite (runner + bus + cli + config, **3445 tests**): green — the single failure is a **pre-existing** live-`claude` integration test (verified identical on clean `main`; requires host auth this box lacks).

Ships in **v6.8.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
