### PR TITLE
feat(substrates): API-P1.3 — ApiAgentHarness (no tools) + agent loop + resolver wiring

### DIFF
--- a/src/common/inference/inference-config-schema.ts
+++ b/src/common/inference/inference-config-schema.ts
@@ -1,0 +1,155 @@
+// API-P0.2 (epic #2055, D6) — the machine-layer `inference` config SCHEMA,
+// extracted to a dependency-free LEAF module so BOTH top-level config shapes
+// (`CortexConfigSchema` in `../types/cortex-config.ts` AND the legacy
+// `AgentConfigSchema` in `../types/config.ts`) can carry an `inference` block by
+// importing this file — WITHOUT the config↔cortex-config import cycle that a
+// shared definition living in either of those files would create (API-P1.3,
+// #2063). `cortex-config.ts` re-exports these symbols, so every existing
+// `import … from "../types/cortex-config"` keeps working unchanged.
+//
+// This module depends only on zod + the two leaf inference modules
+// (`./secret-ref`, `./types`) — never on a config module — so it can be imported
+// from anywhere without a cycle.
+//
+// Security posture (design §"Secrets and egress", D6):
+//   - `providers.*.apiKey` and every `providers.*.headers.*` value is a SECRET
+//     REFERENCE (`env:NAME`, see {@link SecretRefSchema}), never a literal.
+//     Resolution to the value happens at CALL TIME in the harness/factory
+//     ({@link resolveSecretRef}); the parsed/serialized config holds only the
+//     reference, so a config dump/log shows `env:NAME`, never the secret.
+//   - `providers.*.baseUrl` is a reviewed MODEL-EGRESS destination — this block
+//     is the single place those destinations are declared.
+//   - Profiles are POLICY-BEARING: `modelClass` + `dataResidency` carry the
+//     class + data residency the registry/harness enforce.
+//
+// Phase-0 decisions baked in (issue #2057 stop-and-ask):
+//   - Q2 capabilities are CONFIGURED-ONLY (an optional static override), never
+//     probed at startup.
+//   - Q5 provider-specific knobs live under ONE namespaced opaque `options`
+//     escape hatch per profile — no vendor wire fields as first-class config.
+
+import { z } from "zod/v4";
+
+import { SecretRefSchema } from "./secret-ref";
+import type { ProviderCapabilities } from "./types";
+
+/**
+ * Optional static capability override for a provider. Keys align 1:1 with
+ * {@link ProviderCapabilities} (API-P0.3); every field is optional so a config
+ * declares only the flags it means to override. CONFIGURED-only (issue #2057
+ * Q2) — cortex does NOT probe a provider at startup; whatever is (or isn't)
+ * declared here is the whole truth. The `satisfies` check binds the shape to
+ * `ProviderCapabilities` so a drift in the contract fails typecheck here.
+ */
+export const ProviderCapabilitiesOverrideSchema = z
+  .object({
+    streaming: z.boolean().optional(),
+    tools: z.boolean().optional(),
+    parallelTools: z.boolean().optional(),
+    images: z.boolean().optional(),
+    documents: z.boolean().optional(),
+    structuredOutput: z.boolean().optional(),
+    serverContinuation: z.boolean().optional(),
+    promptCaching: z.boolean().optional(),
+  })
+  .strict();
+
+// Compile-time guard: the override keys are exactly the ProviderCapabilities
+// keys (all made optional). If API-P0.3 adds/removes/renames a capability, this
+// assignment fails typecheck until the override schema is updated in lockstep.
+type _CapabilitiesOverrideMatchesContract = z.infer<
+  typeof ProviderCapabilitiesOverrideSchema
+> extends Partial<ProviderCapabilities>
+  ? Partial<ProviderCapabilities> extends z.infer<typeof ProviderCapabilitiesOverrideSchema>
+    ? true
+    : never
+  : never;
+const _capabilitiesOverrideContractOk: _CapabilitiesOverrideMatchesContract = true;
+void _capabilitiesOverrideContractOk;
+
+/**
+ * A model-provider declaration: the wire protocol, the reviewed egress
+ * destination (`baseUrl`), and the SECRET-REFERENCE credentials. `apiKey` and
+ * every `headers` value are `env:NAME` references (never literals) resolved at
+ * call time — the parsed config never carries a resolved secret.
+ */
+export const InferenceProviderSchema = z
+  .object({
+    /** Wire protocol the harness speaks to this provider. */
+    protocol: z.enum(["anthropic-messages", "openai-chat-completions"]),
+    /** Reviewed model-egress destination. Declared here so egress review has one file. */
+    baseUrl: z.url(),
+    /** Provider API key — a `env:NAME` secret reference, resolved at call time, never a literal. */
+    apiKey: SecretRefSchema,
+    /**
+     * Optional extra request headers. Values are ALSO secret references
+     * (`env:NAME`) — a header can carry a token — resolved at call time, never
+     * literals on the parsed config.
+     */
+    headers: z.record(z.string().min(1), SecretRefSchema).optional(),
+    /** Optional static capability override (configured-only; no startup probe). */
+    capabilities: ProviderCapabilitiesOverrideSchema.optional(),
+  })
+  .strict();
+
+/**
+ * A named inference profile: the policy-bearing selection of a provider + model
+ * + generation bound + model class + data residency. `provider` must name a key
+ * in the sibling `providers` map (enforced by the document-level refinement on
+ * {@link InferenceConfigSchema}).
+ */
+export const InferenceProfileSchema = z
+  .object({
+    /** Key into the sibling `providers` map. Validated to exist at load. */
+    provider: z.string().min(1),
+    /** Provider-neutral model id. */
+    model: z.string().min(1),
+    /** Upper bound on generated tokens. Optional. */
+    maxOutputTokens: z.number().int().positive().optional(),
+    /** Policy: the egress class this profile is permitted. */
+    modelClass: z.enum(["local-only", "frontier", "any"]),
+    /** Policy: declared data-residency label (opaque string; e.g. `us`, `eu`). Optional. */
+    dataResidency: z.string().min(1).optional(),
+    /**
+     * Q5 escape hatch: a SINGLE namespaced, opaque bag of provider-only knobs.
+     * Keyed by provider namespace (e.g. `anthropic`); values are opaque and
+     * never inspected as portable config. Mirrors `ProviderOptions` (API-P0.3).
+     * Portable behaviour must NOT depend on anything here.
+     */
+    options: z.record(z.string().min(1), z.record(z.string(), z.unknown())).optional(),
+  })
+  .strict();
+
+/**
+ * The `inference` config block: a map of providers + a map of profiles.
+ *
+ * Document-level invariant (issue #2057 AC): every `profiles.*.provider` must
+ * name an existing `providers.*` key. A dangling reference fails config load
+ * with a descriptive, per-offender error rather than silently producing a
+ * profile that can never resolve to a provider instance.
+ */
+export const InferenceConfigSchema = z
+  .object({
+    providers: z.record(z.string().min(1), InferenceProviderSchema).default({}),
+    profiles: z.record(z.string().min(1), InferenceProfileSchema).default({}),
+  })
+  .superRefine((cfg, ctx) => {
+    for (const [profileName, profile] of Object.entries(cfg.profiles)) {
+      if (!(profile.provider in cfg.providers)) {
+        const known = Object.keys(cfg.providers);
+        ctx.addIssue({
+          code: "custom",
+          path: ["profiles", profileName, "provider"],
+          message:
+            `inference profile "${profileName}" references provider ` +
+            `"${profile.provider}" which is not defined in inference.providers ` +
+            `(known providers: ${known.length > 0 ? known.join(", ") : "<none>"}).`,
+        });
+      }
+    }
+  });
+
+export type ProviderCapabilitiesOverride = z.infer<typeof ProviderCapabilitiesOverrideSchema>;
+export type InferenceProvider = z.infer<typeof InferenceProviderSchema>;
+export type InferenceProfile = z.infer<typeof InferenceProfileSchema>;
+export type InferenceConfig = z.infer<typeof InferenceConfigSchema>;

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -9,6 +9,11 @@
 import { z } from "zod/v4";
 import { NKEY_PUBKEY_REGEX } from "./nkey";
 import { NatsSubjectsSchema } from "./nats-subjects";
+// API-P1.3 (#2063) — the machine-layer model-provider block. Imported from the
+// dependency-free leaf (NOT `./cortex-config`, which imports THIS file — that
+// would be an eval-order cycle) so both top-level config shapes can carry an
+// `inference` block. `cortex-config.ts` re-exports the same symbol.
+import { InferenceConfigSchema } from "../inference/inference-config-schema";
 import { checkLoopbackSideband, DEFAULT_SIDEBAND_URL } from "../sideband/loopback";
 
 // =============================================================================
@@ -712,6 +717,19 @@ export const AgentConfigSchema = z.object({
       endpoint: z.string(),
     })).default([]),
   }).default(emptyDefault()),
+
+  /**
+   * API-P1.3 (#2063) — model-provider config (`providers` + `profiles`), the
+   * machine-layer block the `ApiAgentHarness` resolves `substrate: api-agent`
+   * agents' `inferenceProfile` against. MIRROR of `CortexConfigSchema.inference`
+   * (see `./cortex-config.ts` for the full security posture — `env:NAME` secret
+   * references, reviewed egress `baseUrl`, policy-bearing `modelClass`).
+   * OPTIONAL (not defaulted) so every pre-existing hand-built `AgentConfig`
+   * literal + fixture stays valid without change — an absent block reads as
+   * `undefined`, and boot substitutes an empty registry (any `api-agent`
+   * dispatch then fails closed at the harness).
+   */
+  inference: InferenceConfigSchema.optional(),
 
   /** cortex#1792 (S6, ADR-0024 D3/OQ6/OQ9) — external plugin-bundle loading
    *  gate (`system.plugins.external`), default off. MIRROR: see

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -35,8 +35,22 @@
 import { z } from "zod/v4";
 
 import { BRAIN_PROTOCOL_ID } from "../../brain/protocol";
-import { SecretRefSchema } from "../inference/secret-ref";
-import type { ProviderCapabilities } from "../inference/types";
+// API-P1.3 (#2063) — the `inference` schema now lives in a dependency-free leaf
+// (see the re-export block below for why). Imported here for the `inference`
+// field on `CortexConfigSchema` AND re-exported so existing importers of these
+// symbols from `../types/cortex-config` keep resolving unchanged.
+import {
+  ProviderCapabilitiesOverrideSchema,
+  InferenceProviderSchema,
+  InferenceProfileSchema,
+  InferenceConfigSchema,
+} from "../inference/inference-config-schema";
+import type {
+  ProviderCapabilitiesOverride,
+  InferenceProvider,
+  InferenceProfile,
+  InferenceConfig,
+} from "../inference/inference-config-schema";
 import { CapabilitySchema } from "./capability";
 import { REVIEW_FLAVORS, reviewFlavorOfCapability } from "./review-flavors";
 import {
@@ -644,6 +658,16 @@ export const AgentRuntimeSchema = z.object({
    *  the legacy `pi-dev` value is the back-compat shim that `resolveReviewEngine`
    *  maps to `engine: sage`. */
   substrate: z.enum(["claude-code", "codex", "pi-dev", "cursor", "custom", "api-agent"]).optional(),
+  /**
+   * API-P1.3 (epic #2055, Phase 1) — the named inference profile this agent
+   * dispatches against when `substrate: api-agent`. Names a key in the
+   * machine-layer `inference.profiles` map; the `ApiAgentHarness` resolves it
+   * through the {@link InferenceRegistry} at dispatch time (fail closed when the
+   * name is unknown / its provider is missing). Ignored by every other
+   * substrate. Optional: an `api-agent` agent with no profile fails closed at
+   * dispatch (a clear terminal), never silently falling back to a default model.
+   */
+  inferenceProfile: z.string().min(1).optional(),
   /** Dispatch mode. `in-process` = cortex's runner spawns the substrate;
    *  `standalone` = arc-installed daemon connects to the bus directly. */
   mode: z.enum(["in-process", "standalone"]),
@@ -1599,126 +1623,25 @@ export type ExecutionConfig = z.infer<typeof ExecutionConfigSchema>;
 //   - Q5 provider-specific knobs live under ONE namespaced opaque `options`
 //     escape hatch per profile — no vendor wire fields as first-class config.
 
-/**
- * Optional static capability override for a provider. Keys align 1:1 with
- * {@link ProviderCapabilities} (API-P0.3); every field is optional so a config
- * declares only the flags it means to override. CONFIGURED-only (issue #2057
- * Q2) — cortex does NOT probe a provider at startup; whatever is (or isn't)
- * declared here is the whole truth. The `satisfies` check binds the shape to
- * `ProviderCapabilities` so a drift in the contract fails typecheck here.
- */
-export const ProviderCapabilitiesOverrideSchema = z
-  .object({
-    streaming: z.boolean().optional(),
-    tools: z.boolean().optional(),
-    parallelTools: z.boolean().optional(),
-    images: z.boolean().optional(),
-    documents: z.boolean().optional(),
-    structuredOutput: z.boolean().optional(),
-    serverContinuation: z.boolean().optional(),
-    promptCaching: z.boolean().optional(),
-  })
-  .strict();
-
-// Compile-time guard: the override keys are exactly the ProviderCapabilities
-// keys (all made optional). If API-P0.3 adds/removes/renames a capability, this
-// assignment fails typecheck until the override schema is updated in lockstep.
-type _CapabilitiesOverrideMatchesContract = z.infer<
-  typeof ProviderCapabilitiesOverrideSchema
-> extends Partial<ProviderCapabilities>
-  ? Partial<ProviderCapabilities> extends z.infer<typeof ProviderCapabilitiesOverrideSchema>
-    ? true
-    : never
-  : never;
-const _capabilitiesOverrideContractOk: _CapabilitiesOverrideMatchesContract = true;
-void _capabilitiesOverrideContractOk;
-
-/**
- * A model-provider declaration: the wire protocol, the reviewed egress
- * destination (`baseUrl`), and the SECRET-REFERENCE credentials. `apiKey` and
- * every `headers` value are `env:NAME` references (never literals) resolved at
- * call time — the parsed config never carries a resolved secret.
- */
-export const InferenceProviderSchema = z
-  .object({
-    /** Wire protocol the harness speaks to this provider. */
-    protocol: z.enum(["anthropic-messages", "openai-chat-completions"]),
-    /** Reviewed model-egress destination. Declared here so egress review has one file. */
-    baseUrl: z.url(),
-    /** Provider API key — a `env:NAME` secret reference, resolved at call time, never a literal. */
-    apiKey: SecretRefSchema,
-    /**
-     * Optional extra request headers. Values are ALSO secret references
-     * (`env:NAME`) — a header can carry a token — resolved at call time, never
-     * literals on the parsed config.
-     */
-    headers: z.record(z.string().min(1), SecretRefSchema).optional(),
-    /** Optional static capability override (configured-only; no startup probe). */
-    capabilities: ProviderCapabilitiesOverrideSchema.optional(),
-  })
-  .strict();
-
-/**
- * A named inference profile: the policy-bearing selection of a provider + model
- * + generation bound + model class + data residency. `provider` must name a key
- * in the sibling `providers` map (enforced by the document-level refinement on
- * {@link InferenceConfigSchema}).
- */
-export const InferenceProfileSchema = z
-  .object({
-    /** Key into the sibling `providers` map. Validated to exist at load. */
-    provider: z.string().min(1),
-    /** Provider-neutral model id. */
-    model: z.string().min(1),
-    /** Upper bound on generated tokens. Optional. */
-    maxOutputTokens: z.number().int().positive().optional(),
-    /** Policy: the egress class this profile is permitted. */
-    modelClass: z.enum(["local-only", "frontier", "any"]),
-    /** Policy: declared data-residency label (opaque string; e.g. `us`, `eu`). Optional. */
-    dataResidency: z.string().min(1).optional(),
-    /**
-     * Q5 escape hatch: a SINGLE namespaced, opaque bag of provider-only knobs.
-     * Keyed by provider namespace (e.g. `anthropic`); values are opaque and
-     * never inspected as portable config. Mirrors `ProviderOptions` (API-P0.3).
-     * Portable behaviour must NOT depend on anything here.
-     */
-    options: z.record(z.string().min(1), z.record(z.string(), z.unknown())).optional(),
-  })
-  .strict();
-
-/**
- * The `inference` config block: a map of providers + a map of profiles.
- *
- * Document-level invariant (issue #2057 AC): every `profiles.*.provider` must
- * name an existing `providers.*` key. A dangling reference fails config load
- * with a descriptive, per-offender error rather than silently producing a
- * profile that can never resolve to a provider instance.
- */
-export const InferenceConfigSchema = z
-  .object({
-    providers: z.record(z.string().min(1), InferenceProviderSchema).default({}),
-    profiles: z.record(z.string().min(1), InferenceProfileSchema).default({}),
-  })
-  .superRefine((cfg, ctx) => {
-    for (const [profileName, profile] of Object.entries(cfg.profiles)) {
-      if (!(profile.provider in cfg.providers)) {
-        const known = Object.keys(cfg.providers);
-        ctx.addIssue({
-          code: "custom",
-          path: ["profiles", profileName, "provider"],
-          message:
-            `inference profile "${profileName}" references provider ` +
-            `"${profile.provider}" which is not defined in inference.providers ` +
-            `(known providers: ${known.length > 0 ? known.join(", ") : "<none>"}).`,
-        });
-      }
-    }
-  });
-
-export type ProviderCapabilitiesOverride = z.infer<typeof ProviderCapabilitiesOverrideSchema>;
-export type InferenceProvider = z.infer<typeof InferenceProviderSchema>;
-export type InferenceProfile = z.infer<typeof InferenceProfileSchema>;
-export type InferenceConfig = z.infer<typeof InferenceConfigSchema>;
+// API-P1.3 (#2063) — the `inference` schema definitions were MOVED to the
+// dependency-free leaf `../inference/inference-config-schema.ts` so the legacy
+// `AgentConfigSchema` (in `./config.ts`) can also carry an `inference` block
+// without forming a config↔cortex-config import cycle. Re-exported here (from the
+// local imports at the top of this file) so every existing
+// `import … from "../types/cortex-config"` (registry, tests, harness) keeps
+// resolving unchanged. See that file for the full doc + security posture.
+export {
+  ProviderCapabilitiesOverrideSchema,
+  InferenceProviderSchema,
+  InferenceProfileSchema,
+  InferenceConfigSchema,
+};
+export type {
+  ProviderCapabilitiesOverride,
+  InferenceProvider,
+  InferenceProfile,
+  InferenceConfig,
+};
 
 /**
  * cortex#1792 (S6, ADR-0024 D3/OQ6/OQ9) — the `system.plugins.external` gate.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -144,6 +144,7 @@ import type { PluginRuntimeDeps, RendererHandle } from "./gateway/plugin-runtime
 import { deriveStackId, DEFAULT_STREAM_MAX_BYTES } from "./common/types/cortex-config";
 import type {
   Agent,
+  AgentRuntime,
   BusConfig,
   Policy,
   ReflexActivationConfig,
@@ -250,6 +251,9 @@ import type { Surfaces } from "./common/types/surfaces";
 import type { SurfaceGateway } from "./gateway/surface-gateway";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
+// API-P1.3 (#2063) — build the inference registry (real provider factories
+// injected) so `substrate: api-agent` agents resolve their `inferenceProfile`.
+import { createInferenceRegistry } from "./substrates/api-agent/provider-factories";
 // S2 (cortex#1160) — per-agent chat dispatch listeners derive their scoped
 // subscription subject (`local.{principal}.{stack}.tasks.@{enc-did}.>`) via the
 // canonical myelin subject builder so the subscribe-side pattern matches the
@@ -3684,10 +3688,26 @@ export async function startCortex(
   // Shared options every listener carries — only `receivingAgentId` + the
   // scoped `subjects` differ per agent. Built once so the per-agent wiring
   // can't drift between listeners.
+  // API-P1.3 (#2063) — thread receiving agents' runtime configs + the inference
+  // registry into the dispatch listener so `substrate: api-agent` agents resolve
+  // through the `ApiAgentHarness`. The map is the BOOT snapshot of `mergedAgents`
+  // (agents with a `runtime` block only); the registry wires the real provider
+  // factories over the machine-layer `inference` config (empty → any `api-agent`
+  // dispatch fails closed at the harness). claude-code agents are untouched.
+  const agentRuntimesById = new Map<string, AgentRuntime>();
+  for (const a of mergedAgents) {
+    if (a.runtime !== undefined) agentRuntimesById.set(a.id, a.runtime);
+  }
+  const inferenceRegistry = createInferenceRegistry(
+    config.inference ?? { providers: {}, profiles: {} },
+  );
+
   const sharedDispatchListenerOpts = {
     runtime,
     source: systemEventSource,
     stack: derivedStack.stack,
+    agentRuntimesById,
+    inferenceRegistry,
     ...(policyEngine !== undefined && { policyEngine }),
     trustResolver,
     // TC-0 (#628) — verifier knobs resolved from `security.signing`. `off`/

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -81,7 +81,12 @@ import {
   resolveSourceNetwork,
   subjectMatches,
 } from "../bus/surface-router";
-import type { PolicyFederated, PolicyFederatedNetwork } from "../common/types/cortex-config";
+import type {
+  AgentRuntime,
+  PolicyFederated,
+  PolicyFederatedNetwork,
+} from "../common/types/cortex-config";
+import type { InferenceRegistry } from "../common/inference/registry";
 import type {
   SystemAccessDeniedReason,
   SystemAccessSignedBy,
@@ -404,6 +409,22 @@ export interface DispatchListenerOptions {
    * that supply only one configure deliberately incomplete state).
    */
   receivingAgentId?: string;
+  /**
+   * API-P1.3 (#2063) — receiving agents' runtime configs indexed by agent id,
+   * used to thread the DISPATCHED-TO agent's `substrate` + `inferenceProfile`
+   * into the harness resolver. When present, the handler looks up the
+   * `receivingAgentId`'s `AgentRuntime` here and passes it to
+   * `HarnessResolver.resolve(...)` so `substrate: api-agent` agents dispatch
+   * through the `ApiAgentHarness`. Absent (or an agent with no `substrate`)
+   * preserves the pre-P1.3 behaviour — every ordinary dispatch → claude-code.
+   */
+  agentRuntimesById?: Map<string, AgentRuntime>;
+  /**
+   * API-P1.3 (#2063) — the inference registry the `api-agent` substrate resolves
+   * its profile through. Threaded to `HarnessResolver`. Absent on stacks with no
+   * `inference` config → an `api-agent` dispatch fails closed at the harness.
+   */
+  inferenceRegistry?: InferenceRegistry;
   /**
    * cortex#480 — the receiving stack's signing DID (e.g.
    * `did:mf:andreas-meta-factory`). Threaded through to
@@ -801,6 +822,8 @@ export function createDispatchListener(
     policyEngine,
     trustResolver,
     receivingAgentId,
+    agentRuntimesById,
+    inferenceRegistry,
     principalId,
     stackIdentity,
     stackNKeyPub,
@@ -882,6 +905,8 @@ export function createDispatchListener(
         rejectEmpty,
         principalId,
         receivingAgentId,
+        agentRuntimesById,
+        inferenceRegistry,
         stackIdentity,
         stackNKeyPub,
         resignSigner,
@@ -1309,6 +1334,10 @@ interface DispatchHandlerContext {
   rejectEmpty: boolean;
   principalId: string | undefined;
   receivingAgentId: string | undefined;
+  /** API-P1.3 (#2063) — receiving agents' runtime configs by id, for substrate selection. */
+  agentRuntimesById: Map<string, AgentRuntime> | undefined;
+  /** API-P1.3 (#2063) — inference registry the `api-agent` substrate resolves through. */
+  inferenceRegistry: InferenceRegistry | undefined;
   /** cortex#480 — receiving stack's signing DID for own-stack trust. */
   stackIdentity: string | undefined;
   /** cortex#480 — receiving stack's NKey pubkey for crypto-verify pass. */
@@ -1382,6 +1411,8 @@ async function handleDispatchEnvelope(
     rejectEmpty,
     principalId,
     receivingAgentId,
+    agentRuntimesById,
+    inferenceRegistry,
     stackIdentity,
     stackNKeyPub,
     resignSigner,
@@ -2074,18 +2105,24 @@ async function handleDispatchEnvelope(
   }
 
   // API-P0.5 (#2060, D3) — harness selection lives in the HarnessResolver
-  // seam, not inline. Construction is byte-identical to the pre-extraction
-  // ternary. The receiving agent's `AgentRuntime` is not threaded into this
-  // seam today (only `receivingAgentId`), so we pass `undefined` and the
-  // resolver falls to the `claude-code` default for ordinary dispatch (D3);
-  // API-P1.3 threads the real agent when it wires the `api-agent` substrate.
+  // seam, not inline. API-P1.3 (#2063) threads the DISPATCHED-TO agent's
+  // runtime config into the seam so `substrate: api-agent` agents resolve
+  // through the `ApiAgentHarness`. We look the receiving agent up by
+  // `receivingAgentId` in the runtime map (both may be absent — legacy /
+  // single-agent stacks — in which case `receivingAgent` is undefined and the
+  // resolver falls to the `claude-code` default, byte-identical to pre-P1.3).
+  const receivingAgent =
+    receivingAgentId !== undefined
+      ? agentRuntimesById?.get(receivingAgentId)
+      : undefined;
   const harnessResolver = new DefaultHarnessResolver({
     source,
     ccSessionFactory,
     agentTeamFactory,
+    ...(inferenceRegistry !== undefined && { inferenceRegistry }),
   });
   const harness: SessionHarness = harnessResolver.resolve(
-    undefined,
+    receivingAgent,
     envelope.distribution_mode,
   );
 
@@ -2101,7 +2138,9 @@ async function handleDispatchEnvelope(
     "session-spawning",
     "info",
     traceCtx,
-    envelope.distribution_mode === "delegate" ? "agent-team" : "claude-code",
+    // API-P1.3 — trace the ACTUAL resolved substrate (was hard-coded to
+    // delegate?agent-team:claude-code; now `api-agent` is a live third value).
+    harness.id,
   );
 
   // Drain the harness's lifecycle stream onto the bus. The harness

--- a/src/runner/harness-resolver.ts
+++ b/src/runner/harness-resolver.ts
@@ -21,12 +21,13 @@
 //                                        `substrate`, **defaulting to
 //                                        `claude-code` when unset** (D3).
 //
-// The ordinary-dispatch `switch` is deliberately structured so a future
-// `api-agent` substrate (API-P1.3) is a ONE-LINE addition — a new `case`
-// alongside `claude-code`. Do NOT add `api-agent` here (out of scope for
-// P0.5); today every substrate value resolves to `ClaudeCodeHarness`,
-// exactly as the pre-extraction ternary did (it never consulted the
-// substrate at all — all non-delegate dispatches went to claude-code).
+// The ordinary-dispatch `switch` selects on the receiving agent's configured
+// `substrate`, defaulting to `claude-code` when unset. API-P1.3 added the
+// `api-agent` case (direct-API harness resolved through the injected
+// `InferenceRegistry`); every other substrate value still resolves to
+// `ClaudeCodeHarness`, so a claude-code agent (or one with no substrate) behaves
+// exactly as the pre-extraction ternary did (all non-delegate dispatches →
+// claude-code).
 
 import type { AgentRuntime } from "../common/types/cortex-config";
 import type { DistributionMode } from "../bus/myelin/envelope-validator";
@@ -36,6 +37,8 @@ import {
   ClaudeCodeHarness,
   type CCSessionFactory,
 } from "../substrates/claude-code/harness";
+import { ApiAgentHarness } from "../substrates/api-agent/harness";
+import { InferenceRegistry } from "../common/inference/registry";
 import { AgentTeamHarness, type AgentTeamFactory } from "./agent-team";
 
 /**
@@ -56,6 +59,14 @@ export interface HarnessResolverDeps {
   source: SystemEventSource;
   ccSessionFactory: CCSessionFactory | undefined;
   agentTeamFactory: AgentTeamFactory | undefined;
+  /**
+   * API-P1.3 — the inference registry the `api-agent` substrate resolves its
+   * profile through. Optional so the pre-existing claude-code / delegate call
+   * sites and tests construct the resolver unchanged; when an `api-agent`
+   * dispatch arrives with no registry wired, the harness is built against an
+   * empty registry and fails closed (unknown-profile) at dispatch.
+   */
+  inferenceRegistry?: InferenceRegistry;
 }
 
 /**
@@ -97,11 +108,31 @@ export class DefaultHarnessResolver implements HarnessResolver {
     // behaviour (all non-delegate dispatches → ClaudeCodeHarness).
     const substrate = agent?.substrate ?? "claude-code";
     switch (substrate) {
-      // API-P1.3 will add: case "api-agent": return this.apiAgentHarness();
+      case "api-agent":
+        return this.apiAgentHarness(agent);
       case "claude-code":
       default:
         return this.claudeCodeHarness();
     }
+  }
+
+  /**
+   * API-P1.3 — the direct-API substrate. Reads the receiving agent's
+   * `inferenceProfile` (the harness fails closed when it is absent) and resolves
+   * it through the injected registry. When no registry was wired, use an empty
+   * one so an `api-agent` dispatch fails closed (`unknown-profile`) rather than
+   * throwing — the claude-code default path is unaffected.
+   */
+  private apiAgentHarness(agent: AgentRuntime | undefined): SessionHarness {
+    const { source } = this.deps;
+    const registry =
+      this.deps.inferenceRegistry ??
+      new InferenceRegistry({ providers: {}, profiles: {} }, {});
+    return new ApiAgentHarness({
+      source,
+      registry,
+      inferenceProfile: agent?.inferenceProfile,
+    });
   }
 
   private agentTeamHarness(): SessionHarness {

--- a/src/substrates/api-agent/__tests__/harness.test.ts
+++ b/src/substrates/api-agent/__tests__/harness.test.ts
@@ -1,0 +1,448 @@
+// API-P1.3 (issue #2063) — LIVE contract tests for `ApiAgentHarness`, driven end
+// to end through the harness → `InferenceRegistry` → real provider → shared fake
+// streaming server (API-P1.5 scaffold). Never a live provider, never paid creds.
+//
+// REUSE WITHOUT TOUCHING THE SHARED METER: the shared
+// `src/providers/__tests__/contract.ts` holds the epic progress meter (one
+// `test.todo` per case per gated slice) and is edited by a SIBLING slice — we
+// must not touch it. Instead we import its exported case-name constants
+// (`HARNESS_CONTRACT_CASES` + `PROVIDER_CONTRACT_CASES`) and the exported fake
+// server (`startFakeStreamingServer`), and name our live tests with those exact
+// strings, so this file is the api-agent-harness slice's live proof of the same
+// cases the meter tracks — with ZERO edits to the shared files.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  HARNESS_CONTRACT_CASES,
+  PROVIDER_CONTRACT_CASES,
+} from "../../../providers/__tests__/contract";
+import {
+  startFakeStreamingServer,
+  type FakeStreamingServer,
+} from "../../../providers/__tests__/fake-streaming-server";
+import { InferenceConfigSchema } from "../../../common/types/cortex-config";
+import type { DispatchEventSource } from "../../../bus/dispatch-events";
+import type {
+  DispatchRequest,
+  MyelinEnvelope,
+} from "../../../common/substrates/types";
+import { ApiAgentHarness } from "../harness";
+import { createInferenceRegistry } from "../provider-factories";
+import { DefaultHarnessResolver } from "../../../runner/harness-resolver";
+import type { AgentRuntime } from "../../../common/types/cortex-config";
+
+// Name harness tests verbatim from the shared meter's case lists (so a rename in
+// the meter breaks compilation here rather than silently drifting).
+const HCASE = (needle: string): string => {
+  const found = HARNESS_CONTRACT_CASES.find((c) => c.includes(needle));
+  if (!found) throw new Error(`no shared HARNESS contract case matching "${needle}"`);
+  return found;
+};
+const PCASE = (needle: string): string => {
+  const found = PROVIDER_CONTRACT_CASES.find((c) => c.includes(needle));
+  if (!found) throw new Error(`no shared PROVIDER contract case matching "${needle}"`);
+  return found;
+};
+
+const SOURCE: DispatchEventSource = {
+  principal: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+const REQUEST_ID = "11111111-1111-4111-8111-111111111111";
+const API_KEY = "sk-secret-DO-NOT-LEAK-abc123";
+const TEST_ENV = { TEST_KEY: API_KEY };
+const SSE_HEADERS = { "content-type": "text/event-stream" } as const;
+
+// ── SSE frame builders (OpenAI Chat Completions wire; the fake server ignores
+// the request path, so pointing baseUrl at it works for the openai adapter). ──
+const sse = (obj: unknown): string => `data: ${JSON.stringify(obj)}\n\n`;
+const DONE = "data: [DONE]\n\n";
+const contentChunk = (text: string): string =>
+  sse({ choices: [{ index: 0, delta: { content: text }, finish_reason: null }] });
+const finishChunk = (reason = "stop"): string =>
+  sse({ choices: [{ index: 0, delta: {}, finish_reason: reason }] });
+const usageChunk = (input: number, output: number): string =>
+  sse({ choices: [], usage: { prompt_tokens: input, completion_tokens: output } });
+
+let server: FakeStreamingServer;
+
+beforeEach(() => {
+  server = startFakeStreamingServer();
+});
+afterEach(async () => {
+  await server.stop();
+});
+
+/** Build a registry whose one profile points the openai adapter at the fake server. */
+function makeHarness(overrides?: {
+  inferenceProfile?: string | undefined;
+  now?: () => number;
+}): ApiAgentHarness {
+  const config = InferenceConfigSchema.parse({
+    providers: {
+      test: {
+        protocol: "openai-chat-completions",
+        baseUrl: `${server.url}/v1`,
+        apiKey: "env:TEST_KEY",
+      },
+    },
+    profiles: {
+      fast: { provider: "test", model: "test-model", modelClass: "any" },
+    },
+  });
+  const registry = createInferenceRegistry(config, { env: TEST_ENV });
+  return new ApiAgentHarness({
+    source: SOURCE,
+    registry,
+    inferenceProfile:
+      overrides !== undefined && "inferenceProfile" in overrides
+        ? overrides.inferenceProfile
+        : "fast",
+    ...(overrides?.now !== undefined ? { now: overrides.now } : {}),
+  });
+}
+
+function makeRequest(overrides: Partial<DispatchRequest> = {}): DispatchRequest {
+  return {
+    persona: { path: "/agents/cortex.md", content: "# Cortex\nBe terse." },
+    prompt: "say hello",
+    tools: { allow: [] },
+    context: [],
+    agent: { id: "cortex", displayName: "Cortex" },
+    requestId: REQUEST_ID,
+    ...overrides,
+  };
+}
+
+async function drain(it: AsyncIterable<MyelinEnvelope>): Promise<MyelinEnvelope[]> {
+  const out: MyelinEnvelope[] = [];
+  for await (const env of it) out.push(env);
+  return out;
+}
+
+const startedOf = (envs: MyelinEnvelope[]): MyelinEnvelope[] =>
+  envs.filter((e) => e.type === "dispatch.task.started");
+const terminalsOf = (envs: MyelinEnvelope[]): MyelinEnvelope[] =>
+  envs.filter(
+    (e) =>
+      e.type === "dispatch.task.completed" ||
+      e.type === "dispatch.task.failed" ||
+      e.type === "dispatch.task.aborted",
+  );
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// ── Happy path + lifecycle invariant ──────────────────────────────────────────
+describe("provider contract · api-agent-harness (live, #2063)", () => {
+  test(HCASE("exactly one started event"), async () => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("hi there") + finishChunk("stop") + DONE }],
+    });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    expect(startedOf(envs)).toHaveLength(1);
+    expect(envs[0]?.type).toBe("dispatch.task.started");
+  });
+
+  test(HCASE("exactly one terminal event"), async () => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("done") + finishChunk("stop") + DONE }],
+    });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    // Happy path → completed, carrying the assistant text.
+    expect(terminals[0]?.type).toBe("dispatch.task.completed");
+    expect(terminals[0]?.payload.chat_response).toBe("done");
+    // Terminal is the LAST yield; iterator closes after it.
+    expect(envs[envs.length - 1]?.type).toBe("dispatch.task.completed");
+  });
+
+  test(HCASE("correlation identifiers stable"), async () => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("x") + finishChunk("stop") + DONE }],
+    });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    const ids = new Set(envs.map((e) => e.correlation_id));
+    expect(ids.size).toBe(1);
+    expect([...ids][0]).toBe(REQUEST_ID); // UUID-shaped requestId is reused verbatim
+  });
+
+  test(HCASE("shuts down cleanly on request without leaking"), async () => {
+    // A stream that hangs open forces the harness's inactivity/abort path to own
+    // teardown. We shut down mid-flight and assert a clean single terminal — no
+    // hang (the afterEach `server.stop()` completing is the no-leak proof).
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("partial ") }],
+      hangOpen: true,
+    });
+    const harness = makeHarness();
+    const collected: Promise<MyelinEnvelope[]> = drain(harness.dispatch(makeRequest()));
+    await sleep(25); // let the loop enter its await on the hanging stream
+    await harness.shutdown({ graceful: false });
+
+    const envs = await collected;
+    expect(startedOf(envs)).toHaveLength(1);
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.aborted");
+  });
+
+  // ── Limits + cancellation ───────────────────────────────────────────────────
+  test(HCASE("fails closed on a denied policy / tool grant"), async () => {
+    // Tool grant present → rejected BEFORE any provider call (D5). ZERO network.
+    const envs = await drain(
+      makeHarness().dispatch(makeRequest({ tools: { allow: ["Bash"] } })),
+    );
+
+    expect(startedOf(envs)).toHaveLength(1);
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+    expect(String(terminals[0]?.payload.error_summary)).toContain(
+      "unsupported_capability",
+    );
+    expect(server.requests).toHaveLength(0); // never dispatched to the provider
+  });
+
+  test(PCASE("rejects an unsupported_capability request before dispatch"), async () => {
+    // Attachments present → rejected BEFORE any provider call. ZERO network.
+    const envs = await drain(
+      makeHarness().dispatch(
+        makeRequest({
+          context: [{ kind: "attachments", data: [{ filename: "x.png" }] }],
+        }),
+      ),
+    );
+
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+    expect(String(terminals[0]?.payload.error_summary)).toContain(
+      "unsupported_capability",
+    );
+    expect(server.requests).toHaveLength(0);
+  });
+
+  test(
+    PCASE("honors cancellation and both timeout types") + " · inactivity gap",
+    async () => {
+      server.enqueue({
+        status: 200,
+        headers: SSE_HEADERS,
+        chunks: [{ data: contentChunk("slow") }],
+        hangOpen: true,
+      });
+      const envs = await drain(
+        makeHarness().dispatch(
+          makeRequest({ timeoutMs: 10_000, inactivityMs: 40 }),
+        ),
+      );
+
+      const terminals = terminalsOf(envs);
+      expect(terminals).toHaveLength(1);
+      expect(terminals[0]?.type).toBe("dispatch.task.failed");
+      expect(String(terminals[0]?.payload.error_summary)).toContain("inactivity");
+    },
+  );
+
+  test(
+    PCASE("honors cancellation and both timeout types") + " · wall-clock deadline",
+    async () => {
+      server.enqueue({
+        status: 200,
+        headers: SSE_HEADERS,
+        chunks: [{ data: contentChunk("slow") }],
+        hangOpen: true,
+      });
+      const envs = await drain(
+        makeHarness().dispatch(
+          makeRequest({ timeoutMs: 40, inactivityMs: 10_000 }),
+        ),
+      );
+
+      const terminals = terminalsOf(envs);
+      expect(terminals).toHaveLength(1);
+      expect(terminals[0]?.type).toBe("dispatch.task.failed");
+      expect(String(terminals[0]?.payload.error_summary)).toContain("wall-clock");
+    },
+  );
+
+  test(
+    PCASE("honors cancellation and both timeout types") + " · cancellation → aborted",
+    async () => {
+      server.enqueue({
+        status: 200,
+        headers: SSE_HEADERS,
+        chunks: [{ data: contentChunk("partial ") }],
+        hangOpen: true,
+      });
+      const harness = makeHarness();
+      const collected = drain(harness.dispatch(makeRequest({ timeoutMs: 10_000 })));
+      await sleep(25);
+      await harness.shutdown({ graceful: false });
+
+      const envs = await collected;
+      const terminals = terminalsOf(envs);
+      expect(terminals).toHaveLength(1);
+      expect(terminals[0]?.type).toBe("dispatch.task.aborted");
+      expect(String(terminals[0]?.payload.reason)).toContain("cancelled");
+    },
+  );
+
+  // ── Provider error seam (providers YIELD errors; loop → failed terminal) ──────
+  test(PCASE("authentication (401)"), async () => {
+    server.enqueue({ status: 401, chunks: [{ data: '{"error":{"message":"nope-should-not-leak"}}' }] });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+    const summary = String(terminals[0]?.payload.error_summary);
+    expect(summary).toContain("401");
+    // The redacted provider summary carries no secret and no raw body detail.
+    expect(summary).not.toContain("nope-should-not-leak");
+    expect(summary).not.toContain(API_KEY);
+  });
+
+  test(PCASE("in-stream error that arrives AFTER a committed HTTP 200"), async () => {
+    const payload =
+      contentChunk("partial ") +
+      sse({ error: { type: "server_error", code: "internal", message: "boom-should-not-leak" } });
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+    expect(String(terminals[0]?.payload.error_summary)).not.toContain("boom-should-not-leak");
+  });
+
+  test(PCASE("malformed / truncated streams"), async () => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("half") }],
+      abortAfterChunks: true, // truncated: no terminal frame
+    });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+  });
+
+  // ── Usage accounting → Mission Control token fields ───────────────────────────
+  test(PCASE("normalizes usage from a final usage frame"), async () => {
+    const payload = contentChunk("hello") + finishChunk("stop") + usageChunk(11, 7) + DONE;
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+    const completed = envs.find((e) => e.type === "dispatch.task.completed");
+    expect(completed).toBeDefined();
+    // Usage lands on MC's existing token field names.
+    expect(completed?.payload.input_tokens).toBe(11);
+    expect(completed?.payload.output_tokens).toBe(7);
+  });
+
+  test(PCASE("omits the final usage frame (missing usage)"), async () => {
+    const payload = contentChunk("hello") + finishChunk("stop") + DONE;
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+    const completed = envs.find((e) => e.type === "dispatch.task.completed");
+    expect(completed).toBeDefined();
+    // No usage frame → no token fields fabricated on the wire.
+    expect(completed?.payload.input_tokens).toBeUndefined();
+    expect(completed?.payload.output_tokens).toBeUndefined();
+  });
+
+  test(PCASE("keeps secrets absent from errors, events, snapshots, and logs"), async () => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("hi") + finishChunk("stop") + DONE }],
+    });
+    const ok = await drain(makeHarness().dispatch(makeRequest()));
+    server.enqueue({ status: 401, chunks: [{ data: '{"error":{"message":"denied"}}' }] });
+    const bad = await drain(makeHarness().dispatch(makeRequest()));
+
+    const serialized = JSON.stringify([...ok, ...bad]);
+    expect(serialized).not.toContain(API_KEY);
+  });
+
+  // ── Profile resolution fails closed ───────────────────────────────────────────
+  test("fails closed to a failed terminal when the inferenceProfile is unknown", async () => {
+    const envs = await drain(
+      makeHarness({ inferenceProfile: "does-not-exist" }).dispatch(makeRequest()),
+    );
+    const terminals = terminalsOf(envs);
+    expect(startedOf(envs)).toHaveLength(1);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+    expect(server.requests).toHaveLength(0); // never reached a provider
+  });
+
+  test("fails closed to a failed terminal when no inferenceProfile is configured", async () => {
+    const envs = await drain(
+      makeHarness({ inferenceProfile: undefined }).dispatch(makeRequest()),
+    );
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+    expect(server.requests).toHaveLength(0);
+  });
+});
+
+// ── claude-code NON-REGRESSION (resolver selection unchanged) ──────────────────
+describe("harness resolver — substrate selection (api-agent + non-regression)", () => {
+  const deps = {
+    source: SOURCE,
+    ccSessionFactory: undefined,
+    agentTeamFactory: undefined,
+  };
+
+  test("undefined agent → claude-code (pre-P1.3 default preserved)", () => {
+    const resolver = new DefaultHarnessResolver(deps);
+    expect(resolver.resolve(undefined, undefined).id).toBe("claude-code");
+  });
+
+  test("substrate: claude-code → claude-code (unchanged)", () => {
+    const resolver = new DefaultHarnessResolver(deps);
+    const agent: AgentRuntime = {
+      substrate: "claude-code",
+      mode: "in-process",
+      capabilities: [],
+    };
+    expect(resolver.resolve(agent, undefined).id).toBe("claude-code");
+  });
+
+  test("delegate mode → agent-team (unchanged)", () => {
+    const resolver = new DefaultHarnessResolver(deps);
+    expect(resolver.resolve(undefined, "delegate").id).toBe("agent-team");
+  });
+
+  test("substrate: api-agent → api-agent", () => {
+    const resolver = new DefaultHarnessResolver(deps);
+    const agent: AgentRuntime = {
+      substrate: "api-agent",
+      inferenceProfile: "fast",
+      mode: "in-process",
+      capabilities: [],
+    };
+    expect(resolver.resolve(agent, undefined).id).toBe("api-agent");
+  });
+});

--- a/src/substrates/api-agent/agent-loop.ts
+++ b/src/substrates/api-agent/agent-loop.ts
@@ -1,0 +1,290 @@
+// API-P1.3 (epic #2055, Phase 1, decisions D1/D5) — the api-agent AGENT LOOP.
+//
+// The loop is the engine underneath `ApiAgentHarness`: it consumes a provider's
+// normalized `ModelProvider.stream(request)` and reduces it to a single terminal
+// OUTCOME (`completed` / `failed` / `aborted`) plus the accumulated assistant
+// text, usage, and provider request id. The harness (`./harness.ts`) turns that
+// outcome into the ONE terminal Myelin lifecycle envelope the `SessionHarness`
+// contract requires.
+//
+// WHY A PURE FUNCTION (not a generator): the harness owns the lifecycle-envelope
+// yields (exactly one `started`, exactly one terminal). The loop owns the
+// provider-stream mechanics — timers, cancellation, event accumulation — and
+// returns a value. Keeping the two apart makes the one-terminal invariant a
+// property of the harness's straight-line control flow, not of interleaved
+// generator state.
+//
+// LIMITS + CANCELLATION (D1 — cortex owns limits, not the provider): the loop
+// races each provider event against a wall-clock deadline AND an inactivity gap
+// (reset on every event), plus an injected `AbortSignal` for dispatch
+// cancellation. A timeout maps to a `failed` outcome (basic mapping; the full
+// error-kind→lifecycle table is the sibling slice API-P1.4); cancellation maps
+// to `aborted`. On any early exit the loop CLOSES the provider iterator
+// (`iterator.return()`), which runs the provider's stream `finally` and releases
+// the underlying HTTP connection — no leaked sockets.
+//
+// PROVIDER ERROR SEAM (D2 — providers YIELD an `{type:"error"}` event, never
+// throw): the loop consumes that event and maps it to a `failed` outcome
+// carrying ONLY the redacted `ProviderError.summary` — never raw detail, headers,
+// or secrets. A provider that nonetheless rejects `next()` (contract violation)
+// is caught and collapsed to a fixed, secret-free `failed` summary.
+//
+// NO TOOLS (D5): Phase 1 is text-only. If a provider emits a `tool_call.*` event
+// the loop IGNORES it (never executes anything) — tool execution is Phase 3.
+
+import type {
+  FinishReason,
+  ModelEvent,
+  ModelProvider,
+  ModelRequest,
+} from "../../common/inference/types";
+import type { ProviderError } from "../../common/inference/errors";
+
+/** Token accounting accumulated from the provider's `usage` event. */
+export interface AgentLoopUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+}
+
+/**
+ * The single terminal outcome the loop reduces a provider stream to. The harness
+ * maps this 1:1 onto a terminal lifecycle envelope.
+ */
+export type AgentLoopOutcome =
+  | {
+      kind: "completed";
+      /** Full accumulated assistant text (untruncated). */
+      text: string;
+      finishReason: FinishReason;
+      usage?: AgentLoopUsage;
+      providerRequestId?: string;
+    }
+  | {
+      kind: "failed";
+      /** REDACTED summary only — never raw provider detail or secrets. */
+      summary: string;
+      providerRequestId?: string;
+    }
+  | { kind: "aborted"; reason: string };
+
+/** Inputs to {@link runAgentLoop}. */
+export interface AgentLoopOptions {
+  provider: ModelProvider;
+  request: ModelRequest;
+  /** Wall-clock deadline for the whole dispatch, in ms. */
+  wallClockMs: number;
+  /** Max gap between provider events before the loop trips inactivity, in ms. */
+  inactivityMs: number;
+  /** Dispatch cancellation. When aborted the loop yields an `aborted` outcome. */
+  signal?: AbortSignal;
+  /** Injectable clock (tests). Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** Result of racing the provider iterator against the limits + cancellation. */
+type NextStep =
+  | { type: "event"; result: IteratorResult<ModelEvent> }
+  | { type: "threw" }
+  | { type: "timeout" }
+  | { type: "aborted" };
+
+/**
+ * Race one `iterator.next()` against a time budget and the cancellation signal.
+ * Settles at most once. The pending `next()` is abandoned on timeout/abort —
+ * the caller closes the iterator afterwards, which tears the stream down.
+ */
+function raceNext(
+  iterator: AsyncIterator<ModelEvent>,
+  budgetMs: number,
+  signal: AbortSignal | undefined,
+): Promise<NextStep> {
+  return new Promise<NextStep>((resolve) => {
+    let settled = false;
+    const finish = (step: NextStep): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (signal !== undefined) signal.removeEventListener("abort", onAbort);
+      resolve(step);
+    };
+    const onAbort = (): void => {
+      finish({ type: "aborted" });
+    };
+
+    if (signal?.aborted) {
+      // Already cancelled — resolve directly (no timer/listener to clean up).
+      resolve({ type: "aborted" });
+      return;
+    }
+    const timer = setTimeout(() => {
+      finish({ type: "timeout" });
+    }, budgetMs);
+    if (signal !== undefined) {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    iterator.next().then(
+      (result) => {
+        finish({ type: "event", result });
+      },
+      // Providers YIELD errors rather than throwing; a rejection is a contract
+      // violation. Collapse it to a fixed step — the raw error is dropped so no
+      // provider/connection detail can leak into the outcome summary.
+      () => {
+        finish({ type: "threw" });
+      },
+    );
+  });
+}
+
+/**
+ * Best-effort close of the provider iterator so its stream `finally` runs and
+ * releases the underlying HTTP connection.
+ *
+ * FIRE-AND-FORGET — deliberately NOT awaited. On a timeout / cancellation the
+ * provider generator is suspended at `await reader.read()` on a stream that has
+ * not produced a frame (e.g. a hung connection); `iterator.return()` cannot run
+ * that generator's `finally` until the pending read settles, so awaiting it here
+ * would re-introduce the very hang the limit exists to break. We request the
+ * return (which the provider's own `finally` honours by cancelling the reader the
+ * moment the read settles) and let the loop return its terminal outcome
+ * immediately. Any rejection from the return is swallowed — teardown is
+ * idempotent and nothing actionable remains.
+ */
+function closeIterator(iterator: AsyncIterator<ModelEvent>): void {
+  try {
+    const returned = iterator.return?.();
+    if (returned !== undefined) {
+      void returned.catch(() => {
+        /* teardown of an already-aborted stream can reject — nothing to do. */
+      });
+    }
+  } catch (_err) {
+    // `iterator.return` itself threw synchronously (non-conforming iterator);
+    // the connection teardown is idempotent, so there is nothing actionable.
+  }
+}
+
+/** Map a yielded provider `error` event to a `failed` outcome (redacted only). */
+function errorOutcome(
+  error: ProviderError,
+  accumulatedRequestId: string | undefined,
+): AgentLoopOutcome {
+  // Prefer the error's own provider request id for correlation; fall back to any
+  // id seen earlier in the stream. API-P1.4 refines the error-kind→lifecycle
+  // mapping (e.g. rate_limit back-pressure); here every provider error is a
+  // `failed` terminal carrying ONLY the redacted summary.
+  const requestId = error.providerRequestId ?? accumulatedRequestId;
+  return {
+    kind: "failed",
+    summary: error.summary,
+    ...(requestId !== undefined ? { providerRequestId: requestId } : {}),
+  };
+}
+
+/**
+ * Drive `provider.stream(request)` to a single terminal outcome under the
+ * dispatch's limits + cancellation. See the file header for the full contract.
+ */
+export async function runAgentLoop(
+  opts: AgentLoopOptions,
+): Promise<AgentLoopOutcome> {
+  const { provider, request, wallClockMs, inactivityMs, signal } = opts;
+  const now = opts.now ?? ((): number => Date.now());
+
+  if (signal?.aborted) {
+    return { kind: "aborted", reason: "cancelled" };
+  }
+
+  const iterator = provider.stream(request)[Symbol.asyncIterator]();
+  const wallDeadline = now() + wallClockMs;
+
+  let text = "";
+  let usage: AgentLoopUsage | undefined;
+  let providerRequestId: string | undefined;
+  let finishReason: FinishReason | undefined;
+
+  try {
+    for (;;) {
+      const wallRemaining = wallDeadline - now();
+      if (wallRemaining <= 0) {
+        return {
+          kind: "failed",
+          summary: "wall-clock timeout",
+          ...(providerRequestId !== undefined ? { providerRequestId } : {}),
+        };
+      }
+      // The binding budget is whichever limit expires first — the inactivity
+      // gap (reset every iteration) or the remaining wall-clock.
+      const budget = Math.min(wallRemaining, inactivityMs);
+      const step = await raceNext(iterator, budget, signal);
+
+      if (step.type === "aborted") {
+        return { kind: "aborted", reason: "cancelled" };
+      }
+      if (step.type === "timeout") {
+        // Classify which limit bound: wall-clock if the hard deadline passed,
+        // otherwise the inactivity gap. Both map to a `failed` terminal here.
+        const wallHit = now() >= wallDeadline;
+        return {
+          kind: "failed",
+          summary: wallHit ? "wall-clock timeout" : "inactivity timeout",
+          ...(providerRequestId !== undefined ? { providerRequestId } : {}),
+        };
+      }
+      if (step.type === "threw") {
+        return {
+          kind: "failed",
+          summary: "provider stream error",
+          ...(providerRequestId !== undefined ? { providerRequestId } : {}),
+        };
+      }
+
+      if (step.result.done === true) break;
+      const value = step.result.value;
+
+      switch (value.type) {
+        case "response.started":
+          if (value.providerRequestId !== undefined) {
+            providerRequestId = value.providerRequestId;
+          }
+          break;
+        case "text.delta":
+          text += value.text;
+          break;
+        case "usage":
+          usage = {
+            inputTokens: value.inputTokens,
+            outputTokens: value.outputTokens,
+            ...(value.cacheReadTokens !== undefined
+              ? { cacheReadTokens: value.cacheReadTokens }
+              : {}),
+          };
+          break;
+        case "response.completed":
+          finishReason = value.finishReason;
+          break;
+        case "error":
+          return errorOutcome(value.error, providerRequestId);
+        case "tool_call.delta":
+        case "tool_call.completed":
+          // D5 — no tools in Phase 1. A text-only request should never elicit a
+          // tool call, but if a provider emits one we IGNORE it (never execute).
+          break;
+      }
+    }
+  } finally {
+    closeIterator(iterator);
+  }
+
+  // Stream ended without an `error` event → success. `response.completed` is the
+  // normal terminator; a provider that closed cleanly without one still
+  // completed (finishReason defaults to "stop").
+  return {
+    kind: "completed",
+    text,
+    finishReason: finishReason ?? "stop",
+    ...(usage !== undefined ? { usage } : {}),
+    ...(providerRequestId !== undefined ? { providerRequestId } : {}),
+  };
+}

--- a/src/substrates/api-agent/harness.ts
+++ b/src/substrates/api-agent/harness.ts
@@ -1,0 +1,389 @@
+// API-P1.3 (epic #2055, Phase 1, decisions D1/D5) — `ApiAgentHarness`.
+//
+// The INTEGRATION KEYSTONE of the epic: the `SessionHarness` that turns raw
+// provider inference into a Cortex dispatch. It makes `substrate: api-agent` +
+// `inferenceProfile: X` dispatch a chat turn end-to-end against a model provider
+// resolved through the `InferenceRegistry` — no CLI child, no ConversationStore
+// (Phase 2), and NO TOOLS (Phase 3, D5).
+//
+// SHAPE: mirrors `ClaudeCodeHarness` (`../claude-code/harness.ts`) — the same
+// lifecycle-envelope constructors, the same per-dispatch correlation-id
+// stabilisation, the same shutdown/active-set discipline — so it is a drop-in on
+// the harness-resolver seam (`runner/harness-resolver.ts`).
+//
+// LIFECYCLE INVARIANT (`SessionHarness` contract): exactly ONE `started` and
+// exactly ONE terminal (`completed` / `failed` / `aborted`) per dispatch, all on
+// one stable `correlation_id`. Every early-exit path below yields `started` then
+// exactly one terminal.
+//
+// FAIL CLOSED (D5): a request that carries attachments or requires tools/skills
+// is rejected with an `unsupported_capability` terminal BEFORE any provider call
+// — never silently dropped, and never a network round-trip. Profile resolution
+// also fails closed: an unknown profile / missing provider yields a `failed`
+// terminal, never a throw deep in the token stream.
+
+import { randomUUID } from "crypto";
+
+import { isUuidLoose } from "../../common/types/uuid";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { InferenceRegistry } from "../../common/inference/registry";
+import type { ModelMessage, ModelRequest } from "../../common/inference/types";
+import type {
+  Capability,
+  DispatchRequest,
+  MyelinEnvelope,
+  SessionHarness,
+} from "../../common/substrates/types";
+import {
+  createDispatchTaskAbortedEvent,
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createDispatchTaskStartedEvent,
+  type DispatchEventSource,
+} from "../../bus/dispatch-events";
+import {
+  truncateDispatchErrorSummary,
+  truncateDispatchResultSummary,
+} from "../../bus/dispatch-lifecycle-summary";
+import { runAgentLoop, type AgentLoopOutcome, type AgentLoopUsage } from "./agent-loop";
+
+// Q6 defaults (design §"Streaming and lifecycle") — the same two-cap model the
+// substrate protocol documents on `DispatchRequest.timeoutMs` / `inactivityMs`.
+const DEFAULT_WALL_CLOCK_MS = 300_000;
+const DEFAULT_INACTIVITY_MS = 60_000;
+
+/** Module-scope warn-once latch for non-UUID `requestId` substitution. */
+let warnedNonUuidRequestId = false;
+
+/** Test-only reset of the module-scope warn-once latch. */
+export function __resetApiAgentWarnedNonUuidRequestId(): void {
+  warnedNonUuidRequestId = false;
+}
+
+/** Constructor options for {@link ApiAgentHarness}. */
+export interface ApiAgentHarnessOpts {
+  /** Envelope source triple stamped onto every lifecycle envelope. */
+  source: DispatchEventSource;
+  /** The inference registry the harness resolves its profile through (fail closed). */
+  registry: InferenceRegistry;
+  /**
+   * The receiving agent's `inferenceProfile` name (from its `runtime` block).
+   * `undefined` → the harness fails closed at dispatch (a clear terminal), never
+   * silently falling back to a default model.
+   */
+  inferenceProfile: string | undefined;
+  /** Optional declared capabilities (surfaces on `harness.capabilities`). */
+  capabilities?: Capability[];
+  /** Injectable clock (tests). Threaded to the agent loop. */
+  now?: () => number;
+}
+
+/**
+ * Reason a dispatch is refused up front (D5). `undefined` ⇒ serviceable.
+ * Checked BEFORE any provider call so a tool/attachment request costs zero
+ * network.
+ */
+function unsupportedCapabilityReason(req: DispatchRequest): string | undefined {
+  if (req.tools.allow.length > 0) {
+    return "the api-agent substrate does not execute tools (Phase 3)";
+  }
+  if (req.allowedSkills !== undefined && req.allowedSkills.length > 0) {
+    return "the api-agent substrate does not grant skills (Phase 3)";
+  }
+  for (const ctx of req.context) {
+    if (ctx.kind !== "attachments") continue;
+    const data = ctx.data;
+    const nonEmpty = Array.isArray(data) ? data.length > 0 : data != null;
+    if (nonEmpty) return "the api-agent substrate does not accept attachments";
+  }
+  return undefined;
+}
+
+/**
+ * Build a normalized {@link ModelRequest} FROM THE DISPATCH REQUEST. Phase 1
+ * rebuilds the "conversation" from the request alone (no ConversationStore —
+ * that's Phase 2): the persona/system becomes `instructions`, and the prompt
+ * becomes the single user turn. Text only (D5/Phase 1).
+ */
+function buildModelRequest(req: DispatchRequest, model: string): ModelRequest {
+  const messages: ModelMessage[] = [
+    { role: "user", content: [{ type: "text", text: req.prompt }] },
+  ];
+  const instructions = req.persona?.content;
+  return {
+    model,
+    ...(instructions !== undefined && instructions !== ""
+      ? { instructions }
+      : {}),
+    messages,
+  };
+}
+
+/**
+ * Stamp usage + provider request id onto a `completed` envelope's payload using
+ * Mission Control's existing token field names (`input_tokens` / `output_tokens`
+ * / `cache_read_tokens`) plus `provider_request_id` for cross-system
+ * correlation. The myelin schema accepts additional payload properties (same
+ * mechanism `cc_session_id` / `response_routing` ride), so this widens the
+ * payload without a wire-grammar change. Cost is left unset (the provider
+ * reports tokens, not price) — MC reads a NULL cost column as an honest 0.
+ */
+function stampUsage(
+  env: Envelope,
+  usage: AgentLoopUsage | undefined,
+  providerRequestId: string | undefined,
+): Envelope {
+  if (usage === undefined && providerRequestId === undefined) return env;
+  return {
+    ...env,
+    payload: {
+      ...env.payload,
+      ...(usage !== undefined
+        ? {
+            input_tokens: usage.inputTokens,
+            output_tokens: usage.outputTokens,
+            ...(usage.cacheReadTokens !== undefined
+              ? { cache_read_tokens: usage.cacheReadTokens }
+              : {}),
+          }
+        : {}),
+      ...(providerRequestId !== undefined
+        ? { provider_request_id: providerRequestId }
+        : {}),
+    },
+  };
+}
+
+/**
+ * Direct-API substrate harness — streams a model provider resolved through the
+ * `InferenceRegistry` and reduces it to a Cortex dispatch lifecycle. See the
+ * file header for the full contract.
+ */
+export class ApiAgentHarness implements SessionHarness {
+  readonly id = "api-agent" as const;
+  readonly capabilities: Capability[];
+
+  private readonly source: DispatchEventSource;
+  private readonly registry: InferenceRegistry;
+  private readonly inferenceProfile: string | undefined;
+  private readonly now: (() => number) | undefined;
+
+  /**
+   * In-flight dispatches' abort controllers — `shutdown({ graceful: false })`
+   * aborts them so active agent loops settle to an `aborted` terminal fast.
+   */
+  private readonly activeControllers = new Set<AbortController>();
+  private shuttingDown = false;
+
+  constructor(opts: ApiAgentHarnessOpts) {
+    this.source = opts.source;
+    this.registry = opts.registry;
+    this.inferenceProfile = opts.inferenceProfile;
+    this.capabilities = opts.capabilities ?? [];
+    this.now = opts.now;
+  }
+
+  async *dispatch(req: DispatchRequest): AsyncIterable<MyelinEnvelope> {
+    const correlationId = this.correlationFor(req);
+    const startedAt = new Date();
+    yield this.buildStarted(req, startedAt, correlationId);
+
+    if (this.shuttingDown) {
+      yield this.buildFailed(req, startedAt, correlationId, "harness shutting down");
+      return;
+    }
+
+    // FAIL CLOSED (D5) — reject tools/attachments BEFORE any provider call. Zero
+    // network: we never construct or stream the provider on this path.
+    const unsupported = unsupportedCapabilityReason(req);
+    if (unsupported !== undefined) {
+      yield this.buildFailed(
+        req,
+        startedAt,
+        correlationId,
+        `unsupported_capability: ${unsupported}`,
+      );
+      return;
+    }
+
+    // Resolve the agent's inference profile — fail closed to a terminal, never a
+    // throw. An absent profile is a config error surfaced as a clear failure.
+    if (this.inferenceProfile === undefined) {
+      yield this.buildFailed(
+        req,
+        startedAt,
+        correlationId,
+        "api-agent dispatch has no inferenceProfile configured",
+      );
+      return;
+    }
+    const resolution = this.registry.resolveProfile(this.inferenceProfile);
+    if (!resolution.ok) {
+      yield this.buildFailed(req, startedAt, correlationId, resolution.error.message);
+      return;
+    }
+    const resolved = resolution.profile;
+
+    const request = buildModelRequest(req, resolved.model);
+
+    // One controller per dispatch, tracked for shutdown-driven cancellation.
+    const controller = new AbortController();
+    this.activeControllers.add(controller);
+    // Close the race with a shutdown that landed between the flag check above
+    // and this registration (`shutdown` can flip the flag from another task
+    // between those two points). Read via a method so control-flow analysis
+    // does not narrow the field to the `false` it held at the earlier check.
+    if (this.isShuttingDown()) controller.abort();
+
+    let outcome: AgentLoopOutcome;
+    try {
+      outcome = await runAgentLoop({
+        provider: resolved.provider,
+        request,
+        wallClockMs: req.timeoutMs ?? DEFAULT_WALL_CLOCK_MS,
+        inactivityMs: req.inactivityMs ?? DEFAULT_INACTIVITY_MS,
+        signal: controller.signal,
+        ...(this.now !== undefined ? { now: this.now } : {}),
+      });
+    } catch (err) {
+      // The loop is defensive and should not throw, but a raw error must never
+      // escape to the runner (it could carry provider detail). Map to a failed
+      // terminal with a fixed, redacted summary; log the raw message to stderr.
+      process.stderr.write(
+        `api-agent-harness: agent loop threw: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+      outcome = { kind: "failed", summary: "agent loop error" };
+    } finally {
+      this.activeControllers.delete(controller);
+    }
+
+    yield this.buildTerminal(req, startedAt, correlationId, outcome);
+  }
+
+  // Substrate contract — `shutdown` is `Promise<void>`; the body is synchronous
+  // (aborts are issued, active loops observe them via the signal), so the
+  // require-await rule fires. The contract wins, matching ClaudeCodeHarness.
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async shutdown(opts: { graceful: boolean }): Promise<void> {
+    this.shuttingDown = true;
+    if (opts.graceful) return;
+    for (const controller of this.activeControllers) {
+      try {
+        controller.abort();
+      } catch (err) {
+        // Aborting an already-settled controller can throw on some runtimes;
+        // log and continue so every in-flight dispatch is signalled.
+        process.stderr.write(
+          `api-agent-harness: shutdown abort failed: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /** Read the shutdown flag through a call boundary (defeats CFA narrowing). */
+  private isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  /**
+   * Per-dispatch correlation key — `requestId` when UUID-shaped, else a fresh
+   * UUID (the envelope schema only admits UUID `correlation_id`). Mirrors the
+   * claude-code harness's defensive substitution, with a one-time warning.
+   */
+  private correlationFor(req: DispatchRequest): string {
+    if (isUuidLoose(req.requestId)) return req.requestId;
+    if (!warnedNonUuidRequestId) {
+      console.warn(
+        `api-agent-harness: requestId "${req.requestId}" is not UUID-shaped — ` +
+          `substituting a generated correlation_id (this warning fires once per process)`,
+      );
+      warnedNonUuidRequestId = true;
+    }
+    return randomUUID();
+  }
+
+  private buildStarted(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+  ): Envelope {
+    return createDispatchTaskStartedEvent({
+      source: this.source,
+      taskId: req.requestId,
+      agentId: req.agent.id,
+      correlationId,
+      startedAt,
+    });
+  }
+
+  private buildFailed(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+    errorSummary: string,
+  ): Envelope {
+    return createDispatchTaskFailedEvent({
+      source: this.source,
+      taskId: req.requestId,
+      agentId: req.agent.id,
+      correlationId,
+      startedAt,
+      failedAt: new Date(),
+      errorSummary: truncateDispatchErrorSummary(errorSummary),
+    });
+  }
+
+  private buildTerminal(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+    outcome: AgentLoopOutcome,
+  ): Envelope {
+    switch (outcome.kind) {
+      case "completed": {
+        const env = createDispatchTaskCompletedEvent({
+          source: this.source,
+          taskId: req.requestId,
+          agentId: req.agent.id,
+          correlationId,
+          startedAt,
+          completedAt: new Date(),
+          ...(outcome.text !== ""
+            ? {
+                resultSummary: truncateDispatchResultSummary(outcome.text),
+                // Full assistant reply for the chat round-trip (dispatch sink).
+                chatResponse: outcome.text,
+              }
+            : {}),
+        });
+        return stampUsage(env, outcome.usage, outcome.providerRequestId);
+      }
+      case "aborted":
+        return createDispatchTaskAbortedEvent({
+          source: this.source,
+          taskId: req.requestId,
+          agentId: req.agent.id,
+          correlationId,
+          startedAt,
+          abortedAt: new Date(),
+          reason: outcome.reason,
+        });
+      case "failed":
+      default:
+        return this.buildFailed(
+          req,
+          startedAt,
+          correlationId,
+          outcome.summary,
+        );
+    }
+  }
+}

--- a/src/substrates/api-agent/provider-factories.ts
+++ b/src/substrates/api-agent/provider-factories.ts
@@ -1,0 +1,95 @@
+// API-P1.3 (epic #2055, Phase 1) — the REAL provider-factory wiring: the
+// dependency-injection point API-P0.4's `InferenceRegistry` documented. The
+// registry takes a `protocol → factory` map and never imports the concrete
+// provider classes; THIS module supplies them, mapping a schema-validated
+// `InferenceProvider` config entry onto each provider's actual constructor.
+//
+// SECRETS: the registry hands the factory the provider config with its secret
+// REFERENCES (`apiKey` / `headers.*` as `env:NAME`) intact. The shipped provider
+// constructors (`AnthropicMessagesProvider` / `OpenAICompatibleProvider`) take a
+// LITERAL key, so the factory resolves the reference via `resolveSecretRef` at
+// construction time — which the registry does LAZILY on first `resolveProfile`,
+// so an unused provider with an unset env var never resolves (and never throws).
+// The resolved value lives on the provider instance only; it is never written
+// back onto config and never logged (both providers keep it out of every error,
+// event, and log line).
+
+import type {
+  ProviderFactory,
+  ProviderFactoryMap,
+} from "../../common/inference/registry";
+import { InferenceRegistry } from "../../common/inference/registry";
+import type { InferenceConfig, InferenceProvider } from "../../common/types/cortex-config";
+import { resolveSecretRef } from "../../common/inference/secret-ref";
+import { AnthropicMessagesProvider } from "../../providers/anthropic/messages-provider";
+import { OpenAICompatibleProvider } from "../../providers/openai-compatible/chat-completions-provider";
+
+/** Options for the factory wiring — `env` is injectable for tests. */
+export interface ProviderFactoryOptions {
+  /** Environment used to resolve `env:NAME` secret references. Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+/** Resolve every `env:NAME` header reference to its literal value at call time. */
+function resolveHeaders(
+  headers: InferenceProvider["headers"],
+  env: Record<string, string | undefined> | undefined,
+): Record<string, string> | undefined {
+  if (headers === undefined) return undefined;
+  const out: Record<string, string> = {};
+  for (const [name, ref] of Object.entries(headers)) {
+    out[name] = resolveSecretRef(ref, env ?? process.env);
+  }
+  return out;
+}
+
+/**
+ * The default `protocol → factory` map wiring the two Phase-1 providers. Each
+ * factory matches the provider's actual constructor signature and resolves
+ * secret references from `opts.env` (default `process.env`).
+ */
+export function defaultProviderFactories(
+  opts: ProviderFactoryOptions = {},
+): ProviderFactoryMap {
+  const env = opts.env;
+
+  const anthropic: ProviderFactory = ({ config }) => {
+    const extraHeaders = resolveHeaders(config.headers, env);
+    return new AnthropicMessagesProvider({
+      apiKey: resolveSecretRef(config.apiKey, env ?? process.env),
+      baseUrl: config.baseUrl,
+      ...(extraHeaders !== undefined ? { extraHeaders } : {}),
+    });
+  };
+
+  const openai: ProviderFactory = ({ name, config }) => {
+    const headers = resolveHeaders(config.headers, env);
+    return new OpenAICompatibleProvider({
+      id: name,
+      baseUrl: config.baseUrl,
+      apiKey: resolveSecretRef(config.apiKey, env ?? process.env),
+      ...(config.capabilities !== undefined
+        ? { capabilities: config.capabilities }
+        : {}),
+      ...(headers !== undefined ? { headers } : {}),
+    });
+  };
+
+  return {
+    "anthropic-messages": anthropic,
+    "openai-chat-completions": openai,
+  };
+}
+
+/**
+ * Build an {@link InferenceRegistry} from a loaded `inference` config with the
+ * real Phase-1 provider factories injected. This is the single boot-time
+ * construction point the harness resolver consumes; pass the result to the
+ * dispatch listener so `substrate: api-agent` agents resolve their profile.
+ */
+export function createInferenceRegistry(
+  config: InferenceConfig,
+  opts: ProviderFactoryOptions = {},
+): InferenceRegistry {
+  return new InferenceRegistry(config, defaultProviderFactories(opts));
+}


### PR DESCRIPTION
Closes #2063 · Part of epic #2055 · Phase 1. The integration keystone — makes `substrate: api-agent` + `inferenceProfile` dispatch end-to-end. No tools (D5).

Adds `src/substrates/api-agent/{harness,agent-loop,provider-factories}.ts` (`ApiAgentHarness implements SessionHarness`) and wires it in:
- **Registry factories:** `provider-factories.ts` builds the injected protocol→factory map (native Anthropic + OpenAI-compatible), matching the shipped constructors; secret references resolve lazily at factory time (registry stays pure). `createInferenceRegistry(config.inference)` at boot in `cortex.ts`, threaded into the dispatch listener.
- **Resolver branch:** `DefaultHarnessResolver.resolve` gains `case "api-agent"`; `claude-code` default and `delegate → AgentTeamHarness` unchanged. Registry optional → absent = fail-closed.
- **Agent-runtime threading:** the resolve call site now looks up the receiving agent's runtime by id (`agentRuntimesById`) and passes it to `resolve(...)` — previously it passed `undefined` (everything → claude-code). Agents with no `substrate` still → claude-code.

Agent loop → Myelin lifecycle: exactly one `started` + one terminal on every path; inactivity + wall-clock deadlines → failed; cancellation/shutdown → aborted; provider `error` event → failed carrying only the redacted summary (no secret/raw detail); usage stamped on the completed envelope. History rebuilt from the request (no ConversationStore — Phase 2). Fail-closed (D5): attachments or tool requirements → `unsupported_capability` BEFORE any provider call (zero network).

Structural note for reviewers: the inference leaf schema was extracted to `src/common/inference/inference-config-schema.ts` to break a `config`↔`cortex-config` module eval cycle (would have crashed at load — caught + fixed); `inference` is threaded via `AgentConfig` (optional there to avoid breaking fixtures), mirrored from `CortexConfigSchema`.

Seams for API-P1.4: full error-kind→lifecycle/back-pressure table (this slice maps all provider errors → failed); joining usage into MC's session-keyed cost rows.

Verification: `bun test src/substrates/api-agent` 21/0; `bun test src/runner` 902/0 (claude-code non-regression); `bun test src/providers` + `src/common/inference` green; `bunx tsc --noEmit` exit 0; eslint clean; vocab-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)