### PR TITLE
feat(inference): API-P0.4 — inference provider registry (profile→provider resolution)

### DIFF
--- a/src/common/inference/__tests__/registry.test.ts
+++ b/src/common/inference/__tests__/registry.test.ts
@@ -1,0 +1,311 @@
+/**
+ * API-P0.4 (epic #2055, Phase 0) — inference provider registry: profile →
+ * provider resolution, FAIL CLOSED.
+ *
+ * The registry is decoupled from the concrete provider classes (API-P1.1/P1.2,
+ * not on main): construction is via an INJECTED `protocol → factory` map. These
+ * tests inject a FAKE factory, so they exercise the registry's resolution +
+ * fail-closed logic on the contract alone.
+ *
+ * Locked in:
+ *   1. HAPPY — a known profile resolves to a bundle whose model / modelClass /
+ *      dataResidency / capabilities all come from config (via the fake factory).
+ *   2. UNKNOWN PROFILE — typed, catchable failure (not an uncaught throw).
+ *   3. MISSING PROVIDER — profile → undefined provider key ⇒ typed failure.
+ *   4. NO FACTORY — provider protocol with no registered factory ⇒ typed failure.
+ *   5. SECRETS — the factory receives the secret REFERENCE untouched; the
+ *      registry never resolves it.
+ */
+
+import { test, expect, describe } from "bun:test";
+import {
+  InferenceRegistry,
+  ProfileResolutionError,
+  type ProviderFactory,
+  type ProviderFactoryMap,
+} from "../registry";
+import type {
+  ProviderCapabilities,
+  ModelProvider,
+  ModelRequest,
+  ModelEvent,
+} from "../types";
+import { InferenceConfigSchema } from "../../types/cortex-config";
+
+// A capability matrix a fake provider advertises. Distinctive values so the
+// happy-path test can prove the resolved `capabilities` come from the provider
+// the factory built (which built them from config), not a hardcoded default.
+const FAKE_CAPS: ProviderCapabilities = {
+  streaming: true,
+  tools: true,
+  parallelTools: false,
+  images: false,
+  documents: false,
+  structuredOutput: true,
+  serverContinuation: false,
+  promptCaching: true,
+};
+
+/** Records what the injected factory saw, so tests can assert the seam. */
+interface FactorySpy {
+  readonly factory: ProviderFactory;
+  readonly calls: { name: string; apiKey: string; protocol: string }[];
+  readonly instances: number;
+}
+
+function makeFactorySpy(): FactorySpy {
+  const calls: FactorySpy["calls"] = [];
+  const state = { instances: 0 };
+  const factory: ProviderFactory = ({ name, config }) => {
+    calls.push({ name, apiKey: config.apiKey, protocol: config.protocol });
+    state.instances += 1;
+    const provider: ModelProvider = {
+      id: name,
+      // Derive capabilities from config so "capabilities come from config"
+      // holds through the factory seam; fall back to FAKE_CAPS.
+      capabilities: { ...FAKE_CAPS, ...(config.capabilities ?? {}) },
+      // eslint-disable-next-line require-yield
+      async *stream(_request: ModelRequest): AsyncIterable<ModelEvent> {
+        throw new Error("fake provider does not stream in this test");
+      },
+    };
+    return provider;
+  };
+  return {
+    factory,
+    calls,
+    get instances() {
+      return state.instances;
+    },
+  };
+}
+
+// A well-formed inference config parsed through the real schema, so the tests
+// resolve exactly what config load would hand the registry. Secrets are
+// `env:NAME` references (never literals), per the P0.2 schema.
+function baseConfig() {
+  return InferenceConfigSchema.parse({
+    providers: {
+      anthropic: {
+        protocol: "anthropic-messages",
+        baseUrl: "https://api.anthropic.example/v1",
+        apiKey: "env:ANTHROPIC_API_KEY",
+      },
+      openai: {
+        protocol: "openai-chat-completions",
+        baseUrl: "https://api.openai.example/v1",
+        apiKey: "env:OPENAI_API_KEY",
+      },
+    },
+    profiles: {
+      "frontier-eu": {
+        provider: "anthropic",
+        model: "claude-sonnet-4",
+        modelClass: "frontier",
+        dataResidency: "eu",
+      },
+    },
+  });
+}
+
+describe("InferenceRegistry.resolveProfile — happy path", () => {
+  test("resolves a known profile to a bundle sourced from config", () => {
+    const spy = makeFactorySpy();
+    const factories: ProviderFactoryMap = {
+      "anthropic-messages": spy.factory,
+    };
+    const registry = new InferenceRegistry(baseConfig(), factories);
+
+    const result = registry.resolveProfile("frontier-eu");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    const { profile } = result;
+
+    // model / modelClass / dataResidency come straight from the profile config.
+    expect(profile.model).toBe("claude-sonnet-4");
+    expect(profile.modelClass).toBe("frontier");
+    expect(profile.dataResidency).toBe("eu");
+    // capabilities come from the provider the factory built (config-derived).
+    expect(profile.capabilities).toEqual(FAKE_CAPS);
+    expect(profile.provider.id).toBe("anthropic");
+  });
+
+  test("caches the provider instance across resolves of the same provider", () => {
+    const spy = makeFactorySpy();
+    const config = InferenceConfigSchema.parse({
+      providers: {
+        anthropic: {
+          protocol: "anthropic-messages",
+          baseUrl: "https://api.anthropic.example/v1",
+          apiKey: "env:ANTHROPIC_API_KEY",
+        },
+      },
+      profiles: {
+        a: { provider: "anthropic", model: "m1", modelClass: "frontier" },
+        b: { provider: "anthropic", model: "m2", modelClass: "any" },
+      },
+    });
+    const registry = new InferenceRegistry(config, {
+      "anthropic-messages": spy.factory,
+    });
+
+    const a = registry.resolveProfile("a");
+    const b = registry.resolveProfile("b");
+    expect(a.ok && b.ok).toBe(true);
+    // One instantiation, shared instance.
+    expect(spy.instances).toBe(1);
+    if (a.ok && b.ok) {
+      expect(a.profile.provider).toBe(b.profile.provider);
+    }
+  });
+
+  test("passes the secret REFERENCE to the factory, never a resolved value", () => {
+    const spy = makeFactorySpy();
+    const registry = new InferenceRegistry(baseConfig(), {
+      "anthropic-messages": spy.factory,
+    });
+
+    registry.resolveProfile("frontier-eu");
+
+    expect(spy.calls).toHaveLength(1);
+    // The registry hands the `env:NAME` reference through untouched — it never
+    // reads the environment or materializes the secret.
+    expect(spy.calls[0]!.apiKey).toBe("env:ANTHROPIC_API_KEY");
+  });
+});
+
+describe("InferenceRegistry.resolveProfile — fail closed", () => {
+  test("unknown profile → typed failure, not an uncaught throw", () => {
+    const spy = makeFactorySpy();
+    const registry = new InferenceRegistry(baseConfig(), {
+      "anthropic-messages": spy.factory,
+    });
+
+    let result!: ReturnType<InferenceRegistry["resolveProfile"]>;
+    // Assert catchable: the call itself does NOT throw.
+    expect(() => {
+      result = registry.resolveProfile("does-not-exist");
+    }).not.toThrow();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toBeInstanceOf(ProfileResolutionError);
+    expect(result.error.code).toBe("unknown-profile");
+    expect(result.error.profileName).toBe("does-not-exist");
+    expect(result.error.message).toContain("does-not-exist");
+  });
+
+  test("profile → missing provider key → typed failure", () => {
+    const spy = makeFactorySpy();
+    // Hand-build a config with a dangling provider reference. The document-level
+    // schema refinement would reject this at load, so bypass it here to prove
+    // the registry ALSO fails closed at resolve time (defense in depth).
+    const config = {
+      providers: {
+        anthropic: InferenceConfigSchema.parse({
+          providers: {
+            anthropic: {
+              protocol: "anthropic-messages" as const,
+              baseUrl: "https://api.anthropic.example/v1",
+              apiKey: "env:ANTHROPIC_API_KEY",
+            },
+          },
+          profiles: {},
+        }).providers.anthropic!,
+      },
+      profiles: {
+        orphan: {
+          provider: "ghost",
+          model: "m",
+          modelClass: "any" as const,
+        },
+      },
+    };
+    const registry = new InferenceRegistry(config, {
+      "anthropic-messages": spy.factory,
+    });
+
+    const result = registry.resolveProfile("orphan");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toBeInstanceOf(ProfileResolutionError);
+    expect(result.error.code).toBe("missing-provider");
+    expect(result.error.message).toContain("ghost");
+    // The factory was never called — we failed before instantiation.
+    expect(spy.instances).toBe(0);
+  });
+
+  test("provider protocol with no registered factory → typed failure", () => {
+    // Config is valid, but the injected map has NO factory for the profile's
+    // provider protocol (`openai-chat-completions`).
+    const config = InferenceConfigSchema.parse({
+      providers: {
+        openai: {
+          protocol: "openai-chat-completions",
+          baseUrl: "https://api.openai.example/v1",
+          apiKey: "env:OPENAI_API_KEY",
+        },
+      },
+      profiles: {
+        cheap: { provider: "openai", model: "gpt-x", modelClass: "any" },
+      },
+    });
+    const spy = makeFactorySpy();
+    const registry = new InferenceRegistry(config, {
+      // Only anthropic registered; openai protocol has no factory.
+      "anthropic-messages": spy.factory,
+    });
+
+    let result!: ReturnType<InferenceRegistry["resolveProfile"]>;
+    expect(() => {
+      result = registry.resolveProfile("cheap");
+    }).not.toThrow();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected failure");
+    expect(result.error).toBeInstanceOf(ProfileResolutionError);
+    expect(result.error.code).toBe("no-factory-for-protocol");
+    expect(result.error.message).toContain("openai-chat-completions");
+    expect(spy.instances).toBe(0);
+  });
+});
+
+describe("InferenceRegistry.validateAll", () => {
+  test("returns no errors when every profile resolves", () => {
+    const registry = new InferenceRegistry(baseConfig(), {
+      "anthropic-messages": makeFactorySpy().factory,
+    });
+    expect(registry.validateAll()).toEqual([]);
+  });
+
+  test("surfaces the failing profiles for config-load pre-flight", () => {
+    // Valid config, but no factory registered for the openai profile.
+    const config = InferenceConfigSchema.parse({
+      providers: {
+        anthropic: {
+          protocol: "anthropic-messages",
+          baseUrl: "https://api.anthropic.example/v1",
+          apiKey: "env:ANTHROPIC_API_KEY",
+        },
+        openai: {
+          protocol: "openai-chat-completions",
+          baseUrl: "https://api.openai.example/v1",
+          apiKey: "env:OPENAI_API_KEY",
+        },
+      },
+      profiles: {
+        good: { provider: "anthropic", model: "m", modelClass: "frontier" },
+        bad: { provider: "openai", model: "g", modelClass: "any" },
+      },
+    });
+    const registry = new InferenceRegistry(config, {
+      "anthropic-messages": makeFactorySpy().factory,
+    });
+
+    const errors = registry.validateAll();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.code).toBe("no-factory-for-protocol");
+    expect(errors[0]!.profileName).toBe("bad");
+  });
+});

--- a/src/common/inference/registry.ts
+++ b/src/common/inference/registry.ts
@@ -1,0 +1,252 @@
+// API-P0.4 (epic #2055, Phase 0) — the inference provider registry: resolve an
+// `inferenceProfile` NAME into a concrete, ready-to-use `ModelProvider` plus the
+// operational facts the harness needs (model, capabilities, model class, data
+// residency). Design §"Harness selection" (fail-closed resolution), §Configuration.
+//
+// FAIL CLOSED is the whole point. An unknown profile, a profile whose provider
+// key is absent, or a provider whose `protocol` has no registered factory must
+// surface a clear, typed, catchable failure at config load / admission — NEVER a
+// throw deep in the token stream. `resolveProfile` therefore RETURNS a typed
+// result (`ProfileResolution`) rather than throwing for the expected failure
+// modes; `validateAll` lets the harness pre-flight every profile at load.
+//
+// DEPENDENCY-INJECTED provider construction. The registry does NOT import the
+// concrete provider classes (`AnthropicMessagesProvider` → API-P1.1,
+// `OpenAICompatibleProvider` → API-P1.2 — neither on main yet). Instead it takes
+// a factory map keyed by `protocol`. The harness slice (API-P1.3) injects the
+// real factories; tests inject fakes. Adding a protocol is a new map entry — no
+// call site in this file changes. This is the extension point (AC: "provider
+// instantiation is keyed by protocol, extensible without touching call sites").
+//
+// SECRETS NEVER MATERIALIZE HERE (P0.2 adversarial review nit). The registry
+// passes the schema-validated secret REFERENCE (`apiKey` / `headers.*`, each an
+// `env:NAME` ref) straight through to the factory on the untouched provider
+// config. It does NOT import or call `resolveSecretRef`, and places NO resolved
+// secret value on any object. Resolution stays at REQUEST time inside the
+// provider (the only correct place — see secret-ref.ts). Credentials belong in
+// the `apiKey` / `headers` reference fields ONLY; the profile `options` bag is an
+// opaque provider-knob escape hatch that cortex never inspects and never resolves
+// secrets from — never route a credential through `options`.
+
+import type { ProviderCapabilities, ModelProvider } from "./types";
+import type {
+  InferenceConfig,
+  InferenceProvider,
+  InferenceProfile,
+} from "../types/cortex-config";
+
+/** The wire protocols a provider can speak (mirrors the config enum). */
+export type InferenceProtocol = InferenceProvider["protocol"];
+
+/** The policy class a profile is permitted (mirrors the config enum). */
+export type ModelClass = InferenceProfile["modelClass"];
+
+/**
+ * Builds a {@link ModelProvider} from a single, schema-validated provider-config
+ * entry. Injected per `protocol` (dependency injection): API-P1.3 wires the real
+ * `AnthropicMessagesProvider` / `OpenAICompatibleProvider` constructors; tests
+ * wire fakes. The `config` passed in still carries the secret REFERENCES
+ * (`apiKey` / `headers.*` as `env:NAME`) untouched — the factory hands them to
+ * the provider, which resolves them at REQUEST time. The factory MUST NOT
+ * resolve or persist a secret value.
+ */
+export type ProviderFactory = (input: {
+  /** The provider's key in `inference.providers` — becomes the provider id. */
+  readonly name: string;
+  /** The schema-validated provider config, secret references intact. */
+  readonly config: InferenceProvider;
+}) => ModelProvider;
+
+/** A `protocol → factory` map. Partial: a protocol with no entry fails closed. */
+export type ProviderFactoryMap = Partial<
+  Record<InferenceProtocol, ProviderFactory>
+>;
+
+/** The concrete, ready-to-use bundle a resolved profile yields. */
+export interface ResolvedProfile {
+  /** The instantiated provider — the harness streams against this. */
+  readonly provider: ModelProvider;
+  /** Provider-neutral model id from the profile config. */
+  readonly model: string;
+  /**
+   * The provider's advertised capability matrix. Configured-only (issue #2057
+   * Q2) — the provider derives it from config; cortex never probes at startup.
+   */
+  readonly capabilities: ProviderCapabilities;
+  /** Policy: the egress class the profile is permitted (from config). */
+  readonly modelClass: ModelClass;
+  /** Policy: declared data-residency label (from config), when set. */
+  readonly dataResidency?: string;
+}
+
+/** The reasons a profile can fail to resolve. All fail closed. */
+export type ProfileResolutionErrorCode =
+  | "unknown-profile"
+  | "missing-provider"
+  | "no-factory-for-protocol"
+  | "provider-instantiation-failed";
+
+/**
+ * A typed, catchable resolution failure. Returned (not thrown) by
+ * {@link InferenceRegistry.resolveProfile} for the expected failure modes so a
+ * caller surfaces it at config load / admission instead of discovering it mid-
+ * stream. It extends `Error` so it carries a descriptive message + stack and is
+ * `instanceof`-checkable; callers may re-throw it if they prefer.
+ */
+export class ProfileResolutionError extends Error {
+  readonly code: ProfileResolutionErrorCode;
+  /** The profile name that failed to resolve. */
+  readonly profileName: string;
+
+  constructor(
+    code: ProfileResolutionErrorCode,
+    profileName: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProfileResolutionError";
+    this.code = code;
+    this.profileName = profileName;
+  }
+}
+
+/** The discriminated result of a profile resolution — never throws for the expected failures. */
+export type ProfileResolution =
+  | { readonly ok: true; readonly profile: ResolvedProfile }
+  | { readonly ok: false; readonly error: ProfileResolutionError };
+
+/**
+ * The inference provider registry. Built from a loaded `inference` config and an
+ * injected `protocol → factory` map; resolves profile names to ready-to-use
+ * provider bundles, failing closed on every unresolvable case.
+ *
+ * Provider instances are created LAZILY on first resolve and cached by provider
+ * key, so profiles sharing a provider reuse one instance.
+ */
+export class InferenceRegistry {
+  private readonly config: InferenceConfig;
+  private readonly factories: ProviderFactoryMap;
+  private readonly providerCache = new Map<string, ModelProvider>();
+
+  constructor(config: InferenceConfig, factories: ProviderFactoryMap) {
+    this.config = config;
+    this.factories = factories;
+  }
+
+  /** The profile names this registry knows about. */
+  profileNames(): string[] {
+    return Object.keys(this.config.profiles);
+  }
+
+  /**
+   * Resolve a profile NAME to its ready-to-use bundle, or a typed failure.
+   * Fail closed: unknown profile, missing provider, or a provider protocol with
+   * no registered factory each yield `{ ok: false, error }` — never a throw.
+   */
+  resolveProfile(name: string): ProfileResolution {
+    const profile = this.config.profiles[name];
+    if (profile === undefined) {
+      const known = this.profileNames();
+      return this.fail(
+        "unknown-profile",
+        name,
+        `inference profile "${name}" is not defined ` +
+          `(known profiles: ${known.length > 0 ? known.join(", ") : "<none>"}).`,
+      );
+    }
+
+    const providerConfig = this.config.providers[profile.provider];
+    if (providerConfig === undefined) {
+      const known = Object.keys(this.config.providers);
+      return this.fail(
+        "missing-provider",
+        name,
+        `inference profile "${name}" references provider "${profile.provider}" ` +
+          `which is not defined in inference.providers ` +
+          `(known providers: ${known.length > 0 ? known.join(", ") : "<none>"}).`,
+      );
+    }
+
+    const factory = this.factories[providerConfig.protocol];
+    if (factory === undefined) {
+      const registered = Object.keys(this.factories);
+      return this.fail(
+        "no-factory-for-protocol",
+        name,
+        `inference profile "${name}" needs a provider factory for protocol ` +
+          `"${providerConfig.protocol}" (provider "${profile.provider}"), but none ` +
+          `is registered (registered protocols: ` +
+          `${registered.length > 0 ? registered.join(", ") : "<none>"}).`,
+      );
+    }
+
+    let provider: ModelProvider;
+    try {
+      provider = this.instantiate(profile.provider, providerConfig, factory);
+    } catch (err) {
+      // Fail closed rather than letting a factory throw escape uncaught. The
+      // provider config is validated by schema, so this is unexpected — surface
+      // it as a typed, catchable failure at resolve time.
+      const detail = err instanceof Error ? err.message : String(err);
+      return this.fail(
+        "provider-instantiation-failed",
+        name,
+        `inference profile "${name}" could not instantiate provider ` +
+          `"${profile.provider}" (protocol "${providerConfig.protocol}"): ${detail}`,
+      );
+    }
+
+    return {
+      ok: true,
+      profile: {
+        provider,
+        model: profile.model,
+        capabilities: provider.capabilities,
+        modelClass: profile.modelClass,
+        ...(profile.dataResidency !== undefined
+          ? { dataResidency: profile.dataResidency }
+          : {}),
+      },
+    };
+  }
+
+  /**
+   * Resolve EVERY profile and return the failures. Empty array ⇒ every profile
+   * resolves. Call this at config load / admission to fail closed up front,
+   * before any request reaches a provider.
+   */
+  validateAll(): ProfileResolutionError[] {
+    const errors: ProfileResolutionError[] = [];
+    for (const name of this.profileNames()) {
+      const result = this.resolveProfile(name);
+      if (!result.ok) {
+        errors.push(result.error);
+      }
+    }
+    return errors;
+  }
+
+  private instantiate(
+    name: string,
+    config: InferenceProvider,
+    factory: ProviderFactory,
+  ): ModelProvider {
+    const cached = this.providerCache.get(name);
+    if (cached !== undefined) {
+      return cached;
+    }
+    // The factory receives the provider config with its secret REFERENCES
+    // (`apiKey` / `headers.*`) intact — the registry never resolves them.
+    const provider = factory({ name, config });
+    this.providerCache.set(name, provider);
+    return provider;
+  }
+
+  private fail(
+    code: ProfileResolutionErrorCode,
+    profileName: string,
+    message: string,
+  ): { ok: false; error: ProfileResolutionError } {
+    return { ok: false, error: new ProfileResolutionError(code, profileName, message) };
+  }
+}


### PR DESCRIPTION
Closes #2059 · Part of epic #2055 · Phase 0. Inference provider registry (profile → provider resolution).

Adds `src/common/inference/registry.ts` — resolves an inference profile name into a ready provider bundle, fail-closed.

- **DI factory seam:** the registry takes an injected `Partial<Record<protocol, ProviderFactory>>`; it does NOT import the concrete provider classes (they land in #2061/#2062). The API-P1.3 harness slice injects the real factories. Adding a protocol is a new map entry — `resolveProfile` and all call sites untouched. A protocol with no registered factory fails closed automatically.
- **`resolveProfile(name)`** returns a discriminated result (`{ok:true,profile}` | `{ok:false,error}`) — never an uncaught throw for the expected failures (unknown-profile / missing-provider / no-factory-for-protocol / provider-instantiation-failed). Error is `instanceof`-checkable with `code` + `profileName`. `validateAll()` lets config load / admission pre-flight every profile up front. Resolved model/modelClass/dataResidency come from config; capabilities from the instantiated provider (configured-only, no probe). Providers cached by key.
- **Secrets stay at request time:** the registry does not resolve credentials — it passes the schema-validated provider config (references intact) straight to the factory; no resolved value lands on any object (asserted by test). Added the review-nit doc note steering credentials to the reference fields, never the opaque options bag.

Verification: `bunx tsc --noEmit` exit 0; `bunx eslint src/common/inference` exit 0; `bun test src/common/inference` → 22 pass / 0 fail (7 new registry tests: happy resolve + each fail-closed mode). Vocab-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)