### PR TITLE
feat(providers): API-P1.2 — OpenAICompatibleProvider + Chat Completions stream parser

### DIFF
--- a/src/providers/openai-compatible/__tests__/chat-completions-provider.test.ts
+++ b/src/providers/openai-compatible/__tests__/chat-completions-provider.test.ts
@@ -1,0 +1,313 @@
+// API-P1.2 (issue #2062) — LIVE contract tests for `OpenAICompatibleProvider`,
+// driven against the shared fake streaming server (API-P1.5 scaffold).
+//
+// REUSE WITHOUT TOUCHING THE SHARED METER: the shared `src/providers/__tests__/
+// contract.ts` holds the epic progress meter (one `test.todo` per case per gated
+// slice) and is edited by a SIBLING slice — we must not touch it. Instead we
+// import its exported case-name constant (`PROVIDER_CONTRACT_CASES`) and the
+// exported fake server (`startFakeStreamingServer`) and name our live tests with
+// those exact strings, so this file is the openai-compatible slice's live proof
+// of the same cases the meter tracks — with zero edits to the shared files.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  PROVIDER_CONTRACT_CASES,
+} from "../../__tests__/contract";
+import {
+  startFakeStreamingServer,
+  type FakeStreamingServer,
+  type StreamChunk,
+} from "../../__tests__/fake-streaming-server";
+import type { ModelEvent, ModelRequest } from "../../../common/inference/types";
+import { OpenAICompatibleProvider } from "../chat-completions-provider";
+
+// Stable indices into the shared case list, so our test names stay verbatim in
+// sync with the meter even if the list is reordered.
+const CASE = (needle: string): string => {
+  const found = PROVIDER_CONTRACT_CASES.find((c) => c.includes(needle));
+  if (!found) throw new Error(`no shared contract case matching "${needle}"`);
+  return found;
+};
+
+const SSE_HEADERS = { "content-type": "text/event-stream" } as const;
+const API_KEY = "sk-secret-DO-NOT-LEAK-abc123";
+
+let server: FakeStreamingServer;
+
+beforeEach(() => {
+  server = startFakeStreamingServer();
+});
+afterEach(async () => {
+  await server.stop();
+});
+
+function makeProvider(overrides?: {
+  capabilities?: ConstructorParameters<typeof OpenAICompatibleProvider>[0]["capabilities"];
+  apiKey?: string;
+}): OpenAICompatibleProvider {
+  return new OpenAICompatibleProvider({
+    baseUrl: `${server.url}/v1`,
+    apiKey: overrides?.apiKey ?? API_KEY,
+    ...(overrides?.capabilities ? { capabilities: overrides.capabilities } : {}),
+  });
+}
+
+const REQUEST: ModelRequest = {
+  model: "test-model",
+  instructions: "be terse",
+  messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+};
+
+// ── SSE frame builders ────────────────────────────────────────────────────────
+const sse = (obj: unknown): string => `data: ${JSON.stringify(obj)}\n\n`;
+const DONE = "data: [DONE]\n\n";
+const contentChunk = (text: string): string =>
+  sse({ choices: [{ index: 0, delta: { content: text }, finish_reason: null }] });
+const finishChunk = (reason = "stop"): string =>
+  sse({ choices: [{ index: 0, delta: {}, finish_reason: reason }] });
+const usageChunk = (input: number, output: number): string =>
+  sse({ choices: [], usage: { prompt_tokens: input, completion_tokens: output } });
+
+function singleByteChunks(s: string): StreamChunk[] {
+  const bytes = new TextEncoder().encode(s);
+  return Array.from(bytes, (b) => ({ data: new Uint8Array([b]) }));
+}
+
+async function drain(provider: OpenAICompatibleProvider): Promise<ModelEvent[]> {
+  const events: ModelEvent[] = [];
+  for await (const ev of provider.stream(REQUEST)) events.push(ev);
+  return events;
+}
+
+function textOf(events: readonly ModelEvent[]): string {
+  let out = "";
+  for (const e of events) if (e.type === "text.delta") out += e.text;
+  return out;
+}
+
+function firstError(events: readonly ModelEvent[]) {
+  const ev = events.find((e) => e.type === "error");
+  return ev?.type === "error" ? ev.error : undefined;
+}
+
+describe("provider contract · openai-compatible (live, #2062)", () => {
+  test(CASE("Unicode grapheme split across frame boundaries"), async () => {
+    // A 4-byte emoji plus surrounding ASCII, streamed ONE BYTE PER FRAME so every
+    // multi-byte codepoint AND every `data:` line is split across chunk
+    // boundaries — the strongest form of the split-frame stress.
+    const payload = contentChunk("a🌱b") + finishChunk("stop") + DONE;
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: singleByteChunks(payload) });
+
+    const events = await drain(makeProvider());
+
+    expect(events[0]?.type).toBe("response.started");
+    expect(textOf(events)).toBe("a🌱b");
+    const last = events[events.length - 1];
+    expect(last?.type).toBe("response.completed");
+    if (last?.type === "response.completed") expect(last.finishReason).toBe("stop");
+  });
+
+  test(CASE("unknown / unrecognized event variants"), async () => {
+    const payload =
+      sse({ object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] }) +
+      sse({ foo: "bar", weird: true }) +
+      "data: 42\n\n" + // valid JSON, non-object — must be ignored, not fatal
+      contentChunk("ok") +
+      finishChunk("stop") +
+      DONE;
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await drain(makeProvider());
+
+    expect(textOf(events)).toBe("ok");
+    expect(events[events.length - 1]?.type).toBe("response.completed");
+    expect(firstError(events)).toBeUndefined();
+  });
+
+  test(CASE("authentication (401)"), async () => {
+    server.enqueue({ status: 401, chunks: [{ data: '{"error":{"message":"nope"}}' }] });
+    const events = await drain(makeProvider());
+    expect(events.some((e) => e.type === "response.started")).toBe(false);
+    const err = firstError(events);
+    expect(err?.kind).toBe("authentication");
+    expect(err?.retryable).toBe(false);
+  });
+
+  test(CASE("rate_limit (429)"), async () => {
+    server.enqueue({ status: 429, headers: { "retry-after": "2" }, chunks: [{ data: "{}" }] });
+    const err = firstError(await drain(makeProvider()));
+    expect(err?.kind).toBe("rate_limit");
+    expect(err?.retryable).toBe(true);
+    expect(err?.retryAfterMs).toBe(2000);
+  });
+
+  test(CASE("overloaded (529)"), async () => {
+    server.enqueue({ status: 529, chunks: [{ data: "{}" }] });
+    const err = firstError(await drain(makeProvider()));
+    expect(err?.kind).toBe("overloaded");
+    expect(err?.retryable).toBe(true);
+  });
+
+  test(CASE("unavailable (503)"), async () => {
+    server.enqueue({ status: 503, chunks: [{ data: "{}" }] });
+    const err = firstError(await drain(makeProvider()));
+    expect(err?.kind).toBe("unavailable");
+    expect(err?.retryable).toBe(true);
+  });
+
+  test("maps invalid_request (400) responses to the normalized invalid_request error", async () => {
+    server.enqueue({ status: 400, chunks: [{ data: '{"error":{"message":"bad"}}' }] });
+    const err = firstError(await drain(makeProvider()));
+    expect(err?.kind).toBe("invalid_request");
+    expect(err?.retryable).toBe(false);
+  });
+
+  test(CASE("in-stream error that arrives AFTER a committed HTTP 200"), async () => {
+    const payload =
+      contentChunk("partial ") +
+      sse({ error: { type: "server_error", code: "internal", message: "boom-should-not-leak" } });
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await drain(makeProvider());
+
+    expect(events.some((e) => e.type === "response.started")).toBe(true);
+    expect(textOf(events)).toBe("partial ");
+    const err = firstError(events);
+    expect(err).toBeDefined();
+    // No completed event once an in-stream error is surfaced.
+    expect(events.some((e) => e.type === "response.completed")).toBe(false);
+    // The free-form provider message must NOT leak into the redacted summary.
+    expect(err?.summary).not.toContain("boom-should-not-leak");
+  });
+
+  test(CASE("malformed / truncated streams") + " · malformed JSON frame", async () => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: "data: {this is not json}\n\n" }],
+    });
+    const events = await drain(makeProvider());
+    expect(events.some((e) => e.type === "response.started")).toBe(true);
+    expect(firstError(events)?.kind).toBe("malformed_response");
+    expect(events.some((e) => e.type === "response.completed")).toBe(false);
+  });
+
+  test(CASE("malformed / truncated streams") + " · truncated after 200", async () => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("half") }],
+      abortAfterChunks: true, // abrupt close, no terminal frame
+    });
+    const events = await drain(makeProvider());
+    expect(events.some((e) => e.type === "response.started")).toBe(true);
+    expect(firstError(events)?.kind).toBe("malformed_response");
+    expect(events.some((e) => e.type === "response.completed")).toBe(false);
+  });
+
+  test(CASE("normalizes usage from a final usage frame"), async () => {
+    const payload = contentChunk("hello") + finishChunk("stop") + usageChunk(11, 7) + DONE;
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await drain(makeProvider());
+    const usage = events.find((e) => e.type === "usage");
+    expect(usage).toBeDefined();
+    if (usage?.type === "usage") {
+      expect(usage.inputTokens).toBe(11);
+      expect(usage.outputTokens).toBe(7);
+    }
+    expect(events[events.length - 1]?.type).toBe("response.completed");
+  });
+
+  test(CASE("omits the final usage frame (missing usage)"), async () => {
+    // Ollama-style: content + finish + [DONE], NO usage object at all.
+    const payload = contentChunk("hello") + finishChunk("stop") + DONE;
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const events = await drain(makeProvider());
+
+    // Provider completes cleanly and emits NO usage event (not a zeroed one).
+    expect(events.some((e) => e.type === "usage")).toBe(false);
+    expect(textOf(events)).toBe("hello");
+    const last = events[events.length - 1];
+    expect(last?.type).toBe("response.completed");
+    if (last?.type === "response.completed") expect(last.finishReason).toBe("stop");
+  });
+
+  test(CASE("rejects an unsupported_capability request before dispatch"), async () => {
+    // Default capabilities have images:false — an image request must be rejected
+    // BEFORE any network call.
+    const provider = makeProvider();
+    const request: ModelRequest = {
+      model: "test-model",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image_ref", source: { kind: "url", url: "https://x/y.png" } }],
+        },
+      ],
+    };
+    const events: ModelEvent[] = [];
+    for await (const ev of provider.stream(request)) events.push(ev);
+
+    expect(events).toHaveLength(1);
+    expect(firstError(events)?.kind).toBe("unsupported_capability");
+    expect(server.requests).toHaveLength(0); // never dispatched
+  });
+
+  test("capabilities default conservative and are overridable from profile config", async () => {
+    const dflt = makeProvider();
+    expect(dflt.capabilities).toEqual({
+      streaming: true,
+      tools: false,
+      parallelTools: false,
+      images: false,
+      documents: false,
+      structuredOutput: false,
+      serverContinuation: false,
+      promptCaching: false,
+    });
+
+    // An override flipping images on lets an image request through to dispatch.
+    const withImages = makeProvider({ capabilities: { images: true } });
+    expect(withImages.capabilities.images).toBe(true);
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: DONE }] });
+    const events: ModelEvent[] = [];
+    for await (const ev of withImages.stream({
+      model: "test-model",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image_ref", source: { kind: "url", url: "https://x/y.png" } }],
+        },
+      ],
+    })) {
+      events.push(ev);
+    }
+    expect(firstError(events)?.kind).not.toBe("unsupported_capability");
+    expect(server.requests).toHaveLength(1); // it WAS dispatched
+  });
+
+  test(CASE("keeps secrets absent from errors, events, snapshots, and logs"), async () => {
+    // Success path.
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("hi") + finishChunk("stop") + DONE }],
+    });
+    const ok = await drain(makeProvider());
+    // Error path.
+    server.enqueue({ status: 401, chunks: [{ data: '{"error":{"message":"denied"}}' }] });
+    const bad = await drain(makeProvider());
+
+    const serialized = JSON.stringify([...ok, ...bad]);
+    expect(serialized).not.toContain(API_KEY);
+    expect(serialized.toLowerCase()).not.toContain("authorization");
+    expect(serialized).not.toContain("Bearer");
+
+    // The key WAS actually sent to the provider (proving redaction, not omission).
+    const authHeaders = server.requests.map((r) => r.headers.authorization);
+    expect(authHeaders).toContain(`Bearer ${API_KEY}`);
+  });
+});

--- a/src/providers/openai-compatible/__tests__/chat-completions-provider.test.ts
+++ b/src/providers/openai-compatible/__tests__/chat-completions-provider.test.ts
@@ -204,6 +204,11 @@ describe("provider contract · openai-compatible (live, #2062)", () => {
     expect(events.some((e) => e.type === "response.started")).toBe(true);
     expect(firstError(events)?.kind).toBe("malformed_response");
     expect(events.some((e) => e.type === "response.completed")).toBe(false);
+    // The async iterable completes normally (no throw) and its FINAL event is the
+    // normalized error — the read-loop swallows the abort and ends cleanly.
+    const last = events[events.length - 1];
+    expect(last?.type).toBe("error");
+    if (last?.type === "error") expect(last.error.kind).toBe("malformed_response");
   });
 
   test(CASE("normalizes usage from a final usage frame"), async () => {

--- a/src/providers/openai-compatible/chat-completions-provider.ts
+++ b/src/providers/openai-compatible/chat-completions-provider.ts
@@ -1,0 +1,484 @@
+// API-P1.2 (epic #2055, Phase 1, decision D2) — `OpenAICompatibleProvider`: a
+// `ModelProvider` for the PORTABLE CORE of streamed OpenAI Chat Completions, so
+// Cortex can call OpenAI-compatible services incl. local ones (Ollama, LM Studio).
+//
+// Design §"External protocol constraints → OpenAI-compatible services" +
+// decision D2: "OpenAI-compatible" is a family of PARTIAL implementations, NOT a
+// capability guarantee. So this adapter declares capabilities from config and
+// REJECTS unsupported requests rather than assuming features silently discard.
+// It shares the normalized contract (`src/common/inference/`) with the native
+// Anthropic adapter but keeps its own request construction, stream parsing, error
+// classification, and request-id handling (D2: adapters are NOT merged).
+//
+// Phase 1 is TEXT ONLY. The OpenAI Responses API, stateful continuation, hosted
+// tools, and tool execution are explicitly OUT OF SCOPE (design open Q6, Phase 4;
+// tools → Phase 3). No secret (API key, Authorization header, raw body) ever
+// reaches a `ProviderError.summary`, a `ModelEvent`, or a log line.
+
+import type {
+  FinishReason,
+  MessageContent,
+  MessageRole,
+  ModelEvent,
+  ModelProvider,
+  ModelRequest,
+  ProviderCapabilities,
+} from "../../common/inference/types";
+import type { ProviderError, ProviderErrorKind } from "../../common/inference/errors";
+import { parseChatCompletionsStream } from "./stream-parser";
+
+/** Minimal `fetch` shape the provider depends on — injectable for tests. */
+export type FetchLike = (
+  input: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  },
+) => Promise<Response>;
+
+/**
+ * Construction config for {@link OpenAICompatibleProvider}. Deliberately
+ * self-contained: it accepts the pieces an inference profile (API-P0.2) resolves
+ * — `baseUrl`, resolved `apiKey`, and a `capabilities` override — without coupling
+ * to that not-yet-landed schema. When the profile schema lands, its resolver maps
+ * onto this shape.
+ */
+export interface OpenAICompatibleProviderConfig {
+  /** Stable provider id surfaced on {@link ModelProvider.id}. */
+  readonly id?: string;
+  /**
+   * API base URL, e.g. `https://api.openai.com/v1` or a local
+   * `http://127.0.0.1:11434/v1`. `/chat/completions` is appended.
+   */
+  readonly baseUrl: string;
+  /**
+   * Resolved API key. Optional — local OpenAI-compatible servers (Ollama,
+   * LM Studio) commonly need none. When present it is sent as a Bearer token and
+   * NEVER surfaces in an error, event, or log.
+   */
+  readonly apiKey?: string;
+  /**
+   * Capability overrides. Defaults are CONSERVATIVE (streaming on; tools, images,
+   * structured output, etc. off) because compatibility does not imply support;
+   * a profile turns a feature on only when the target endpoint genuinely has it.
+   */
+  readonly capabilities?: Partial<ProviderCapabilities>;
+  /**
+   * The `ModelRequest.options` namespace whose bag is merged onto the wire body.
+   * Defaults to `"openai"`.
+   */
+  readonly optionsNamespace?: string;
+  /** Extra request headers (e.g. an org id). Never a place for secrets in logs. */
+  readonly headers?: Record<string, string>;
+  /** Injected `fetch` (tests); defaults to the global `fetch`. */
+  readonly fetch?: FetchLike;
+}
+
+/**
+ * Conservative capability defaults. `streaming` is the one thing every
+ * OpenAI-compatible Chat Completions endpoint supports; everything else is OFF
+ * until a profile explicitly enables it (design: reject rather than assume).
+ * `serverContinuation` and `promptCaching` are always false on this protocol —
+ * those live on the Responses API / native adapters, not portable Chat Completions.
+ */
+const CONSERVATIVE_CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  tools: false,
+  parallelTools: false,
+  images: false,
+  documents: false,
+  structuredOutput: false,
+  serverContinuation: false,
+  promptCaching: false,
+};
+
+function makeError(
+  kind: ProviderErrorKind,
+  retryable: boolean,
+  summary: string,
+  extra?: { retryAfterMs?: number; providerRequestId?: string },
+): ProviderError {
+  const err: ProviderError = { kind, retryable, summary };
+  if (extra?.retryAfterMs !== undefined) err.retryAfterMs = extra.retryAfterMs;
+  if (extra?.providerRequestId !== undefined) {
+    err.providerRequestId = extra.providerRequestId;
+  }
+  return err;
+}
+
+/** Provider request id for correlation — safe to log (never a secret). */
+function extractRequestId(response: Response): string | undefined {
+  return (
+    response.headers.get("x-request-id") ??
+    response.headers.get("x-requestid") ??
+    undefined
+  );
+}
+
+/** Parse `retry-after-ms` / `retry-after` (seconds) into milliseconds. */
+function parseRetryAfterMs(headers: Headers): number | undefined {
+  const ms = headers.get("retry-after-ms");
+  if (ms) {
+    const n = Number(ms);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  const secs = headers.get("retry-after");
+  if (secs) {
+    const n = Number(secs);
+    if (Number.isFinite(n) && n >= 0) return n * 1000;
+  }
+  return undefined;
+}
+
+/**
+ * Map an HTTP status onto a normalized {@link ProviderError}. Summaries carry the
+ * status ONLY — never the response body (which may echo request content) and
+ * never any header value beyond the safe request id.
+ */
+function statusToProviderError(response: Response): ProviderError {
+  const providerRequestId = extractRequestId(response);
+  const retryAfterMs = parseRetryAfterMs(response.headers);
+  const status = response.status;
+  switch (status) {
+    case 401:
+      return makeError("authentication", false, "authentication failed (HTTP 401)", {
+        providerRequestId,
+      });
+    case 403:
+      return makeError("authorization", false, "authorization failed (HTTP 403)", {
+        providerRequestId,
+      });
+    case 408:
+      return makeError("timeout", true, "provider request timed out (HTTP 408)", {
+        providerRequestId,
+      });
+    case 429:
+      return makeError("rate_limit", true, "rate limited (HTTP 429)", {
+        retryAfterMs,
+        providerRequestId,
+      });
+    case 400:
+      return makeError("invalid_request", false, "invalid request (HTTP 400)", {
+        providerRequestId,
+      });
+    case 529:
+      return makeError("overloaded", true, "provider overloaded (HTTP 529)", {
+        retryAfterMs,
+        providerRequestId,
+      });
+    case 503:
+      return makeError("unavailable", true, "provider unavailable (HTTP 503)", {
+        retryAfterMs,
+        providerRequestId,
+      });
+    default:
+      break;
+  }
+  if (status >= 500) {
+    return makeError("unavailable", true, `provider error (HTTP ${status})`, {
+      retryAfterMs,
+      providerRequestId,
+    });
+  }
+  if (status >= 400) {
+    return makeError("invalid_request", false, `request rejected (HTTP ${status})`, {
+      providerRequestId,
+    });
+  }
+  // Non-2xx that is neither 4xx nor 5xx — unexpected; treat as unavailable.
+  return makeError("unavailable", true, `unexpected status (HTTP ${status})`, {
+    providerRequestId,
+  });
+}
+
+/**
+ * Map an in-band `{"error": …}` frame (delivered AFTER a committed 200) onto a
+ * normalized error. Classifies by the OpenAI-style `type`/`code` STRINGS only —
+ * the free-form `message` is deliberately excluded from the summary so no echoed
+ * request content can leak.
+ */
+function inStreamPayloadToError(payload: unknown): ProviderError {
+  const obj =
+    payload !== null && typeof payload === "object"
+      ? (payload as Record<string, unknown>)
+      : {};
+  const type = typeof obj.type === "string" ? obj.type : undefined;
+  const code = typeof obj.code === "string" ? obj.code : undefined;
+  const signal = `${type ?? ""} ${code ?? ""}`;
+
+  let kind: ProviderErrorKind = "unavailable";
+  let retryable = true;
+  if (/rate.?limit/i.test(signal)) {
+    kind = "rate_limit";
+    retryable = true;
+  } else if (/content.?filter/i.test(signal)) {
+    kind = "content_filter";
+    retryable = false;
+  } else if (/overloaded/i.test(signal)) {
+    kind = "overloaded";
+    retryable = true;
+  } else if (/invalid.?request/i.test(signal)) {
+    kind = "invalid_request";
+    retryable = false;
+  } else if (/auth/i.test(signal)) {
+    kind = "authentication";
+    retryable = false;
+  }
+
+  const detail = [
+    type ? `type=${type}` : undefined,
+    code ? `code=${code}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  const summary = detail
+    ? `in-stream provider error (${detail})`
+    : "in-stream provider error";
+  return makeError(kind, retryable, summary);
+}
+
+/** OpenAI-compatible wire role for a normalized message role. */
+function toWireRole(role: MessageRole): "system" | "user" | "assistant" | "tool" {
+  return role;
+}
+
+/** Flatten a message's content parts to plain text (Phase 1 is text only). */
+function textOfContent(content: readonly MessageContent[]): string {
+  return content
+    .filter((part): part is Extract<MessageContent, { type: "text" }> => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+/**
+ * Detect a request that asks for a capability the provider has NOT declared, so
+ * it can be rejected BEFORE dispatch (design: reject unsupported rather than let
+ * the provider silently discard). Returns a reason string, or `undefined` if the
+ * request is serviceable.
+ */
+function unsupportedReason(
+  request: ModelRequest,
+  capabilities: ProviderCapabilities,
+): string | undefined {
+  for (const message of request.messages) {
+    for (const part of message.content) {
+      if (part.type === "image_ref" && !capabilities.images) {
+        return "request includes image content but the provider's images capability is disabled";
+      }
+      if (
+        (part.type === "tool_call" || part.type === "tool_result") &&
+        !capabilities.tools
+      ) {
+        return "request includes tool content but the provider's tools capability is disabled";
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Iterate a `ReadableStream<Uint8Array>` as an async generator, cancelling the
+ * reader on early exit. Abandoning the provider's stream (the harness cancelling)
+ * runs this `finally`, which cancels the reader and tears down the fetch body —
+ * the provider's resource-release contract, with limits owned by the harness (D1).
+ */
+async function* readableToByteChunks(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<Uint8Array> {
+  const reader = stream.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      yield value;
+    }
+  } finally {
+    // Best-effort cancel; releases the underlying connection on early abandonment.
+    void reader.cancel().catch(() => {
+      /* reader may already be closed/errored — nothing actionable to do. */
+    });
+  }
+}
+
+/**
+ * `ModelProvider` over streamed OpenAI-compatible Chat Completions. Text only for
+ * Phase 1; see the file header for scope and the capability contract.
+ */
+export class OpenAICompatibleProvider implements ModelProvider {
+  readonly id: string;
+  readonly capabilities: ProviderCapabilities;
+
+  private readonly endpoint: string;
+  private readonly apiKey?: string;
+  private readonly optionsNamespace: string;
+  private readonly extraHeaders: Record<string, string>;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(config: OpenAICompatibleProviderConfig) {
+    this.id = config.id ?? "openai-compatible";
+    this.capabilities = { ...CONSERVATIVE_CAPABILITIES, ...(config.capabilities ?? {}) };
+    this.endpoint = `${config.baseUrl.replace(/\/+$/, "")}/chat/completions`;
+    if (config.apiKey !== undefined) this.apiKey = config.apiKey;
+    this.optionsNamespace = config.optionsNamespace ?? "openai";
+    this.extraHeaders = { ...(config.headers ?? {}) };
+    this.fetchImpl = config.fetch ?? ((input, init) => fetch(input, init));
+  }
+
+  /** Assemble the Chat Completions wire body from the normalized request. */
+  private buildBody(request: ModelRequest): Record<string, unknown> {
+    const messages: { role: string; content: string }[] = [];
+    if (request.instructions) {
+      messages.push({ role: "system", content: request.instructions });
+    }
+    for (const message of request.messages) {
+      messages.push({
+        role: toWireRole(message.role),
+        content: textOfContent(message.content),
+      });
+    }
+
+    const body: Record<string, unknown> = {
+      model: request.model,
+      messages,
+      stream: true,
+      // Ask for usage in the terminal frame; compatible servers MAY ignore this,
+      // which the parser + provider handle by emitting no usage event.
+      stream_options: { include_usage: true },
+    };
+    if (typeof request.maxOutputTokens === "number") {
+      body.max_tokens = request.maxOutputTokens;
+    }
+    // The single namespaced provider-only escape hatch (design open Q5). Merged
+    // last so a profile can set sampling knobs the core contract does not model.
+    const extra = request.options?.[this.optionsNamespace];
+    if (extra) Object.assign(body, extra);
+    return body;
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
+    // 1. Reject unsupported capabilities BEFORE any network call.
+    const reason = unsupportedReason(request, this.capabilities);
+    if (reason) {
+      yield { type: "error", error: makeError("unsupported_capability", false, reason) };
+      return;
+    }
+
+    // 2. POST the streamed request. A pre-response failure (DNS, refused) → unavailable.
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      ...this.extraHeaders,
+    };
+    if (this.apiKey) headers.authorization = `Bearer ${this.apiKey}`;
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(this.endpoint, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(this.buildBody(request)),
+      });
+    } catch {
+      // The thrown error may reference the URL but never the key; use a fixed,
+      // secret-free summary regardless.
+      yield {
+        type: "error",
+        error: makeError("unavailable", true, "failed to reach provider"),
+      };
+      return;
+    }
+
+    // 3. Non-2xx → normalized error, no stream started.
+    if (!response.ok) {
+      yield { type: "error", error: statusToProviderError(response) };
+      return;
+    }
+
+    // 4. Committed 200 — the response has started.
+    const providerRequestId = extractRequestId(response);
+    yield providerRequestId !== undefined
+      ? { type: "response.started", providerRequestId }
+      : { type: "response.started" };
+
+    if (!response.body) {
+      // A 200 with no body is a malformed response for a streaming endpoint.
+      yield {
+        type: "error",
+        error: makeError("malformed_response", true, "empty response stream"),
+      };
+      return;
+    }
+
+    // 5. Parse the SSE stream, mapping parser events onto normalized ModelEvents.
+    // A well-formed Chat Completions stream terminates with a `finish_reason`
+    // and/or the `[DONE]` sentinel; a clean close with NEITHER is a truncated
+    // stream (the common shape when a connection is reset after a committed 200).
+    let finishReason: FinishReason | undefined;
+    try {
+      for await (const ev of parseChatCompletionsStream(
+        readableToByteChunks(response.body),
+      )) {
+        switch (ev.kind) {
+          case "text":
+            yield { type: "text.delta", text: ev.text };
+            break;
+          case "finish":
+            finishReason = ev.reason;
+            break;
+          case "usage":
+            yield ev.cacheReadTokens !== undefined
+              ? {
+                  type: "usage",
+                  inputTokens: ev.inputTokens,
+                  outputTokens: ev.outputTokens,
+                  cacheReadTokens: ev.cacheReadTokens,
+                }
+              : {
+                  type: "usage",
+                  inputTokens: ev.inputTokens,
+                  outputTokens: ev.outputTokens,
+                };
+            break;
+          case "stream-error":
+            // An error frame after 200 — terminal; no completed event.
+            yield { type: "error", error: inStreamPayloadToError(ev.payload) };
+            return;
+          case "malformed":
+            yield {
+              type: "error",
+              error: makeError("malformed_response", false, "malformed response stream"),
+            };
+            return;
+          case "done":
+            // Terminal sentinel — stop reading and finish cleanly below.
+            yield { type: "response.completed", finishReason: finishReason ?? "stop" };
+            return;
+        }
+      }
+    } catch {
+      // The byte stream threw mid-read — a truncated/aborted stream after 200.
+      yield {
+        type: "error",
+        error: makeError("malformed_response", true, "response stream ended unexpectedly"),
+      };
+      return;
+    }
+
+    // 6. Stream ended without `[DONE]`. If a `finish_reason` was seen, the server
+    // simply closed after the final frame (tolerated). If NOTHING terminal was
+    // seen, the stream was truncated after 200 — surface it as malformed.
+    if (finishReason === undefined) {
+      yield {
+        type: "error",
+        error: makeError(
+          "malformed_response",
+          true,
+          "response stream ended without a terminal frame",
+        ),
+      };
+      return;
+    }
+    yield { type: "response.completed", finishReason };
+  }
+}

--- a/src/providers/openai-compatible/chat-completions-provider.ts
+++ b/src/providers/openai-compatible/chat-completions-provider.ts
@@ -289,7 +289,21 @@ async function* readableToByteChunks(
   const reader = stream.getReader();
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      let result: Awaited<ReturnType<typeof reader.read>>;
+      try {
+        result = await reader.read();
+      } catch (_err) {
+        // A mid-stream read rejection — an aborted / truncated connection (incl.
+        // the way `ReadableStreamDefaultController.error()` surfaces under Bun,
+        // which rejects the pending `read()` rather than EOF-ing). END ITERATION
+        // CLEANLY so the provider's structural check ("stream ended without a
+        // terminal frame") classifies it as a normalized `malformed_response`,
+        // instead of letting the raw abort escape as an uncaught error. `_err`
+        // may carry raw provider/connection detail; it is deliberately dropped —
+        // nothing from it reaches a summary, event, or log.
+        return;
+      }
+      const { done, value } = result;
       if (done) return;
       yield value;
     }

--- a/src/providers/openai-compatible/stream-parser.ts
+++ b/src/providers/openai-compatible/stream-parser.ts
@@ -1,0 +1,232 @@
+// API-P1.2 (epic #2055, Phase 1, decision D2) — Chat Completions SSE stream
+// parser: the PORTABLE CORE of streamed OpenAI-compatible responses. Design
+// §"External protocol constraints → OpenAI-compatible services": target the
+// portable core of streamed Chat Completions; "OpenAI-compatible" is a family of
+// partial implementations, so parse defensively and never assume optional pieces
+// (notably `usage`, which many compatible servers — Ollama, LM Studio — omit).
+//
+// This module is TRANSPORT- and POLICY-neutral: it consumes a stream of raw byte
+// chunks and yields small, normalized parser events. It maps NOTHING to HTTP
+// status and constructs NO `ProviderError` (that is the provider's job) — it only
+// surfaces `stream-error` (an in-band `{"error": …}` frame) and `malformed`
+// (a `data:` line whose JSON did not parse) for the provider to classify.
+//
+// It never throws on unknown/extra fields (unknown event variants are ignored,
+// per the contract case) and never throws on its own; a truncated stream shows
+// up as the underlying byte iterator throwing, which propagates to the caller.
+
+import type { FinishReason } from "../../common/inference/types";
+
+/**
+ * One normalized event emitted by {@link parseChatCompletionsStream}. Deliberately
+ * smaller than the wire chunk: the provider translates these onto the public
+ * {@link import("../../common/inference/types").ModelEvent} union.
+ */
+export type ChatCompletionsParserEvent =
+  /** A content delta from `choices[].delta.content`. */
+  | { readonly kind: "text"; readonly text: string }
+  /** A normalized `choices[].finish_reason`. */
+  | { readonly kind: "finish"; readonly reason: FinishReason }
+  /** A usage frame — emitted ONLY when the server actually sent `usage`. */
+  | {
+      readonly kind: "usage";
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly cacheReadTokens?: number;
+    }
+  /** An in-band error frame (`{"error": …}`) delivered AFTER a committed 200. */
+  | { readonly kind: "stream-error"; readonly payload: unknown }
+  /** A `data:` line whose JSON failed to parse (malformed stream). */
+  | { readonly kind: "malformed"; readonly detail: string }
+  /** The terminal `data: [DONE]` sentinel. */
+  | { readonly kind: "done" };
+
+/**
+ * Map an OpenAI Chat Completions `finish_reason` onto the normalized
+ * {@link FinishReason}. Unknown/absent reasons collapse to `"stop"` — the parser
+ * only emits a `finish` event when the wire actually carried a non-null reason.
+ */
+function normalizeFinishReason(raw: unknown): FinishReason {
+  switch (raw) {
+    case "stop":
+      return "stop";
+    case "length":
+      return "length";
+    case "tool_calls":
+    case "function_call":
+      return "tool_use";
+    case "content_filter":
+      return "content_filter";
+    default:
+      return "stop";
+  }
+}
+
+/** Narrow an unknown to a plain object without widening to `any`. */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Translate one already-parsed Chat Completions chunk object into zero or more
+ * parser events. Defensive throughout: a chunk missing `choices`, `delta`, or
+ * `usage` simply yields fewer events rather than erroring.
+ */
+function* eventsForChunk(
+  obj: Record<string, unknown>,
+): Generator<ChatCompletionsParserEvent> {
+  // In-band error frame — a structured error delivered mid-stream (after 200).
+  if ("error" in obj && obj.error != null) {
+    yield { kind: "stream-error", payload: obj.error };
+    return;
+  }
+
+  const choices = Array.isArray(obj.choices) ? obj.choices : [];
+  // Chat Completions streams a single choice per chunk in the common case, but a
+  // server MAY interleave several; walk them all rather than assuming index 0.
+  for (const choice of choices) {
+    const choiceObj = asRecord(choice);
+    if (!choiceObj) continue;
+
+    const delta = asRecord(choiceObj.delta);
+    const content = delta?.content;
+    if (typeof content === "string" && content.length > 0) {
+      yield { kind: "text", text: content };
+    }
+
+    const finishReason = choiceObj.finish_reason;
+    if (finishReason != null) {
+      yield { kind: "finish", reason: normalizeFinishReason(finishReason) };
+    }
+  }
+
+  // Usage arrives on a late chunk (typically with empty `choices`) ONLY when the
+  // server honors `stream_options.include_usage`. Absence is normal — emit nothing.
+  const usage = asRecord(obj.usage);
+  if (usage) {
+    const inputTokens = asNumber(usage.prompt_tokens) ?? 0;
+    const outputTokens = asNumber(usage.completion_tokens) ?? 0;
+    const cacheReadTokens = asNumber(
+      asRecord(usage.prompt_tokens_details)?.cached_tokens,
+    );
+    yield cacheReadTokens !== undefined
+      ? { kind: "usage", inputTokens, outputTokens, cacheReadTokens }
+      : { kind: "usage", inputTokens, outputTokens };
+  }
+}
+
+/**
+ * Dispatch one fully-assembled SSE `data:` payload. Returns `true` when the
+ * terminal `[DONE]` sentinel was seen so the caller can stop reading.
+ */
+function* dispatchData(
+  data: string,
+): Generator<ChatCompletionsParserEvent, boolean> {
+  const trimmed = data.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed === "[DONE]") {
+    yield { kind: "done" };
+    return true;
+  }
+  let obj: unknown;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    // A `data:` frame that is not valid JSON — a malformed stream. Surface it and
+    // let the provider classify; do NOT throw (keeps the generator well-behaved).
+    yield { kind: "malformed", detail: "invalid JSON in SSE data frame" };
+    return true;
+  }
+  const record = asRecord(obj);
+  if (!record) {
+    // Valid JSON that is not an object (e.g. a bare number/string) — an unknown
+    // variant. Ignore it rather than aborting the stream.
+    return false;
+  }
+  yield* eventsForChunk(record);
+  return false;
+}
+
+/**
+ * Parse a Chat Completions Server-Sent Events byte stream into normalized
+ * {@link ChatCompletionsParserEvent}s.
+ *
+ * Handles:
+ *   - UTF-8 multi-byte graphemes split across chunk boundaries (streaming decode);
+ *   - `data:` lines split across arbitrary chunk boundaries (line buffering);
+ *   - multi-line `data:` fields (joined with `\n` per the SSE spec);
+ *   - the terminal `data: [DONE]` sentinel;
+ *   - `finish_reason`, `usage` (when present), and in-band `{"error": …}` frames;
+ *   - SSE comments (`:` lines) and non-`data` fields (`event:`/`id:`/`retry:`),
+ *     which are ignored.
+ *
+ * Never throws on its own. A truncated stream manifests as `byteChunks` throwing,
+ * which propagates to the caller (the provider maps it to a malformed response).
+ */
+export async function* parseChatCompletionsStream(
+  byteChunks: AsyncIterable<Uint8Array>,
+): AsyncGenerator<ChatCompletionsParserEvent> {
+  const decoder = new TextDecoder("utf-8");
+  let lineBuffer = "";
+  // Accumulated `data:` field lines for the SSE event currently being assembled.
+  let dataLines: string[] = [];
+
+  // Flush the current event's accumulated data (on a blank separator line or at
+  // end of stream). Yields its events and signals whether `[DONE]` was reached.
+  function* flushEvent(): Generator<ChatCompletionsParserEvent, boolean> {
+    if (dataLines.length === 0) return false;
+    const data = dataLines.join("\n");
+    dataLines = [];
+    return yield* dispatchData(data);
+  }
+
+  function* handleLine(
+    rawLine: string,
+  ): Generator<ChatCompletionsParserEvent, boolean> {
+    // Strip a trailing CR so CRLF-framed streams parse identically to LF.
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (line.length === 0) {
+      // Blank line — event boundary. Dispatch whatever data we accumulated.
+      return yield* flushEvent();
+    }
+    if (line.startsWith(":")) {
+      // SSE comment / keep-alive — ignore.
+      return false;
+    }
+    if (line.startsWith("data:")) {
+      let value = line.slice("data:".length);
+      if (value.startsWith(" ")) value = value.slice(1);
+      dataLines.push(value);
+      return false;
+    }
+    // Other SSE fields (`event:`, `id:`, `retry:`) carry no content we normalize.
+    return false;
+  }
+
+  for await (const chunk of byteChunks) {
+    lineBuffer += decoder.decode(chunk, { stream: true });
+    let newlineIndex = lineBuffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const rawLine = lineBuffer.slice(0, newlineIndex);
+      lineBuffer = lineBuffer.slice(newlineIndex + 1);
+      const done = yield* handleLine(rawLine);
+      if (done) return;
+      newlineIndex = lineBuffer.indexOf("\n");
+    }
+  }
+
+  // Flush any trailing bytes the decoder held, then any unterminated final line
+  // and pending event — some servers close without a trailing blank line.
+  lineBuffer += decoder.decode();
+  if (lineBuffer.length > 0) {
+    const done = yield* handleLine(lineBuffer);
+    if (done) return;
+  }
+  yield* flushEvent();
+}


### PR DESCRIPTION
Closes #2062 · Part of epic #2055 · Phase 1. OpenAI-compatible (Chat Completions) adapter (D2).

Adds `src/providers/openai-compatible/{stream-parser,chat-completions-provider}.ts` — `OpenAICompatibleProvider implements ModelProvider` over the portable core of streamed Chat Completions (targets generic compatible servers incl. local ones like Ollama/LM Studio). Text content for Phase 1. No OpenAI Responses API (out of scope).

- Pure SSE parser: streaming UTF-8 decode (graphemes split across frames), line-buffered `data:` frames, `[DONE]` sentinel, `finish_reason`, `usage` only if present, in-band error frames, unknown variants skipped. Clean close with no terminal frame → `malformed_response`.
- HTTP status → normalized `ProviderErrorKind` (401/403/408/429+retry-after/400/503/529/other); tolerates error-after-200 and truncated streams; rejects images/tools before dispatch with `unsupported_capability`. The provider credential is placed only on the transport auth header and appears in no event, error, or log (asserted by test).
- capabilities: conservative defaults (streaming true; tools/images/structuredOutput false; serverContinuation/promptCaching false), overridable from config.

Tests in `src/providers/openai-compatible/__tests__/` reuse the guard's exported shared cases + fake server; `contract.ts` untouched (sibling-safe). 15 pass incl. Unicode frame-splitting, unknown variants, each HTTP class, error-after-200 (message-not-leaked), truncation, **missing-usage (Ollama-style)**, unsupported-capability rejection (zero network), and secret-absence.

Note (integration seam for API-P1.3): the provider owns no cancellation/timeout — per design D1 the harness owns wall-clock/idle limits; the provider only releases the reader when the consumer abandons the stream. Its config currently uses a self-contained shape; the P0.4 registry maps the P0.2 profile onto it when both land.

Verification: `bunx tsc --noEmit` exit 0; `bunx eslint src/providers/openai-compatible` exit 0; `bun test src/providers/openai-compatible` → 15 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)