### PR TITLE
test(providers): API-P1.5 — shared provider contract-test suite (the guard)

### DIFF
--- a/src/providers/__tests__/contract.test.ts
+++ b/src/providers/__tests__/contract.test.ts
@@ -1,0 +1,18 @@
+/**
+ * API-P1.5 (issue #2065) — Bun test entrypoint for the shared provider contract
+ * suite (THE GUARD / epic progress meter).
+ *
+ * Bun's test runner only discovers files whose name contains `.test` / `.spec`.
+ * The actual enumeration — one `describe` per gated slice, every design
+ * §"Verification strategy" case as a `test.todo` — lives in `./contract.ts`,
+ * which registers its `describe`/`test.todo` blocks as an import side-effect.
+ * This file exists solely to make `bun test src/providers/__tests__` load it.
+ *
+ * Wave 1: importing this file prints the pending todos grouped per slice and
+ * performs ZERO network I/O (todos never execute). Each gated slice
+ * (#2061 anthropic / #2062 openai-compatible / #2063 harness) later flips its
+ * own todos in `./contract.ts` to live `test(...)` bodies; no change is needed
+ * here.
+ */
+
+import "./contract";

--- a/src/providers/__tests__/contract.ts
+++ b/src/providers/__tests__/contract.ts
@@ -1,0 +1,134 @@
+/**
+ * API-P1.5 (issue #2065) — Shared provider contract-test suite: THE GUARD.
+ *
+ * WHAT THIS IS
+ * ------------
+ * One shared contract suite that every model-provider adapter and the API agent
+ * harness must pass, run against recorded fixtures + the local fake streaming
+ * HTTP server (`./fake-streaming-server.ts`) — never a live provider, never paid
+ * credentials in CI (design §"Verification strategy").
+ *
+ * Per the plan-breakdown SOP this file is the epic's PROGRESS METER. It lands in
+ * Wave 1 (this issue, #2065) with a `test.todo(...)` entry for EVERY case in the
+ * design's verification strategy, grouped one `describe` block per gated slice:
+ *
+ *   - `anthropic`         → converted to live tests by API-P1.1 (issue #2061)
+ *   - `openai-compatible` → converted to live tests by API-P1.2 (issue #2062)
+ *   - `api-agent-harness` → converted to live tests by API-P1.3 (issue #2063)
+ *
+ * HOW EACH SLICE FLIPS ITS TODOS (the meter mechanic)
+ * ---------------------------------------------------
+ * When a gated slice lands it OWNS its `describe` block below. It replaces each
+ * `test.todo("…")` string in its block with a live `test("…", async () => { … })`
+ * that:
+ *   1. imports the now-existing contract types from `src/common/inference/`
+ *      (added by API-P0.3 / #2058) and the slice's provider factory;
+ *   2. stands up `startFakeStreamingServer()`, enqueues the fixture frames for
+ *      the case, points the provider `baseUrl` at `server.url`;
+ *   3. drives the provider/harness and asserts the normalized contract outcome.
+ * Because the case NAMES are stable, the suite output is a live burndown: every
+ * flipped todo is one epic checkbox ticked.
+ *
+ * SCAFFOLD CONSTRAINT (Wave 1 — READ BEFORE EDITING)
+ * --------------------------------------------------
+ * This branch is cut from origin/main, which does NOT yet contain
+ * `src/common/inference/` — issue #2058 (contract types) lands separately. So on
+ * Wave 1 the todos below are PLAIN STRINGS ONLY. They deliberately reference no
+ * not-yet-existing type, provider, or symbol; importing one here would break
+ * typecheck before the dependency slice merges. `test.todo(name)` registers a
+ * pending test that is reported but never executed, so this file performs ZERO
+ * network I/O and cannot fail the build. Keep it that way until your slice lands.
+ *
+ * CASE LIST (design §"Verification strategy")
+ * -------------------------------------------
+ * The ten provider-contract cases apply to EVERY gated slice (acceptance
+ * criterion: "every case present as at least a test.todo for each gated slice").
+ * The `api-agent-harness` slice additionally carries the five harness-specific
+ * cases. The secret-absence case is a FIRST-CLASS named todo in every slice, not
+ * an optional add-on.
+ */
+
+import { describe, test } from "bun:test";
+
+/**
+ * The ten provider-contract cases from design §"Verification strategy", shared
+ * verbatim across all three gated slices. Exported so a landing slice can assert
+ * it has covered the full set (and so this list is the single source of truth
+ * for the case names the progress meter tracks).
+ */
+export const PROVIDER_CONTRACT_CASES: readonly string[] = [
+  "streams text with a Unicode grapheme split across frame boundaries",
+  "reassembles tool-call JSON split across arbitrary chunk boundaries (parser-level)",
+  "tolerates unknown / unrecognized event variants without aborting the stream",
+  "honors cancellation and both timeout types — wall-clock deadline and inactivity/idle gap",
+  "maps authentication (401) responses to the normalized authentication error",
+  "maps rate_limit (429) responses to the normalized rate_limit error",
+  "maps overloaded (529) responses to the normalized overloaded error",
+  "maps unavailable (503) responses to the normalized unavailable error",
+  "surfaces an in-stream error that arrives AFTER a committed HTTP 200",
+  "fails cleanly on malformed / truncated streams",
+  "normalizes usage from a final usage frame",
+  "handles a stream that omits the final usage frame (missing usage)",
+  "rejects an unsupported_capability request before dispatch",
+  "keeps secrets absent from errors, events, snapshots, and logs",
+] as const;
+
+/**
+ * The five harness-specific cases from design §"Verification strategy" — the
+ * lifecycle/fail-closed contract the `ApiAgentHarness` must satisfy on top of
+ * the provider-contract cases.
+ */
+export const HARNESS_CONTRACT_CASES: readonly string[] = [
+  "emits exactly one started event per run",
+  "emits exactly one terminal event per run",
+  "keeps correlation identifiers stable across the run's event stream",
+  "shuts down cleanly on request without leaking the provider connection",
+  "fails closed on a denied policy / tool grant (no silent tool execution)",
+] as const;
+
+/**
+ * Register the Wave 1 `test.todo` scaffold for one gated slice.
+ *
+ * On Wave 1 this emits the case list as pending todos. When the owning slice
+ * lands it replaces this call in its `describe` block with live `test(...)`
+ * bodies (see "HOW EACH SLICE FLIPS ITS TODOS" above) — the todo names it flips
+ * are exactly the strings in {@link PROVIDER_CONTRACT_CASES} (+
+ * {@link HARNESS_CONTRACT_CASES} for the harness).
+ */
+function registerContractTodos(cases: readonly string[]): void {
+  for (const name of cases) {
+    // Bun's types require a body, but `test.todo` never executes it under a
+    // normal `bun test` run (only with the explicit `--todo` flag). The body is
+    // a deliberate throw so the case stays a pending todo even under `--todo`
+    // (a todo whose body throws remains todo; an empty passing body would be
+    // flagged as a todo that "passed unexpectedly"). It references NO
+    // not-yet-existing type — the owning slice replaces the whole `test.todo`
+    // call with a live `test(...)` when it lands.
+    test.todo(name, () => {
+      throw new Error(`unimplemented contract case: ${name}`);
+    });
+  }
+}
+
+// ── anthropic ───────────────────────────────────────────────────────────────
+// Owned by API-P1.1 (issue #2061 — native Anthropic Messages adapter).
+// Flips these todos to live tests against src/providers/anthropic/.
+describe("provider contract · anthropic", () => {
+  registerContractTodos(PROVIDER_CONTRACT_CASES);
+});
+
+// ── openai-compatible ─────────────────────────────────────────────────────────
+// Owned by API-P1.2 (issue #2062 — OpenAI-compatible Chat Completions adapter).
+// Flips these todos to live tests against src/providers/openai-compatible/.
+describe("provider contract · openai-compatible", () => {
+  registerContractTodos(PROVIDER_CONTRACT_CASES);
+});
+
+// ── api-agent-harness ─────────────────────────────────────────────────────────
+// Owned by API-P1.3 (issue #2063 — ApiAgentHarness). Carries the full provider
+// contract PLUS the harness-specific lifecycle/fail-closed cases.
+// Flips these todos to live tests against src/substrates/api-agent/.
+describe("provider contract · api-agent-harness", () => {
+  registerContractTodos(PROVIDER_CONTRACT_CASES);
+  registerContractTodos(HARNESS_CONTRACT_CASES);
+});

--- a/src/providers/__tests__/fake-streaming-server.ts
+++ b/src/providers/__tests__/fake-streaming-server.ts
@@ -1,0 +1,198 @@
+/**
+ * API-P1.5 (issue #2065) — Reusable fake streaming HTTP server for the shared
+ * provider contract-test suite.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Every model-provider adapter (`src/providers/anthropic/`,
+ * `src/providers/openai-compatible/`) and the API agent harness
+ * (`src/substrates/api-agent/`) must pass the SAME contract suite
+ * (`./contract.ts`), run against recorded fixtures + a LOCAL fake HTTP server —
+ * never a live provider and never paid credentials (design
+ * §"Verification strategy": "CI correctness must not depend on provider
+ * availability or paid credentials"). This module is that fake server.
+ *
+ * It is a thin, dependency-free wrapper over `Bun.serve` that lets a test:
+ *   - enqueue a scripted response (status, headers, and a stream of raw byte
+ *     chunks emitted with controllable inter-chunk delays);
+ *   - split a payload across ARBITRARY frame boundaries — the core stress the
+ *     stream-parser cases need (Unicode split mid-codepoint, tool-call JSON
+ *     split mid-token);
+ *   - simulate an in-stream error AFTER a 200 has been committed (bytes then an
+ *     abrupt close), a truncated/malformed stream, and an inactivity gap that
+ *     trips the idle-timeout path;
+ *   - assert on exactly what the adapter sent (captured requests), so the
+ *     "secrets absent from logs" class has a request-capture surface to check.
+ *
+ * SCAFFOLD NOTE (Wave 1)
+ * ----------------------
+ * This branch is cut from origin/main, which does NOT yet contain
+ * `src/common/inference/` (issue #2058 lands separately). This helper is
+ * therefore deliberately typed ONLY in terms of Web/Bun primitives (`Request`,
+ * `Response`, byte chunks) — it imports NO provider or inference types. When the
+ * gated slices (#2061 anthropic / #2062 openai-compatible / #2063 harness) land,
+ * their live `test(...)` bodies point a real provider factory at
+ * `server.url` and drive these primitives; this file does not change shape.
+ *
+ * ZERO external network: `Bun.serve({ hostname: "127.0.0.1", port: 0 })` binds
+ * loopback on an ephemeral port. Nothing here reaches the internet.
+ */
+
+/** A single scripted chunk in a streamed response body. */
+export interface StreamChunk {
+  /** Raw bytes (or UTF-8 string) to write. Strings are encoded as UTF-8. */
+  readonly data: string | Uint8Array;
+  /** Milliseconds to wait BEFORE writing this chunk (simulates network gaps / inactivity). */
+  readonly delayMs?: number;
+}
+
+/** A scripted response the fake server will play back for the next request. */
+export interface ScriptedResponse {
+  /** HTTP status code (e.g. 200, 401, 429, 529, 503). */
+  readonly status?: number;
+  /** Response headers (e.g. `content-type: text/event-stream`). */
+  readonly headers?: Record<string, string>;
+  /**
+   * Ordered chunks to stream once the 200 (or other status) is committed.
+   * For non-stream error responses, pass a single chunk with the JSON error body.
+   */
+  readonly chunks?: readonly StreamChunk[];
+  /**
+   * Abort the connection AFTER the scripted chunks are written, WITHOUT a clean
+   * terminal frame — models "an in-stream error after HTTP success" and
+   * "truncated stream". Default false (clean close).
+   */
+  readonly abortAfterChunks?: boolean;
+  /**
+   * Hang the connection open indefinitely after the last chunk instead of
+   * closing — models the inactivity-timeout path (the adapter's idle timer must
+   * fire, not the server). Default false.
+   */
+  readonly hangOpen?: boolean;
+}
+
+/** A request the fake server captured, for assertions (incl. secret-absence). */
+export interface CapturedRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly path: string;
+  readonly headers: Record<string, string>;
+  readonly body: string;
+}
+
+export interface FakeStreamingServer {
+  /** Base URL, e.g. `http://127.0.0.1:53411`. Point the provider `baseUrl` here. */
+  readonly url: string;
+  /** Bound loopback port. */
+  readonly port: number;
+  /** Queue a response to be played back for the next inbound request (FIFO). */
+  enqueue(response: ScriptedResponse): void;
+  /** All requests captured so far, in arrival order. */
+  readonly requests: readonly CapturedRequest[];
+  /** Clear captured requests and any queued responses. */
+  reset(): void;
+  /** Stop the server and free the port. Await in test teardown. */
+  stop(): Promise<void>;
+}
+
+const encoder = new TextEncoder();
+
+function toBytes(data: string | Uint8Array): Uint8Array {
+  return typeof data === "string" ? encoder.encode(data) : data;
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Start a loopback fake streaming HTTP server on an ephemeral port.
+ *
+ * The server plays back enqueued {@link ScriptedResponse}s in FIFO order. If no
+ * response is queued for an inbound request it replies `500 no scripted
+ * response` so a test that forgets to `enqueue` fails loudly rather than hanging.
+ */
+export function startFakeStreamingServer(): FakeStreamingServer {
+  const queue: ScriptedResponse[] = [];
+  const captured: CapturedRequest[] = [];
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(req) {
+      const headers: Record<string, string> = {};
+      req.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+      const body = await req.text();
+      const { pathname } = new URL(req.url);
+      captured.push({
+        method: req.method,
+        url: req.url,
+        path: pathname,
+        headers,
+        body,
+      });
+
+      const scripted = queue.shift();
+      if (!scripted) {
+        return new Response("no scripted response", { status: 500 });
+      }
+
+      const status = scripted.status ?? 200;
+      const respHeaders = scripted.headers ?? {};
+      const chunks = scripted.chunks ?? [];
+
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          try {
+            for (const chunk of chunks) {
+              if (chunk.delayMs && chunk.delayMs > 0) {
+                await sleep(chunk.delayMs);
+              }
+              controller.enqueue(toBytes(chunk.data));
+            }
+            if (scripted.hangOpen) {
+              // Never close — force the adapter's inactivity timer to fire.
+              return;
+            }
+            if (scripted.abortAfterChunks) {
+              // Abrupt close without a clean terminal frame (in-stream error /
+              // truncated stream). controller.error triggers a network-level
+              // abort on the client side.
+              controller.error(new Error("simulated in-stream abort"));
+              return;
+            }
+            controller.close();
+          } catch (err) {
+            controller.error(
+              err instanceof Error ? err : new Error(String(err)),
+            );
+          }
+        },
+      });
+
+      return new Response(stream, { status, headers: respHeaders });
+    },
+  });
+
+  return {
+    url: server.url.origin,
+    // `port: 0` requested an ephemeral port; after `Bun.serve` returns, the OS
+    // has bound a concrete port. Bun types `Server.port` as optional, so coerce
+    // the (always-present here) value to satisfy the `number` interface.
+    port: server.port ?? 0,
+    enqueue(response: ScriptedResponse) {
+      queue.push(response);
+    },
+    get requests() {
+      return captured;
+    },
+    reset() {
+      queue.length = 0;
+      captured.length = 0;
+    },
+    async stop() {
+      await server.stop(true);
+    },
+  };
+}


### PR DESCRIPTION
Closes #2065 · Part of epic #2055 · Phase 1. The epic's progress meter.

Adds `src/providers/__tests__/{fake-streaming-server,contract,contract.test}.ts`: a reusable loopback fake streaming HTTP server + the shared contract suite scaffolded as **47 `test.todo`** across 3 gated slices (anthropic / openai-compatible / api-agent-harness), covering every design §Verification-strategy case incl. the first-class secret-absence assertion. Cut from origin/main; imports no `src/common/inference/` types yet (independence). Slices #2061/#2062/#2063 flip their own todos to live tests on landing.

Verification: `bun test src/providers/__tests__` → 0 pass / 47 todo / 0 fail, zero network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)