### PR TITLE
feat(systemd): L1 — auto-render systemd user units on Linux (templates + renderer + e2e) (cortex#2071)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,16 @@ jobs:
       # contradicting the issue's own acceptance criterion that zero matches is
       # green at this stage. Guard on the "matched 0 tests" message so a real
       # test failure still fails the job once cortex#2071 lands.
-      - name: bun test (systemd-e2e placeholder — cortex#2071 will populate)
+      #
+      # SYSTEMD_E2E=1 is this job's explicit opt-in for
+      # scripts/__tests__/systemd-render-e2e.test.ts (cortex#2071) — that test
+      # gates on this exact env var (not a broader "CI=true" or "Linux with a
+      # systemd session" signal) precisely so it runs ONLY here and not in the
+      # plain Test job, which has no systemd-user session bootstrap but still
+      # satisfied a looser check (cortex#2103 review finding).
+      - name: bun test (systemd-e2e)
+        env:
+          SYSTEMD_E2E: "1"
         run: |
           set +e
           output=$(bun test --test-name-pattern systemd-e2e 2>&1)

--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -42,12 +42,15 @@ Verify each before starting:
 **Platform — macOS and Linux both supported.** The runtime is OS-agnostic (Bun,
 NATS, and the config `.conf` are identical); only the **service manager** differs:
 - **macOS** — launchd. `arc upgrade` renders the plists (`src/services/`) for you.
-- **Linux** — systemd **user** units. Auto-rendering is tracked in
-  [cortex#2071](https://github.com/the-metafactory/cortex/issues/2071); until it
-  ships, use the **validated template units in Appendix A** — one `nats@.service`
-  + one `cortex@.service` serve every stack via the `%i` instance parameter
+- **Linux** — systemd **user** units. `arc install`/`arc upgrade cortex` render
+  the two committed template units — `src/services/nats@.service` +
+  `src/services/cortex@.service` — into `~/.config/systemd/user/`
+  ([cortex#2071](https://github.com/the-metafactory/cortex/issues/2071)); one
+  pair serves every stack via the `%i` instance parameter
   (`systemctl --user enable --now cortex@<slug>`). cortex's `daemon-locator`
-  finds it. (Or run directly: `bun src/cortex.ts start --config <pointer>`.)
+  finds it. For a from-source clone, a manual setup, or the exact enable/start
+  commands, see **Appendix A** (same units, byte-consistent with the shipped
+  files). (Or run directly: `bun src/cortex.ts start --config <pointer>`.)
 
 ## 2. Install
 
@@ -352,10 +355,16 @@ Community-validated on a clean Debian 13 x64 bring-up (thanks Vincent Zontini �
 his fuller walkthrough with Discord-side steps lives in
 [this gist](https://gist.github.com/vpzed/fc3b8da5ee9ecaea4a0d17e567ffbb17)).
 These are systemd **template units**: the text after `@` becomes `%i` (the stack
-slug), so ONE pair of files serves every stack on the host. Auto-rendering of
-these units by `arc upgrade cortex` is tracked in
-[cortex#2071](https://github.com/the-metafactory/cortex/issues/2071); until it
-ships, create them by hand as below.
+slug), so ONE pair of files serves every stack on the host.
+
+**Arc-managed installs (Path A) render these automatically** — `arc install`/
+`arc upgrade cortex` copies the checked-in `src/services/nats@.service` +
+`src/services/cortex@.service` into `~/.config/systemd/user/` for you
+([cortex#2071](https://github.com/the-metafactory/cortex/issues/2071)); you do
+not need to create the files below by hand. The blocks in A.2/A.3 are kept
+inline — byte-identical to the shipped `src/services/*.service` files — as the
+reference for a **from-source clone** (Path B, no `arc` lifecycle scripts) or
+for manually inspecting/recreating what the renderer installs.
 
 ### A.1 One-time host preparation
 
@@ -411,12 +420,14 @@ Wants=nats@%i.service
 [Service]
 Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin
 Type=simple
+WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace
 ExecStart=%h/.local/bin/cortex start --config %h/.config/metafactory/cortex/%i/%i.yaml
 Restart=on-failure
 RestartSec=10
 RestartSteps=5
 RestartMaxDelaySec=300
 
+ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace
 ExecStartPre=/usr/bin/mkdir -p %h/.local/state/metafactory/cortex/logs
 StandardOutput=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.log
 StandardError=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.error.log
@@ -429,7 +440,10 @@ WantedBy=default.target
 matching nats instance up with the stack. The escalating restart backoff
 (10 s → capped at 300 s over 5 steps) stops a misconfigured stack from
 hot-looping. Log paths are the XDG state dir — the same paths §5's
-healthy-boot gate greps.
+healthy-boot gate greps. `WorkingDirectory=` (+ its matching `ExecStartPre`
+mkdir) points a dispatched session's default cwd at a dedicated per-stack
+workspace dir instead of `$HOME` (systemd's default when unset) — see
+[cortex#2097](https://github.com/the-metafactory/cortex/issues/2097).
 
 > `RestartSteps=`/`RestartMaxDelaySec=` need systemd ≥ 254 (Debian 13 ships
 > ≥ 254; on older hosts drop those two lines and keep `RestartSec=10`).
@@ -449,7 +463,9 @@ Then run §5's healthy-boot gate against
 `~/.local/state/metafactory/cortex/logs/cortex-$CTX_SLUG.log` and the
 functional gate (@mention as principal → reply; non-principal → silence).
 
-**Upgrades:** `arc upgrade cortex` handles code + seed provisioning; after an
-upgrade, `systemctl --user restart "cortex@$CTX_SLUG"` picks up the new build
-(launchd restart is automated on macOS; the systemd analogue arrives with
-cortex#2071).
+**Upgrades:** `arc upgrade cortex` handles code + seed provisioning, re-renders
+the two unit files (§ above), and — for an **arc-managed install** — restarts
+every currently-active `cortex@<slug>` itself (the systemd analogue of the
+launchd restart that's automated on macOS). For a **from-source clone** (no
+`arc` lifecycle scripts), restart manually: `systemctl --user restart
+"cortex@$CTX_SLUG"`.

--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -420,13 +420,22 @@ Wants=nats@%i.service
 [Service]
 Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin
 Type=simple
-WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace
+# "-" prefix: a missing WorkingDirectory is not fatal (verified: without it,
+# a cold start fails outright with EXIT_CHDIR before ExecStartPre ever runs).
+# With it, ExecStartPre's mkdir below creates the dir, then ExecStart's own
+# chdir succeeds.
+WorkingDirectory=-%h/.local/share/metafactory/cortex/%i/workspace
 ExecStart=%h/.local/bin/cortex start --config %h/.config/metafactory/cortex/%i/%i.yaml
 Restart=on-failure
 RestartSec=10
+# RestartSteps=/RestartMaxDelaySec= need systemd >= 254 (Debian 13 ships >=
+# 254; verified on systemd 249 they are ignored with a startup journal
+# warning, RestartSec=10 alone still applies — graceful degradation, not a
+# hard failure, on older hosts).
 RestartSteps=5
 RestartMaxDelaySec=300
 
+ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace
 ExecStartPre=/usr/bin/mkdir -p %h/.local/state/metafactory/cortex/logs
 StandardOutput=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.log
 StandardError=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.error.log
@@ -442,26 +451,17 @@ hot-looping. Log paths are the XDG state dir — the same paths §5's
 healthy-boot gate greps. `WorkingDirectory=` points a dispatched session's
 default cwd at a dedicated per-stack workspace dir instead of `$HOME`
 (systemd's default when unset) — see
-[cortex#2097](https://github.com/the-metafactory/cortex/issues/2097).
-**That directory must exist BEFORE you enable the unit** — systemd enters
-`WorkingDirectory=` before running *any* exec command, including
-`ExecStartPre`, so a missing workspace dir fails the unit outright
-(`ExecStartPre` can't rescue it by creating its own prerequisite). An
-arc-managed install creates it for you (the renderer ensures every
-discovered stack's workspace dir exists on every render); §A.4 below has the
-one-time manual `mkdir` for everyone else.
-
-> `RestartSteps=`/`RestartMaxDelaySec=` need systemd ≥ 254 (Debian 13 ships
-> ≥ 254; on older hosts drop those two lines and keep `RestartSec=10`).
+[cortex#2097](https://github.com/the-metafactory/cortex/issues/2097). The
+directory is **self-creating**: the `-` prefix tolerates it being absent at
+enable time, and the matching `ExecStartPre` line creates it before
+`ExecStart`'s own chdir runs — no manual step needed even on a from-nothing
+host. (An arc-managed install also proactively pre-creates it for every
+already-discovered stack at render time — belt-and-braces, not required for
+correctness.)
 
 ### A.4 Enable, start, verify
 
 ```bash
-# Workspace dir for THIS stack — must exist before cortex@ is enabled (see
-# the WorkingDirectory note in §A.3); arc-managed installs get this from the
-# renderer automatically, this is the manual equivalent.
-mkdir -p "$HOME/.local/share/metafactory/cortex/$CTX_SLUG/workspace"
-
 systemctl --user daemon-reload
 systemctl --user enable --now "nats@$CTX_SLUG"
 curl -sf "http://127.0.0.1:$CTX_NATS_MON/healthz"   # → {"status":"ok"}

--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -427,7 +427,6 @@ RestartSec=10
 RestartSteps=5
 RestartMaxDelaySec=300
 
-ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace
 ExecStartPre=/usr/bin/mkdir -p %h/.local/state/metafactory/cortex/logs
 StandardOutput=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.log
 StandardError=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.error.log
@@ -440,10 +439,17 @@ WantedBy=default.target
 matching nats instance up with the stack. The escalating restart backoff
 (10 s → capped at 300 s over 5 steps) stops a misconfigured stack from
 hot-looping. Log paths are the XDG state dir — the same paths §5's
-healthy-boot gate greps. `WorkingDirectory=` (+ its matching `ExecStartPre`
-mkdir) points a dispatched session's default cwd at a dedicated per-stack
-workspace dir instead of `$HOME` (systemd's default when unset) — see
+healthy-boot gate greps. `WorkingDirectory=` points a dispatched session's
+default cwd at a dedicated per-stack workspace dir instead of `$HOME`
+(systemd's default when unset) — see
 [cortex#2097](https://github.com/the-metafactory/cortex/issues/2097).
+**That directory must exist BEFORE you enable the unit** — systemd enters
+`WorkingDirectory=` before running *any* exec command, including
+`ExecStartPre`, so a missing workspace dir fails the unit outright
+(`ExecStartPre` can't rescue it by creating its own prerequisite). An
+arc-managed install creates it for you (the renderer ensures every
+discovered stack's workspace dir exists on every render); §A.4 below has the
+one-time manual `mkdir` for everyone else.
 
 > `RestartSteps=`/`RestartMaxDelaySec=` need systemd ≥ 254 (Debian 13 ships
 > ≥ 254; on older hosts drop those two lines and keep `RestartSec=10`).
@@ -451,6 +457,11 @@ workspace dir instead of `$HOME` (systemd's default when unset) — see
 ### A.4 Enable, start, verify
 
 ```bash
+# Workspace dir for THIS stack — must exist before cortex@ is enabled (see
+# the WorkingDirectory note in §A.3); arc-managed installs get this from the
+# renderer automatically, this is the manual equivalent.
+mkdir -p "$HOME/.local/share/metafactory/cortex/$CTX_SLUG/workspace"
+
 systemctl --user daemon-reload
 systemctl --user enable --now "nats@$CTX_SLUG"
 curl -sf "http://127.0.0.1:$CTX_NATS_MON/healthz"   # → {"status":"ok"}

--- a/scripts/__tests__/systemd-render-e2e.test.ts
+++ b/scripts/__tests__/systemd-render-e2e.test.ts
@@ -128,18 +128,29 @@ describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
     writeFileSync(join(configDir, SLUG, `${SLUG}.yaml`), "");
     writeFileSync(join(configDir, SLUG, "system", "system.yaml"), "");
 
-    // Deliberately NOT pre-creating the log dirs or the workspace dir here —
-    // render_cortex_systemd_units (ensure_stack_log_dirs +
-    // ensure_stack_workspace_dirs) must create all three itself. Asserting
-    // that below is the actual regression test for the PR#2103 review
-    // BLOCKER 1 fix (a fresh host with NEITHER pre-created used to fail
+    // Deliberately NOT pre-creating the nats log dir or the workspace dir
+    // here — render_cortex_systemd_units (ensure_stack_log_dirs +
+    // ensure_stack_workspace_dirs) must create both itself. Asserting that
+    // below is the actual regression test for the PR#2103 review BLOCKER 1
+    // fix (a fresh host with neither pre-created used to fail
     // EXIT_STDOUT/EXIT_CHDIR before this fix).
     //
-    // The two log dirs are NOT in restoreFns: they're host-wide permanent
+    // The CORTEX log dir is the one exception: ensure_stack_log_dirs
+    // deliberately does NOT create it (see its docstring — that's
+    // postinstall.sh's §1b state-bootstrap's authority alone, gated by the
+    // XDG wave-5 migration, cortex#1903; a second PR#2103 review round found
+    // the renderer creating it anyway broke that invariant in CI's plain Test
+    // job). This test drives render_cortex_systemd_units in isolation,
+    // without postinstall.sh's §1b ever running, so — exactly like a real
+    // arc-managed flow, where §1b already ran before anyone gets to enabling
+    // a unit — it has to create this one prerequisite itself.
+    //
+    // Neither log dir is in restoreFns: they're host-wide permanent
     // infrastructure (same class as ~/.claude/events — created once, kept
     // forever), not slug/test-scoped state, so leaving them behind after this
     // test matches what a real install would do too. Only the workspace dir
     // (slug-scoped) and the unit/binary files this test wrote are unwound.
+    mkdirSync(CORTEX_LOGS_DIR, { recursive: true });
 
     try {
       // 1. Render the real checked-in templates into the real unit dir,

--- a/scripts/__tests__/systemd-render-e2e.test.ts
+++ b/scripts/__tests__/systemd-render-e2e.test.ts
@@ -1,0 +1,128 @@
+// Real end-to-end coverage for scripts/lib/systemd-render.sh against an
+// ACTUAL systemd --user session: render → enable --now nats@/cortex@ → is-
+// active → the restart-on-upgrade path (cortex#2071 executor addendum's
+// verification recipe). This is deliberately split out of
+// systemd-render.test.ts (which is fully mocked and safe to run anywhere) —
+// this file drives the real `systemctl --user` against the real inherited
+// $HOME, because the running systemd user MANAGER resolves its unit search
+// path from ITS OWN startup environment, not from whatever $HOME this test
+// process exports — so a scratch-HOME trick (as the mocked suite uses)
+// cannot isolate this test the way it isolates that one.
+//
+// Runs ONLY in the dedicated `systemd-e2e` CI job (cortex#2092, dbus/
+// XDG_RUNTIME_DIR bootstrap + `bun test --test-name-pattern systemd-e2e`),
+// gated on BOTH `CI=true` (GitHub Actions sets this) AND a live systemd-user
+// bus — never on a real developer machine, even a Linux desktop with its own
+// systemd-user session, where blindly stubbing ~/.local/bin/cortex or
+// enabling/disabling units could clobber a REAL install. Test name and
+// describe block both carry "systemd-e2e" so the CI job's
+// `--test-name-pattern systemd-e2e` picks this up.
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const LIB = join(REPO_ROOT, "scripts", "lib", "systemd-render.sh");
+
+function sh(cmd: string, args: string[]) {
+  return spawnSync(cmd, args, { encoding: "utf8" });
+}
+
+function hasSystemdUserSession(): boolean {
+  if (process.platform !== "linux") return false;
+  const probe = sh("systemctl", ["--user", "show-environment"]);
+  return probe.status === 0;
+}
+
+// CI-only gate (see file header) — deliberately NOT just "Linux with a
+// systemd-user session", which would also match a real developer desktop.
+const RUN_E2E = process.env.CI === "true" && hasSystemdUserSession();
+
+const SLUG = "e2e2071";
+const HOME_DIR = homedir();
+const UNIT_DIR = join(HOME_DIR, ".config", "systemd", "user");
+const LOCAL_BIN = join(HOME_DIR, ".local", "bin");
+
+describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
+  test.skipIf(!RUN_E2E)("render → enable --now nats@/cortex@ → is-active → restart-on-upgrade", () => {
+    mkdirSync(LOCAL_BIN, { recursive: true });
+
+    // Stub nats-server/cortex — a real long-running Type=simple process that
+    // ignores its args, so `systemctl --user enable --now` has something
+    // real to mark active without needing an actual NATS server or a linked
+    // cortex CLI on the bare CI runner. Back up + restore anything already
+    // there (belt-and-braces; a fresh Actions runner never has these, but a
+    // stub must never end up permanently shadowing a real binary).
+    const backups: Array<{ path: string; backup: string }> = [];
+    for (const name of ["nats-server", "cortex"]) {
+      const p = join(LOCAL_BIN, name);
+      if (existsSync(p)) {
+        const backup = `${p}.systemd-e2e-backup`;
+        renameSync(p, backup);
+        backups.push({ path: p, backup });
+      }
+      writeFileSync(p, "#!/bin/sh\nexec sleep 3600\n");
+      chmodSync(p, 0o755);
+    }
+
+    let configDir = "";
+    try {
+      // 1. Render the real checked-in templates into the real unit dir.
+      const render = sh("bash", ["-c", `source "${LIB}" && render_cortex_systemd_units "${REPO_ROOT}" "${UNIT_DIR}"`]);
+      if (render.status !== 0) throw new Error(`render_cortex_systemd_units failed:\n${render.stdout}${render.stderr}`);
+      expect(existsSync(join(UNIT_DIR, "nats@.service"))).toBe(true);
+      expect(existsSync(join(UNIT_DIR, "cortex@.service"))).toBe(true);
+
+      // 2. Enable + start both instances for the e2e slug.
+      const enableNats = sh("systemctl", ["--user", "enable", "--now", `nats@${SLUG}`]);
+      if (enableNats.status !== 0) throw new Error(`enable nats@${SLUG} failed:\n${enableNats.stdout}${enableNats.stderr}`);
+      const enableCortex = sh("systemctl", ["--user", "enable", "--now", `cortex@${SLUG}`]);
+      if (enableCortex.status !== 0) throw new Error(`enable cortex@${SLUG} failed:\n${enableCortex.stdout}${enableCortex.stderr}`);
+
+      // 3. is-active.
+      expect(sh("systemctl", ["--user", "is-active", "--quiet", `nats@${SLUG}`]).status).toBe(0);
+      expect(sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]).status).toBe(0);
+
+      // 4. Restart-on-upgrade path — restart_running_systemd_stacks discovers
+      //    the slug from a config-dir fixture and must restart the ACTIVE
+      //    cortex@e2e2071 instance (mirrors what postupgrade.sh does after
+      //    `arc upgrade cortex`).
+      configDir = mkdtempSync(join(tmpdir(), "cortex-systemd-e2e-config-"));
+      mkdirSync(join(configDir, SLUG, "system"), { recursive: true });
+      writeFileSync(join(configDir, SLUG, `${SLUG}.yaml`), "");
+      writeFileSync(join(configDir, SLUG, "system", "system.yaml"), "");
+
+      const restart = sh("bash", ["-c", `source "${LIB}" && restart_running_systemd_stacks "${configDir}"`]);
+      if (restart.status !== 0) throw new Error(`restart_running_systemd_stacks failed:\n${restart.stdout}${restart.stderr}`);
+      expect(restart.stdout).toContain(`cortex@${SLUG} restarted`);
+      expect(sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]).status).toBe(0);
+    } finally {
+      // Stop + disable the e2e instances and remove the rendered units + stub
+      // binaries, restoring any pre-existing binary from its backup — leaves
+      // the runner's systemd-user state exactly as found.
+      sh("systemctl", ["--user", "disable", "--now", `cortex@${SLUG}`]);
+      sh("systemctl", ["--user", "disable", "--now", `nats@${SLUG}`]);
+      rmSync(join(UNIT_DIR, "nats@.service"), { force: true });
+      rmSync(join(UNIT_DIR, "cortex@.service"), { force: true });
+      sh("systemctl", ["--user", "daemon-reload"]);
+      for (const name of ["nats-server", "cortex"]) {
+        rmSync(join(LOCAL_BIN, name), { force: true });
+      }
+      for (const { path, backup } of backups) {
+        renameSync(backup, path);
+      }
+      if (configDir) rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Documents the skip reason in CI output when the gate isn't satisfied (e.g.
+// this file running under the plain `test` job, which has no systemd-user
+// session bootstrap) so "0 tests ran" doesn't read as a silent hole.
+afterAll(() => {
+  if (!RUN_E2E) {
+    console.log("systemd-e2e: skipped (requires CI=true + a live systemd --user session — see file header)");
+  }
+});

--- a/scripts/__tests__/systemd-render-e2e.test.ts
+++ b/scripts/__tests__/systemd-render-e2e.test.ts
@@ -17,10 +17,16 @@
 // Ubuntu runner — still satisfies a bare "is there a systemd-user bus"
 // probe, so that check alone let this test leak into the wrong job) and NOT
 // on "Linux + a live systemd-user session" alone, which would also match a
-// real developer's Linux desktop, where blindly stubbing ~/.local/bin/cortex
-// or enabling/disabling units could clobber a REAL install. Test name and
-// describe block both carry "systemd-e2e" so the CI job's
-// `--test-name-pattern systemd-e2e` picks this up.
+// real developer's Linux desktop, where blindly stubbing ~/.local/bin/cortex,
+// enabling/disabling units, or touching an existing nats@.service/
+// cortex@.service could clobber a REAL install. Test name and describe block
+// both carry "systemd-e2e" so the CI job's `--test-name-pattern systemd-e2e`
+// picks this up.
+//
+// Every mutation this test makes to the real $HOME (stub binaries, unit
+// files, the workspace dir) is backed up before and restored in `finally` —
+// on the off chance this ever ran on a box with a genuine install present
+// (it shouldn't, given the gate above), it must not orphan a live stack.
 import { afterAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "fs";
@@ -50,15 +56,16 @@ const SLUG = "e2e2071";
 const HOME_DIR = homedir();
 const UNIT_DIR = join(HOME_DIR, ".config", "systemd", "user");
 const LOCAL_BIN = join(HOME_DIR, ".local", "bin");
-const CORTEX_LOGS_DIR = join(HOME_DIR, ".local", "state", "metafactory", "cortex", "logs");
+const WORKSPACE_DIR = join(HOME_DIR, ".local", "share", "metafactory", "cortex", SLUG);
 const NATS_LOGS_DIR = join(HOME_DIR, ".local", "state", "nats", "logs");
+const CORTEX_LOGS_DIR = join(HOME_DIR, ".local", "state", "metafactory", "cortex", "logs");
 
 // Captures `systemctl --user status` + the tail of `journalctl --user` for a
 // unit so a future CI failure explains itself instead of just reporting "not
 // active" — this is exactly the diagnostic gap that made the cortex#2103
-// review round-trip necessary; verified against a real systemd 257 user
-// session that this is enough to see the actual failing ExecStartPre/exec
-// (e.g. `code=exited, status=200/CHDIR` or `status=209/STDOUT`).
+// review round-trip necessary; verified against a real systemd user session
+// that this is enough to see the actual failing ExecStartPre/exec (e.g.
+// `code=exited, status=200/CHDIR` or `status=209/STDOUT`).
 function diagnose(unit: string): string {
   const status = sh("systemctl", ["--user", "status", unit, "--no-pager", "-l"]);
   const journal = sh("journalctl", ["--user", "-u", unit, "--no-pager"]);
@@ -69,63 +76,82 @@ function diagnose(unit: string): string {
   );
 }
 
+// Backs up path (rename aside) if it already exists, returning a restore
+// function. Used for every real-$HOME path this test touches (stub
+// binaries AND the unit files — PR#2103 review finding: only the binaries
+// were backed up in the previous round, the unit files were unconditionally
+// overwritten/removed) so a pre-existing file is never lost, and only files
+// this test itself created get deleted in cleanup.
+function backup(path: string): () => void {
+  if (!existsSync(path)) {
+    return () => rmSync(path, { force: true, recursive: true });
+  }
+  const savedAt = `${path}.systemd-e2e-backup`;
+  renameSync(path, savedAt);
+  return () => {
+    rmSync(path, { force: true, recursive: true });
+    renameSync(savedAt, path);
+  };
+}
+
 describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
   test.skipIf(!RUN_E2E)("render → enable --now nats@/cortex@ → is-active → restart-on-upgrade", () => {
     mkdirSync(LOCAL_BIN, { recursive: true });
+    mkdirSync(UNIT_DIR, { recursive: true });
+
+    const restoreFns: Array<() => void> = [];
+    // Unit files first (mirrors render_cortex_systemd_units writing them),
+    // then the stub binaries, then the workspace dir — order doesn't matter
+    // for correctness, but restoring in reverse in `finally` undoes them
+    // cleanly regardless.
+    restoreFns.push(backup(join(UNIT_DIR, "nats@.service")));
+    restoreFns.push(backup(join(UNIT_DIR, "cortex@.service")));
+    restoreFns.push(backup(WORKSPACE_DIR));
 
     // Stub nats-server/cortex — a real long-running Type=simple process that
     // ignores its args, so `systemctl --user enable --now` has something
     // real to mark active without needing an actual NATS server or a linked
     // cortex CLI on the bare CI runner. `sleep infinity` (not a bounded
-    // duration) so it can never exit on its own during the test. Back up +
-    // restore anything already there (belt-and-braces; a fresh Actions
-    // runner never has these, but a stub must never end up permanently
-    // shadowing a real binary).
-    const backups: Array<{ path: string; backup: string }> = [];
+    // duration) so it can never exit on its own during the test.
     for (const name of ["nats-server", "cortex"]) {
       const p = join(LOCAL_BIN, name);
-      if (existsSync(p)) {
-        const backup = `${p}.systemd-e2e-backup`;
-        renameSync(p, backup);
-        backups.push({ path: p, backup });
-      }
+      restoreFns.push(backup(p));
       writeFileSync(p, "#!/bin/sh\nexec sleep infinity\n");
       chmodSync(p, 0o755);
     }
 
     // Config-dir fixture (created BEFORE render, not after) so render_cortex_
     // systemd_units' ensure_stack_workspace_dirs sees this slug and creates
-    // ~/.local/share/metafactory/cortex/<slug>/workspace before cortex@ is
-    // ever enabled. WorkingDirectory= is entered before ANY exec command of
-    // the unit runs (including ExecStartPre) — verified against a real
-    // systemd 257 user session that a missing workspace dir fails the unit
-    // outright (EXIT_CHDIR) with no way for the unit file to self-heal —
-    // this is exactly why ensure_stack_workspace_dirs exists.
+    // the workspace dir before cortex@ is ever enabled.
     const configDir = mkdtempSync(join(tmpdir(), "cortex-systemd-e2e-config-"));
     mkdirSync(join(configDir, SLUG, "system"), { recursive: true });
     writeFileSync(join(configDir, SLUG, `${SLUG}.yaml`), "");
     writeFileSync(join(configDir, SLUG, "system", "system.yaml"), "");
 
-    // The two units' StandardOutput=/StandardError=append: log dirs need the
-    // SAME pre-existence treatment as WorkingDirectory= (verified: it's also
-    // set up before ExecStartPre runs, so `ExecStartPre=mkdir -p <that dir>`
-    // can't self-heal a missing one either). In the real documented flows
-    // this is already covered — README-AGENTS.md Appendix A §A.1 hand-creates
-    // nats-server's; postinstall.sh's state bootstrap (§1b) creates cortex's,
-    // host-independent — but this test exercises render/enable/restart in
-    // isolation without running either, so it replicates both prerequisites
-    // directly rather than silently depending on a coincidence of test order.
-    mkdirSync(NATS_LOGS_DIR, { recursive: true });
-    mkdirSync(CORTEX_LOGS_DIR, { recursive: true });
+    // Deliberately NOT pre-creating the log dirs or the workspace dir here —
+    // render_cortex_systemd_units (ensure_stack_log_dirs +
+    // ensure_stack_workspace_dirs) must create all three itself. Asserting
+    // that below is the actual regression test for the PR#2103 review
+    // BLOCKER 1 fix (a fresh host with NEITHER pre-created used to fail
+    // EXIT_STDOUT/EXIT_CHDIR before this fix).
+    //
+    // The two log dirs are NOT in restoreFns: they're host-wide permanent
+    // infrastructure (same class as ~/.claude/events — created once, kept
+    // forever), not slug/test-scoped state, so leaving them behind after this
+    // test matches what a real install would do too. Only the workspace dir
+    // (slug-scoped) and the unit/binary files this test wrote are unwound.
 
     try {
       // 1. Render the real checked-in templates into the real unit dir,
-      //    passing the config-dir fixture so the workspace dir gets created.
+      //    passing the config-dir fixture so the workspace + log dirs get
+      //    created deterministically (not relying on test setup order).
       const render = sh("bash", ["-c", `source "${LIB}" && render_cortex_systemd_units "${REPO_ROOT}" "${UNIT_DIR}" "${configDir}"`]);
       if (render.status !== 0) throw new Error(`render_cortex_systemd_units failed:\n${render.stdout}${render.stderr}`);
       expect(existsSync(join(UNIT_DIR, "nats@.service"))).toBe(true);
       expect(existsSync(join(UNIT_DIR, "cortex@.service"))).toBe(true);
-      expect(existsSync(join(HOME_DIR, ".local", "share", "metafactory", "cortex", SLUG, "workspace"))).toBe(true);
+      expect(existsSync(join(WORKSPACE_DIR, "workspace"))).toBe(true);
+      expect(existsSync(NATS_LOGS_DIR)).toBe(true);
+      expect(existsSync(CORTEX_LOGS_DIR)).toBe(true);
 
       // 2. Enable + start both instances for the e2e slug.
       const enableNats = sh("systemctl", ["--user", "enable", "--now", `nats@${SLUG}`]);
@@ -152,22 +178,15 @@ describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
       if (stillActive.status !== 0) throw new Error(`cortex@${SLUG} not active after restart:\n${diagnose(`cortex@${SLUG}`)}`);
       expect(stillActive.status).toBe(0);
     } finally {
-      // Stop + disable the e2e instances and remove the rendered units + stub
-      // binaries, restoring any pre-existing binary from its backup — leaves
-      // the runner's systemd-user state exactly as found.
+      // Stop + disable the e2e instances FIRST (before any file is removed/
+      // restored underneath a still-running unit), then unwind every backup
+      // in reverse — restoring any pre-existing unit file/binary/workspace
+      // dir and deleting only what this test itself created.
       sh("systemctl", ["--user", "disable", "--now", `cortex@${SLUG}`]);
       sh("systemctl", ["--user", "disable", "--now", `nats@${SLUG}`]);
-      rmSync(join(UNIT_DIR, "nats@.service"), { force: true });
-      rmSync(join(UNIT_DIR, "cortex@.service"), { force: true });
+      for (const restore of restoreFns.reverse()) restore();
       sh("systemctl", ["--user", "daemon-reload"]);
-      for (const name of ["nats-server", "cortex"]) {
-        rmSync(join(LOCAL_BIN, name), { force: true });
-      }
-      for (const { path, backup } of backups) {
-        renameSync(backup, path);
-      }
       rmSync(configDir, { recursive: true, force: true });
-      rmSync(join(HOME_DIR, ".local", "share", "metafactory", "cortex", SLUG), { recursive: true, force: true });
     }
   });
 });

--- a/scripts/__tests__/systemd-render-e2e.test.ts
+++ b/scripts/__tests__/systemd-render-e2e.test.ts
@@ -10,11 +10,15 @@
 // cannot isolate this test the way it isolates that one.
 //
 // Runs ONLY in the dedicated `systemd-e2e` CI job (cortex#2092, dbus/
-// XDG_RUNTIME_DIR bootstrap + `bun test --test-name-pattern systemd-e2e`),
-// gated on BOTH `CI=true` (GitHub Actions sets this) AND a live systemd-user
-// bus — never on a real developer machine, even a Linux desktop with its own
-// systemd-user session, where blindly stubbing ~/.local/bin/cortex or
-// enabling/disabling units could clobber a REAL install. Test name and
+// XDG_RUNTIME_DIR bootstrap), gated on an explicit `SYSTEMD_E2E=1` opt-in env
+// var that ONLY that job's test step sets (.github/workflows/ci.yml) — NOT on
+// "CI=true" (GitHub Actions sets that in EVERY job, including the plain Test
+// job, which has no systemd-user session bootstrap but — on a GitHub-hosted
+// Ubuntu runner — still satisfies a bare "is there a systemd-user bus"
+// probe, so that check alone let this test leak into the wrong job) and NOT
+// on "Linux + a live systemd-user session" alone, which would also match a
+// real developer's Linux desktop, where blindly stubbing ~/.local/bin/cortex
+// or enabling/disabling units could clobber a REAL install. Test name and
 // describe block both carry "systemd-e2e" so the CI job's
 // `--test-name-pattern systemd-e2e` picks this up.
 import { afterAll, describe, expect, test } from "bun:test";
@@ -36,14 +40,34 @@ function hasSystemdUserSession(): boolean {
   return probe.status === 0;
 }
 
-// CI-only gate (see file header) — deliberately NOT just "Linux with a
-// systemd-user session", which would also match a real developer desktop.
-const RUN_E2E = process.env.CI === "true" && hasSystemdUserSession();
+// Opt-in gate (see file header) — deliberately an explicit env var the CI job
+// sets on its OWN test step, not a general "looks like CI" or "looks like
+// Linux with systemd" signal. Either of those leaked this test into the plain
+// Test job in practice (cortex#2103 review).
+const RUN_E2E = process.env.SYSTEMD_E2E === "1" && hasSystemdUserSession();
 
 const SLUG = "e2e2071";
 const HOME_DIR = homedir();
 const UNIT_DIR = join(HOME_DIR, ".config", "systemd", "user");
 const LOCAL_BIN = join(HOME_DIR, ".local", "bin");
+const CORTEX_LOGS_DIR = join(HOME_DIR, ".local", "state", "metafactory", "cortex", "logs");
+const NATS_LOGS_DIR = join(HOME_DIR, ".local", "state", "nats", "logs");
+
+// Captures `systemctl --user status` + the tail of `journalctl --user` for a
+// unit so a future CI failure explains itself instead of just reporting "not
+// active" — this is exactly the diagnostic gap that made the cortex#2103
+// review round-trip necessary; verified against a real systemd 257 user
+// session that this is enough to see the actual failing ExecStartPre/exec
+// (e.g. `code=exited, status=200/CHDIR` or `status=209/STDOUT`).
+function diagnose(unit: string): string {
+  const status = sh("systemctl", ["--user", "status", unit, "--no-pager", "-l"]);
+  const journal = sh("journalctl", ["--user", "-u", unit, "--no-pager"]);
+  const journalTail = journal.stdout.trim().split("\n").slice(-20).join("\n");
+  return (
+    `--- systemctl --user status ${unit} --no-pager -l ---\n${status.stdout}${status.stderr}\n` +
+    `--- journalctl --user -u ${unit} --no-pager | tail -20 ---\n${journalTail}\n${journal.stderr}`
+  );
+}
 
 describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
   test.skipIf(!RUN_E2E)("render → enable --now nats@/cortex@ → is-active → restart-on-upgrade", () => {
@@ -52,9 +76,11 @@ describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
     // Stub nats-server/cortex — a real long-running Type=simple process that
     // ignores its args, so `systemctl --user enable --now` has something
     // real to mark active without needing an actual NATS server or a linked
-    // cortex CLI on the bare CI runner. Back up + restore anything already
-    // there (belt-and-braces; a fresh Actions runner never has these, but a
-    // stub must never end up permanently shadowing a real binary).
+    // cortex CLI on the bare CI runner. `sleep infinity` (not a bounded
+    // duration) so it can never exit on its own during the test. Back up +
+    // restore anything already there (belt-and-braces; a fresh Actions
+    // runner never has these, but a stub must never end up permanently
+    // shadowing a real binary).
     const backups: Array<{ path: string; backup: string }> = [];
     for (const name of ["nats-server", "cortex"]) {
       const p = join(LOCAL_BIN, name);
@@ -63,41 +89,68 @@ describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
         renameSync(p, backup);
         backups.push({ path: p, backup });
       }
-      writeFileSync(p, "#!/bin/sh\nexec sleep 3600\n");
+      writeFileSync(p, "#!/bin/sh\nexec sleep infinity\n");
       chmodSync(p, 0o755);
     }
 
-    let configDir = "";
+    // Config-dir fixture (created BEFORE render, not after) so render_cortex_
+    // systemd_units' ensure_stack_workspace_dirs sees this slug and creates
+    // ~/.local/share/metafactory/cortex/<slug>/workspace before cortex@ is
+    // ever enabled. WorkingDirectory= is entered before ANY exec command of
+    // the unit runs (including ExecStartPre) — verified against a real
+    // systemd 257 user session that a missing workspace dir fails the unit
+    // outright (EXIT_CHDIR) with no way for the unit file to self-heal —
+    // this is exactly why ensure_stack_workspace_dirs exists.
+    const configDir = mkdtempSync(join(tmpdir(), "cortex-systemd-e2e-config-"));
+    mkdirSync(join(configDir, SLUG, "system"), { recursive: true });
+    writeFileSync(join(configDir, SLUG, `${SLUG}.yaml`), "");
+    writeFileSync(join(configDir, SLUG, "system", "system.yaml"), "");
+
+    // The two units' StandardOutput=/StandardError=append: log dirs need the
+    // SAME pre-existence treatment as WorkingDirectory= (verified: it's also
+    // set up before ExecStartPre runs, so `ExecStartPre=mkdir -p <that dir>`
+    // can't self-heal a missing one either). In the real documented flows
+    // this is already covered — README-AGENTS.md Appendix A §A.1 hand-creates
+    // nats-server's; postinstall.sh's state bootstrap (§1b) creates cortex's,
+    // host-independent — but this test exercises render/enable/restart in
+    // isolation without running either, so it replicates both prerequisites
+    // directly rather than silently depending on a coincidence of test order.
+    mkdirSync(NATS_LOGS_DIR, { recursive: true });
+    mkdirSync(CORTEX_LOGS_DIR, { recursive: true });
+
     try {
-      // 1. Render the real checked-in templates into the real unit dir.
-      const render = sh("bash", ["-c", `source "${LIB}" && render_cortex_systemd_units "${REPO_ROOT}" "${UNIT_DIR}"`]);
+      // 1. Render the real checked-in templates into the real unit dir,
+      //    passing the config-dir fixture so the workspace dir gets created.
+      const render = sh("bash", ["-c", `source "${LIB}" && render_cortex_systemd_units "${REPO_ROOT}" "${UNIT_DIR}" "${configDir}"`]);
       if (render.status !== 0) throw new Error(`render_cortex_systemd_units failed:\n${render.stdout}${render.stderr}`);
       expect(existsSync(join(UNIT_DIR, "nats@.service"))).toBe(true);
       expect(existsSync(join(UNIT_DIR, "cortex@.service"))).toBe(true);
+      expect(existsSync(join(HOME_DIR, ".local", "share", "metafactory", "cortex", SLUG, "workspace"))).toBe(true);
 
       // 2. Enable + start both instances for the e2e slug.
       const enableNats = sh("systemctl", ["--user", "enable", "--now", `nats@${SLUG}`]);
-      if (enableNats.status !== 0) throw new Error(`enable nats@${SLUG} failed:\n${enableNats.stdout}${enableNats.stderr}`);
+      if (enableNats.status !== 0) throw new Error(`enable nats@${SLUG} failed:\n${enableNats.stdout}${enableNats.stderr}\n${diagnose(`nats@${SLUG}`)}`);
       const enableCortex = sh("systemctl", ["--user", "enable", "--now", `cortex@${SLUG}`]);
-      if (enableCortex.status !== 0) throw new Error(`enable cortex@${SLUG} failed:\n${enableCortex.stdout}${enableCortex.stderr}`);
+      if (enableCortex.status !== 0) throw new Error(`enable cortex@${SLUG} failed:\n${enableCortex.stdout}${enableCortex.stderr}\n${diagnose(`cortex@${SLUG}`)}`);
 
       // 3. is-active.
-      expect(sh("systemctl", ["--user", "is-active", "--quiet", `nats@${SLUG}`]).status).toBe(0);
-      expect(sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]).status).toBe(0);
+      const activeNats = sh("systemctl", ["--user", "is-active", "--quiet", `nats@${SLUG}`]);
+      if (activeNats.status !== 0) throw new Error(`nats@${SLUG} is not active:\n${diagnose(`nats@${SLUG}`)}`);
+      expect(activeNats.status).toBe(0);
+      const activeCortex = sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]);
+      if (activeCortex.status !== 0) throw new Error(`cortex@${SLUG} is not active:\n${diagnose(`cortex@${SLUG}`)}`);
+      expect(activeCortex.status).toBe(0);
 
       // 4. Restart-on-upgrade path — restart_running_systemd_stacks discovers
-      //    the slug from a config-dir fixture and must restart the ACTIVE
+      //    the slug from the config-dir fixture and must restart the ACTIVE
       //    cortex@e2e2071 instance (mirrors what postupgrade.sh does after
       //    `arc upgrade cortex`).
-      configDir = mkdtempSync(join(tmpdir(), "cortex-systemd-e2e-config-"));
-      mkdirSync(join(configDir, SLUG, "system"), { recursive: true });
-      writeFileSync(join(configDir, SLUG, `${SLUG}.yaml`), "");
-      writeFileSync(join(configDir, SLUG, "system", "system.yaml"), "");
-
       const restart = sh("bash", ["-c", `source "${LIB}" && restart_running_systemd_stacks "${configDir}"`]);
       if (restart.status !== 0) throw new Error(`restart_running_systemd_stacks failed:\n${restart.stdout}${restart.stderr}`);
       expect(restart.stdout).toContain(`cortex@${SLUG} restarted`);
-      expect(sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]).status).toBe(0);
+      const stillActive = sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]);
+      if (stillActive.status !== 0) throw new Error(`cortex@${SLUG} not active after restart:\n${diagnose(`cortex@${SLUG}`)}`);
+      expect(stillActive.status).toBe(0);
     } finally {
       // Stop + disable the e2e instances and remove the rendered units + stub
       // binaries, restoring any pre-existing binary from its backup — leaves
@@ -113,16 +166,17 @@ describe("systemd-e2e: real render + enable + restart (cortex#2071)", () => {
       for (const { path, backup } of backups) {
         renameSync(backup, path);
       }
-      if (configDir) rmSync(configDir, { recursive: true, force: true });
+      rmSync(configDir, { recursive: true, force: true });
+      rmSync(join(HOME_DIR, ".local", "share", "metafactory", "cortex", SLUG), { recursive: true, force: true });
     }
   });
 });
 
 // Documents the skip reason in CI output when the gate isn't satisfied (e.g.
-// this file running under the plain `test` job, which has no systemd-user
-// session bootstrap) so "0 tests ran" doesn't read as a silent hole.
+// this file running under the plain `test` job, which never sets
+// SYSTEMD_E2E) so "0 tests ran" doesn't read as a silent hole.
 afterAll(() => {
   if (!RUN_E2E) {
-    console.log("systemd-e2e: skipped (requires CI=true + a live systemd --user session — see file header)");
+    console.log("systemd-e2e: skipped (requires SYSTEMD_E2E=1 + a live systemd --user session — see file header)");
   }
 });

--- a/scripts/__tests__/systemd-render.sh
+++ b/scripts/__tests__/systemd-render.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # cortex#2071 (L1, Linux host support) — unit tests for scripts/lib/systemd-render.sh:
-# marker-header idempotency, daemon-reload-only-on-change, the Darwin/
-# systemd-less no-ops, the bin-symlink + linger warnings, and the
-# restart-only-if-active loop.
+# marker-header idempotency, hand-authored-unit protection, daemon-reload-only-
+# on-change, the Darwin/systemd-less no-ops, the bin-symlink + linger warnings,
+# the restart-only-if-active loop, and (PR#2103 review round 2) the guarded-
+# systemctl / set -e survival behavior plus the timeout wrapper.
 #
 # Tests run entirely in a scratch $HOME; no live ~/.config/systemd/user or
 # systemctl/loginctl is touched — both are mocked via PATH override, same
@@ -71,8 +72,14 @@ export HOME="${TMPHOME}"
 source "${SCRIPT_DIR}/lib/systemd-render.sh"
 
 # Mock bin dir: uname (force "Linux" so the render path runs on any host this
-# suite executes on), systemctl (trace log + controllable is-active), and
-# loginctl (controllable Linger value).
+# suite executes on), systemctl (trace log + controllable is-active/
+# daemon-reload/restart failure injection), and loginctl (controllable
+# Linger value). `timeout` itself is NOT mocked — the real coreutils
+# `timeout` (present on both macOS-via-homebrew dev boxes and every Ubuntu CI
+# runner) transparently wraps the mocked systemctl/loginctl below, so
+# run_with_timeout's normal path is exercised for real; only its "timeout not
+# installed" degrade path needs a PATH trick (see the run_with_timeout
+# section).
 MOCK_BIN="${TMPHOME}/mock-bin"
 mkdir -p "${MOCK_BIN}"
 
@@ -83,18 +90,30 @@ EOF
 chmod +x "${MOCK_BIN}/uname"
 
 export SYSTEMCTL_LOG="${TMPHOME}/systemctl.log"
-# ACTIVE_UNITS: newline-separated unit names `systemctl --user is-active
+# ACTIVE_UNITS_FILE: newline-separated unit names `systemctl --user is-active
 # --quiet <unit>` should report active (exit 0) for; anything else exits 1.
 export ACTIVE_UNITS_FILE="${TMPHOME}/active-units"
 : > "${ACTIVE_UNITS_FILE}"
+# FAIL_DAEMON_RELOAD=1 → `daemon-reload` exits 1 (simulates a wedged/unavailable bus).
+# FAIL_RESTART_UNITS="unit1 unit2" → `restart <unit>` exits 1 iff <unit> is listed.
 cat > "${MOCK_BIN}/systemctl" <<'EOF'
 #!/bin/sh
 printf 'systemctl %s\n' "$*" >> "${SYSTEMCTL_LOG:-/dev/null}"
-# is-active --quiet <unit>: exit 0 iff <unit> is listed in ACTIVE_UNITS_FILE.
 if [ "$1" = "--user" ] && [ "$2" = "is-active" ]; then
   unit="$4"
   grep -qxF "${unit}" "${ACTIVE_UNITS_FILE:-/dev/null}" && exit 0
   exit 1
+fi
+if [ "$1" = "--user" ] && [ "$2" = "daemon-reload" ]; then
+  [ "${FAIL_DAEMON_RELOAD:-0}" = "1" ] && exit 1
+  exit 0
+fi
+if [ "$1" = "--user" ] && [ "$2" = "restart" ]; then
+  unit="$3"
+  for u in ${FAIL_RESTART_UNITS:-}; do
+    [ "$u" = "$unit" ] && exit 1
+  done
+  exit 0
 fi
 exit 0
 EOF
@@ -152,28 +171,44 @@ assert_file_exists "cortex@.service written" "${UNIT_DIR}/cortex@.service"
 assert_eq "first render → change count 1" "1" "${SYSTEMD_RENDER_CHANGE_COUNT}"
 assert_eq "marker is line 1" "# rendered-by: cortex systemd-render v1" \
   "$(sed -n '1p' "${UNIT_DIR}/cortex@.service")"
-assert_grep_file "WorkingDirectory line present (workspace addendum, cortex#2097)" \
-  "${UNIT_DIR}/cortex@.service" 'WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace'
-# NO matching ExecStartPre mkdir line for the workspace dir: verified against a
-# real systemd 257 user session that WorkingDirectory= is entered before ANY
-# exec command (including ExecStartPre) runs, so that line could never have
-# self-healed a missing workspace dir (EXIT_CHDIR before it could run) — it
-# was removed in favor of ensure_stack_workspace_dirs (render-time, slug-aware,
-# actually able to create the directory before systemd ever tries to chdir
-# into it). The logs ExecStartPre line stays (belt-and-braces re-creation).
-assert_false "dead workspace ExecStartPre line NOT present (removed, cortex#2071 PR fixup)" \
-  bash -c "grep -qF 'ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace' '${UNIT_DIR}/cortex@.service'"
+assert_grep_file "WorkingDirectory carries the '-' prefix (PR#2103 BLOCKER 1 fix — missing dir is non-fatal)" \
+  "${UNIT_DIR}/cortex@.service" 'WorkingDirectory=-%h/.local/share/metafactory/cortex/%i/workspace'
+assert_grep_file "matching ExecStartPre workspace mkdir line present (belt-and-braces; works now that '-' lets it run)" \
+  "${UNIT_DIR}/cortex@.service" 'ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace'
 
 # Re-render with IDENTICAL content → no-op, change count NOT bumped again.
 render_systemd_unit "${CORTEX_DIR}/src/services/cortex@.service" "${UNIT_DIR}/cortex@.service"
 assert_eq "unchanged re-render → change count stays 1" "1" "${SYSTEMD_RENDER_CHANGE_COUNT}"
 
-# A hand-edited (drifted) dst → next render overwrites and bumps the count.
-printf 'stale hand-edit\n' > "${UNIT_DIR}/cortex@.service"
+# A MARKED dst with a stale/drifted body (e.g. rendered by an older version of
+# this renderer, or the checked-in template changed) → still OURS (marker
+# present), gets overwritten normally: count bumps, marker stays line 1.
+{ printf '%s\n' "# rendered-by: cortex systemd-render v1"; printf 'stale marked content\n'; } > "${UNIT_DIR}/cortex@.service"
 render_systemd_unit "${CORTEX_DIR}/src/services/cortex@.service" "${UNIT_DIR}/cortex@.service"
-assert_eq "drifted dst → re-rendered, change count bumps to 2" "2" "${SYSTEMD_RENDER_CHANGE_COUNT}"
-assert_eq "drifted dst → marker restored as line 1" "# rendered-by: cortex systemd-render v1" \
+assert_eq "marked-but-stale dst → re-rendered, change count bumps to 2" "2" "${SYSTEMD_RENDER_CHANGE_COUNT}"
+assert_eq "marked-but-stale dst → marker still line 1 after re-render" "# rendered-by: cortex systemd-render v1" \
   "$(sed -n '1p' "${UNIT_DIR}/cortex@.service")"
+
+# ── Hand-authored-unit protection (PR#2103 review MAJOR finding) ──
+# A dst that exists WITHOUT the marker (e.g. hand-copied per Appendix A
+# before this renderer existed, or a from-source operator's customization)
+# must be left COMPLETELY untouched: not overwritten, not deleted,
+# byte-identical before and after, and the change counter must NOT move.
+HAND_REF="$(mktemp)"
+cat > "${HAND_REF}" <<'EOF'
+[Unit]
+Description=My own hand-authored cortex unit, please do not touch
+EOF
+cp "${HAND_REF}" "${UNIT_DIR}/cortex@.service"
+HAND_BEFORE_COUNT="${SYSTEMD_RENDER_CHANGE_COUNT}"
+HAND_WARN="$(mktemp)"
+render_systemd_unit "${CORTEX_DIR}/src/services/cortex@.service" "${UNIT_DIR}/cortex@.service" 2>"${HAND_WARN}"
+assert_true "hand-authored dst is byte-identical after render (never touched)" \
+  cmp -s "${HAND_REF}" "${UNIT_DIR}/cortex@.service"
+assert_eq "hand-authored dst → change count NOT bumped" "${HAND_BEFORE_COUNT}" "${SYSTEMD_RENDER_CHANGE_COUNT}"
+assert_grep_file "hand-authored dst → warns it was left untouched" "${HAND_WARN}" \
+  "exists without the cortex systemd-render marker"
+rm -f "${HAND_WARN}" "${HAND_REF}"
 
 # Missing template source → warns, returns non-zero, nothing written.
 reset_unit_dir
@@ -183,11 +218,23 @@ assert_false "missing template source → non-zero" \
 assert_false "missing template source → nothing written" \
   test -e "${UNIT_DIR}/does-not-exist.service"
 
-# ─── Section 3: render_cortex_systemd_units — orchestration ───────
+# ─── Section 3: ensure_stack_log_dirs ──────────────────────────────
+printf '\n=== ensure_stack_log_dirs ===\n'
+
+rm -rf "${HOME}/.local/state/nats" "${HOME}/.local/state/metafactory"
+ensure_stack_log_dirs
+assert_true "nats log dir created (nothing else creates this on Linux)" \
+  test -d "${HOME}/.local/state/nats/logs"
+assert_true "cortex log dir created (deterministic, independent of postinstall's bootstrap)" \
+  test -d "${HOME}/.local/state/metafactory/cortex/logs"
+# Idempotent — a second call on already-existing dirs is a clean no-op.
+assert_true "re-running is a clean no-op" ensure_stack_log_dirs
+
+# ─── Section 4: render_cortex_systemd_units — orchestration ───────
 printf '\n=== render_cortex_systemd_units ===\n'
 
-# Config-dir fixture with two discoverable stacks — used both for the
-# workspace-dir-creation assertions below and for Section 6's restart tests.
+# Config-dir fixture with two discoverable stacks — used for the
+# workspace-dir-creation assertions below and for the restart-loop tests.
 CONFIG_DIR="${TMPHOME}/config"
 mkdir -p "${CONFIG_DIR}/work/system" "${CONFIG_DIR}/halden/system"
 : > "${CONFIG_DIR}/work/work.yaml"
@@ -225,31 +272,65 @@ assert_eq "systemd-less Linux → zero systemctl calls" "0" "$(wc -l < "${SYSTEM
 export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
 
 # Real systemd Linux host, fresh unit dir → both units rendered, exactly one
-# daemon-reload call (not one per unit), AND both discovered stacks' workspace
-# dirs exist (cortex@.service's WorkingDirectory= must pre-exist before
-# enable/start — see ensure_stack_workspace_dirs's docstring; verified against
-# a real systemd 257 user session, not just asserted here).
+# daemon-reload call (not one per unit), the two host-wide log dirs exist, AND
+# both discovered stacks' workspace dirs exist (defense-in-depth pre-creation
+# — the units also self-heal this via the "-" WorkingDirectory prefix, but a
+# proactive render-time create means an arc-managed upgrade never needs to
+# fall back to that path at all).
 reset_unit_dir
-rm -rf "${HOME}/.local/share/metafactory/cortex"
+rm -rf "${HOME}/.local/share/metafactory/cortex" "${HOME}/.local/state/nats" "${HOME}/.local/state/metafactory"
 : > "${SYSTEMCTL_LOG}"
 render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 assert_file_exists "nats@.service rendered" "${UNIT_DIR}/nats@.service"
 assert_file_exists "cortex@.service rendered" "${UNIT_DIR}/cortex@.service"
 assert_eq "fresh render (2 units changed) → exactly 1 daemon-reload call" "1" \
   "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}")"
+assert_true "render creates the nats log dir" test -d "${HOME}/.local/state/nats/logs"
+assert_true "render creates the cortex log dir" test -d "${HOME}/.local/state/metafactory/cortex/logs"
 assert_true "render also creates 'work' stack's workspace dir" \
   test -d "${HOME}/.local/share/metafactory/cortex/work/workspace"
 assert_true "render also creates 'halden' stack's workspace dir" \
   test -d "${HOME}/.local/share/metafactory/cortex/halden/workspace"
 
-# Re-render with nothing changed → zero daemon-reload calls (workspace-dir
+# Re-render with nothing changed → zero daemon-reload calls (workspace/log-dir
 # creation is idempotent — mkdir -p on an existing dir is a no-op).
 : > "${SYSTEMCTL_LOG}"
 render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 assert_eq "no-op re-render → zero daemon-reload calls" "0" \
   "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}" || true)"
 
-# ─── Section 3b: ensure_stack_workspace_dirs (standalone) ─────────
+# ── BLOCKER 2: a failing daemon-reload must not abort the caller ──
+reset_unit_dir
+: > "${SYSTEMCTL_LOG}"
+export FAIL_DAEMON_RELOAD=1
+RELOAD_ERR="$(mktemp)"
+set +e
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}" 2>"${RELOAD_ERR}"
+RELOAD_RC=$?
+set -e
+assert_eq "render_cortex_systemd_units returns 0 even when daemon-reload fails" "0" "${RELOAD_RC}"
+assert_grep_file "failing daemon-reload is warned, not silently swallowed" "${RELOAD_ERR}" \
+  "daemon-reload failed"
+assert_file_exists "units were still rendered despite the reload failure" "${UNIT_DIR}/cortex@.service"
+rm -f "${RELOAD_ERR}"
+unset FAIL_DAEMON_RELOAD
+
+# ── BLOCKER 2, end to end: a `set -e` caller (mirrors postinstall.sh/
+# postupgrade.sh's own shebang) must run PAST a failing daemon-reload, not
+# abort mid-script. ──
+reset_unit_dir
+export FAIL_DAEMON_RELOAD=1
+SETE_OUT="$(mktemp)"
+set +e
+bash -c "set -e; source '${SCRIPT_DIR}/lib/systemd-render.sh'; render_cortex_systemd_units '${CORTEX_DIR}' '${UNIT_DIR}' '${CONFIG_DIR}'; echo SCRIPT_COMPLETED" > "${SETE_OUT}" 2>&1
+SETE_RC=$?
+set -e
+assert_eq "a 'set -e' caller completes (exit 0) despite the failing daemon-reload" "0" "${SETE_RC}"
+assert_grep_file "the caller ran past the guarded daemon-reload call" "${SETE_OUT}" "SCRIPT_COMPLETED"
+rm -f "${SETE_OUT}"
+unset FAIL_DAEMON_RELOAD
+
+# ─── Section 5: ensure_stack_workspace_dirs (standalone) ──────────
 printf '\n=== ensure_stack_workspace_dirs ===\n'
 
 rm -rf "${HOME}/.local/share/metafactory/cortex"
@@ -265,7 +346,7 @@ mkdir -p "${EMPTY_CONFIG_DIR}"
 assert_true "no stacks → ensure_stack_workspace_dirs is a clean no-op" \
   ensure_stack_workspace_dirs "${EMPTY_CONFIG_DIR}"
 
-# ─── Section 4: verify_cortex_bin_symlink ─────────────────────────
+# ─── Section 6: verify_cortex_bin_symlink ─────────────────────────
 printf '\n=== verify_cortex_bin_symlink ===\n'
 
 rm -rf "${HOME}/.local/bin"
@@ -276,7 +357,7 @@ mkdir -p "${HOME}/.local/bin"
 printf '#!/bin/sh\n' > "${HOME}/.local/bin/cortex"
 assert_true "present ~/.local/bin/cortex → passes" verify_cortex_bin_symlink
 
-# ─── Section 5: warn_systemd_linger ───────────────────────────────
+# ─── Section 7: warn_systemd_linger ───────────────────────────────
 printf '\n=== warn_systemd_linger ===\n'
 
 export LINGER_VALUE="yes"
@@ -296,10 +377,10 @@ assert_false "warn_systemd_linger never invokes sudo itself" \
 rm -f "${WARN_OUT}"
 export LINGER_VALUE="yes"
 
-# ─── Section 6: restart_running_systemd_stacks ────────────────────
+# ─── Section 8: restart_running_systemd_stacks ────────────────────
 printf '\n=== restart_running_systemd_stacks ===\n'
 
-# Reuses the CONFIG_DIR fixture (work + halden stacks) set up before Section 3.
+# Reuses the CONFIG_DIR fixture (work + halden stacks) from Section 4.
 
 # Only 'work' is active.
 : > "${ACTIVE_UNITS_FILE}"
@@ -320,6 +401,55 @@ assert_eq "inactive 'halden' IS checked (is-active called)" "1" \
 restart_running_systemd_stacks "${CONFIG_DIR}" > /dev/null
 assert_eq "nothing active → zero restart calls" "0" \
   "$(grep -c '^systemctl --user restart ' "${SYSTEMCTL_LOG}" || true)"
+
+# ── BLOCKER 2: one failed restart must not abort the loop or hide the
+# remaining stacks — it's collected and reported, everything else proceeds. ──
+: > "${ACTIVE_UNITS_FILE}"
+printf 'cortex@work\ncortex@halden\n' >> "${ACTIVE_UNITS_FILE}"
+export FAIL_RESTART_UNITS="cortex@work"
+: > "${SYSTEMCTL_LOG}"
+RESTART_OUT="$(mktemp)"
+set +e
+restart_running_systemd_stacks "${CONFIG_DIR}" > "${RESTART_OUT}" 2>&1
+RESTART_RC=$?
+set -e
+assert_eq "restart_running_systemd_stacks returns 0 even with a failed restart" "0" "${RESTART_RC}"
+assert_grep_file "the failed unit is reported per-unit" "${RESTART_OUT}" "cortex@work restart FAILED"
+assert_grep_file "the failed unit is named in the end-of-run summary" "${RESTART_OUT}" \
+  "failed to restart: cortex@work"
+assert_eq "the OTHER active stack (halden) still restarts despite work's failure" "1" \
+  "$(grep -c '^systemctl --user restart cortex@halden$' "${SYSTEMCTL_LOG}")"
+rm -f "${RESTART_OUT}"
+unset FAIL_RESTART_UNITS
+
+# ── BLOCKER 2, end to end: a `set -e` caller must run PAST a failed restart. ──
+: > "${ACTIVE_UNITS_FILE}"
+printf 'cortex@work\n' >> "${ACTIVE_UNITS_FILE}"
+export FAIL_RESTART_UNITS="cortex@work"
+SETE_RESTART_OUT="$(mktemp)"
+set +e
+bash -c "set -e; source '${SCRIPT_DIR}/lib/systemd-render.sh'; restart_running_systemd_stacks '${CONFIG_DIR}'; echo SCRIPT_COMPLETED" > "${SETE_RESTART_OUT}" 2>&1
+SETE_RESTART_RC=$?
+set -e
+assert_eq "a 'set -e' caller completes (exit 0) despite the failed restart" "0" "${SETE_RESTART_RC}"
+assert_grep_file "the caller ran past the guarded restart call" "${SETE_RESTART_OUT}" "SCRIPT_COMPLETED"
+rm -f "${SETE_RESTART_OUT}"
+unset FAIL_RESTART_UNITS
+: > "${ACTIVE_UNITS_FILE}"
+
+# ─── Section 9: run_with_timeout ───────────────────────────────────
+printf '\n=== run_with_timeout ===\n'
+
+# Normal path: the real `timeout` (present on this dev box / any Ubuntu CI
+# runner via coreutils) transparently wraps the call.
+assert_eq "wraps a successful command through the real timeout binary" "hello" \
+  "$(run_with_timeout echo hello)"
+
+# Degrade path: PATH with no `timeout` on it at all → falls back to a bare
+# call. `echo` is a shell builtin so it needs no PATH resolution, isolating
+# this case to exactly the `command -v timeout` branch under test.
+assert_eq "degrades to a bare call when timeout is absent from PATH" "hi" \
+  "$(PATH="${MOCK_BIN}" run_with_timeout echo hi)"
 
 # ─── Results ──────────────────────────────────────────────────────
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/__tests__/systemd-render.sh
+++ b/scripts/__tests__/systemd-render.sh
@@ -225,9 +225,15 @@ rm -rf "${HOME}/.local/state/nats" "${HOME}/.local/state/metafactory"
 ensure_stack_log_dirs
 assert_true "nats log dir created (nothing else creates this on Linux)" \
   test -d "${HOME}/.local/state/nats/logs"
-assert_true "cortex log dir created (deterministic, independent of postinstall's bootstrap)" \
+# The cortex log dir is DELIBERATELY NOT this function's job — see its
+# docstring. Regression case: an earlier version of this function created it
+# unconditionally, which broke scripts/__tests__/postinstall-state-bootstrap.sh's
+# invariant that an UPGRADE box gets ZERO writes to the canonical cortex state
+# tree from postinstall until cortex#1903's gated migration runs (PR#2103
+# review round 3, caught live in CI's plain Test job).
+assert_false "cortex log dir NOT created here (owned by postinstall's §1b + the XDG wave-5 gate)" \
   test -d "${HOME}/.local/state/metafactory/cortex/logs"
-# Idempotent — a second call on already-existing dirs is a clean no-op.
+# Idempotent — a second call on an already-existing dir is a clean no-op.
 assert_true "re-running is a clean no-op" ensure_stack_log_dirs
 
 # ─── Section 4: render_cortex_systemd_units — orchestration ───────
@@ -272,9 +278,9 @@ assert_eq "systemd-less Linux → zero systemctl calls" "0" "$(wc -l < "${SYSTEM
 export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
 
 # Real systemd Linux host, fresh unit dir → both units rendered, exactly one
-# daemon-reload call (not one per unit), the two host-wide log dirs exist, AND
-# both discovered stacks' workspace dirs exist (defense-in-depth pre-creation
-# — the units also self-heal this via the "-" WorkingDirectory prefix, but a
+# daemon-reload call (not one per unit), the nats log dir exists, AND both
+# discovered stacks' workspace dirs exist (defense-in-depth pre-creation — the
+# units also self-heal this via the "-" WorkingDirectory prefix, but a
 # proactive render-time create means an arc-managed upgrade never needs to
 # fall back to that path at all).
 reset_unit_dir
@@ -286,7 +292,12 @@ assert_file_exists "cortex@.service rendered" "${UNIT_DIR}/cortex@.service"
 assert_eq "fresh render (2 units changed) → exactly 1 daemon-reload call" "1" \
   "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}")"
 assert_true "render creates the nats log dir" test -d "${HOME}/.local/state/nats/logs"
-assert_true "render creates the cortex log dir" test -d "${HOME}/.local/state/metafactory/cortex/logs"
+# Regression guard (PR#2103 review round 3): render_cortex_systemd_units must
+# NEVER create the canonical cortex state tree — that's postinstall.sh's §1b
+# / the XDG wave-5 gated migration's authority alone, on EVERY host shape,
+# fresh or upgrade (see ensure_stack_log_dirs' docstring).
+assert_false "render does NOT create the cortex canonical state tree" \
+  test -d "${HOME}/.local/state/metafactory/cortex"
 assert_true "render also creates 'work' stack's workspace dir" \
   test -d "${HOME}/.local/share/metafactory/cortex/work/workspace"
 assert_true "render also creates 'halden' stack's workspace dir" \

--- a/scripts/__tests__/systemd-render.sh
+++ b/scripts/__tests__/systemd-render.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+# cortex#2071 (L1, Linux host support) — unit tests for scripts/lib/systemd-render.sh:
+# marker-header idempotency, daemon-reload-only-on-change, the Darwin/
+# systemd-less no-ops, the bin-symlink + linger warnings, and the
+# restart-only-if-active loop.
+#
+# Tests run entirely in a scratch $HOME; no live ~/.config/systemd/user or
+# systemctl/loginctl is touched — both are mocked via PATH override, same
+# pattern as plist-render-bin-cutover.sh's launchctl mock. `uname` is ALSO
+# mocked so the Linux-only render path is exercised regardless of the host
+# actually running this suite (macOS dev box or Linux CI runner alike);
+# systemd_host_detected's /run/systemd/system check is redirected via
+# SYSTEMD_HOST_MARKER so "systemd-less host" is testable without touching the
+# real /run.
+#
+# Run:
+#   bash scripts/__tests__/systemd-render.sh
+#
+# Exit code: 0 = all pass, non-zero = failure count.
+
+set -euo pipefail
+
+# ─── Test harness ─────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+pass() { printf '  ✓ %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass "${label}"
+  else
+    fail "${label}: expected «${expected}» got «${actual}»"
+  fi
+}
+
+assert_true() {
+  local label="$1"; shift
+  if "$@"; then pass "${label}"; else fail "${label}"; fi
+}
+
+assert_false() {
+  local label="$1"; shift
+  if "$@"; then fail "${label}"; else pass "${label}"; fi
+}
+
+assert_file_exists() {
+  local label="$1" path="$2"
+  if [ -f "${path}" ]; then pass "${label}"; else fail "${label}: not found: ${path}"; fi
+}
+
+assert_grep_file() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "${needle}" "${file}"; then pass "${label}"; else fail "${label}"; fi
+}
+
+# ─── Fixtures ─────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "${TMPHOME}"' EXIT
+export HOME="${TMPHOME}"
+
+# Source AFTER HOME is set (functions read ${HOME} at call time, so ordering
+# doesn't strictly matter, but keep it explicit — same convention as the
+# plist-render bin-cutover suite).
+# shellcheck source=scripts/lib/systemd-render.sh
+source "${SCRIPT_DIR}/lib/systemd-render.sh"
+
+# Mock bin dir: uname (force "Linux" so the render path runs on any host this
+# suite executes on), systemctl (trace log + controllable is-active), and
+# loginctl (controllable Linger value).
+MOCK_BIN="${TMPHOME}/mock-bin"
+mkdir -p "${MOCK_BIN}"
+
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Linux"
+EOF
+chmod +x "${MOCK_BIN}/uname"
+
+export SYSTEMCTL_LOG="${TMPHOME}/systemctl.log"
+# ACTIVE_UNITS: newline-separated unit names `systemctl --user is-active
+# --quiet <unit>` should report active (exit 0) for; anything else exits 1.
+export ACTIVE_UNITS_FILE="${TMPHOME}/active-units"
+: > "${ACTIVE_UNITS_FILE}"
+cat > "${MOCK_BIN}/systemctl" <<'EOF'
+#!/bin/sh
+printf 'systemctl %s\n' "$*" >> "${SYSTEMCTL_LOG:-/dev/null}"
+# is-active --quiet <unit>: exit 0 iff <unit> is listed in ACTIVE_UNITS_FILE.
+if [ "$1" = "--user" ] && [ "$2" = "is-active" ]; then
+  unit="$4"
+  grep -qxF "${unit}" "${ACTIVE_UNITS_FILE:-/dev/null}" && exit 0
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "${MOCK_BIN}/systemctl"
+
+export LINGER_VALUE="yes"
+cat > "${MOCK_BIN}/loginctl" <<'EOF'
+#!/bin/sh
+printf '%s' "${LINGER_VALUE:-yes}"
+EOF
+chmod +x "${MOCK_BIN}/loginctl"
+
+export PATH="${MOCK_BIN}:${PATH}"
+
+# A minimal but complete cortex_dir carrying the two real checked-in unit
+# templates, so render_systemd_unit exercises the actual shipped content.
+CORTEX_DIR="${REPO_ROOT}"
+
+reset_unit_dir() {
+  UNIT_DIR="${TMPHOME}/unit-dir"
+  rm -rf "${UNIT_DIR}"
+}
+
+# ─── Section 1: systemd_host_detected ─────────────────────────────
+printf '\n=== systemd_host_detected ===\n'
+
+# Neither /run marker nor ~/.config/systemd/user present → not detected.
+export SYSTEMD_HOST_MARKER="${TMPHOME}/no-such-run-systemd-system"
+rm -rf "${HOME}/.config/systemd/user"
+assert_false "neither signal present → not detected" systemd_host_detected
+
+# /run marker present (faked via override) → detected.
+mkdir -p "${TMPHOME}/fake-run-systemd-system"
+export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
+assert_true "run-systemd marker present → detected" systemd_host_detected
+
+# Fallback: marker absent, but ~/.config/systemd/user already exists.
+export SYSTEMD_HOST_MARKER="${TMPHOME}/no-such-run-systemd-system"
+mkdir -p "${HOME}/.config/systemd/user"
+assert_true "~/.config/systemd/user present → detected (fallback)" systemd_host_detected
+rm -rf "${HOME}/.config/systemd/user"
+
+# Restore a present marker for the rest of the suite.
+export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
+
+# ─── Section 2: render_systemd_unit — marker + idempotency ────────
+printf '\n=== render_systemd_unit ===\n'
+
+reset_unit_dir
+mkdir -p "${UNIT_DIR}"
+SYSTEMD_RENDER_CHANGE_COUNT=0
+
+render_systemd_unit "${CORTEX_DIR}/src/services/cortex@.service" "${UNIT_DIR}/cortex@.service"
+assert_file_exists "cortex@.service written" "${UNIT_DIR}/cortex@.service"
+assert_eq "first render → change count 1" "1" "${SYSTEMD_RENDER_CHANGE_COUNT}"
+assert_eq "marker is line 1" "# rendered-by: cortex systemd-render v1" \
+  "$(sed -n '1p' "${UNIT_DIR}/cortex@.service")"
+assert_grep_file "WorkingDirectory line present (workspace addendum, cortex#2097)" \
+  "${UNIT_DIR}/cortex@.service" 'WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace'
+assert_grep_file "matching ExecStartPre mkdir line present" \
+  "${UNIT_DIR}/cortex@.service" 'ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace'
+
+# Re-render with IDENTICAL content → no-op, change count NOT bumped again.
+render_systemd_unit "${CORTEX_DIR}/src/services/cortex@.service" "${UNIT_DIR}/cortex@.service"
+assert_eq "unchanged re-render → change count stays 1" "1" "${SYSTEMD_RENDER_CHANGE_COUNT}"
+
+# A hand-edited (drifted) dst → next render overwrites and bumps the count.
+printf 'stale hand-edit\n' > "${UNIT_DIR}/cortex@.service"
+render_systemd_unit "${CORTEX_DIR}/src/services/cortex@.service" "${UNIT_DIR}/cortex@.service"
+assert_eq "drifted dst → re-rendered, change count bumps to 2" "2" "${SYSTEMD_RENDER_CHANGE_COUNT}"
+assert_eq "drifted dst → marker restored as line 1" "# rendered-by: cortex systemd-render v1" \
+  "$(sed -n '1p' "${UNIT_DIR}/cortex@.service")"
+
+# Missing template source → warns, returns non-zero, nothing written.
+reset_unit_dir
+mkdir -p "${UNIT_DIR}"
+assert_false "missing template source → non-zero" \
+  render_systemd_unit "${CORTEX_DIR}/src/services/does-not-exist.service" "${UNIT_DIR}/does-not-exist.service"
+assert_false "missing template source → nothing written" \
+  test -e "${UNIT_DIR}/does-not-exist.service"
+
+# ─── Section 3: render_cortex_systemd_units — orchestration ───────
+printf '\n=== render_cortex_systemd_units ===\n'
+
+# Darwin (real uname on this suite is overridden to Linux via the mock; drive
+# the Darwin guard directly by shadowing uname with a Darwin-reporting mock
+# for this one case).
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Darwin"
+EOF
+reset_unit_dir
+: > "${SYSTEMCTL_LOG}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+assert_false "Darwin → no-op, unit dir not even created" test -d "${UNIT_DIR}"
+assert_eq "Darwin → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
+
+# Restore the Linux-reporting uname mock for the rest of the suite.
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Linux"
+EOF
+
+# systemd-less Linux host → no-op, unit dir not created.
+export SYSTEMD_HOST_MARKER="${TMPHOME}/no-such-run-systemd-system"
+rm -rf "${HOME}/.config/systemd/user"
+reset_unit_dir
+: > "${SYSTEMCTL_LOG}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+assert_false "systemd-less Linux → no-op, unit dir not created" test -d "${UNIT_DIR}"
+assert_eq "systemd-less Linux → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
+export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
+
+# Real systemd Linux host, fresh unit dir → both units rendered, exactly one
+# daemon-reload call (not one per unit).
+reset_unit_dir
+: > "${SYSTEMCTL_LOG}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+assert_file_exists "nats@.service rendered" "${UNIT_DIR}/nats@.service"
+assert_file_exists "cortex@.service rendered" "${UNIT_DIR}/cortex@.service"
+assert_eq "fresh render (2 units changed) → exactly 1 daemon-reload call" "1" \
+  "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}")"
+
+# Re-render with nothing changed → zero daemon-reload calls.
+: > "${SYSTEMCTL_LOG}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+assert_eq "no-op re-render → zero daemon-reload calls" "0" \
+  "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}" || true)"
+
+# ─── Section 4: verify_cortex_bin_symlink ─────────────────────────
+printf '\n=== verify_cortex_bin_symlink ===\n'
+
+rm -rf "${HOME}/.local/bin"
+mkdir -p "${HOME}/.local/bin"
+assert_false "missing ~/.local/bin/cortex → warns, non-zero" verify_cortex_bin_symlink
+
+mkdir -p "${HOME}/.local/bin"
+printf '#!/bin/sh\n' > "${HOME}/.local/bin/cortex"
+assert_true "present ~/.local/bin/cortex → passes" verify_cortex_bin_symlink
+
+# ─── Section 5: warn_systemd_linger ───────────────────────────────
+printf '\n=== warn_systemd_linger ===\n'
+
+export LINGER_VALUE="yes"
+assert_true "Linger=yes → passes, no warning" warn_systemd_linger
+
+export LINGER_VALUE="no"
+WARN_OUT="$(mktemp)"
+set +e
+warn_systemd_linger 2>"${WARN_OUT}"
+WARN_RC=$?
+set -e
+assert_eq "Linger=no → non-zero" "1" "${WARN_RC}"
+assert_grep_file "Linger=no → exact remediation command printed" "${WARN_OUT}" \
+  'sudo loginctl enable-linger'
+assert_false "warn_systemd_linger never invokes sudo itself" \
+  bash -c "grep -q '^sudo ' '${WARN_OUT}'"
+rm -f "${WARN_OUT}"
+export LINGER_VALUE="yes"
+
+# ─── Section 6: restart_running_systemd_stacks ────────────────────
+printf '\n=== restart_running_systemd_stacks ===\n'
+
+CONFIG_DIR="${TMPHOME}/config"
+mkdir -p "${CONFIG_DIR}/work/system" "${CONFIG_DIR}/halden/system"
+: > "${CONFIG_DIR}/work/work.yaml"
+: > "${CONFIG_DIR}/work/system/system.yaml"
+: > "${CONFIG_DIR}/halden/halden.yaml"
+: > "${CONFIG_DIR}/halden/system/system.yaml"
+
+# Only 'work' is active.
+: > "${ACTIVE_UNITS_FILE}"
+printf 'cortex@work\n' >> "${ACTIVE_UNITS_FILE}"
+
+: > "${SYSTEMCTL_LOG}"
+restart_running_systemd_stacks "${CONFIG_DIR}" > /dev/null
+assert_eq "only active 'work' is restarted" "1" \
+  "$(grep -c '^systemctl --user restart cortex@work$' "${SYSTEMCTL_LOG}")"
+assert_eq "inactive 'halden' is NOT restarted" "0" \
+  "$(grep -c '^systemctl --user restart cortex@halden$' "${SYSTEMCTL_LOG}" || true)"
+assert_eq "inactive 'halden' IS checked (is-active called)" "1" \
+  "$(grep -c '^systemctl --user is-active --quiet cortex@halden$' "${SYSTEMCTL_LOG}")"
+
+# Nothing active → nothing restarted, no stack silently started.
+: > "${ACTIVE_UNITS_FILE}"
+: > "${SYSTEMCTL_LOG}"
+restart_running_systemd_stacks "${CONFIG_DIR}" > /dev/null
+assert_eq "nothing active → zero restart calls" "0" \
+  "$(grep -c '^systemctl --user restart ' "${SYSTEMCTL_LOG}" || true)"
+
+# ─── Results ──────────────────────────────────────────────────────
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/scripts/__tests__/systemd-render.sh
+++ b/scripts/__tests__/systemd-render.sh
@@ -154,8 +154,15 @@ assert_eq "marker is line 1" "# rendered-by: cortex systemd-render v1" \
   "$(sed -n '1p' "${UNIT_DIR}/cortex@.service")"
 assert_grep_file "WorkingDirectory line present (workspace addendum, cortex#2097)" \
   "${UNIT_DIR}/cortex@.service" 'WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace'
-assert_grep_file "matching ExecStartPre mkdir line present" \
-  "${UNIT_DIR}/cortex@.service" 'ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace'
+# NO matching ExecStartPre mkdir line for the workspace dir: verified against a
+# real systemd 257 user session that WorkingDirectory= is entered before ANY
+# exec command (including ExecStartPre) runs, so that line could never have
+# self-healed a missing workspace dir (EXIT_CHDIR before it could run) — it
+# was removed in favor of ensure_stack_workspace_dirs (render-time, slug-aware,
+# actually able to create the directory before systemd ever tries to chdir
+# into it). The logs ExecStartPre line stays (belt-and-braces re-creation).
+assert_false "dead workspace ExecStartPre line NOT present (removed, cortex#2071 PR fixup)" \
+  bash -c "grep -qF 'ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace' '${UNIT_DIR}/cortex@.service'"
 
 # Re-render with IDENTICAL content → no-op, change count NOT bumped again.
 render_systemd_unit "${CORTEX_DIR}/src/services/cortex@.service" "${UNIT_DIR}/cortex@.service"
@@ -179,6 +186,15 @@ assert_false "missing template source → nothing written" \
 # ─── Section 3: render_cortex_systemd_units — orchestration ───────
 printf '\n=== render_cortex_systemd_units ===\n'
 
+# Config-dir fixture with two discoverable stacks — used both for the
+# workspace-dir-creation assertions below and for Section 6's restart tests.
+CONFIG_DIR="${TMPHOME}/config"
+mkdir -p "${CONFIG_DIR}/work/system" "${CONFIG_DIR}/halden/system"
+: > "${CONFIG_DIR}/work/work.yaml"
+: > "${CONFIG_DIR}/work/system/system.yaml"
+: > "${CONFIG_DIR}/halden/halden.yaml"
+: > "${CONFIG_DIR}/halden/system/system.yaml"
+
 # Darwin (real uname on this suite is overridden to Linux via the mock; drive
 # the Darwin guard directly by shadowing uname with a Darwin-reporting mock
 # for this one case).
@@ -188,7 +204,7 @@ echo "Darwin"
 EOF
 reset_unit_dir
 : > "${SYSTEMCTL_LOG}"
-render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 assert_false "Darwin → no-op, unit dir not even created" test -d "${UNIT_DIR}"
 assert_eq "Darwin → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
 
@@ -203,26 +219,51 @@ export SYSTEMD_HOST_MARKER="${TMPHOME}/no-such-run-systemd-system"
 rm -rf "${HOME}/.config/systemd/user"
 reset_unit_dir
 : > "${SYSTEMCTL_LOG}"
-render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 assert_false "systemd-less Linux → no-op, unit dir not created" test -d "${UNIT_DIR}"
 assert_eq "systemd-less Linux → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
 export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
 
 # Real systemd Linux host, fresh unit dir → both units rendered, exactly one
-# daemon-reload call (not one per unit).
+# daemon-reload call (not one per unit), AND both discovered stacks' workspace
+# dirs exist (cortex@.service's WorkingDirectory= must pre-exist before
+# enable/start — see ensure_stack_workspace_dirs's docstring; verified against
+# a real systemd 257 user session, not just asserted here).
 reset_unit_dir
+rm -rf "${HOME}/.local/share/metafactory/cortex"
 : > "${SYSTEMCTL_LOG}"
-render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 assert_file_exists "nats@.service rendered" "${UNIT_DIR}/nats@.service"
 assert_file_exists "cortex@.service rendered" "${UNIT_DIR}/cortex@.service"
 assert_eq "fresh render (2 units changed) → exactly 1 daemon-reload call" "1" \
   "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}")"
+assert_true "render also creates 'work' stack's workspace dir" \
+  test -d "${HOME}/.local/share/metafactory/cortex/work/workspace"
+assert_true "render also creates 'halden' stack's workspace dir" \
+  test -d "${HOME}/.local/share/metafactory/cortex/halden/workspace"
 
-# Re-render with nothing changed → zero daemon-reload calls.
+# Re-render with nothing changed → zero daemon-reload calls (workspace-dir
+# creation is idempotent — mkdir -p on an existing dir is a no-op).
 : > "${SYSTEMCTL_LOG}"
-render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 assert_eq "no-op re-render → zero daemon-reload calls" "0" \
   "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}" || true)"
+
+# ─── Section 3b: ensure_stack_workspace_dirs (standalone) ─────────
+printf '\n=== ensure_stack_workspace_dirs ===\n'
+
+rm -rf "${HOME}/.local/share/metafactory/cortex"
+ensure_stack_workspace_dirs "${CONFIG_DIR}"
+assert_true "'work' workspace dir created" \
+  test -d "${HOME}/.local/share/metafactory/cortex/work/workspace"
+assert_true "'halden' workspace dir created" \
+  test -d "${HOME}/.local/share/metafactory/cortex/halden/workspace"
+
+# A config dir with no discoverable stacks → no-op, no error.
+EMPTY_CONFIG_DIR="${TMPHOME}/empty-config"
+mkdir -p "${EMPTY_CONFIG_DIR}"
+assert_true "no stacks → ensure_stack_workspace_dirs is a clean no-op" \
+  ensure_stack_workspace_dirs "${EMPTY_CONFIG_DIR}"
 
 # ─── Section 4: verify_cortex_bin_symlink ─────────────────────────
 printf '\n=== verify_cortex_bin_symlink ===\n'
@@ -258,12 +299,7 @@ export LINGER_VALUE="yes"
 # ─── Section 6: restart_running_systemd_stacks ────────────────────
 printf '\n=== restart_running_systemd_stacks ===\n'
 
-CONFIG_DIR="${TMPHOME}/config"
-mkdir -p "${CONFIG_DIR}/work/system" "${CONFIG_DIR}/halden/system"
-: > "${CONFIG_DIR}/work/work.yaml"
-: > "${CONFIG_DIR}/work/system/system.yaml"
-: > "${CONFIG_DIR}/halden/halden.yaml"
-: > "${CONFIG_DIR}/halden/system/system.yaml"
+# Reuses the CONFIG_DIR fixture (work + halden stacks) set up before Section 3.
 
 # Only 'work' is active.
 : > "${ACTIVE_UNITS_FILE}"

--- a/scripts/__tests__/systemd-render.test.ts
+++ b/scripts/__tests__/systemd-render.test.ts
@@ -1,0 +1,29 @@
+// bun-test wrapper for scripts/__tests__/systemd-render.sh so the systemd
+// unit renderer (marker/idempotency/no-ops/warnings — cortex#2071) is gated
+// by CI's `bun test`, not just runnable by hand. Mirrors the
+// plist-render-bin-cutover.test.ts pattern (spawn the shell suite, assert
+// exit 0).
+//
+// The shell suite runs entirely in a scratch $HOME with mocked uname/
+// systemctl/loginctl — no live ~/.config/systemd/user or systemd session is
+// touched, so this runs identically on the Linux CI runner and a macOS dev
+// box. The real systemctl --user end-to-end path (enable --now against an
+// actual systemd-user session) lives in systemd-render-e2e.test.ts instead.
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SUITE = join(REPO_ROOT, "scripts", "__tests__", "systemd-render.sh");
+
+describe("systemd-render shell suite (cortex#2071)", () => {
+  test("marker/idempotency/no-ops/warnings pass (exit 0)", () => {
+    const res = spawnSync("bash", [SUITE], { cwd: REPO_ROOT, encoding: "utf8" });
+    const out = `${res.stdout}${res.stderr}`;
+    // Surface the shell suite's own trace when it fails so the failing case is
+    // visible in the bun-test output.
+    if (res.status !== 0) throw new Error(`shell suite failed (exit ${res.status}):\n${out}`);
+    expect(res.status).toBe(0);
+    expect(out).toContain("0 failed");
+  });
+});

--- a/scripts/lib/systemd-render.sh
+++ b/scripts/lib/systemd-render.sh
@@ -22,12 +22,14 @@
 #   source "${SCRIPT_DIR}/lib/systemd-render.sh"
 #   render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 #
-# Functions never write outside ${UNIT_DIR}, the per-stack workspace/log dirs
-# under ${HOME}/.local/{share,state}, and ${HOME}/.local/state/nats/logs (the
-# linger/symlink checks are read-only).
+# Functions never write outside ${UNIT_DIR}, ${HOME}/.local/share/metafactory/
+# cortex/<slug>/workspace (per discovered stack), and ${HOME}/.local/state/nats/
+# logs. Deliberately NOT ${HOME}/.local/state/metafactory/cortex — that tree's
+# creation is postinstall.sh's §1b state bootstrap's authority alone (see
+# ensure_stack_log_dirs' docstring); the linger/symlink checks are read-only.
 #
-# PR#2103 adversarial review (two rounds) found this file's first cut
-# unsafe in three ways, all fixed here:
+# PR#2103 adversarial review (three rounds) found this file's first cut unsafe
+# in four ways, all fixed here:
 #   - the shipped units could not start on a fresh host at all (WorkingDirectory/
 #     StandardOutput both fail-closed on a missing directory, BEFORE any exec
 #     command including ExecStartPre runs — see render_cortex_systemd_units'
@@ -37,7 +39,13 @@
 #     (see run_with_timeout + the guarded call sites below);
 #   - render_systemd_unit clobbered a hand-authored unit unconditionally —
 #     Appendix A explicitly invites hand-copying these exact files, so a
-#     marker-less dst is now left untouched (see render_systemd_unit).
+#     marker-less dst is now left untouched (see render_systemd_unit);
+#   - the first fix for the StandardOutput/EXIT_STDOUT half of the fresh-host
+#     bug unconditionally created the CANONICAL cortex state tree, which broke
+#     the XDG wave-5 gated-migration invariant that an upgrade box gets NO
+#     canonical-tree writes from postinstall until cortex#1903's migration
+#     runs (see ensure_stack_log_dirs' docstring — this class of bug is why
+#     the existing test suite matters even for code that looks unrelated).
 
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # plist-render.sh provides discover_stack_slugs — stack enumeration is shared,
@@ -174,33 +182,43 @@ warn_systemd_linger() {
   return 0
 }
 
-# Ensure the two host-wide log dirs both units' `StandardOutput=`/
-# `StandardError=append:` lines write into actually exist, at RENDER time —
-# not via the units' own `ExecStartPre=mkdir -p` lines, which CANNOT do this
-# job on a cold start.
+# Ensure the nats-server log dir both units' (well, nats@.service's own)
+# `StandardOutput=`/`StandardError=append:` lines write into actually
+# exists, at RENDER time — not via the unit's own `ExecStartPre=mkdir -p`
+# line, which CANNOT do this job on a cold start.
 #
 # Verified empirically (systemd 257, Debian trixie AND independently on
 # Ubuntu 22.04 / systemd 249): `StandardOutput=append:<path>` is opened
 # BEFORE any exec command of the unit runs, including ExecStartPre — a
 # missing log dir fails the unit outright (systemd exit reason
 # EXIT_STDOUT/209) before ExecStartPre's own `mkdir -p` of that same
-# directory ever gets to execute. The ExecStartPre lines stay in both unit
-# files as belt-and-braces (a harmless no-op once the dir already exists,
-# and they DO help if a warm dir gets deleted between a stop and the next
-# stop — just never on the very first cold start), but the actual
-# cold-start guarantee has to come from here.
+# directory ever gets to execute. The ExecStartPre line stays in the unit
+# file as belt-and-braces (a harmless no-op once the dir already exists, and
+# it DOES help if a warm dir gets deleted between a stop and the next start —
+# just never on the very first cold start), but the actual cold-start
+# guarantee has to come from here: nothing else in the codebase creates
+# `~/.local/state/nats/logs` (nats-server is an external dependency;
+# README-AGENTS.md Appendix A §A.1 hand-creates it for the manual path, this
+# is the arc-managed equivalent).
 #
-# `~/.local/state/nats/logs` — nothing else in the codebase creates this
-# (nats-server is an external dependency; README-AGENTS.md Appendix A §A.1
-# hand-creates it for the manual path, this is the arc-managed equivalent).
-# `~/.local/state/metafactory/cortex/logs` — postinstall.sh's state-bootstrap
-# (§1b, migrate-state-dir-exec.ts) already creates this on install, but only
-# on a genuinely fresh box and only via a bun subprocess that's allowed to
-# no-op on error; recreating it here too makes the guarantee deterministic
-# and host-independent of that script having run first or succeeded.
+# `~/.local/state/metafactory/cortex/logs` is DELIBERATELY NOT created here,
+# even though cortex@.service needs the identical guarantee. That directory
+# is part of the CANONICAL CORTEX STATE TREE, whose creation is owned
+# end-to-end by postinstall.sh's §1b state bootstrap (migrate-state-dir-exec.ts)
+# under the XDG wave-5 gated migration (cortex#1903) — verified via
+# scripts/__tests__/postinstall-state-bootstrap.sh's own invariant: on an
+# UPGRADE box (legacy grove state present, not yet migrated) postinstall must
+# write NOTHING state-related, no canonical tree at all, until the gated
+# migration explicitly runs. This function creating even just the logs/
+# subdirectory unconditionally would violate that invariant (confirmed: it
+# broke that exact test in PR#2103 review round 3 before this comment was
+# written) — a genuinely fresh box gets the tree from §1b already; an
+# upgrade-in-progress box is intentionally left alone by both. The residual
+# gap (a NOT-YET-migrated upgrade box trying to `enable` a NEW stack before
+# cortex#1903's migration completes) belongs to that migration, not this
+# renderer duplicating its authority.
 ensure_stack_log_dirs() {
   mkdir -p "${HOME}/.local/state/nats/logs"
-  mkdir -p "${HOME}/.local/state/metafactory/cortex/logs"
 }
 
 # Ensure the per-stack workspace dir exists for every discovered stack
@@ -228,11 +246,13 @@ ensure_stack_workspace_dirs() {
 }
 
 # Render nats@.service + cortex@.service into UNIT_DIR from the templates
-# checked in under CORTEX_DIR/src/services/, ensure the host-wide log dirs
-# and every discovered stack's workspace dir exist (see ensure_stack_log_dirs
-# / ensure_stack_workspace_dirs), then run the bun-guard-analogue symlink
-# check and the linger check. `systemctl --user daemon-reload` runs at most
-# once, and only when at least one unit's content actually changed.
+# checked in under CORTEX_DIR/src/services/, ensure the nats log dir and every
+# discovered stack's workspace dir exist (see ensure_stack_log_dirs /
+# ensure_stack_workspace_dirs — the cortex log dir is deliberately NOT this
+# function's job, see ensure_stack_log_dirs' docstring), then run the
+# bun-guard-analogue symlink check and the linger check. `systemctl --user
+# daemon-reload` runs at most once, and only when at least one unit's content
+# actually changed.
 #
 # Never aborts the caller: `daemon-reload` is guarded (a transient bus
 # failure prints a warning and continues — postinstall.sh/postupgrade.sh both

--- a/scripts/lib/systemd-render.sh
+++ b/scripts/lib/systemd-render.sh
@@ -20,10 +20,24 @@
 #
 # Usage (in the calling script):
 #   source "${SCRIPT_DIR}/lib/systemd-render.sh"
-#   render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+#   render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 #
-# Functions never write outside ${UNIT_DIR} (the linger/symlink checks are
-# read-only).
+# Functions never write outside ${UNIT_DIR}, the per-stack workspace/log dirs
+# under ${HOME}/.local/{share,state}, and ${HOME}/.local/state/nats/logs (the
+# linger/symlink checks are read-only).
+#
+# PR#2103 adversarial review (two rounds) found this file's first cut
+# unsafe in three ways, all fixed here:
+#   - the shipped units could not start on a fresh host at all (WorkingDirectory/
+#     StandardOutput both fail-closed on a missing directory, BEFORE any exec
+#     command including ExecStartPre runs — see render_cortex_systemd_units'
+#     and ensure_stack_workspace_dirs' docstrings);
+#   - a `systemctl --user` failure under the callers' `set -e` could abort the
+#     whole install/upgrade, or silently truncate the stack-restart loop
+#     (see run_with_timeout + the guarded call sites below);
+#   - render_systemd_unit clobbered a hand-authored unit unconditionally —
+#     Appendix A explicitly invites hand-copying these exact files, so a
+#     marker-less dst is now left untouched (see render_systemd_unit).
 
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # plist-render.sh provides discover_stack_slugs — stack enumeration is shared,
@@ -34,11 +48,28 @@ LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${LIB_DIR}/plist-render.sh"
 
 # Marker contract (coordinates with the rollback issue cortex#2093): every
-# unit this renderer installs carries this header as its FIRST line. Removal
-# (#2093) only deletes marker-bearing files, so a hand-authored unit at the
-# same path (e.g. a principal who followed Appendix A by hand before
-# upgrading) is never silently touched by either render or rollback.
+# unit THIS RENDERER WROTE carries this header as its first line.
+# render_systemd_unit only ever overwrites a dst that already carries it (or
+# doesn't exist yet); a marker-less dst — e.g. a principal who hand-copied
+# Appendix A before this renderer existed — is left untouched, warned about,
+# and never rendered over. Removal (#2093) uses the same rule to decide what
+# it may delete.
 SYSTEMD_UNIT_MARKER="# rendered-by: cortex systemd-render v1"
+
+# Timeout wrapper around every systemctl/loginctl --user call in this file —
+# a wedged --user D-Bus session must not hang `arc install`/`arc upgrade`
+# indefinitely (PR#2103 review). Degrades to a bare call when `timeout`
+# (coreutils) isn't installed, which is rare but not guaranteed on every
+# minimal distro.
+#
+# Args: the command + its args, e.g. `run_with_timeout systemctl --user ...`
+run_with_timeout() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 30 "$@"
+  else
+    "$@"
+  fi
+}
 
 # True if this host plausibly runs systemd. Two independent signals so the
 # check doesn't depend on ${UNIT_DIR} already existing:
@@ -59,14 +90,24 @@ systemd_host_detected() {
 }
 
 # Render ONE unit file: read $1 (checked-in template), prepend the marker
-# header, and write it to $2 (dest) ONLY if the result differs from what's
-# already there. On an actual write, bumps the caller-visible
-# SYSTEMD_RENDER_CHANGE_COUNT counter (reset by the caller before the loop) so
-# render_cortex_systemd_units can gate the single daemon-reload call on
-# whether ANY unit changed — systemd's daemon-reload is a global unit-file
-# rescan; firing it every upgrade even when nothing changed is needless churn
-# (#2071 executor addendum: "idempotent render + daemon-reload only on
-# change").
+# header, and write it to $2 (dest) — UNLESS dst already exists WITHOUT the
+# marker, in which case it is left completely untouched (see the
+# hand-authored-unit note below). On an actual write, bumps the
+# caller-visible SYSTEMD_RENDER_CHANGE_COUNT counter (reset by the caller
+# before the loop) so render_cortex_systemd_units can gate the single
+# daemon-reload call on whether ANY unit changed — systemd's daemon-reload is
+# a global unit-file rescan; firing it every upgrade even when nothing
+# changed is needless churn (#2071 executor addendum: "idempotent render +
+# daemon-reload only on change").
+#
+# Hand-authored-unit protection (PR#2103 review MAJOR finding): README-AGENTS.md
+# Appendix A explicitly invited operators to hand-copy these exact files
+# before this renderer existed, and a from-source install may still have a
+# customized unit at this path. A marker-less dst is therefore NOT
+# necessarily stale output from an old version of this renderer — it may be
+# someone's deliberate customization — so it is left alone, not overwritten.
+# The marker is the ONLY ownership signal this function trusts: present →
+# we rendered it, safe to keep in sync; absent → not ours, don't touch it.
 #
 # Args: $1 src file  $2 dst path
 render_systemd_unit() {
@@ -77,6 +118,12 @@ render_systemd_unit() {
     echo "  ⚠ Template missing: ${src}" >&2
     return 1
   fi
+
+  if [ -f "${dst}" ] && [ "$(sed -n '1p' "${dst}" 2>/dev/null)" != "${SYSTEMD_UNIT_MARKER}" ]; then
+    echo "  ⊘ ${name} exists without the cortex systemd-render marker — leaving it untouched (hand-authored or externally managed; delete it or add the marker line yourself to let the renderer manage it)" >&2
+    return 0
+  fi
+
   # G-30-style atomic render (mirrors plist-render.sh's render_stack_plist): a
   # bare redirect onto a live unit path could leave a truncated file visible
   # to systemd if the render is interrupted mid-write.
@@ -112,13 +159,14 @@ verify_cortex_bin_symlink() {
 # user's session — and every --user unit with it — the moment their last
 # login session ends (SSH logout, etc.). loginctl's `Linger` user property is
 # `yes`/`no`; anything else (including loginctl erroring, e.g. no
-# systemd-logind) is treated as "not confirmed enabled" and warned. NEVER sudo
-# here (#2071 executor addendum) — only print the exact remediation command
-# (same shape as Appendix A §A.1) for the operator to run themselves.
+# systemd-logind, or timing out — see run_with_timeout) is treated as "not
+# confirmed enabled" and warned. NEVER sudo here (#2071 executor addendum) —
+# only print the exact remediation command (same shape as Appendix A §A.1)
+# for the operator to run themselves.
 warn_systemd_linger() {
   local user linger
   user="$(id -un)"
-  linger="$(loginctl show-user "${user}" --property=Linger --value 2>/dev/null || true)"
+  linger="$(run_with_timeout loginctl show-user "${user}" --property=Linger --value 2>/dev/null || true)"
   if [ "${linger}" != "yes" ]; then
     echo "  ⚠ linger not enabled for ${user} — systemd will stop your cortex services on logout. Enable with: sudo loginctl enable-linger \"${user}\"" >&2
     return 1
@@ -126,54 +174,48 @@ warn_systemd_linger() {
   return 0
 }
 
-# Restart only ACTIVE cortex@<slug> instances after an upgrade — the systemd
-# mirror of postupgrade.sh's plist reload_stack_unless_skipped loop. Unlike
-# the Darwin side, preupgrade.sh's stop/kill block is Darwin-only (see
-# preupgrade.sh's cortex#1909 note), so there is no RUNNING_STACKS_FILE to
-# replay here; "was it running" is answered directly via `systemctl --user
-# is-active`. A stack that isn't currently active is left alone — this must
-# never START a stack that wasn't running (same "no stack left down; none
-# started that wasn't running" symmetry goal as the plist path, just checked
-# live instead of from recorded state).
+# Ensure the two host-wide log dirs both units' `StandardOutput=`/
+# `StandardError=append:` lines write into actually exist, at RENDER time —
+# not via the units' own `ExecStartPre=mkdir -p` lines, which CANNOT do this
+# job on a cold start.
 #
-# NOTE: CORTEX_UPGRADE_SKIP_RESTART parity (sparing a production stack from
-# restart) is explicitly NOT implemented here — preupgrade.sh documents that
-# gap as Linux/systemd territory for cortex#1909, not this issue.
+# Verified empirically (systemd 257, Debian trixie AND independently on
+# Ubuntu 22.04 / systemd 249): `StandardOutput=append:<path>` is opened
+# BEFORE any exec command of the unit runs, including ExecStartPre — a
+# missing log dir fails the unit outright (systemd exit reason
+# EXIT_STDOUT/209) before ExecStartPre's own `mkdir -p` of that same
+# directory ever gets to execute. The ExecStartPre lines stay in both unit
+# files as belt-and-braces (a harmless no-op once the dir already exists,
+# and they DO help if a warm dir gets deleted between a stop and the next
+# stop — just never on the very first cold start), but the actual
+# cold-start guarantee has to come from here.
 #
-# Args: $1 CONFIG_DIR — cortex config dir (stacks are discovered from here)
-restart_running_systemd_stacks() {
-  local config_dir="$1"
-  local slug unit
-  while IFS= read -r slug; do
-    [ -z "${slug}" ] && continue
-    unit="cortex@${slug}"
-    if systemctl --user is-active --quiet "${unit}" 2>/dev/null; then
-      systemctl --user restart "${unit}"
-      echo "  ✓ ${unit} restarted"
-    else
-      echo "  ⊘ ${unit} not active — not restarted"
-    fi
-  done < <(discover_stack_slugs "${config_dir}")
+# `~/.local/state/nats/logs` — nothing else in the codebase creates this
+# (nats-server is an external dependency; README-AGENTS.md Appendix A §A.1
+# hand-creates it for the manual path, this is the arc-managed equivalent).
+# `~/.local/state/metafactory/cortex/logs` — postinstall.sh's state-bootstrap
+# (§1b, migrate-state-dir-exec.ts) already creates this on install, but only
+# on a genuinely fresh box and only via a bun subprocess that's allowed to
+# no-op on error; recreating it here too makes the guarantee deterministic
+# and host-independent of that script having run first or succeeded.
+ensure_stack_log_dirs() {
+  mkdir -p "${HOME}/.local/state/nats/logs"
+  mkdir -p "${HOME}/.local/state/metafactory/cortex/logs"
 }
 
 # Ensure the per-stack workspace dir exists for every discovered stack
-# (cortex#2097's `WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace`
+# (cortex#2097's `WorkingDirectory=-%h/.local/share/metafactory/cortex/%i/workspace`
 # on cortex@.service).
 #
-# This is NOT optional belt-and-braces — it's load-bearing. Verified
-# empirically (systemd 257, Debian trixie): `WorkingDirectory=` is entered
-# BEFORE *any* exec command of the unit runs, including ExecStartPre — a
-# missing WorkingDirectory fails the unit outright (systemd exit reason
-# EXIT_CHDIR/200) before ExecStartPre's own `mkdir -p` of that same path ever
-# gets to execute. The unit file cannot self-heal this; the directory must
-# already exist by the time `systemctl --user enable/start` runs.
-#
-# Until cortex#2097 ships (stack scaffolding creates this dir itself), NOTHING
-# else in the codebase creates it — so this is the one prerequisite render
-# time can and must cover, mirroring how README-AGENTS.md Appendix A §A.1
-# hand-creates nats-server's log dir as a one-time host-prep step for the
-# same reason (see the ExecStartPre note on render_cortex_systemd_units below
-# for why the *log* dirs don't need this treatment).
+# Defense-in-depth, not the only guard: the unit's `WorkingDirectory=` now
+# carries the `-` prefix (missing dir is non-fatal — ExecStartPre's own
+# `mkdir -p` of the same path then creates it, and ExecStart's chdir
+# succeeds; verified empirically against a real systemd user session with NO
+# other actor pre-creating the dir). This function covers every ALREADY
+# DISCOVERED stack proactively at render time (so an arc-managed upgrade
+# never even needs the self-heal path); later-created stacks (before
+# cortex#2097's stack-scaffold ships its own creation step) fall through to
+# the unit's own self-heal on first enable.
 #
 # Args: $1 CONFIG_DIR — cortex config dir (stacks are discovered from here)
 ensure_stack_workspace_dirs() {
@@ -186,24 +228,16 @@ ensure_stack_workspace_dirs() {
 }
 
 # Render nats@.service + cortex@.service into UNIT_DIR from the templates
-# checked in under CORTEX_DIR/src/services/, ensure every discovered stack's
-# workspace dir exists (see ensure_stack_workspace_dirs), then run the
-# bun-guard-analogue symlink check and the linger check.
-# `systemctl --user daemon-reload` runs at most once, and only when at least
-# one unit's content actually changed.
+# checked in under CORTEX_DIR/src/services/, ensure the host-wide log dirs
+# and every discovered stack's workspace dir exist (see ensure_stack_log_dirs
+# / ensure_stack_workspace_dirs), then run the bun-guard-analogue symlink
+# check and the linger check. `systemctl --user daemon-reload` runs at most
+# once, and only when at least one unit's content actually changed.
 #
-# NOTE on the units' `ExecStartPre=/usr/bin/mkdir -p .../logs` lines: those
-# are NOT dead code the way an un-pre-created WorkingDirectory is, but they
-# are also not a substitute for pre-creating the parent on a truly fresh
-# host — `StandardOutput=append:<path under that dir>` is set up before
-# ExecStartPre runs too, so on a from-nothing host the very first start
-# needs the log dir to already exist (README-AGENTS.md Appendix A §A.1 hand-
-# creates nats-server's; postinstall.sh's state bootstrap creates cortex's,
-# host-independent). The ExecStartPre line's job is the idempotent
-# re-creation case (dir survives; a later restart is a no-op mkdir), which is
-# genuinely useful — it's only the *cold-start* case that needs an external
-# actor, which is why workspace (with no OTHER creator yet, pre-cortex#2097)
-# gets handled here explicitly and logs (which already have one) don't.
+# Never aborts the caller: `daemon-reload` is guarded (a transient bus
+# failure prints a warning and continues — postinstall.sh/postupgrade.sh both
+# run under `set -e`, and an unguarded systemctl call here would silently
+# abort the whole install/upgrade on a flaky bus; PR#2103 review BLOCKER 2).
 #
 # No-ops (silently, exit 0) on Darwin and on a systemd-less host — see
 # systemd_host_detected().
@@ -224,6 +258,7 @@ render_cortex_systemd_units() {
   fi
 
   mkdir -p "${unit_dir}"
+  ensure_stack_log_dirs
 
   SYSTEMD_RENDER_CHANGE_COUNT=0
   local unit
@@ -232,11 +267,60 @@ render_cortex_systemd_units() {
   done
 
   if [ "${SYSTEMD_RENDER_CHANGE_COUNT}" -gt 0 ]; then
-    systemctl --user daemon-reload
-    echo "  ✓ systemd user daemon reloaded (${SYSTEMD_RENDER_CHANGE_COUNT} unit(s) changed)"
+    if run_with_timeout systemctl --user daemon-reload; then
+      echo "  ✓ systemd user daemon reloaded (${SYSTEMD_RENDER_CHANGE_COUNT} unit(s) changed)"
+    else
+      echo "  ⚠ systemctl --user daemon-reload failed (bus unavailable or timed out) — rendered units may not be picked up until the next successful reload; re-run \`arc upgrade cortex\` or \`systemctl --user daemon-reload\` manually" >&2
+    fi
   fi
 
   ensure_stack_workspace_dirs "${config_dir}"
   verify_cortex_bin_symlink || true
   warn_systemd_linger || true
+}
+
+# Restart only ACTIVE cortex@<slug> instances after an upgrade — the systemd
+# mirror of postupgrade.sh's plist reload_stack_unless_skipped loop. Unlike
+# the Darwin side, preupgrade.sh's stop/kill block is Darwin-only (see
+# preupgrade.sh's cortex#1909 note), so there is no RUNNING_STACKS_FILE to
+# replay here; "was it running" is answered directly via `systemctl --user
+# is-active`. A stack that isn't currently active is left alone — this must
+# never START a stack that wasn't running (same "no stack left down; none
+# started that wasn't running" symmetry goal as the plist path, just checked
+# live instead of from recorded state).
+#
+# Never aborts the caller and never stops early on one bad stack (PR#2103
+# review BLOCKER 2): an unguarded `systemctl --user restart` failing under
+# the caller's `set -e` would abort postupgrade.sh mid-loop, silently
+# skipping every stack after the one that failed. Each restart is guarded;
+# failures are collected and reported in a single summary line at the end,
+# and the function itself always returns 0.
+#
+# NOTE: CORTEX_UPGRADE_SKIP_RESTART parity (sparing a production stack from
+# restart) is explicitly NOT implemented here — preupgrade.sh documents that
+# gap as Linux/systemd territory for cortex#1909, not this issue.
+#
+# Args: $1 CONFIG_DIR — cortex config dir (stacks are discovered from here)
+restart_running_systemd_stacks() {
+  local config_dir="$1"
+  local slug unit failed=""
+  while IFS= read -r slug; do
+    [ -z "${slug}" ] && continue
+    unit="cortex@${slug}"
+    if run_with_timeout systemctl --user is-active --quiet "${unit}" 2>/dev/null; then
+      if run_with_timeout systemctl --user restart "${unit}"; then
+        echo "  ✓ ${unit} restarted"
+      else
+        echo "  ✗ ${unit} restart FAILED (bus unavailable, timed out, or the restart itself failed) — check \`systemctl --user status ${unit}\`" >&2
+        failed="${failed}${failed:+ }${unit}"
+      fi
+    else
+      echo "  ⊘ ${unit} not active — not restarted"
+    fi
+  done < <(discover_stack_slugs "${config_dir}")
+
+  if [ -n "${failed}" ]; then
+    echo "  ⚠ restart_running_systemd_stacks: failed to restart: ${failed} — investigate manually, the rest of the upgrade completed" >&2
+  fi
+  return 0
 }

--- a/scripts/lib/systemd-render.sh
+++ b/scripts/lib/systemd-render.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# Cortex systemd user-unit renderer — Linux twin of plist-render.sh.
+#
+# cortex#2071 (L1 of the Linux host support epic, arc design/linux-host-support.md
+# / arc#309): auto-renders the two systemd TEMPLATE units (nats@.service,
+# cortex@.service) checked in at src/services/ into ~/.config/systemd/user/, so
+# `arc upgrade cortex` gives Linux the same "no hand-written service files"
+# experience Darwin gets from plist-render.sh. Content is community-validated
+# on Debian 13 (README-AGENTS.md Appendix A is the byte-consistent doc twin).
+#
+# Unlike plist-render.sh, there is NO per-stack render: these are systemd
+# TEMPLATE units — the `%i` instance specifier IS the stack slug, resolved by
+# systemd itself at unit-start time (DD-L1, #2071 executor addendum) — so ONE
+# copy of each file serves every stack on the host. "Render" here means: copy
+# the checked-in unit + stamp the marker header + idempotent diff-check +
+# daemon-reload only when something actually changed. No __TOKEN__
+# substitution is needed today — ExecStart execs %h/.local/bin/cortex
+# directly, so there is no bun-path or cortex-dir templating the way the
+# plist's __BUN_PATH__/__CORTEX_DIR__ needs.
+#
+# Usage (in the calling script):
+#   source "${SCRIPT_DIR}/lib/systemd-render.sh"
+#   render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+#
+# Functions never write outside ${UNIT_DIR} (the linger/symlink checks are
+# read-only).
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# plist-render.sh provides discover_stack_slugs — stack enumeration is shared,
+# host-independent logic, no reason to fork it for the systemd side. Sourcing
+# here (rather than relying on the caller to have sourced it already) lets
+# this file be sourced standalone (tests do exactly that).
+# shellcheck source=scripts/lib/plist-render.sh
+source "${LIB_DIR}/plist-render.sh"
+
+# Marker contract (coordinates with the rollback issue cortex#2093): every
+# unit this renderer installs carries this header as its FIRST line. Removal
+# (#2093) only deletes marker-bearing files, so a hand-authored unit at the
+# same path (e.g. a principal who followed Appendix A by hand before
+# upgrading) is never silently touched by either render or rollback.
+SYSTEMD_UNIT_MARKER="# rendered-by: cortex systemd-render v1"
+
+# True if this host plausibly runs systemd. Two independent signals so the
+# check doesn't depend on ${UNIT_DIR} already existing:
+#   - /run/systemd/system — the standard "systemd is PID 1" marker, present
+#     from first boot on any systemd host, well before we ever touch
+#     ~/.config/systemd/user. Overridable via SYSTEMD_HOST_MARKER for tests
+#     (the real /run/systemd/system can't be faked-absent from a test).
+#   - ~/.config/systemd/user existing — fallback for a container/chroot where
+#     the marker file is absent but a systemd user session was configured
+#     anyway (e.g. a hand-followed Appendix A before this renderer existed).
+# Neither present → treat the host as systemd-less and skip silently (no
+# warning): a WSL1 box, a minimal container, or a non-systemd distro is not a
+# cortex misconfiguration.
+systemd_host_detected() {
+  [ -d "${SYSTEMD_HOST_MARKER:-/run/systemd/system}" ] && return 0
+  [ -d "${HOME}/.config/systemd/user" ] && return 0
+  return 1
+}
+
+# Render ONE unit file: read $1 (checked-in template), prepend the marker
+# header, and write it to $2 (dest) ONLY if the result differs from what's
+# already there. On an actual write, bumps the caller-visible
+# SYSTEMD_RENDER_CHANGE_COUNT counter (reset by the caller before the loop) so
+# render_cortex_systemd_units can gate the single daemon-reload call on
+# whether ANY unit changed — systemd's daemon-reload is a global unit-file
+# rescan; firing it every upgrade even when nothing changed is needless churn
+# (#2071 executor addendum: "idempotent render + daemon-reload only on
+# change").
+#
+# Args: $1 src file  $2 dst path
+render_systemd_unit() {
+  local src="$1" dst="$2"
+  local name
+  name="$(basename "${dst}")"
+  if [ ! -f "${src}" ]; then
+    echo "  ⚠ Template missing: ${src}" >&2
+    return 1
+  fi
+  # G-30-style atomic render (mirrors plist-render.sh's render_stack_plist): a
+  # bare redirect onto a live unit path could leave a truncated file visible
+  # to systemd if the render is interrupted mid-write.
+  local tmp="${dst}.tmp"
+  { printf '%s\n' "${SYSTEMD_UNIT_MARKER}"; cat "${src}"; } > "${tmp}"
+  if [ -f "${dst}" ] && cmp -s "${tmp}" "${dst}"; then
+    rm -f "${tmp}"
+    echo "  ⊘ ${name} unchanged"
+    return 0
+  fi
+  mv -f "${tmp}" "${dst}"
+  echo "  ✓ ${name} rendered → ${dst}"
+  SYSTEMD_RENDER_CHANGE_COUNT=$((${SYSTEMD_RENDER_CHANGE_COUNT:-0} + 1))
+}
+
+# bun-guard analogue (#2071 executor addendum). Unlike the plist path
+# (resolve_bun_path — __BUN_PATH__ is sed-substituted into the plist), the
+# systemd units exec %h/.local/bin/cortex directly and need no bun-path
+# substitution at all. What CAN still be missing is the symlink itself (this
+# renderer running ahead of, or independent of, a completed arc install) —
+# warn loudly rather than let ExecStart silently fail-and-respawn-loop with no
+# explanation visible in the unit file.
+verify_cortex_bin_symlink() {
+  local target="${HOME}/.local/bin/cortex"
+  if [ ! -e "${target}" ]; then
+    echo "  ⚠ ${target} not found — the rendered cortex@.service unit's ExecStart will fail. Run \`arc install cortex\` (or \`arc upgrade cortex\`) first." >&2
+    return 1
+  fi
+  return 0
+}
+
+# Linger check (Appendix A §A.1). Without lingering, systemd tears down the
+# user's session — and every --user unit with it — the moment their last
+# login session ends (SSH logout, etc.). loginctl's `Linger` user property is
+# `yes`/`no`; anything else (including loginctl erroring, e.g. no
+# systemd-logind) is treated as "not confirmed enabled" and warned. NEVER sudo
+# here (#2071 executor addendum) — only print the exact remediation command
+# (same shape as Appendix A §A.1) for the operator to run themselves.
+warn_systemd_linger() {
+  local user linger
+  user="$(id -un)"
+  linger="$(loginctl show-user "${user}" --property=Linger --value 2>/dev/null || true)"
+  if [ "${linger}" != "yes" ]; then
+    echo "  ⚠ linger not enabled for ${user} — systemd will stop your cortex services on logout. Enable with: sudo loginctl enable-linger \"${user}\"" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Restart only ACTIVE cortex@<slug> instances after an upgrade — the systemd
+# mirror of postupgrade.sh's plist reload_stack_unless_skipped loop. Unlike
+# the Darwin side, preupgrade.sh's stop/kill block is Darwin-only (see
+# preupgrade.sh's cortex#1909 note), so there is no RUNNING_STACKS_FILE to
+# replay here; "was it running" is answered directly via `systemctl --user
+# is-active`. A stack that isn't currently active is left alone — this must
+# never START a stack that wasn't running (same "no stack left down; none
+# started that wasn't running" symmetry goal as the plist path, just checked
+# live instead of from recorded state).
+#
+# NOTE: CORTEX_UPGRADE_SKIP_RESTART parity (sparing a production stack from
+# restart) is explicitly NOT implemented here — preupgrade.sh documents that
+# gap as Linux/systemd territory for cortex#1909, not this issue.
+#
+# Args: $1 CONFIG_DIR — cortex config dir (stacks are discovered from here)
+restart_running_systemd_stacks() {
+  local config_dir="$1"
+  local slug unit
+  while IFS= read -r slug; do
+    [ -z "${slug}" ] && continue
+    unit="cortex@${slug}"
+    if systemctl --user is-active --quiet "${unit}" 2>/dev/null; then
+      systemctl --user restart "${unit}"
+      echo "  ✓ ${unit} restarted"
+    else
+      echo "  ⊘ ${unit} not active — not restarted"
+    fi
+  done < <(discover_stack_slugs "${config_dir}")
+}
+
+# Render nats@.service + cortex@.service into UNIT_DIR from the templates
+# checked in under CORTEX_DIR/src/services/, then run the bun-guard-analogue
+# symlink check and the linger check. `systemctl --user daemon-reload` runs at
+# most once, and only when at least one unit's content actually changed.
+#
+# No-ops (silently, exit 0) on Darwin and on a systemd-less host — see
+# systemd_host_detected().
+#
+# Args: $1 CORTEX_DIR — repo root (unit templates live under src/services/)
+#       $2 UNIT_DIR   — target dir, typically ${HOME}/.config/systemd/user
+render_cortex_systemd_units() {
+  local cortex_dir="$1"
+  local unit_dir="$2"
+
+  if [ "$(uname)" = "Darwin" ]; then
+    return 0
+  fi
+  if ! systemd_host_detected; then
+    return 0
+  fi
+
+  mkdir -p "${unit_dir}"
+
+  SYSTEMD_RENDER_CHANGE_COUNT=0
+  local unit
+  for unit in nats@.service cortex@.service; do
+    render_systemd_unit "${cortex_dir}/src/services/${unit}" "${unit_dir}/${unit}" || true
+  done
+
+  if [ "${SYSTEMD_RENDER_CHANGE_COUNT}" -gt 0 ]; then
+    systemctl --user daemon-reload
+    echo "  ✓ systemd user daemon reloaded (${SYSTEMD_RENDER_CHANGE_COUNT} unit(s) changed)"
+  fi
+
+  verify_cortex_bin_symlink || true
+  warn_systemd_linger || true
+}

--- a/scripts/lib/systemd-render.sh
+++ b/scripts/lib/systemd-render.sh
@@ -54,7 +54,7 @@ SYSTEMD_UNIT_MARKER="# rendered-by: cortex systemd-render v1"
 # cortex misconfiguration.
 systemd_host_detected() {
   [ -d "${SYSTEMD_HOST_MARKER:-/run/systemd/system}" ] && return 0
-  [ -d "${HOME}/.config/systemd/user" ] && return 0
+  [ -d "${HOME}/.config/systemd/user" ] && return 0  # xdg-audit:allow(resolver-internal host detection — the canonical systemd user-unit dir is the fallback existence signal, not a legacy path; cortex#2071)
   return 1
 }
 
@@ -156,19 +156,65 @@ restart_running_systemd_stacks() {
   done < <(discover_stack_slugs "${config_dir}")
 }
 
+# Ensure the per-stack workspace dir exists for every discovered stack
+# (cortex#2097's `WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace`
+# on cortex@.service).
+#
+# This is NOT optional belt-and-braces — it's load-bearing. Verified
+# empirically (systemd 257, Debian trixie): `WorkingDirectory=` is entered
+# BEFORE *any* exec command of the unit runs, including ExecStartPre — a
+# missing WorkingDirectory fails the unit outright (systemd exit reason
+# EXIT_CHDIR/200) before ExecStartPre's own `mkdir -p` of that same path ever
+# gets to execute. The unit file cannot self-heal this; the directory must
+# already exist by the time `systemctl --user enable/start` runs.
+#
+# Until cortex#2097 ships (stack scaffolding creates this dir itself), NOTHING
+# else in the codebase creates it — so this is the one prerequisite render
+# time can and must cover, mirroring how README-AGENTS.md Appendix A §A.1
+# hand-creates nats-server's log dir as a one-time host-prep step for the
+# same reason (see the ExecStartPre note on render_cortex_systemd_units below
+# for why the *log* dirs don't need this treatment).
+#
+# Args: $1 CONFIG_DIR — cortex config dir (stacks are discovered from here)
+ensure_stack_workspace_dirs() {
+  local config_dir="$1"
+  local slug
+  while IFS= read -r slug; do
+    [ -z "${slug}" ] && continue
+    mkdir -p "${HOME}/.local/share/metafactory/cortex/${slug}/workspace"
+  done < <(discover_stack_slugs "${config_dir}")
+}
+
 # Render nats@.service + cortex@.service into UNIT_DIR from the templates
-# checked in under CORTEX_DIR/src/services/, then run the bun-guard-analogue
-# symlink check and the linger check. `systemctl --user daemon-reload` runs at
-# most once, and only when at least one unit's content actually changed.
+# checked in under CORTEX_DIR/src/services/, ensure every discovered stack's
+# workspace dir exists (see ensure_stack_workspace_dirs), then run the
+# bun-guard-analogue symlink check and the linger check.
+# `systemctl --user daemon-reload` runs at most once, and only when at least
+# one unit's content actually changed.
+#
+# NOTE on the units' `ExecStartPre=/usr/bin/mkdir -p .../logs` lines: those
+# are NOT dead code the way an un-pre-created WorkingDirectory is, but they
+# are also not a substitute for pre-creating the parent on a truly fresh
+# host — `StandardOutput=append:<path under that dir>` is set up before
+# ExecStartPre runs too, so on a from-nothing host the very first start
+# needs the log dir to already exist (README-AGENTS.md Appendix A §A.1 hand-
+# creates nats-server's; postinstall.sh's state bootstrap creates cortex's,
+# host-independent). The ExecStartPre line's job is the idempotent
+# re-creation case (dir survives; a later restart is a no-op mkdir), which is
+# genuinely useful — it's only the *cold-start* case that needs an external
+# actor, which is why workspace (with no OTHER creator yet, pre-cortex#2097)
+# gets handled here explicitly and logs (which already have one) don't.
 #
 # No-ops (silently, exit 0) on Darwin and on a systemd-less host — see
 # systemd_host_detected().
 #
 # Args: $1 CORTEX_DIR — repo root (unit templates live under src/services/)
 #       $2 UNIT_DIR   — target dir, typically ${HOME}/.config/systemd/user
+#       $3 CONFIG_DIR — cortex config dir, for ensure_stack_workspace_dirs
 render_cortex_systemd_units() {
   local cortex_dir="$1"
   local unit_dir="$2"
+  local config_dir="$3"
 
   if [ "$(uname)" = "Darwin" ]; then
     return 0
@@ -190,6 +236,7 @@ render_cortex_systemd_units() {
     echo "  ✓ systemd user daemon reloaded (${SYSTEMD_RENDER_CHANGE_COUNT} unit(s) changed)"
   fi
 
+  ensure_stack_workspace_dirs "${config_dir}"
   verify_cortex_bin_symlink || true
   warn_systemd_linger || true
 }

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -109,7 +109,7 @@ elif [ "$(uname)" = "Linux" ]; then
   # community-validated on Debian 13, README-AGENTS.md Appendix A). No-ops
   # silently on a systemd-less host (see systemd_host_detected in the lib).
   UNIT_DIR="${HOME}/.config/systemd/user"
-  render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+  render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 fi
 
 echo ""

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -25,6 +25,10 @@ EVENTS_DIR="${CLAUDE_DIR}/events"
 # definitions — no source-time side effects).
 # shellcheck source=scripts/lib/plist-render.sh
 source "${SCRIPT_DIR}/lib/plist-render.sh"
+# systemd-render.sh (cortex#2071) provides the Linux twin of §4's plist
+# rendering. Also all function definitions — no source-time side effects.
+# shellcheck source=scripts/lib/systemd-render.sh
+source "${SCRIPT_DIR}/lib/systemd-render.sh"
 # XDG wave-4 (cortex#1869): resolve the active config dir (canonical
 # ~/.config/metafactory/cortex once migrated, legacy trees during transition, or
 # $CORTEX_CONFIG_DIR). On a fresh install none exist yet → resolves to the
@@ -89,7 +93,7 @@ else
   echo "  ⊘ Relay policy exists (~/.claude/relay/relay-policy.yaml — not overwriting)"
 fi
 
-# ─── 4. Launchd plist rendering (macOS only) ─────────────────────
+# ─── 4. Service-unit rendering (launchd on macOS, systemd on Linux) ─
 # Holly cortex#52 round 1 major: the sed-templating block + awk agent-name
 # extractor lived here AND in postupgrade.sh. Extracted to a shared lib
 # (already sourced up-front, for resolve_config_dir).
@@ -100,6 +104,12 @@ warn_stack_identity_drift "${CONFIG_DIR}"
 if [ "$(uname)" = "Darwin" ]; then
   LAUNCH_DIR="${HOME}/Library/LaunchAgents"
   render_cortex_plists "${CORTEX_DIR}" "${LAUNCH_DIR}" "${CONFIG_DIR}"
+elif [ "$(uname)" = "Linux" ]; then
+  # cortex#2071: render the systemd user units (nats@.service, cortex@.service —
+  # community-validated on Debian 13, README-AGENTS.md Appendix A). No-ops
+  # silently on a systemd-less host (see systemd_host_detected in the lib).
+  UNIT_DIR="${HOME}/.config/systemd/user"
+  render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
 fi
 
 echo ""

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -21,6 +21,10 @@ CLAUDE_DIR="${HOME}/.claude"
 # canonical-first (it is all function definitions — no source-time side effects).
 # shellcheck source=scripts/lib/plist-render.sh
 source "${SCRIPT_DIR}/lib/plist-render.sh"
+# systemd-render.sh (cortex#2071) provides the Linux twin of §3's plist
+# re-templating + reload.
+# shellcheck source=scripts/lib/systemd-render.sh
+source "${SCRIPT_DIR}/lib/systemd-render.sh"
 # XDG wave-4 (cortex#1869): resolve the ACTIVE config dir (canonical
 # ~/.config/metafactory/cortex once migrated, the legacy trees during transition,
 # or $CORTEX_CONFIG_DIR) instead of hardcoding the pre-move `~/.config/cortex` —
@@ -155,6 +159,18 @@ if [ "$(uname)" = "Darwin" ]; then
       reload_stack_unless_skipped "${LAUNCH_DIR}" "${slug}"
     done < <(discover_stack_slugs "${CONFIG_DIR}")
   fi
+elif [ "$(uname)" = "Linux" ]; then
+  # ─── 3'. Re-template + restart systemd user units (cortex#2071) ──
+  # No-ops silently on a systemd-less host (see systemd_host_detected).
+  UNIT_DIR="${HOME}/.config/systemd/user"
+  render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+
+  # ─── 4'. Restart running stacks ───────────────────────────────────
+  # Unlike the Darwin side, preupgrade.sh never stops anything on Linux (its
+  # stop/kill block is Darwin-only), so there is no recorded running-set to
+  # replay — restart_running_systemd_stacks checks `systemctl --user
+  # is-active` live per discovered slug and only restarts what's already up.
+  restart_running_systemd_stacks "${CONFIG_DIR}"
 fi
 
 echo "  ✓ Cortex upgrade complete"

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -163,7 +163,7 @@ elif [ "$(uname)" = "Linux" ]; then
   # ─── 3'. Re-template + restart systemd user units (cortex#2071) ──
   # No-ops silently on a systemd-less host (see systemd_host_detected).
   UNIT_DIR="${HOME}/.config/systemd/user"
-  render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}"
+  render_cortex_systemd_units "${CORTEX_DIR}" "${UNIT_DIR}" "${CONFIG_DIR}"
 
   # ─── 4'. Restart running stacks ───────────────────────────────────
   # Unlike the Darwin side, preupgrade.sh never stops anything on Linux (its

--- a/scripts/xdg-audit-allow.yaml
+++ b/scripts/xdg-audit-allow.yaml
@@ -295,6 +295,16 @@ allow:
     match: \.config/systemd/user
     reason: Appendix A Debian runbook — documents systemd's CANONICAL user-unit directory (community-validated units a human copies by hand; systemd itself honors $XDG_CONFIG_HOME). The L1 auto-renderer resolves the path programmatically (cortex#2071)
     owner: cortex#2071
+  - pattern: systemd-userdir
+    path: scripts/postinstall.sh
+    match: UNIT_DIR="\$\{HOME\}/\.config/systemd/user"
+    reason: L1 auto-renderer target dir (cortex#2071) — the canonical systemd user-unit search path; render_cortex_systemd_units is the programmatic resolver this pattern otherwise asks for
+    owner: cortex#2071
+  - pattern: systemd-userdir
+    path: scripts/postupgrade.sh
+    match: UNIT_DIR="\$\{HOME\}/\.config/systemd/user"
+    reason: L1 auto-renderer target dir (cortex#2071) — the canonical systemd user-unit search path; render_cortex_systemd_units is the programmatic resolver this pattern otherwise asks for
+    owner: cortex#2071
   - pattern: config-tree
     path: docs/design-cloud-api.md
     match: ~/\.config/grove

--- a/src/services/cortex@.service
+++ b/src/services/cortex@.service
@@ -6,13 +6,22 @@ Wants=nats@%i.service
 [Service]
 Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin
 Type=simple
-WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace
+# "-" prefix: a missing WorkingDirectory is not fatal (verified: without it,
+# a cold start fails outright with EXIT_CHDIR before ExecStartPre ever runs).
+# With it, ExecStartPre's mkdir below creates the dir, then ExecStart's own
+# chdir succeeds.
+WorkingDirectory=-%h/.local/share/metafactory/cortex/%i/workspace
 ExecStart=%h/.local/bin/cortex start --config %h/.config/metafactory/cortex/%i/%i.yaml
 Restart=on-failure
 RestartSec=10
+# RestartSteps=/RestartMaxDelaySec= need systemd >= 254 (Debian 13 ships >=
+# 254; verified on systemd 249 they are ignored with a startup journal
+# warning, RestartSec=10 alone still applies — graceful degradation, not a
+# hard failure, on older hosts).
 RestartSteps=5
 RestartMaxDelaySec=300
 
+ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace
 ExecStartPre=/usr/bin/mkdir -p %h/.local/state/metafactory/cortex/logs
 StandardOutput=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.log
 StandardError=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.error.log

--- a/src/services/cortex@.service
+++ b/src/services/cortex@.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Cortex stack: %i
+After=network.target nats@%i.service
+Wants=nats@%i.service
+
+[Service]
+Environment=PATH=%h/.local/bin:%h/.bun/bin:/usr/local/bin:/usr/bin:/bin
+Type=simple
+WorkingDirectory=%h/.local/share/metafactory/cortex/%i/workspace
+ExecStart=%h/.local/bin/cortex start --config %h/.config/metafactory/cortex/%i/%i.yaml
+Restart=on-failure
+RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
+
+ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace
+ExecStartPre=/usr/bin/mkdir -p %h/.local/state/metafactory/cortex/logs
+StandardOutput=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.log
+StandardError=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.error.log
+
+[Install]
+WantedBy=default.target

--- a/src/services/cortex@.service
+++ b/src/services/cortex@.service
@@ -13,7 +13,6 @@ RestartSec=10
 RestartSteps=5
 RestartMaxDelaySec=300
 
-ExecStartPre=/usr/bin/mkdir -p %h/.local/share/metafactory/cortex/%i/workspace
 ExecStartPre=/usr/bin/mkdir -p %h/.local/state/metafactory/cortex/logs
 StandardOutput=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.log
 StandardError=append:%h/.local/state/metafactory/cortex/logs/cortex-%i.error.log

--- a/src/services/nats@.service
+++ b/src/services/nats@.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=NATS server (cortex stack: %i)
+After=network.target
+
+[Service]
+PrivateTmp=true
+Type=simple
+ExecStart=%h/.local/bin/nats-server -c %h/.config/nats/%i.conf
+Restart=on-failure
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s SIGUSR2 $MAINPID
+TimeoutStopSec=150
+
+ExecStartPre=/usr/bin/mkdir -p %h/.local/state/nats/logs
+StandardOutput=append:%h/.local/state/nats/logs/nats-server-%i.log
+StandardError=append:%h/.local/state/nats/logs/nats-server-%i.error.log
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Closes #2071. Epic arc#312 Wave 1 Lane A.

Ships src/services/{nats@,cortex@}.service (canonical, byte-identical to README-AGENTS.md Appendix A incl. the #2097 WorkingDirectory lines) + scripts/lib/systemd-render.sh (marker-guarded idempotent render, daemon-reload on change only, linger warn never sudo, restart-only-if-active) wired into postinstall/postupgrade behind the Linux branch.

Tests: 31-case mocked shell suite green; e2e gated to CI-only (deliberately stricter than platform detection — it manipulates real units, so it refuses to run outside a disposable runner) and named to match the systemd-e2e job pattern from #2092. xdg-audit GATE PASS with 2 narrow allow entries (owner #2071).

**This PR's systemd-e2e CI job is the first live-systemd run of the renderer** — implemented on macOS, mock-proven, live signal lands here. Trust-path lane: adversarial review pass running in parallel; merge blocked on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)