### PR TITLE
feat(inference): API-P0.2 — inference config schema + secret-reference resolution

### DIFF
--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -107,6 +107,7 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       maxAttachmentsPerMessage: 10,
     },
     execution: { default: "local", backends: [] },
+    inference: { providers: {}, profiles: {} },
     plugins: { external: false },
     github: {
       webhookSecret: "",

--- a/src/common/inference/__tests__/inference-config.test.ts
+++ b/src/common/inference/__tests__/inference-config.test.ts
@@ -1,0 +1,234 @@
+/**
+ * API-P0.2 (epic #2055, Phase 0, D6) — `inference` config schema + secret-
+ * reference resolution.
+ *
+ * This is a SECURITY-SENSITIVE lane (provider credentials + model egress). The
+ * tests lock in the three load-time invariants and the one call-time seam:
+ *
+ *   1. ACCEPT — the design §Configuration example block parses.
+ *   2. REJECT — a profile referencing a missing provider fails load with a
+ *      descriptive, path-pointed error; a literal (non-`env:`) secret is rejected.
+ *   3. REDACTION — a loaded/serialized config shows `env:NAME` references only;
+ *      no resolved secret value ever appears on the object or in a dump/log.
+ *   4. RESOLUTION — the secret VALUE is materialized only by `resolveSecretRef`,
+ *      at call time, from the environment; a missing env var throws (never a value).
+ */
+
+import { test, expect, describe } from "bun:test";
+import { InferenceConfigSchema } from "../../types/cortex-config";
+import {
+  SecretRefSchema,
+  resolveSecretRef,
+  secretRefEnvVar,
+  SecretRefResolutionError,
+  SECRET_REF_PATTERN,
+} from "../secret-ref";
+
+// The design §Configuration example block (issue #2057 "What to build").
+const EXAMPLE_INFERENCE = {
+  providers: {
+    anthropic: {
+      protocol: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "env:ANTHROPIC_API_KEY",
+      headers: {
+        "anthropic-beta": "env:ANTHROPIC_BETA_HEADER",
+      },
+      capabilities: {
+        streaming: true,
+        tools: true,
+        images: true,
+        structuredOutput: false,
+      },
+    },
+    "local-llama": {
+      protocol: "openai-chat-completions",
+      baseUrl: "http://localhost:11434/v1",
+      apiKey: "env:LOCAL_LLAMA_KEY",
+    },
+  },
+  profiles: {
+    "default-frontier": {
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      maxOutputTokens: 8192,
+      modelClass: "frontier",
+      dataResidency: "us",
+    },
+    "on-box": {
+      provider: "local-llama",
+      model: "llama-3.3-70b",
+      modelClass: "local-only",
+      options: {
+        anthropic: { foo: "bar" },
+      },
+    },
+  },
+} as const;
+
+describe("InferenceConfigSchema — accept", () => {
+  test("parses the design §Configuration example block without error", () => {
+    const parsed = InferenceConfigSchema.parse(EXAMPLE_INFERENCE);
+    expect(Object.keys(parsed.providers)).toEqual(["anthropic", "local-llama"]);
+    expect(Object.keys(parsed.profiles)).toEqual(["default-frontier", "on-box"]);
+    expect(parsed.profiles["default-frontier"]?.modelClass).toBe("frontier");
+    expect(parsed.profiles["on-box"]?.modelClass).toBe("local-only");
+  });
+
+  test("empty providers/profiles maps are valid (block is optional)", () => {
+    const parsed = InferenceConfigSchema.parse({});
+    expect(parsed.providers).toEqual({});
+    expect(parsed.profiles).toEqual({});
+  });
+
+  test("modelClass accepts exactly local-only | frontier | any", () => {
+    for (const modelClass of ["local-only", "frontier", "any"] as const) {
+      const parsed = InferenceConfigSchema.parse({
+        providers: { p: { protocol: "anthropic-messages", baseUrl: "https://x.example", apiKey: "env:K" } },
+        profiles: { pr: { provider: "p", model: "m", modelClass } },
+      });
+      expect(parsed.profiles.pr?.modelClass).toBe(modelClass);
+    }
+  });
+});
+
+describe("InferenceConfigSchema — reject", () => {
+  test("a profile referencing a missing provider fails load with a descriptive error", () => {
+    const result = InferenceConfigSchema.safeParse({
+      providers: {
+        anthropic: { protocol: "anthropic-messages", baseUrl: "https://api.anthropic.com", apiKey: "env:K" },
+      },
+      profiles: {
+        broken: { provider: "does-not-exist", model: "m", modelClass: "any" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected parse failure");
+    const issue = result.error.issues.find((i) => i.path.join(".") === "profiles.broken.provider");
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain("does-not-exist");
+    expect(issue?.message).toContain("not defined in inference.providers");
+  });
+
+  test("rejects an invalid modelClass literal", () => {
+    const result = InferenceConfigSchema.safeParse({
+      providers: { p: { protocol: "anthropic-messages", baseUrl: "https://x.example", apiKey: "env:K" } },
+      profiles: { pr: { provider: "p", model: "m", modelClass: "premium" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a LITERAL apiKey (non-env: reference) — never a raw secret in config", () => {
+    const result = InferenceConfigSchema.safeParse({
+      providers: {
+        anthropic: {
+          protocol: "anthropic-messages",
+          baseUrl: "https://api.anthropic.com",
+          apiKey: "sk-ant-THIS-IS-A-LITERAL-SECRET",
+        },
+      },
+      profiles: {},
+    });
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("expected parse failure");
+    const issue = result.error.issues.find((i) => i.path.join(".") === "providers.anthropic.apiKey");
+    expect(issue?.message).toContain("env:NAME");
+  });
+
+  test("rejects a LITERAL header value (non-env: reference)", () => {
+    const result = InferenceConfigSchema.safeParse({
+      providers: {
+        anthropic: {
+          protocol: "anthropic-messages",
+          baseUrl: "https://api.anthropic.com",
+          apiKey: "env:K",
+          headers: { authorization: "Bearer sk-live-literal" },
+        },
+      },
+      profiles: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an unknown protocol", () => {
+    const result = InferenceConfigSchema.safeParse({
+      providers: { p: { protocol: "grpc-magic", baseUrl: "https://x.example", apiKey: "env:K" } },
+      profiles: {},
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("secret redaction — no resolved value on the parsed/serialized config", () => {
+  const SECRET_VALUE = "sk-ant-SUPER-SECRET-VALUE-DO-NOT-LEAK";
+
+  test("a config dump/log shows env:NAME references, never the secret value", () => {
+    // Populate the environment as a live daemon would.
+    process.env.ANTHROPIC_API_KEY = SECRET_VALUE;
+    process.env.ANTHROPIC_BETA_HEADER = "beta-secret-token";
+    process.env.LOCAL_LLAMA_KEY = "local-secret";
+    try {
+      const parsed = InferenceConfigSchema.parse(EXAMPLE_INFERENCE);
+
+      // The reference survives on the object; the value does not.
+      expect(parsed.providers.anthropic?.apiKey).toBe("env:ANTHROPIC_API_KEY");
+      expect(parsed.providers.anthropic?.headers?.["anthropic-beta"]).toBe("env:ANTHROPIC_BETA_HEADER");
+
+      // A JSON dump (the shape a log/serialize would emit) carries no secret value.
+      const dumped = JSON.stringify(parsed);
+      expect(dumped).not.toContain(SECRET_VALUE);
+      expect(dumped).not.toContain("beta-secret-token");
+      expect(dumped).not.toContain("local-secret");
+      expect(dumped).toContain("env:ANTHROPIC_API_KEY");
+
+      // Belt-and-suspenders: walk every string leaf, prove no env value leaked.
+      const leaves: string[] = [];
+      const walk = (v: unknown): void => {
+        if (typeof v === "string") leaves.push(v);
+        else if (Array.isArray(v)) v.forEach(walk);
+        else if (v && typeof v === "object") Object.values(v).forEach(walk);
+      };
+      walk(parsed);
+      for (const leaf of leaves) {
+        expect(leaf).not.toBe(SECRET_VALUE);
+        expect(leaf).not.toBe("beta-secret-token");
+        expect(leaf).not.toBe("local-secret");
+      }
+    } finally {
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.ANTHROPIC_BETA_HEADER;
+      delete process.env.LOCAL_LLAMA_KEY;
+    }
+  });
+});
+
+describe("resolveSecretRef — call-time resolution only", () => {
+  test("resolves env:NAME from the injected environment", () => {
+    expect(resolveSecretRef("env:MY_KEY", { MY_KEY: "the-value" })).toBe("the-value");
+  });
+
+  test("throws (never returns a value) when the env var is unset", () => {
+    expect(() => resolveSecretRef("env:MISSING", {})).toThrow(SecretRefResolutionError);
+  });
+
+  test("throws when the env var is empty / whitespace-only", () => {
+    expect(() => resolveSecretRef("env:BLANK", { BLANK: "   " })).toThrow(SecretRefResolutionError);
+  });
+
+  test("throws on a malformed (non-env:) reference — never returns a value", () => {
+    // A malformed ref cannot name a resolvable secret; resolution throws rather
+    // than silently returning some fallback the harness might send upstream.
+    expect(() => resolveSecretRef("not-a-ref", { "not-a-ref": "should-be-ignored" })).toThrow(
+      SecretRefResolutionError,
+    );
+  });
+
+  test("SecretRefSchema + helpers agree on the env:NAME shape", () => {
+    expect(SecretRefSchema.safeParse("env:ANTHROPIC_API_KEY").success).toBe(true);
+    expect(SecretRefSchema.safeParse("env:").success).toBe(false);
+    expect(SecretRefSchema.safeParse("literal").success).toBe(false);
+    expect(secretRefEnvVar("env:ABC_123")).toBe("ABC_123");
+    expect(secretRefEnvVar("nope")).toBeUndefined();
+    expect(SECRET_REF_PATTERN.test("env:X")).toBe(true);
+  });
+});

--- a/src/common/inference/secret-ref.ts
+++ b/src/common/inference/secret-ref.ts
@@ -1,0 +1,110 @@
+// API-P0.2 (epic #2055, Phase 0, decision D6) — secret-reference primitive for
+// the `inference` config block (providers' `apiKey` + header values). Design
+// §"Secrets and egress": provider credentials are SECURITY-SENSITIVE — a
+// leaked model-provider key is direct egress + billable abuse — so they never
+// live as literals in the config and never touch the parsed/serialized config
+// object.
+//
+// The convention is a REFERENCE, not a value: a config field holds the string
+// `env:NAME`, which names an environment variable. Resolution to the real
+// secret happens AT CALL TIME (in the harness / provider registry, → API-P0.4),
+// via {@link resolveSecretRef} — never at parse time. Consequences:
+//
+//   1. The parsed `LoadedConfig` contains only `env:NAME` references. Dumping,
+//      logging, or serializing it shows references, never secret values.
+//   2. A resolved value exists only transiently in the harness call frame that
+//      makes the provider request; it is never written back onto config.
+//
+// This differs deliberately from the surface-token `__ENV__` placeholder scheme
+// (`resolve-env-placeholders.ts`), which resolves at config-LOAD and lands the
+// value on the in-memory config so an adapter's `connect()` can read it. That
+// is the wrong model for model-provider keys: a load-time-resolved value would
+// sit on the config object and leak through any config dump/log. The `env:NAME`
+// reference keeps the value OFF the object entirely (D6 / the redaction AC).
+
+import { z } from "zod/v4";
+
+/**
+ * A secret reference is exactly `env:NAME`, where NAME is a conventional
+ * environment-variable identifier (letter/underscore start, then
+ * alphanumerics/underscores). Anchored end-to-end: a literal secret (e.g.
+ * `sk-ant-…`) or a partial occurrence (`Bearer env:X`) does NOT match and is
+ * rejected by {@link SecretRefSchema} — literals are never accepted (design
+ * §Configuration: "SECRET REFERENCE — never a literal").
+ */
+export const SECRET_REF_PATTERN = /^env:([A-Za-z_][A-Za-z0-9_]*)$/;
+
+/**
+ * Zod schema for a secret reference. Validates the `env:NAME` SHAPE only — it
+ * does NOT read the environment, so parsing a config never resolves (and never
+ * captures) a secret value. A non-`env:` literal is REJECTED with a descriptive
+ * message pointing the principal at the reference convention.
+ */
+export const SecretRefSchema = z
+  .string()
+  .regex(
+    SECRET_REF_PATTERN,
+    "must be a secret reference of the form `env:NAME` (e.g. `env:ANTHROPIC_API_KEY`), " +
+      "never a literal secret — the value is resolved from that environment variable at " +
+      "call time and never stored in config",
+  );
+
+/** A validated `env:NAME` secret reference. */
+export type SecretRef = z.infer<typeof SecretRefSchema>;
+
+/**
+ * Extract the environment-variable NAME from a secret reference, or `undefined`
+ * if the string is not a well-formed `env:NAME` reference. Does not touch the
+ * environment.
+ */
+export function secretRefEnvVar(ref: string): string | undefined {
+  return SECRET_REF_PATTERN.exec(ref)?.[1];
+}
+
+/**
+ * Raised when a secret reference cannot be resolved at call time — the
+ * referenced environment variable is unset or empty. Carries the env-var NAME
+ * (never a value; there is none to carry) so the operator sees exactly which
+ * variable to export.
+ */
+export class SecretRefResolutionError extends Error {
+  public readonly envVar: string;
+
+  constructor(envVar: string) {
+    super(
+      `inference: secret reference env:${envVar} could not be resolved — ` +
+        `environment variable ${envVar} is unset or empty. Export ${envVar} in the ` +
+        `cortex daemon's environment before it issues a model request. The value is ` +
+        `resolved at call time and never stored in config.`,
+    );
+    this.name = "SecretRefResolutionError";
+    this.envVar = envVar;
+  }
+}
+
+/**
+ * Resolve a secret reference to its value AT CALL TIME. Reads
+ * `env[NAME]` for a `env:NAME` reference; throws {@link SecretRefResolutionError}
+ * if the reference is malformed or the variable is unset / empty / whitespace.
+ *
+ * This is the ONLY function that materializes a secret value. Callers (the
+ * harness / provider registry) invoke it at the moment of a provider request
+ * and hold the result in the local call frame ONLY — never assign it back onto
+ * any config object, and never log it.
+ *
+ * `env` is injectable for testing; defaults to `process.env`.
+ */
+export function resolveSecretRef(
+  ref: string,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const envVar = secretRefEnvVar(ref);
+  if (envVar === undefined) {
+    throw new SecretRefResolutionError(ref);
+  }
+  const value = env[envVar];
+  if (value === undefined || value.trim() === "") {
+    throw new SecretRefResolutionError(envVar);
+  }
+  return value;
+}

--- a/src/common/inference/secret-ref.ts
+++ b/src/common/inference/secret-ref.ts
@@ -64,7 +64,7 @@ export function secretRefEnvVar(ref: string): string | undefined {
 /**
  * Raised when a secret reference cannot be resolved at call time — the
  * referenced environment variable is unset or empty. Carries the env-var NAME
- * (never a value; there is none to carry) so the operator sees exactly which
+ * (never a value; there is none to carry) so the principal sees exactly which
  * variable to export.
  */
 export class SecretRefResolutionError extends Error {

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -35,6 +35,8 @@
 import { z } from "zod/v4";
 
 import { BRAIN_PROTOCOL_ID } from "../../brain/protocol";
+import { SecretRefSchema } from "../inference/secret-ref";
+import type { ProviderCapabilities } from "../inference/types";
 import { CapabilitySchema } from "./capability";
 import { REVIEW_FLAVORS, reviewFlavorOfCapability } from "./review-flavors";
 import {
@@ -1568,6 +1570,155 @@ export const ExecutionConfigSchema = z.object({
 });
 
 export type ExecutionConfig = z.infer<typeof ExecutionConfigSchema>;
+
+// =============================================================================
+// Inference — model-provider config (API-P0.2, epic #2055, Phase 0, D6)
+// =============================================================================
+//
+// The machine/substrate-layer `inference` block. Lives in the SAME layer as
+// `claude`/`execution` (repo CLAUDE.md §"Configuration files" — substrate,
+// whole-stack blast radius), NOT a per-stack file. Consumed by the provider
+// registry (→ API-P0.4) and harness (→ API-P1.3).
+//
+// Security posture (design §"Secrets and egress", D6):
+//   - `providers.*.apiKey` and every `providers.*.headers.*` value is a SECRET
+//     REFERENCE (`env:NAME`, see {@link SecretRefSchema}), never a literal.
+//     Resolution to the value happens at CALL TIME in the harness
+//     ({@link resolveSecretRef}); the parsed/serialized config holds only the
+//     reference, so a config dump/log shows `env:NAME`, never the secret.
+//   - `providers.*.baseUrl` is a reviewed MODEL-EGRESS destination — this block
+//     is the single place those destinations are declared, so a security review
+//     of egress has one file to read.
+//   - Profiles are POLICY-BEARING: `modelClass` (restricted to
+//     `local-only`/`frontier`/`any`) and `dataResidency` carry the class + data
+//     residency the registry/harness enforce.
+//
+// Phase-0 decisions baked in (issue #2057 stop-and-ask):
+//   - Q2 capabilities are CONFIGURED-ONLY (an optional static override), never
+//     probed at startup.
+//   - Q5 provider-specific knobs live under ONE namespaced opaque `options`
+//     escape hatch per profile — no vendor wire fields as first-class config.
+
+/**
+ * Optional static capability override for a provider. Keys align 1:1 with
+ * {@link ProviderCapabilities} (API-P0.3); every field is optional so a config
+ * declares only the flags it means to override. CONFIGURED-only (issue #2057
+ * Q2) — cortex does NOT probe a provider at startup; whatever is (or isn't)
+ * declared here is the whole truth. The `satisfies` check binds the shape to
+ * `ProviderCapabilities` so a drift in the contract fails typecheck here.
+ */
+export const ProviderCapabilitiesOverrideSchema = z
+  .object({
+    streaming: z.boolean().optional(),
+    tools: z.boolean().optional(),
+    parallelTools: z.boolean().optional(),
+    images: z.boolean().optional(),
+    documents: z.boolean().optional(),
+    structuredOutput: z.boolean().optional(),
+    serverContinuation: z.boolean().optional(),
+    promptCaching: z.boolean().optional(),
+  })
+  .strict();
+
+// Compile-time guard: the override keys are exactly the ProviderCapabilities
+// keys (all made optional). If API-P0.3 adds/removes/renames a capability, this
+// assignment fails typecheck until the override schema is updated in lockstep.
+type _CapabilitiesOverrideMatchesContract = z.infer<
+  typeof ProviderCapabilitiesOverrideSchema
+> extends Partial<ProviderCapabilities>
+  ? Partial<ProviderCapabilities> extends z.infer<typeof ProviderCapabilitiesOverrideSchema>
+    ? true
+    : never
+  : never;
+const _capabilitiesOverrideContractOk: _CapabilitiesOverrideMatchesContract = true;
+void _capabilitiesOverrideContractOk;
+
+/**
+ * A model-provider declaration: the wire protocol, the reviewed egress
+ * destination (`baseUrl`), and the SECRET-REFERENCE credentials. `apiKey` and
+ * every `headers` value are `env:NAME` references (never literals) resolved at
+ * call time — the parsed config never carries a resolved secret.
+ */
+export const InferenceProviderSchema = z
+  .object({
+    /** Wire protocol the harness speaks to this provider. */
+    protocol: z.enum(["anthropic-messages", "openai-chat-completions"]),
+    /** Reviewed model-egress destination. Declared here so egress review has one file. */
+    baseUrl: z.url(),
+    /** Provider API key — a `env:NAME` secret reference, resolved at call time, never a literal. */
+    apiKey: SecretRefSchema,
+    /**
+     * Optional extra request headers. Values are ALSO secret references
+     * (`env:NAME`) — a header can carry a token — resolved at call time, never
+     * literals on the parsed config.
+     */
+    headers: z.record(z.string().min(1), SecretRefSchema).optional(),
+    /** Optional static capability override (configured-only; no startup probe). */
+    capabilities: ProviderCapabilitiesOverrideSchema.optional(),
+  })
+  .strict();
+
+/**
+ * A named inference profile: the policy-bearing selection of a provider + model
+ * + generation bound + model class + data residency. `provider` must name a key
+ * in the sibling `providers` map (enforced by the document-level refinement on
+ * {@link InferenceConfigSchema}).
+ */
+export const InferenceProfileSchema = z
+  .object({
+    /** Key into the sibling `providers` map. Validated to exist at load. */
+    provider: z.string().min(1),
+    /** Provider-neutral model id. */
+    model: z.string().min(1),
+    /** Upper bound on generated tokens. Optional. */
+    maxOutputTokens: z.number().int().positive().optional(),
+    /** Policy: the egress class this profile is permitted. */
+    modelClass: z.enum(["local-only", "frontier", "any"]),
+    /** Policy: declared data-residency label (opaque string; e.g. `us`, `eu`). Optional. */
+    dataResidency: z.string().min(1).optional(),
+    /**
+     * Q5 escape hatch: a SINGLE namespaced, opaque bag of provider-only knobs.
+     * Keyed by provider namespace (e.g. `anthropic`); values are opaque and
+     * never inspected as portable config. Mirrors `ProviderOptions` (API-P0.3).
+     * Portable behaviour must NOT depend on anything here.
+     */
+    options: z.record(z.string().min(1), z.record(z.string(), z.unknown())).optional(),
+  })
+  .strict();
+
+/**
+ * The `inference` config block: a map of providers + a map of profiles.
+ *
+ * Document-level invariant (issue #2057 AC): every `profiles.*.provider` must
+ * name an existing `providers.*` key. A dangling reference fails config load
+ * with a descriptive, per-offender error rather than silently producing a
+ * profile that can never resolve to a provider instance.
+ */
+export const InferenceConfigSchema = z
+  .object({
+    providers: z.record(z.string().min(1), InferenceProviderSchema).default({}),
+    profiles: z.record(z.string().min(1), InferenceProfileSchema).default({}),
+  })
+  .superRefine((cfg, ctx) => {
+    for (const [profileName, profile] of Object.entries(cfg.profiles)) {
+      if (!(profile.provider in cfg.providers)) {
+        const known = Object.keys(cfg.providers);
+        ctx.addIssue({
+          code: "custom",
+          path: ["profiles", profileName, "provider"],
+          message:
+            `inference profile "${profileName}" references provider ` +
+            `"${profile.provider}" which is not defined in inference.providers ` +
+            `(known providers: ${known.length > 0 ? known.join(", ") : "<none>"}).`,
+        });
+      }
+    }
+  });
+
+export type ProviderCapabilitiesOverride = z.infer<typeof ProviderCapabilitiesOverrideSchema>;
+export type InferenceProvider = z.infer<typeof InferenceProviderSchema>;
+export type InferenceProfile = z.infer<typeof InferenceProfileSchema>;
+export type InferenceConfig = z.infer<typeof InferenceConfigSchema>;
 
 /**
  * cortex#1792 (S6, ADR-0024 D3/OQ6/OQ9) — the `system.plugins.external` gate.
@@ -3228,6 +3379,16 @@ export const CortexConfigSchema = z.object({
 
   /** Execution backends — local default, plus optional remotes. */
   execution: emptyDefault(ExecutionConfigSchema),
+
+  /**
+   * API-P0.2 (epic #2055, D6) — model-provider config: `providers` (egress
+   * destinations + `env:NAME` secret-reference credentials) + `profiles`
+   * (policy-bearing provider/model/class selections). Secret values are
+   * resolved at CALL TIME by the harness and never live on this object. See
+   * {@link InferenceConfigSchema}. Optional — a stack with no model-provider
+   * config omits it and defaults to an empty providers/profiles map.
+   */
+  inference: InferenceConfigSchema.default({ providers: {}, profiles: {} }),
 
   /** cortex#1792 (S6, ADR-0024 D3/OQ6/OQ9) — external plugin-bundle loading
    *  gate. Default-off; see {@link PluginsConfigSchema} for the full


### PR DESCRIPTION
Closes #2057 · Part of epic #2055 · Phase 0. Secrets / model-egress slice (D6).

Adds the substrate-layer inference config: provider schema, profile schema, and the top-level inference schema in cortex-config.ts (alongside the claude/execution blocks), plus a small secret-reference primitive module.

Security posture:
- Credentials are stored as references, not values. The reference schema is a pure shape check and never reads the environment, so the parsed/serialized config never materializes a secret. Resolution happens only in a dedicated resolver function, called at request time by the registry/harness (out of scope here).
- Literal (non-reference) credential and header values are rejected at parse time.
- A redaction test populates the environment, parses the example config, serializes + leaf-walks it, and asserts no secret value appears anywhere.
- modelClass is constrained to the three allowed literals; a profile pointing at a missing provider fails config load via a document-level superRefine with a path-pointed message; capability flags are a configured-only override bound to the shared ProviderCapabilities type (open Q2); vendor-specific knobs are confined to a single namespaced opaque options bag (open Q5).

Verification: 14 tests pass (accept / reject / redaction / call-time resolution); tsc --noEmit exit 0; eslint --quiet exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)