### PR TITLE
feat(providers): API-P1.1 — AnthropicMessagesProvider + SSE stream parser

### DIFF
--- a/src/providers/anthropic/__tests__/messages-provider.test.ts
+++ b/src/providers/anthropic/__tests__/messages-provider.test.ts
@@ -1,0 +1,298 @@
+/**
+ * API-P1.1 (issue #2061) — live contract tests for the native Anthropic Messages
+ * provider, run against the shared fake streaming HTTP server (API-P1.5).
+ *
+ * REUSE WITHOUT TOUCHING THE SHARED SCAFFOLD
+ * ------------------------------------------
+ * A sibling slice owns `src/providers/__tests__/contract.ts` (it flips the
+ * `anthropic` `test.todo`s there). To avoid a parallel edit conflict this file
+ * lives under `src/providers/anthropic/__tests__/` and IMPORTS — never edits —
+ * the shared assets from that scaffold:
+ *   - `PROVIDER_CONTRACT_CASES` (the canonical case-name list) from `contract.ts`;
+ *   - `startFakeStreamingServer` from `fake-streaming-server.ts`.
+ * Each live test is NAMED by looking its title up in `PROVIDER_CONTRACT_CASES`
+ * (`caseName(...)`), so the suite stays a faithful burn-down of the shared cases
+ * even though the todo flip itself happens in the sibling's file.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ModelEvent, ModelRequest } from "../../../common/inference/types";
+import { AnthropicMessagesProvider } from "../messages-provider";
+import { mapAnthropicMessagesStream } from "../stream-parser";
+import { PROVIDER_CONTRACT_CASES } from "../../__tests__/contract";
+import {
+  startFakeStreamingServer,
+  type StreamChunk,
+} from "../../__tests__/fake-streaming-server";
+
+// A deliberately recognizable fake secret. Every test asserts it never escapes
+// into an event, error, or serialized snapshot.
+const SECRET = "sk-ant-SECRET-must-never-leak-0xDEADBEEF";
+
+const server = startFakeStreamingServer();
+afterAll(() => server.stop());
+beforeEach(() => server.reset());
+
+/** Resolve a shared contract-case title by a unique substring (keeps names in sync). */
+function caseName(substring: string): string {
+  const match = PROVIDER_CONTRACT_CASES.find((c) => c.includes(substring));
+  if (!match) throw new Error(`no shared contract case matching: ${substring}`);
+  return match;
+}
+
+function newProvider(): AnthropicMessagesProvider {
+  return new AnthropicMessagesProvider({ apiKey: SECRET, baseUrl: server.url });
+}
+
+/** Serialize one SSE frame: `event:`/`data:` lines terminated by a blank line. */
+function frame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** Split a UTF-8 string into raw N-byte slices — stresses frame AND codepoint splits. */
+function byteChunks(text: string, size: number): StreamChunk[] {
+  const bytes = new TextEncoder().encode(text);
+  const chunks: StreamChunk[] = [];
+  for (let i = 0; i < bytes.length; i += size) {
+    chunks.push({ data: bytes.slice(i, i + size) });
+  }
+  return chunks;
+}
+
+const SSE_HEADERS = { "content-type": "text/event-stream" } as const;
+const JSON_HEADERS = { "content-type": "application/json" } as const;
+
+async function collect(request: ModelRequest): Promise<ModelEvent[]> {
+  const events: ModelEvent[] = [];
+  for await (const event of newProvider().stream(request)) events.push(event);
+  return events;
+}
+
+const textRequest: ModelRequest = {
+  model: "claude-sonnet-test",
+  instructions: "be terse",
+  messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+  maxOutputTokens: 64,
+};
+
+describe("AnthropicMessagesProvider · native Messages contract", () => {
+  test("advertises Anthropic capabilities (serverContinuation:false, promptCaching:true)", () => {
+    const caps = newProvider().capabilities;
+    expect(caps.serverContinuation).toBe(false);
+    expect(caps.promptCaching).toBe(true);
+    expect(caps.streaming).toBe(true);
+    expect(caps.tools).toBe(true);
+    expect(caps.images).toBe(true);
+    expect(caps.documents).toBe(true);
+    expect(newProvider().id).toBe("anthropic-messages");
+  });
+
+  test(caseName("Unicode grapheme split across frame boundaries"), async () => {
+    // A full text stream, incl. a 4-byte emoji, chopped into tiny raw byte
+    // slices so both SSE frames AND the emoji's codepoint split across chunks.
+    const payload =
+      frame("message_start", {
+        type: "message_start",
+        message: { id: "msg_1", role: "assistant", usage: { input_tokens: 10, output_tokens: 1, cache_read_input_tokens: 4 } },
+      }) +
+      frame("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }) +
+      frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello " } }) +
+      frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "world 🌍!" } }) +
+      frame("content_block_stop", { type: "content_block_stop", index: 0 }) +
+      frame("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 12 } }) +
+      frame("message_stop", { type: "message_stop" });
+
+    server.enqueue({ status: 200, headers: { ...SSE_HEADERS, "request-id": "req_abc" }, chunks: byteChunks(payload, 5) });
+
+    const events = await collect(textRequest);
+    const started = events.find((e) => e.type === "response.started");
+    expect(started).toEqual({ type: "response.started", providerRequestId: "req_abc" });
+
+    const text = events.filter((e) => e.type === "text.delta").map((e) => (e as { text: string }).text).join("");
+    expect(text).toBe("Hello world 🌍!");
+
+    const usage = events.find((e) => e.type === "usage");
+    expect(usage).toEqual({ type: "usage", inputTokens: 10, outputTokens: 12, cacheReadTokens: 4 });
+
+    const completed = events.find((e) => e.type === "response.completed");
+    expect(completed).toEqual({ type: "response.completed", finishReason: "stop" });
+  });
+
+  test(caseName("reassembles tool-call JSON"), async () => {
+    // Parser-level: an input_json_delta block whose JSON is split arbitrarily
+    // must reassemble. Driven straight through the mapper (no tools sent in P1).
+    const fullJson = '{"city":"Auckland 🌏","units":"metric"}';
+    const parts = [fullJson.slice(0, 3), fullJson.slice(3, 10), fullJson.slice(10, 25), fullJson.slice(25)];
+    const payload =
+      frame("message_start", { type: "message_start", message: { id: "msg_t", role: "assistant", usage: { input_tokens: 5, output_tokens: 1 } } }) +
+      frame("content_block_start", { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_1", name: "get_weather", input: {} } }) +
+      parts.map((p) => frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: p } })).join("") +
+      frame("content_block_stop", { type: "content_block_stop", index: 0 }) +
+      frame("message_delta", { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 20 } }) +
+      frame("message_stop", { type: "message_stop" });
+
+    const events: ModelEvent[] = [];
+    for await (const e of mapAnthropicMessagesStream(byteChunksAsync(payload, 4))) events.push(e);
+
+    const deltaJson = events.filter((e) => e.type === "tool_call.delta").map((e) => (e as { json: string }).json).join("");
+    expect(deltaJson).toBe(fullJson);
+
+    const completed = events.find((e) => e.type === "tool_call.completed");
+    expect(completed?.id).toBe("toolu_1");
+    expect(completed?.name).toBe("get_weather");
+    expect(completed?.input).toEqual({ city: "Auckland 🌏", units: "metric" });
+
+    expect(events.at(-1)).toEqual({ type: "response.completed", finishReason: "tool_use" });
+  });
+
+  test(caseName("unknown / unrecognized event variants"), async () => {
+    const payload =
+      frame("message_start", { type: "message_start", message: { id: "msg_u", role: "assistant", usage: { input_tokens: 2, output_tokens: 1 } } }) +
+      frame("some_future_event", { type: "some_future_event", data: { anything: true } }) +
+      frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } }) +
+      frame("another_new_variant", { type: "another_new_variant" }) +
+      frame("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 3 } }) +
+      frame("message_stop", { type: "message_stop" });
+
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await collect(textRequest);
+    expect(events.map((e) => e.type)).toEqual([
+      "response.started",
+      "text.delta",
+      "usage",
+      "response.completed",
+    ]);
+  });
+
+  test(caseName("in-stream error that arrives AFTER a committed HTTP 200"), async () => {
+    const payload =
+      frame("message_start", { type: "message_start", message: { id: "msg_e", role: "assistant", usage: { input_tokens: 3, output_tokens: 1 } } }) +
+      frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "partial" } }) +
+      frame("error", { type: "error", error: { type: "overloaded_error", message: "Overloaded" } });
+
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await collect(textRequest);
+    expect(events.some((e) => e.type === "response.started")).toBe(true);
+    expect(events.some((e) => e.type === "text.delta")).toBe(true);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string } } | undefined;
+    expect(err?.error.kind).toBe("overloaded");
+    // No secret anywhere in the mid-stream error.
+    expect(JSON.stringify(err)).not.toContain(SECRET);
+  });
+
+  test(caseName("malformed / truncated streams"), async () => {
+    const payload =
+      frame("message_start", { type: "message_start", message: { id: "msg_x", role: "assistant", usage: { input_tokens: 1, output_tokens: 1 } } }) +
+      frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "half" } });
+
+    // abortAfterChunks: the connection drops mid-stream with no terminal frame.
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }], abortAfterChunks: true });
+
+    const events = await collect(textRequest);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string } } | undefined;
+    expect(err?.error.kind).toBe("malformed_response");
+  });
+
+  test(caseName("omits the final usage frame"), async () => {
+    const payload =
+      frame("message_start", { type: "message_start", message: { id: "msg_n", role: "assistant", usage: { input_tokens: 7, output_tokens: 1 } } }) +
+      frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "done" } }) +
+      // message_delta carries a stop_reason but NO usage object.
+      frame("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" } }) +
+      frame("message_stop", { type: "message_stop" });
+
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await collect(textRequest);
+    expect(events.some((e) => e.type === "usage")).toBe(false);
+    expect(events.at(-1)).toEqual({ type: "response.completed", finishReason: "stop" });
+  });
+
+  // ── HTTP error-status → ProviderErrorKind mapping ──────────────────────────
+
+  test(caseName("authentication (401)"), async () => {
+    server.enqueue({ status: 401, headers: JSON_HEADERS, chunks: [{ data: JSON.stringify({ type: "error", error: { type: "authentication_error", message: "invalid x-api-key" } }) }] });
+    const events = await collect(textRequest);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string; retryable: boolean; summary: string } };
+    expect(err.error.kind).toBe("authentication");
+    expect(err.error.retryable).toBe(false);
+    expect(err.error.summary).not.toContain(SECRET);
+  });
+
+  test("maps authorization (403) responses to the normalized authorization error", async () => {
+    server.enqueue({ status: 403, headers: JSON_HEADERS, chunks: [{ data: JSON.stringify({ type: "error", error: { type: "permission_error", message: "forbidden" } }) }] });
+    const events = await collect(textRequest);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string } };
+    expect(err.error.kind).toBe("authorization");
+  });
+
+  test(caseName("rate_limit (429)"), async () => {
+    server.enqueue({ status: 429, headers: { ...JSON_HEADERS, "retry-after": "3" }, chunks: [{ data: JSON.stringify({ type: "error", error: { type: "rate_limit_error", message: "slow down" } }) }] });
+    const events = await collect(textRequest);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string; retryable: boolean; retryAfterMs?: number } };
+    expect(err.error.kind).toBe("rate_limit");
+    expect(err.error.retryable).toBe(true);
+    expect(err.error.retryAfterMs).toBe(3000);
+  });
+
+  test(caseName("overloaded (529)"), async () => {
+    server.enqueue({ status: 529, headers: JSON_HEADERS, chunks: [{ data: JSON.stringify({ type: "error", error: { type: "overloaded_error", message: "Overloaded" } }) }] });
+    const events = await collect(textRequest);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string; retryable: boolean } };
+    expect(err.error.kind).toBe("overloaded");
+    expect(err.error.retryable).toBe(true);
+  });
+
+  test(caseName("unavailable (503)"), async () => {
+    server.enqueue({ status: 503, headers: JSON_HEADERS, chunks: [{ data: JSON.stringify({ type: "error", error: { type: "api_error", message: "upstream unavailable" } }) }] });
+    const events = await collect(textRequest);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string; retryable: boolean } };
+    expect(err.error.kind).toBe("unavailable");
+    expect(err.error.retryable).toBe(true);
+  });
+
+  test("maps invalid_request (400) responses to the normalized invalid_request error", async () => {
+    server.enqueue({ status: 400, headers: JSON_HEADERS, chunks: [{ data: JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "bad max_tokens" } }) }] });
+    const events = await collect(textRequest);
+    const err = events.find((e) => e.type === "error") as { type: "error"; error: { kind: string; retryable: boolean } };
+    expect(err.error.kind).toBe("invalid_request");
+    expect(err.error.retryable).toBe(false);
+  });
+
+  // ── Secret hygiene + request shape ─────────────────────────────────────────
+
+  test(caseName("keeps secrets absent"), async () => {
+    const payload =
+      frame("message_start", { type: "message_start", message: { id: "msg_s", role: "assistant", usage: { input_tokens: 4, output_tokens: 1 } } }) +
+      frame("content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "safe" } }) +
+      frame("message_delta", { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 2 } }) +
+      frame("message_stop", { type: "message_stop" });
+
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await collect(textRequest);
+
+    // The key WAS sent on the wire (x-api-key header) …
+    const req = server.requests.at(-1);
+    expect(req?.headers["x-api-key"]).toBe(SECRET);
+    // … the native Messages request was well-formed (system + stream + max_tokens) …
+    const sentBody = JSON.parse(req?.body ?? "{}");
+    expect(sentBody.stream).toBe(true);
+    expect(sentBody.system).toBe("be terse");
+    expect(sentBody.max_tokens).toBe(64);
+    expect(sentBody.model).toBe("claude-sonnet-test");
+    // … but the secret appears in NONE of the normalized events.
+    expect(JSON.stringify(events)).not.toContain(SECRET);
+  });
+});
+
+/** `byteChunks` as an async byte iterable — for driving the mapper directly. */
+async function* byteChunksAsync(text: string, size: number): AsyncGenerator<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  for (let i = 0; i < bytes.length; i += size) {
+    yield bytes.slice(i, i + size);
+  }
+}

--- a/src/providers/anthropic/messages-provider.ts
+++ b/src/providers/anthropic/messages-provider.ts
@@ -1,0 +1,289 @@
+// API-P1.1 (epic #2055, Phase 1, decision D2) — the native Anthropic Messages
+// API adapter. Implements the normalized {@link ModelProvider} contract against
+// Anthropic's `POST /v1/messages` endpoint with `stream: true`. Native Messages,
+// NOT the OpenAI-compat shim (design §Anthropic / D2: production traffic uses
+// Messages directly, which the compat layer does not preserve).
+//
+// Phase 1 sends TEXT content only. The SSE parsing + native→normalized event
+// mapping lives in `./stream-parser.ts`; this file owns request translation,
+// the HTTP call, HTTP-status → `ProviderError` mapping, and capability
+// advertisement.
+//
+// SECURITY: the API key travels ONLY in the `x-api-key` request header. It is
+// never logged and never placed on any `ProviderError.summary`, event, or other
+// output — those surfaces are published onto the bus and shown on the dashboard.
+
+import type {
+  ModelEvent,
+  ModelMessage,
+  ModelProvider,
+  ModelRequest,
+  ProviderCapabilities,
+} from "../../common/inference/types";
+import type {
+  ProviderError,
+  ProviderErrorKind,
+} from "../../common/inference/errors";
+import { mapAnthropicMessagesStream } from "./stream-parser";
+
+const DEFAULT_BASE_URL = "https://api.anthropic.com";
+const DEFAULT_ANTHROPIC_VERSION = "2023-06-01";
+const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+
+/** Constructor options for {@link AnthropicMessagesProvider}. */
+export interface AnthropicMessagesProviderOptions {
+  /** The Anthropic API key. Sent ONLY as the `x-api-key` header; never logged. */
+  readonly apiKey: string;
+  /** API origin. Defaults to `https://api.anthropic.com`. Tests point this at a fake server. */
+  readonly baseUrl?: string;
+  /** `anthropic-version` header value. Defaults to `2023-06-01`. */
+  readonly anthropicVersion?: string;
+  /** `max_tokens` used when a request omits `maxOutputTokens`. Defaults to 4096. */
+  readonly defaultMaxOutputTokens?: number;
+  /** Injected `fetch` (for tests). Defaults to the global `fetch`. */
+  readonly fetchImpl?: typeof fetch;
+  /** Extra request headers merged in (must NOT be used to carry secrets into logs). */
+  readonly extraHeaders?: Readonly<Record<string, string>>;
+}
+
+/** The static capability matrix Anthropic Messages advertises (design §Anthropic). */
+const ANTHROPIC_CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  tools: true,
+  parallelTools: true,
+  images: true,
+  documents: true,
+  structuredOutput: false,
+  // Messages has no portable server-side session to resume across requests.
+  serverContinuation: false,
+  promptCaching: true,
+};
+
+/** Translate one normalized message into a native Anthropic message (text only). */
+function toAnthropicMessage(message: ModelMessage): {
+  role: "user" | "assistant";
+  content: { type: "text"; text: string }[];
+} {
+  // Phase 1 is text-only; a `tool` role has no native Messages equivalent
+  // without tool_result blocks (Phase 3), so it collapses onto `user`.
+  const role = message.role === "assistant" ? "assistant" : "user";
+  const content: { type: "text"; text: string }[] = [];
+  for (const part of message.content) {
+    if (part.type === "text") content.push({ type: "text", text: part.text });
+  }
+  return { role, content };
+}
+
+/** Build the native Messages request body from a normalized {@link ModelRequest}. */
+function toAnthropicRequestBody(
+  request: ModelRequest,
+  defaultMaxOutputTokens: number,
+): Record<string, unknown> {
+  // The single namespaced escape hatch: opaque provider-only knobs merge in
+  // first, then the core fields (which must win and never be overridden).
+  const providerOptions = request.options?.anthropic ?? {};
+  return {
+    ...providerOptions,
+    model: request.model,
+    max_tokens: request.maxOutputTokens ?? defaultMaxOutputTokens,
+    stream: true,
+    ...(request.instructions ? { system: request.instructions } : {}),
+    messages: request.messages.map(toAnthropicMessage),
+  };
+}
+
+/** Parse `retry-after` (seconds) into milliseconds, when present and numeric. */
+function retryAfterMs(headers: Headers): number | undefined {
+  const raw = headers.get("retry-after");
+  if (!raw) return undefined;
+  const seconds = Number(raw);
+  return Number.isFinite(seconds) ? Math.round(seconds * 1000) : undefined;
+}
+
+/** Read the provider request id from response headers (never from the body). */
+function providerRequestId(headers: Headers): string | undefined {
+  return headers.get("request-id") ?? headers.get("x-request-id") ?? undefined;
+}
+
+/**
+ * Map a non-2xx HTTP status onto a normalized {@link ProviderError}. The summary
+ * carries only the status and, when the body is JSON, the provider-authored
+ * `error.type`/`message` (secret-free) — NEVER a header value or the API key.
+ */
+function httpStatusToProviderError(
+  status: number,
+  headers: Headers,
+  bodyText: string,
+  reqId: string | undefined,
+): ProviderError {
+  let kind: ProviderErrorKind;
+  let retryable: boolean;
+  let retry: number | undefined;
+
+  if (status === 401) {
+    kind = "authentication";
+    retryable = false;
+  } else if (status === 403) {
+    kind = "authorization";
+    retryable = false;
+  } else if (status === 429) {
+    kind = "rate_limit";
+    retryable = true;
+    retry = retryAfterMs(headers);
+  } else if (status === 529) {
+    kind = "overloaded";
+    retryable = true;
+    retry = retryAfterMs(headers);
+  } else if (status === 400) {
+    kind = "invalid_request";
+    retryable = false;
+  } else if (status >= 500) {
+    kind = "unavailable";
+    retryable = true;
+    retry = retryAfterMs(headers);
+  } else {
+    // Any other 4xx: treat as a client-side, non-retryable invalid request.
+    kind = "invalid_request";
+    retryable = false;
+  }
+
+  let summary = `HTTP ${status}`;
+  try {
+    const parsed = JSON.parse(bodyText) as { error?: { type?: unknown; message?: unknown } };
+    const err = parsed.error;
+    const typeStr = typeof err?.type === "string" ? err.type : undefined;
+    const messageStr = typeof err?.message === "string" ? err.message : undefined;
+    if (typeStr || messageStr) {
+      summary = `HTTP ${status}: ${[typeStr, messageStr].filter(Boolean).join(" — ")}`;
+    }
+  } catch {
+    // Non-JSON error body: keep the bare `HTTP <status>` summary. The raw body
+    // is intentionally NOT echoed (it could be large / non-diagnostic).
+  }
+
+  return {
+    kind,
+    retryable,
+    summary,
+    ...(retry != null ? { retryAfterMs: retry } : {}),
+    ...(reqId ? { providerRequestId: reqId } : {}),
+  };
+}
+
+/**
+ * Native Anthropic Messages API provider. Streams a normalized {@link ModelEvent}
+ * sequence for a text request; HTTP and in-stream failures surface as a terminal
+ * normalized `error` event (never a thrown raw error carrying secrets).
+ */
+export class AnthropicMessagesProvider implements ModelProvider {
+  readonly id = "anthropic-messages";
+  readonly capabilities: ProviderCapabilities = ANTHROPIC_CAPABILITIES;
+
+  readonly #apiKey: string;
+  readonly #endpoint: string;
+  readonly #anthropicVersion: string;
+  readonly #defaultMaxOutputTokens: number;
+  readonly #fetchImpl: typeof fetch;
+  readonly #extraHeaders: Record<string, string>;
+
+  constructor(options: AnthropicMessagesProviderOptions) {
+    this.#apiKey = options.apiKey;
+    const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.#endpoint = `${baseUrl}/v1/messages`;
+    this.#anthropicVersion = options.anthropicVersion ?? DEFAULT_ANTHROPIC_VERSION;
+    this.#defaultMaxOutputTokens =
+      options.defaultMaxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+    this.#fetchImpl = options.fetchImpl ?? fetch;
+    this.#extraHeaders = { ...(options.extraHeaders ?? {}) };
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
+    const body = JSON.stringify(
+      toAnthropicRequestBody(request, this.#defaultMaxOutputTokens),
+    );
+    const headers: Record<string, string> = {
+      ...this.#extraHeaders,
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      "anthropic-version": this.#anthropicVersion,
+      "x-api-key": this.#apiKey,
+    };
+
+    let response: Response;
+    try {
+      response = await this.#fetchImpl(this.#endpoint, {
+        method: "POST",
+        headers,
+        body,
+      });
+    } catch (_err) {
+      // Transport-level failure (DNS/connect/reset). Surface a normalized error
+      // event; the raw error is NOT interpolated so nothing (e.g. a URL with an
+      // embedded credential) can leak onto the summary.
+      yield {
+        type: "error",
+        error: {
+          kind: "unavailable",
+          retryable: true,
+          summary: "request transport failure",
+        },
+      };
+      return;
+    }
+
+    const reqId = providerRequestId(response.headers);
+
+    if (!response.ok) {
+      let text: string;
+      try {
+        text = await response.text();
+      } catch (_err) {
+        // Body already consumed / connection dropped — fall back to the bare
+        // status summary. Safe to ignore: the status alone drives the kind.
+        text = "";
+      }
+      yield {
+        type: "error",
+        error: httpStatusToProviderError(response.status, response.headers, text, reqId),
+      };
+      return;
+    }
+
+    if (!response.body) {
+      yield {
+        type: "error",
+        error: {
+          kind: "malformed_response",
+          retryable: true,
+          summary: "response had no body",
+          ...(reqId ? { providerRequestId: reqId } : {}),
+        },
+      };
+      return;
+    }
+
+    yield* mapAnthropicMessagesStream(readBody(response.body), {
+      providerRequestId: reqId,
+    });
+  }
+}
+
+/**
+ * Adapt a `ReadableStream<Uint8Array>` (a fetch `Response.body`) to an
+ * `AsyncIterable<Uint8Array>` via an explicit reader, so cancellation releases
+ * the underlying connection deterministically across runtimes.
+ */
+async function* readBody(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<Uint8Array> {
+  const reader = stream.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/src/providers/anthropic/messages-provider.ts
+++ b/src/providers/anthropic/messages-provider.ts
@@ -272,6 +272,14 @@ export class AnthropicMessagesProvider implements ModelProvider {
  * Adapt a `ReadableStream<Uint8Array>` (a fetch `Response.body`) to an
  * `AsyncIterable<Uint8Array>` via an explicit reader, so cancellation releases
  * the underlying connection deterministically across runtimes.
+ *
+ * A mid-stream read REJECTION — an aborted / truncated connection, e.g. the
+ * peer erroring the stream (`controller.error`) after HTTP 200 — is caught and
+ * ends iteration CLEANLY rather than propagating. Whether such an abort surfaces
+ * as a rejected `read()` or a silent EOF is Bun/environment-sensitive (it threw
+ * in CI but not locally), so we never depend on the throw reaching a caller: the
+ * mapper classifies the resulting terminal-frame-less end as `malformed_response`.
+ * The raw error is deliberately NOT surfaced (it could carry provider detail).
  */
 async function* readBody(
   stream: ReadableStream<Uint8Array>,
@@ -279,11 +287,24 @@ async function* readBody(
   const reader = stream.getReader();
   try {
     for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      yield value;
+      let chunk: Awaited<ReturnType<typeof reader.read>>;
+      try {
+        chunk = await reader.read();
+      } catch (_err) {
+        // Aborted / truncated stream. Stop yielding; the mapper sees a stream
+        // that ended without a `message_stop` and emits a normalized
+        // `malformed_response` error. Raw error intentionally swallowed.
+        return;
+      }
+      if (chunk.done) break;
+      yield chunk.value;
     }
   } finally {
-    reader.releaseLock();
+    try {
+      reader.releaseLock();
+    } catch (_err) {
+      // The reader may already be released/errored after an aborted stream;
+      // releasing again is a no-op we can safely ignore.
+    }
   }
 }

--- a/src/providers/anthropic/stream-parser.ts
+++ b/src/providers/anthropic/stream-parser.ts
@@ -1,0 +1,365 @@
+// API-P1.1 (epic #2055, Phase 1, decision D2) — SSE stream parser for the native
+// Anthropic Messages API. Two layers:
+//
+//   1. `parseSSE` — a generic, dependency-free Server-Sent-Events framer. It
+//      buffers a byte stream, decodes UTF-8 with `{ stream: true }` so a
+//      grapheme split mid-codepoint across a frame boundary is reassembled, and
+//      yields `{ event, data }` records on each SSE dispatch (blank-line
+//      terminated). It never inspects payload semantics.
+//
+//   2. `mapAnthropicMessagesStream` — consumes those records, JSON-parses each
+//      `data` payload, and maps Anthropic's typed events (`message_start`,
+//      `content_block_start/delta/stop`, `message_delta`, `message_stop`,
+//      `ping`, `error`) onto the normalized {@link ModelEvent} union. Unknown
+//      event types are ignored (design §Anthropic: "new event variants may be
+//      added, so the adapter must ignore unknown events safely"). `input_json_delta`
+//      deltas are accumulated per content-block index so a tool-call block whose
+//      JSON is split across arbitrary chunk boundaries reassembles cleanly —
+//      Phase 1 sends no tools, but the parser must not choke if a block appears.
+//
+// NO secret, API key, or header value is ever placed on a yielded event or an
+// error summary — everything here may be logged / published / shown on the
+// dashboard (see `ProviderError.summary`).
+
+import type { FinishReason, ModelEvent } from "../../common/inference/types";
+import type {
+  ProviderError,
+  ProviderErrorKind,
+} from "../../common/inference/errors";
+
+// ── Generic SSE framing ──────────────────────────────────────────────────────
+
+/** One dispatched SSE record: the `event:` type and the joined `data:` payload. */
+export interface SSEEvent {
+  /** The `event:` field value, or `"message"` when the frame omitted one. */
+  readonly event: string;
+  /** The joined `data:` lines (multiple `data:` lines are `\n`-joined per spec). */
+  readonly data: string;
+}
+
+/**
+ * Frame a raw byte stream into SSE records. Tolerates fragmented frames (an
+ * event split across chunk boundaries) and split UTF-8 (a multi-byte codepoint
+ * split across chunks) via a streaming `TextDecoder`. Comment lines (`:` prefix,
+ * e.g. keep-alive) and unknown fields (`id:`, `retry:`) are ignored.
+ */
+export async function* parseSSE(
+  body: AsyncIterable<Uint8Array>,
+): AsyncGenerator<SSEEvent> {
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  let eventType = "";
+  let dataLines: string[] = [];
+
+  const dispatch = (): SSEEvent | undefined => {
+    if (dataLines.length === 0 && eventType === "") return undefined;
+    const record: SSEEvent = {
+      event: eventType === "" ? "message" : eventType,
+      data: dataLines.join("\n"),
+    };
+    eventType = "";
+    dataLines = [];
+    return record;
+  };
+
+  for await (const chunk of body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let newlineIndex: number;
+    while ((newlineIndex = buffer.indexOf("\n")) >= 0) {
+      let line = buffer.slice(0, newlineIndex);
+      buffer = buffer.slice(newlineIndex + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+
+      if (line === "") {
+        const record = dispatch();
+        if (record) yield record;
+        continue;
+      }
+      if (line.startsWith(":")) continue; // comment / keep-alive
+
+      const colon = line.indexOf(":");
+      const field = colon === -1 ? line : line.slice(0, colon);
+      let value = colon === -1 ? "" : line.slice(colon + 1);
+      if (value.startsWith(" ")) value = value.slice(1);
+
+      if (field === "event") eventType = value;
+      else if (field === "data") dataLines.push(value);
+      // `id`, `retry`, and any other field are ignored.
+    }
+  }
+
+  // Flush any bytes the streaming decoder was holding, then dispatch a trailing
+  // record if the stream ended without a final blank line.
+  buffer += decoder.decode();
+  if (buffer.length > 0) {
+    let line = buffer;
+    if (line.endsWith("\r")) line = line.slice(0, -1);
+    if (line !== "" && !line.startsWith(":")) {
+      const colon = line.indexOf(":");
+      const field = colon === -1 ? line : line.slice(0, colon);
+      let value = colon === -1 ? "" : line.slice(colon + 1);
+      if (value.startsWith(" ")) value = value.slice(1);
+      if (field === "event") eventType = value;
+      else if (field === "data") dataLines.push(value);
+    }
+  }
+  const tail = dispatch();
+  if (tail) yield tail;
+}
+
+// ── Anthropic-native → normalized event mapping ──────────────────────────────
+
+/** Context the provider supplies to the mapper (id resolved from HTTP headers). */
+export interface AnthropicStreamContext {
+  /** Provider request id, read from the response headers (never from the body). */
+  readonly providerRequestId?: string;
+}
+
+/** Map an Anthropic `stop_reason` onto the normalized {@link FinishReason}. */
+export function mapStopReason(stopReason: unknown): FinishReason {
+  switch (stopReason) {
+    case "end_turn":
+    case "stop_sequence":
+      return "stop";
+    case "max_tokens":
+      return "length";
+    case "tool_use":
+      return "tool_use";
+    case "refusal":
+      return "content_filter";
+    default:
+      return "stop";
+  }
+}
+
+/** Map an Anthropic in-stream `error.type` onto a normalized error kind. */
+export function mapAnthropicErrorType(type: unknown): {
+  kind: ProviderErrorKind;
+  retryable: boolean;
+} {
+  switch (type) {
+    case "authentication_error":
+      return { kind: "authentication", retryable: false };
+    case "permission_error":
+      return { kind: "authorization", retryable: false };
+    case "rate_limit_error":
+      return { kind: "rate_limit", retryable: true };
+    case "overloaded_error":
+      return { kind: "overloaded", retryable: true };
+    case "invalid_request_error":
+    case "not_found_error":
+      return { kind: "invalid_request", retryable: false };
+    case "api_error":
+      return { kind: "unavailable", retryable: true };
+    default:
+      return { kind: "unavailable", retryable: true };
+  }
+}
+
+/**
+ * Build a redacted {@link ProviderError} from an Anthropic error object. Only the
+ * provider-authored `type`/`message` (safe, secret-free) reach the summary.
+ */
+function toProviderError(
+  errorObj: unknown,
+  providerRequestId?: string,
+): ProviderError {
+  const err = (errorObj ?? {}) as { type?: unknown; message?: unknown };
+  const { kind, retryable } = mapAnthropicErrorType(err.type);
+  const typeStr = typeof err.type === "string" ? err.type : "error";
+  const messageStr = typeof err.message === "string" ? err.message : "";
+  const summary = messageStr ? `${typeStr}: ${messageStr}` : typeStr;
+  return { kind, retryable, summary, ...(providerRequestId ? { providerRequestId } : {}) };
+}
+
+interface ToolBlockState {
+  id: string;
+  name: string;
+  json: string;
+}
+
+/**
+ * Consume a raw Anthropic Messages SSE byte stream and yield normalized
+ * {@link ModelEvent}s. Ignores unknown event types safely; if the underlying
+ * body read fails mid-stream (truncated / aborted connection after HTTP 200) it
+ * yields a terminal `error` event with `malformed_response` rather than throwing.
+ */
+export async function* mapAnthropicMessagesStream(
+  body: AsyncIterable<Uint8Array>,
+  ctx: AnthropicStreamContext = {},
+): AsyncGenerator<ModelEvent> {
+  const reqId = ctx.providerRequestId;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens: number | undefined;
+  let sawUsage = false;
+  let finishReason: FinishReason | undefined;
+  let startedEmitted = false;
+  let terminated = false;
+  const toolBlocks = new Map<number, ToolBlockState>();
+
+  try {
+    for await (const sse of parseSSE(body)) {
+      let evt: Record<string, unknown>;
+      try {
+        evt = JSON.parse(sse.data) as Record<string, unknown>;
+      } catch {
+        // A data frame that is not valid JSON: tolerate and skip it rather than
+        // aborting the whole stream (design: be liberal in what we accept).
+        continue;
+      }
+      const type = typeof evt.type === "string" ? evt.type : sse.event;
+
+      switch (type) {
+        case "message_start": {
+          const message = evt.message as { usage?: Record<string, number> } | undefined;
+          const usage = message?.usage;
+          if (usage) {
+            if (typeof usage.input_tokens === "number") inputTokens = usage.input_tokens;
+            if (typeof usage.cache_read_input_tokens === "number")
+              cacheReadTokens = usage.cache_read_input_tokens;
+          }
+          if (!startedEmitted) {
+            startedEmitted = true;
+            yield { type: "response.started", ...(reqId ? { providerRequestId: reqId } : {}) };
+          }
+          break;
+        }
+
+        case "content_block_start": {
+          const index = evt.index as number;
+          const block = evt.content_block as
+            | { type?: string; id?: string; name?: string }
+            | undefined;
+          if (block?.type === "tool_use") {
+            toolBlocks.set(index, {
+              id: typeof block.id === "string" ? block.id : "",
+              name: typeof block.name === "string" ? block.name : "",
+              json: "",
+            });
+          }
+          break;
+        }
+
+        case "content_block_delta": {
+          const index = evt.index as number;
+          const delta = evt.delta as
+            | { type?: string; text?: string; partial_json?: string }
+            | undefined;
+          if (delta?.type === "text_delta") {
+            yield { type: "text.delta", text: delta.text ?? "" };
+          } else if (delta?.type === "input_json_delta") {
+            const state = toolBlocks.get(index);
+            const fragment = delta.partial_json ?? "";
+            if (state) {
+              state.json += fragment;
+              yield {
+                type: "tool_call.delta",
+                id: state.id,
+                ...(state.name ? { name: state.name } : {}),
+                json: fragment,
+              };
+            }
+          }
+          break;
+        }
+
+        case "content_block_stop": {
+          const index = evt.index as number;
+          const state = toolBlocks.get(index);
+          if (state) {
+            let input: unknown;
+            try {
+              input = state.json ? JSON.parse(state.json) : {};
+            } catch {
+              // Malformed accumulated JSON: keep the raw string rather than
+              // throwing — the harness decides how to handle a bad tool call.
+              input = state.json;
+            }
+            yield { type: "tool_call.completed", id: state.id, name: state.name, input };
+            toolBlocks.delete(index);
+          }
+          break;
+        }
+
+        case "message_delta": {
+          const delta = evt.delta as { stop_reason?: unknown } | undefined;
+          if (delta && "stop_reason" in delta && delta.stop_reason != null) {
+            finishReason = mapStopReason(delta.stop_reason);
+          }
+          const usage = evt.usage as Record<string, number> | undefined;
+          if (usage) {
+            if (typeof usage.output_tokens === "number") outputTokens = usage.output_tokens;
+            if (typeof usage.input_tokens === "number") inputTokens = usage.input_tokens;
+            if (typeof usage.cache_read_input_tokens === "number")
+              cacheReadTokens = usage.cache_read_input_tokens;
+            sawUsage = true;
+            yield {
+              type: "usage",
+              inputTokens,
+              outputTokens,
+              ...(cacheReadTokens != null ? { cacheReadTokens } : {}),
+            };
+          }
+          break;
+        }
+
+        case "message_stop": {
+          terminated = true;
+          yield { type: "response.completed", finishReason: finishReason ?? "stop" };
+          break;
+        }
+
+        case "ping":
+          // Keep-alive: meaningful activity for the harness's idle timer, but no
+          // normalized event. Intentionally ignored here.
+          break;
+
+        case "error": {
+          terminated = true;
+          yield { type: "error", error: toProviderError(evt.error, reqId) };
+          return;
+        }
+
+        default:
+          // Unknown / future event variant — ignore safely (design §Anthropic).
+          break;
+      }
+    }
+  } catch (_err) {
+    // The body read failed part-way (truncated / aborted stream after HTTP 200).
+    // Surface a normalized terminal error rather than propagating the raw error,
+    // whose message must never carry request/response detail onto the bus.
+    yield {
+      type: "error",
+      error: {
+        kind: "malformed_response",
+        retryable: true,
+        summary: "stream ended before completion",
+        ...(reqId ? { providerRequestId: reqId } : {}),
+      },
+    };
+    return;
+  }
+
+  // A stream that ends without a terminal `message_stop` (or `error`) frame was
+  // truncated — the connection dropped mid-response after HTTP 200. Some runtimes
+  // surface that as a silent EOF rather than a thrown read error, so detect it
+  // structurally and emit a normalized terminal error.
+  if (!terminated) {
+    yield {
+      type: "error",
+      error: {
+        kind: "malformed_response",
+        retryable: true,
+        summary: "stream ended before completion",
+        ...(reqId ? { providerRequestId: reqId } : {}),
+      },
+    };
+  }
+
+  // `sawUsage` is intentionally read only to keep the missing-usage path
+  // side-effect-free; a stream that never sent a usage frame simply yields no
+  // `usage` event (design: tolerate disconnects before a final usage event).
+  void sawUsage;
+}


### PR DESCRIPTION
Closes #2061 · Part of epic #2055 · Phase 1. Native Anthropic Messages adapter (D2).

Adds `src/providers/anthropic/{stream-parser,messages-provider}.ts` — `AnthropicMessagesProvider implements ModelProvider` (id `anthropic-messages`) over the native Messages API (not the OpenAI-compat shim). Text content for Phase 1.

- SSE framer buffers fragmented frames + streaming decode for split UTF-8; maps native events → normalized `ModelEvent` (message_start→response.started with provider request id, content_block_delta→text.delta, input_json_delta accumulated per block, message_delta→usage+stop_reason, message_stop→response.completed, ping ignored, error→mid-stream error). Unknown event types ignored safely; truncation → `malformed_response`.
- HTTP status → normalized `ProviderErrorKind` (401/403/429+retry-after/529/5xx/400). The provider credential is placed only on the transport auth header and appears in no event, error, or log.
- capabilities: serverContinuation false, promptCaching true, streaming/tools/parallelTools/images/documents true, structuredOutput false.

Tests live in `src/providers/anthropic/__tests__/` and reuse the guard's exported shared cases + fake server — `contract.ts` is untouched (sibling-slice-safe). Coverage: split frames/UTF-8, tool-call JSON reassembly, unknown events, error-after-200, truncation, missing-final-usage, each HTTP class, capability + secret-absence assertions.

Note (integration seam for API-P1.3): pre-200 HTTP errors surface as a yielded `error` `ModelEvent` (uniform with in-stream errors), not a thrown error — the harness slice should consume the error event.

Verification: `bunx tsc --noEmit` exit 0; `bunx eslint src/providers/anthropic` clean; `bun test src/providers/anthropic` → 14 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)