### PR TITLE
fix(xdg-audit): allowlist Appendix A systemd user-unit path — restores red main gate

### DIFF
--- a/scripts/xdg-audit-allow.yaml
+++ b/scripts/xdg-audit-allow.yaml
@@ -290,6 +290,11 @@ allow:
     match: \.config/systemd/user
     reason: grove-namespace subsystem — path accurate as of writing; grove→cortex rename tracked separately (cortex#436)
     owner: G-38
+  - pattern: systemd-userdir
+    path: README-AGENTS.md
+    match: \.config/systemd/user
+    reason: Appendix A Debian runbook — documents systemd's CANONICAL user-unit directory (community-validated units a human copies by hand; systemd itself honors $XDG_CONFIG_HOME). The L1 auto-renderer resolves the path programmatically (cortex#2071)
+    owner: cortex#2071
   - pattern: config-tree
     path: docs/design-cloud-api.md
     match: ~/\.config/grove


### PR DESCRIPTION
Main has been red since #2090 merged (XDG gate, systemd-userdir G-38, 3 sites in README-AGENTS.md Appendix A) — the runbook was merged through a red gate by orchestrator error (mangled checks output misread as green; owning that). This adds ONE narrow allow entry: Appendix A quotes systemd's canonical user-unit directory for humans; the L1 renderer (#2071) resolves it programmatically. Local repo-scope audit: GATE PASS exit 0. Unblocks every open cortex PR (incl. #2098).

🤖 Generated with [Claude Code](https://claude.com/claude-code)