### PR TITLE
fix(dispatch): claude.workspaceDir — dispatched sessions never run in $HOME or the install repo (cortex#2097)

### DIFF
--- a/scripts/__tests__/plist-render-stack-discovery.sh
+++ b/scripts/__tests__/plist-render-stack-discovery.sh
@@ -63,6 +63,27 @@ assert_file_not_exists() {
   fi
 }
 
+# cortex#2097 — render_stack_plist now mkdir's the per-stack workspace dir as
+# a side effect; assert both its presence and its owner-only mode.
+assert_dir_exists() {
+  local label="$1" path="$2"
+  if [ -d "${path}" ]; then
+    pass "${label}"
+  else
+    fail "${label}: dir not found: ${path}"
+  fi
+}
+
+assert_dir_mode() {
+  local label="$1" path="$2" expected="$3" actual
+  actual="$(stat -f '%Lp' "${path}" 2>/dev/null || stat -c '%a' "${path}" 2>/dev/null || echo '?')"
+  if [ "${actual}" = "${expected}" ]; then
+    pass "${label}"
+  else
+    fail "${label}: expected mode ${expected} got ${actual} for ${path}"
+  fi
+}
+
 # ─── Fixtures ─────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -78,6 +99,13 @@ trap 'rm -rf "${TMPBASE}"' EXIT
 CONFIG_DIR="${TMPBASE}/config"
 LAUNCH_DIR="${TMPBASE}/LaunchAgents"
 mkdir -p "${CONFIG_DIR}" "${LAUNCH_DIR}"
+
+# cortex#2097 — render_stack_plist now mkdir's a per-stack workspace dir under
+# ${HOME}/.local/share/metafactory/cortex/<slug>/workspace as a side effect of
+# rendering. Scratch HOME so that side effect (and the __HOME__ substitution
+# already exercised below) never touches the real developer/CI home.
+export HOME="${TMPBASE}/home"
+mkdir -p "${HOME}"
 
 # Mock bun: the real bun isn't needed for slug/render tests; we provide a
 # stub that prints a fixed path so sed substitution produces a valid (non-
@@ -204,6 +232,18 @@ assert_contains "meta-factory plist contains label" "ai.meta-factory.cortex.meta
 assert_contains "meta-factory plist CORTEX_CHANNEL substituted from slug" "meta-factory" "$(cat "${MF_DST}")"
 assert_not_contains "meta-factory plist has no leftover __STACK_SLUG__ placeholder" "__STACK_SLUG__" "$(cat "${MF_DST}")"
 assert_not_contains "meta-factory plist has no leftover CORTEX_DIR" "__CORTEX_DIR__" "$(cat "${MF_DST}")"
+assert_not_contains "meta-factory plist has no leftover __WORKSPACE_DIR__ placeholder" "__WORKSPACE_DIR__" "$(cat "${MF_DST}")"
+# cortex#2097 — WorkingDirectory is the per-stack workspace dir, NOT the
+# cortex install repo (fail-on-old: this must fail if WorkingDirectory ever
+# reverts to __CORTEX_DIR__/REPO_ROOT — the self-editing-exposure regression).
+assert_contains "meta-factory plist WorkingDirectory is the workspace dir" \
+  "${HOME}/.local/share/metafactory/cortex/meta-factory/workspace" "$(cat "${MF_DST}")"
+assert_not_contains "meta-factory plist WorkingDirectory is NOT the cortex repo (fail-on-old)" \
+  "${REPO_ROOT}" "$(cat "${MF_DST}")"
+assert_dir_exists "meta-factory workspace dir created" \
+  "${HOME}/.local/share/metafactory/cortex/meta-factory/workspace"
+assert_dir_mode "meta-factory workspace dir is owner-only (0700)" \
+  "${HOME}/.local/share/metafactory/cortex/meta-factory/workspace" "700"
 assert_not_contains "meta-factory plist carries no CORTEX_AGENT_NAME (vestigial, removed)" "CORTEX_AGENT_NAME" "$(cat "${MF_DST}")"
 assert_not_contains "meta-factory plist carries no CORTEX_AGENT_ID (vestigial, removed)" "CORTEX_AGENT_ID" "$(cat "${MF_DST}")"
 assert_not_contains "meta-factory plist agent id NOT embedded (personal-identity template deleted)" "my-test-agent" "$(cat "${MF_DST}")"
@@ -222,6 +262,13 @@ assert_contains "work plist contains label" "ai.meta-factory.cortex.work" "$(cat
 assert_contains "work plist CORTEX_CHANNEL substituted from slug" "work" "$(cat "${WORK_DST}")"
 assert_not_contains "work plist has no leftover __STACK_SLUG__ placeholder" "__STACK_SLUG__" "$(cat "${WORK_DST}")"
 assert_not_contains "work plist has no leftover CORTEX_DIR" "__CORTEX_DIR__" "$(cat "${WORK_DST}")"
+assert_not_contains "work plist has no leftover __WORKSPACE_DIR__ placeholder" "__WORKSPACE_DIR__" "$(cat "${WORK_DST}")"
+assert_contains "work plist WorkingDirectory is the workspace dir" \
+  "${HOME}/.local/share/metafactory/cortex/work/workspace" "$(cat "${WORK_DST}")"
+assert_not_contains "work plist WorkingDirectory is NOT the cortex repo (fail-on-old)" \
+  "${REPO_ROOT}" "$(cat "${WORK_DST}")"
+assert_dir_exists "work workspace dir created" \
+  "${HOME}/.local/share/metafactory/cortex/work/workspace"
 assert_not_contains "work plist carries no CORTEX_AGENT_NAME (vestigial, removed)" "CORTEX_AGENT_NAME" "$(cat "${WORK_DST}")"
 assert_not_contains "work plist carries no CORTEX_AGENT_ID=luna-work (personal identity, removed)" "luna-work" "$(cat "${WORK_DST}")"
 assert_not_contains "work plist carries no luna identity (personal identity, removed)" "luna" "$(cat "${WORK_DST}")"
@@ -240,6 +287,13 @@ if [ -f "${GENERIC_TEMPLATE}" ]; then
   assert_not_contains "halden plist has no leftover STACK_SLUG" "__STACK_SLUG__" "$(cat "${HALDEN_DST}")"
   assert_not_contains "halden plist has no leftover CONFIG_FILE" "__CONFIG_FILE__" "$(cat "${HALDEN_DST}")"
   assert_not_contains "halden plist has no leftover CORTEX_DIR" "__CORTEX_DIR__" "$(cat "${HALDEN_DST}")"
+  assert_not_contains "halden plist has no leftover __WORKSPACE_DIR__ placeholder" "__WORKSPACE_DIR__" "$(cat "${HALDEN_DST}")"
+  assert_contains "halden plist WorkingDirectory is the workspace dir" \
+    "${HOME}/.local/share/metafactory/cortex/halden/workspace" "$(cat "${HALDEN_DST}")"
+  assert_not_contains "halden plist WorkingDirectory is NOT the cortex repo (fail-on-old)" \
+    "${REPO_ROOT}" "$(cat "${HALDEN_DST}")"
+  assert_dir_exists "halden workspace dir created" \
+    "${HOME}/.local/share/metafactory/cortex/halden/workspace"
 else
   fail "generic stack template missing: ${GENERIC_TEMPLATE}"
 fi

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -365,6 +365,18 @@ render_stack_plist() {
     echo "  ⚠ Template missing: ${src}" >&2
     return 1
   fi
+
+  # cortex#2097 — the daemon's OWN launchd WorkingDirectory moves off the
+  # cortex install repo (self-editing exposure) onto the same slug-scoped
+  # workspace dir the dispatch-cwd fallback resolves (TS side:
+  # `canonicalWorkspaceDir` in data-path.ts — kept byte-identical here since
+  # shell has no import). Created (owner-only) BEFORE the render so launchd
+  # never chdir()s into a directory that doesn't exist yet — the daemon's
+  # first-ever start on a fresh host, same as any upgrade onto this template.
+  local workspace_dir="${HOME}/.local/share/metafactory/cortex/${slug}/workspace"
+  mkdir -p "${workspace_dir}"
+  chmod 700 "${workspace_dir}"
+
   # G-30 (cortex#1866, XDG wave 3): render atomically. A bare `sed > dst`
   # onto a live LaunchAgents path leaves a truncated/partial plist visible if
   # the render is interrupted — launchd would then load garbage. Render to a
@@ -375,9 +387,10 @@ render_stack_plist() {
       -e "s|__HOME__|${HOME}|g" \
       -e "s|__STACK_SLUG__|${slug}|g" \
       -e "s|__CONFIG_PATH__|${config_yaml}|g" \
+      -e "s|__WORKSPACE_DIR__|${workspace_dir}|g" \
       "${src}" > "${dst}.tmp"
   mv -f "${dst}.tmp" "${dst}"
-  echo "  ✓ ${slug} plist rendered → ${dst} (config=${config_yaml})"
+  echo "  ✓ ${slug} plist rendered → ${dst} (config=${config_yaml}, workspace=${workspace_dir})"
 }
 
 # Render plists for relay + all discovered stacks into ${LAUNCH_DIR}.

--- a/src/__tests__/xdg-migration-guard.e2e.test.ts
+++ b/src/__tests__/xdg-migration-guard.e2e.test.ts
@@ -231,6 +231,12 @@ function renderFleet(): {
   writeFileSync(configPath, "principal: {}\n");
   mkdirSync(join(home, ".config", "cortex", "logs"), { recursive: true });
   mkdirSync(join(home, ".claude", "logs"), { recursive: true });
+  // cortex#2097 — the stack plist's WorkingDirectory moved off the cortex
+  // install repo (self-editing exposure) onto the per-stack workspace dir;
+  // materialize it the same way `render_stack_plist` (plist-render.sh) does
+  // — owner-only (0700) — so a correctly-installed fleet verifies fully extant.
+  const workspaceDir = join(cortexDir, slug, "workspace");
+  mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
 
   const tokens = {
     HOME: home,
@@ -238,6 +244,7 @@ function renderFleet(): {
     CONFIG_PATH: configPath,
     STACK_SLUG: slug,
     BUN_PATH: bunPath,
+    WORKSPACE_DIR: workspaceDir,
   };
   return {
     home,

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -1,7 +1,33 @@
-import { test, expect, describe, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { test, expect, describe, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+
+/**
+ * cortex#2097 — FILE-LEVEL $HOME sandbox. The dispatch cwd fallback resolves
+ * `canonicalWorkspaceDir` (data-path.ts) off `process.env.HOME` whenever a
+ * dispatched message's `effectiveDirs` is empty — and `makeConfig()`'s
+ * default `claude.allowedDirs` IS empty, so nearly every pre-existing
+ * `handleMessage()` test in this file (not just the dedicated cortex#2097
+ * suite below) now takes that fallback branch and mkdirSync's a real
+ * directory. Sandbox $HOME for the WHOLE file, once, so none of those
+ * pre-existing tests silently write into the real developer/CI home — the
+ * same "never touch real ~/.config or ~/.claude" isolation this repo
+ * requires of every test, just extended to cover a production behavior this
+ * file didn't have before.
+ */
+let fileScratchHome: string;
+let savedFileHome: string | undefined;
+beforeAll(() => {
+  savedFileHome = process.env.HOME;
+  fileScratchHome = mkdtempSync(join(tmpdir(), "cortex-dispatch-test-home-"));
+  process.env.HOME = fileScratchHome;
+});
+afterAll(() => {
+  if (savedFileHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedFileHome;
+  rmSync(fileScratchHome, { recursive: true, force: true });
+});
 import { MockAdapter } from "../../adapters/mock";
 import { DispatchHandler } from "../dispatch-handler";
 import type { InboundMessage } from "../../adapters/types";
@@ -1182,6 +1208,150 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
     const texts = adapter.sentMessages.map((m) => m.text);
     expect(texts.length).toBe(1);
     expect(texts[0]).toBe("Sorry, I couldn't process that. (exit code: 1)");
+
+    await handler.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#2097 — dispatch cwd fallback. A bare stack (no dirRestrictions, no
+// network/global allowedDirs configured) used to inherit the DAEMON's own
+// cwd — `$HOME` on a Linux systemd unit with no `WorkingDirectory=`, or the
+// cortex install repo itself on the macOS plist — silently widening the
+// dispatched CC session's read/write scope. The fallback resolves a
+// dedicated per-stack workspace dir instead (`canonicalWorkspaceDir`,
+// data-path.ts), mkdir'd owner-only (0700) before spawn.
+// ---------------------------------------------------------------------------
+
+describe("DispatchHandler — dispatch cwd fallback (cortex#2097)", () => {
+  // `canonicalWorkspaceDir` (no explicit `home` arg, matching dispatch-
+  // handler.ts's call site) resolves off `process.env.HOME` — sandbox it to a
+  // scratch dir per test so the mkdirSync side effect never touches the real
+  // developer/CI home (repo convention: tests never touch real ~/.config or
+  // ~/.claude — the XDG data root is the same class of real-home path).
+  let savedHome: string | undefined;
+  let scratchHome: string;
+
+  beforeEach(() => {
+    savedHome = process.env.HOME;
+    scratchHome = mkdtempSync(join(tmpdir(), "cortex-workspace-home-"));
+    process.env.HOME = scratchHome;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(scratchHome, { recursive: true, force: true });
+  });
+
+  test("bare stack: cwd falls back to the per-stack workspace dir, created 0700, and joins allowedDirs", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(), // claude.allowedDirs: [] — bare stack, no dirs configured
+      securityPreamble: "",
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+      stack: "acme",
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    const expected = join(scratchHome, ".local", "share", "metafactory", "cortex", "acme", "workspace");
+    const opts = optsLog()[0]!;
+    expect(opts.cwd).toBe(expected);
+    expect(opts.allowedDirs).toContain(expected);
+    expect(statSync(expected).isDirectory()).toBe(true);
+    // Owner-only — matches the repo's other XDG data-dir mkdirSync calls
+    // (db-utils.ts, event-logger.hook.ts).
+    expect(statSync(expected).mode & 0o777).toBe(0o700);
+
+    await handler.shutdown();
+  });
+
+  test("no stack opt passed: falls back to the 'default' slug (mirrors deriveStackId's own default)", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+      // no `stack` — production always passes one (cortex.ts wires
+      // `derivedStack.stack`), but the type is optional and tests may omit it.
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    const expected = join(scratchHome, ".local", "share", "metafactory", "cortex", "default", "workspace");
+    expect(optsLog()[0]!.cwd).toBe(expected);
+
+    await handler.shutdown();
+  });
+
+  test("configured allowedDirs: cwd is UNCHANGED (regression) — no workspace fallback, nothing extra appended", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig({
+        claude: {
+          timeoutMs: 120_000,
+          asyncTimeoutMs: 900_000,
+          additionalArgs: [],
+          allowedTools: [],
+          disallowedTools: [],
+          allowedDirs: ["/configured/dir"],
+          readOnlyDirs: [],
+        },
+      }),
+      securityPreamble: "",
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+      stack: "acme",
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    const opts = optsLog()[0]!;
+    expect(opts.cwd).toBe("/configured/dir");
+    expect(opts.allowedDirs).toEqual(["/configured/dir"]);
+
+    // The fallback branch never ran — the workspace dir was never created.
+    const wouldBeWorkspace = join(scratchHome, ".local", "share", "metafactory", "cortex", "acme", "workspace");
+    expect(existsSync(wouldBeWorkspace)).toBe(false);
+
+    await handler.shutdown();
+  });
+
+  test("claude.workspaceDir set explicitly: dispatch uses it verbatim, `~` expands", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig({
+        claude: {
+          timeoutMs: 120_000,
+          asyncTimeoutMs: 900_000,
+          additionalArgs: [],
+          allowedTools: [],
+          disallowedTools: [],
+          allowedDirs: [],
+          readOnlyDirs: [],
+          workspaceDir: "~/custom-workspace",
+        },
+      }),
+      securityPreamble: "",
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+      stack: "acme",
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    const expected = join(scratchHome, "custom-workspace");
+    const opts = optsLog()[0]!;
+    expect(opts.cwd).toBe(expected);
+    expect(opts.allowedDirs).toContain(expected);
+    expect(statSync(expected).isDirectory()).toBe(true);
 
     await handler.shutdown();
   });

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -9,8 +9,9 @@
 import { EventEmitter } from "events";
 import { basename } from "path";
 import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
+import { mkdirSync, readFileSync } from "fs";
 import { type AgentConfig, getAllRepos } from "../common/types/config";
+import { canonicalWorkspaceDir } from "../common/data-path";
 import type {
   PlatformAdapter,
   InboundMessage,
@@ -957,17 +958,40 @@ export class DispatchHandler extends EventEmitter {
         ? access.dirRestrictions
         : (networkClaude?.allowedDirs.length ? networkClaude.allowedDirs : this.config.claude.allowedDirs);
       const readOnlyDirs = networkClaude?.readOnlyDirs.length ? networkClaude.readOnlyDirs : this.config.claude.readOnlyDirs;
-      const invokeDirs = [...effectiveDirs, ...readOnlyDirs, ...attachmentDirs];
       const bashGuardDisabled = access.bashGuard === false;
       // G-300: DM role may override bash allowlist; otherwise fall back to network, then global
       const effectiveBashAllowlist = bashGuardDisabled
         ? undefined
         : (access.bashAllowlist ?? networkClaude?.bashAllowlist ?? this.config.claude.bashAllowlist);
-      // G-500: Set cwd to first allowedDir so the agent starts in the right directory
+      // G-500: Set cwd to first allowedDir so the agent starts in the right directory.
+      // cortex#2097 — when NO dir resolves (a bare stack: dirRestrictions,
+      // network allowedDirs, AND global allowedDirs all empty), fall back to
+      // the per-stack workspace dir instead of inheriting the DAEMON's own
+      // cwd — `$HOME` on a Linux systemd unit with no `WorkingDirectory=`, or
+      // the cortex install repo itself on the macOS plist. Either silently
+      // widens the dispatched session's read/write scope to somewhere it must
+      // never be. `claude.workspaceDir` overrides the canonical default when
+      // set; mkdirSync (owner-only, matching the repo's other XDG data dirs)
+      // covers the fresh-host / pre-#2097-upgrade case where it doesn't exist
+      // yet — `stack create` also creates it at scaffold time.
       const firstDir = effectiveDirs[0];
-      const effectiveCwd = firstDir
-        ? firstDir.replace(/^~/, process.env.HOME ?? "~")
-        : undefined;
+      let workspaceFallbackDir: string | undefined;
+      let effectiveCwd: string | undefined;
+      if (firstDir) {
+        effectiveCwd = firstDir.replace(/^~/, process.env.HOME ?? "~");
+      } else {
+        workspaceFallbackDir = this.config.claude.workspaceDir
+          ? this.config.claude.workspaceDir.replace(/^~/, process.env.HOME ?? "~")
+          : canonicalWorkspaceDir(this.stack ?? "default");
+        mkdirSync(workspaceFallbackDir, { recursive: true, mode: 0o700 });
+        effectiveCwd = workspaceFallbackDir;
+      }
+      // cortex#2097 — the workspace dir is only ever a STAND-IN for an empty
+      // effectiveDirs (the branch above), so appending it here can never
+      // duplicate an entry already present in effectiveDirs.
+      const invokeDirs = workspaceFallbackDir
+        ? [...effectiveDirs, workspaceFallbackDir, ...readOnlyDirs, ...attachmentDirs]
+        : [...effectiveDirs, ...readOnlyDirs, ...attachmentDirs];
 
       // H-001: Explicit metadata for spawn boundary
       const groveProject = channelCtx.repoShort ?? undefined;

--- a/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
+++ b/src/cli/cortex/commands/__tests__/e2e-lifecycle/lifecycle.test.ts
@@ -26,7 +26,8 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 import { dispatchStack } from "../../stack";
@@ -111,7 +112,20 @@ function pubkeyFromGenerate(stdout: string): string {
   return pk;
 }
 
+// cortex#2097 — step 1's `stack create --apply` (slugs "hub" + JOINER_STACK_SLUG
+// = "work") now also mkdirSync's the dispatch cwd fallback's canonical
+// workspace dir, resolved off `homedir()` ($HOME on POSIX) — NOT under
+// `--config-dir`, the isolation this suite's temp dirs already give. Sandbox
+// $HOME for the whole file so this walkthrough never writes into the real
+// developer/CI home (and never collides with a REAL "work" stack's data).
+let lifecycleHome: string;
+let savedLifecycleHome: string | undefined;
+
 beforeAll(async () => {
+  savedLifecycleHome = process.env.HOME;
+  lifecycleHome = mkdtempSync(join(tmpdir(), "c1355-home-"));
+  process.env.HOME = lifecycleHome;
+
   resetRegistry();
 
   // --- Mint the ADMIN identity (network admin + hub admin + registry admin —
@@ -156,6 +170,9 @@ afterAll(() => {
   ctx.restoreFetch?.();
   cleanupDirs();
   resetRegistry();
+  if (savedLifecycleHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedLifecycleHome;
+  rmSync(lifecycleHome, { recursive: true, force: true });
 });
 
 describe("C-1355 — E2E admission lifecycle guard", () => {

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -11,7 +11,7 @@
  * fresh tmp dir and asserts dry-run leaves it empty.
  */
 
-import { describe, test, expect, afterEach } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -27,6 +27,28 @@ function freshDir(): string {
 }
 afterEach(() => {
   while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+/**
+ * cortex#2097 — `stack create --apply` now also mkdirSync's the dispatch cwd
+ * fallback's canonical default workspace dir, resolved off `homedir()` (which
+ * reads `$HOME` on POSIX) — NOT under `--config-dir`, the isolation this file's
+ * header comment already documents. Sandbox `$HOME` for the whole file so
+ * `--apply` tests never write into the real developer/CI home; only
+ * `--config-dir` is asserted against directly, so nothing here depends on the
+ * real value of `$HOME`.
+ */
+let stackHome: string;
+let savedStackHome: string | undefined;
+beforeAll(() => {
+  savedStackHome = process.env.HOME;
+  stackHome = mkdtempSync(join(tmpdir(), "c808-stack-cli-home-"));
+  process.env.HOME = stackHome;
+});
+afterAll(() => {
+  if (savedStackHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedStackHome;
+  rmSync(stackHome, { recursive: true, force: true });
 });
 
 /** Seed an existing split-layout stack under <configDir>/<slug>/ with stack.id. */

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -205,6 +205,21 @@ describe("renderScaffold", () => {
     // Must NOT ship the old generic non-slug default.
     expect(system?.contents).not.toMatch(/^\s*name:\s*cortex\s*$/m);
   });
+
+  // cortex#2097 — the scaffold documents the dispatch cwd fallback's
+  // canonical default, slug-scoped, as a COMMENTED line (the dir itself is
+  // created out-of-band by `stack.ts`'s --apply write, not by this pure
+  // renderer — see stack-cli.test.ts for the disk-side assertion).
+  test("system/system.yaml documents claude.workspaceDir's canonical default, commented + slug-scoped (cortex#2097)", () => {
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    expect(system?.contents).toContain(
+      "# workspaceDir: ~/.local/share/metafactory/cortex/demo/workspace",
+    );
+    // Commented, not active — `stack create` never forces the key into the
+    // parsed config; the daemon resolves the same default at runtime absent it.
+    expect(system?.contents).not.toMatch(/^\s*workspaceDir:/m);
+  });
 });
 
 // =============================================================================

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -391,6 +391,13 @@ claude:
   allowedTools: []
   disallowedTools:
     - Write
+  # workspaceDir — the dispatched CC session's cwd when no allowedDirs/
+  # dirRestrictions resolve one (a bare stack — cortex#2097). Scoped to this
+  # stack so its dispatched sessions never inherit the daemon's own cwd
+  # ($HOME / the cortex install repo). \`cortex stack create\` already
+  # created this dir (0700) for you; uncomment only to point it somewhere
+  # else.
+  # workspaceDir: ~/.local/share/metafactory/cortex/${slug}/workspace
 
 execution:
   default: local

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -38,6 +38,7 @@ import { execFileSync } from "child_process";
 import { dirname, join } from "path";
 
 import { resolveConfigDir } from "../../../common/config/config-path";
+import { canonicalWorkspaceDir } from "../../../common/data-path";
 import { homedir } from "os";
 
 import { validateConfigLoads } from "../../../common/config/validate-on-write";
@@ -269,6 +270,12 @@ function runCreate(
   if (!applyRes.ok) return usageError("create", applyRes.reason, json);
 
   const targetDir = join(configDir, slug);
+  // cortex#2097 — the dispatch cwd fallback's canonical default for a bare
+  // stack. Created here (0700) so a FRESH scaffold never hits the
+  // dispatch-time mkdirSync fallback on its very first message; matches
+  // `canonicalWorkspaceDir` in data-path.ts (the TS resolver dispatch-handler
+  // reads at runtime) so the two never drift.
+  const workspaceDir = canonicalWorkspaceDir(slug, homedir());
 
   // --- uniqueness: dir collision ------------------------------------------
   // Never overwrite. Refuse a dir that already exists BEFORE the scan so a
@@ -311,7 +318,7 @@ function runCreate(
 
   // --- dry-run (DEFAULT): print the file set, touch NOTHING ----------------
   if (!applyRes.apply) {
-    return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, false, json);
+    return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, false, json, workspaceDir);
   }
 
   // --- apply: write the file set -------------------------------------------
@@ -330,6 +337,12 @@ function runCreate(
       // tree, and the token is protected before it is ever written.
       chmodSync(dest, 0o600);
     }
+    // cortex#2097 — the dispatch cwd fallback dir, born 0700 (owner-only,
+    // matching the repo's other XDG data dirs — db-utils.ts, event-logger.hook.ts).
+    // Lives under the DATA root (~/.local/share/…), not targetDir (the CONFIG
+    // tree just written above) — a distinct dir the rollback below leaves in
+    // place on failure (nothing secret lands in it at scaffold time).
+    mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
   } catch (err) {
     // Roll back the partial scaffold so a mid-write failure (ENOSPC, EACCES on
     // a subpath, …) doesn't leave a half-written, non-loadable dir that the
@@ -375,7 +388,7 @@ function runCreate(
     );
   }
 
-  return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, true, json);
+  return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, true, json, workspaceDir);
 }
 
 function renderPlan(
@@ -388,6 +401,7 @@ function renderPlan(
   files: ScaffoldFile[],
   applied: boolean,
   json: boolean,
+  workspaceDir: string,
 ): ExitResult {
   if (json) {
     return ok(
@@ -400,6 +414,9 @@ function renderPlan(
             stack_id: stackId,
             agent: agentId,
             seed_path: seedPath,
+            // cortex#2097 — the dispatch cwd fallback dir, created alongside
+            // the config tree (0700).
+            workspace_dir: workspaceDir,
             aligned: "true",
             applied: applied ? "true" : "false",
           },
@@ -416,6 +433,7 @@ function renderPlan(
   lines.push(`  stack.id:   ${stackId}   (born aligned: dir == slug == trailing segment)`);
   lines.push(`  agent:      ${agentId}`);
   lines.push(`  seed path:  ${seedPath}   (auto-provisioned by 'arc upgrade cortex' — NOT generated here)`);
+  lines.push(`  workspace:  ${workspaceDir}   (${applied ? "created" : "would create"}, 0700 — the dispatch cwd fallback dir, cortex#2097)`);
   lines.push("");
   lines.push(`  ${applied ? "wrote" : "would write"} under ${targetDir}:`);
   for (const f of files) lines.push(`    • ${f.relPath}`);

--- a/src/common/data-path.ts
+++ b/src/common/data-path.ts
@@ -245,3 +245,24 @@ export const PUBLISHED_EVENTS_DIR_DEFAULT =
 
 /** The pre-move default literal for `paths.publishedEventsDir` (value-migrator source). */
 export const LEGACY_PUBLISHED_EVENTS_DIR_DEFAULT = "~/.claude/events/published";  // xdg-audit:allow(resolver legacy-fallback constant — by design)
+
+// ────────────────────────────────────────────────── per-stack workspace dir (cortex#2097)
+
+/**
+ * Canonical per-stack workspace dir: `~/.local/share/metafactory/cortex/<slug>/workspace`.
+ *
+ * The dispatch cwd FALLBACK for a bare stack (no `allowedDirs`/`dirRestrictions`
+ * configured) — see `dispatch-handler.ts` G-500. Before this, an unconfigured
+ * stack's dispatched CC session inherited the DAEMON's own cwd: `$HOME` on a
+ * Linux systemd unit with no `WorkingDirectory=` (community #cortex thread,
+ * 2026-07-16 — visible as `~/.claude/projects/-home-<user>/`), or the cortex
+ * install repo itself on the macOS launchd plist. Both silently widen the
+ * assistant's read/write scope to somewhere it must never be. Slug-scoped
+ * (not a flat shared dir) so co-hosted stacks never share one workspace.
+ *
+ * No legacy-fallback probe (unlike the sibling resolvers in this module) —
+ * this is a net-new concept with no prior on-disk location to migrate from.
+ */
+export function canonicalWorkspaceDir(slug: string, home?: string): string {
+  return join(cortexDataDir(home), slug, "workspace");
+}

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -1047,6 +1047,17 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
     expect(parsed.allowedDirs).toEqual([]);
   });
 
+  // cortex#2097 — dispatch cwd fallback's config knob. Optional (no default):
+  // absent means "resolve the canonical per-stack default at dispatch time"
+  // (dispatch-handler.ts / canonicalWorkspaceDir), NOT a fixed schema default,
+  // since the default is slug-scoped and the schema layer has no slug.
+  test("ClaudeConfigSchema.workspaceDir is optional (absent ⇒ undefined) and round-trips a string", () => {
+    expect(ClaudeConfigSchema.parse({}).workspaceDir).toBeUndefined();
+    expect(
+      ClaudeConfigSchema.parse({ workspaceDir: "~/custom-workspace" }).workspaceDir,
+    ).toBe("~/custom-workspace");
+  });
+
   test("AttachmentsConfigSchema applies inner defaults", () => {
     const parsed = AttachmentsConfigSchema.parse({});
     expect(parsed.enabled).toBe(true);

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -694,6 +694,8 @@ export const AgentConfigSchema = z.object({
     allowedDirs: z.array(z.string()).default([]),
     /** Directories the agent can read but not modify. Also passed as --add-dir, with write restriction enforced via security preamble. */
     readOnlyDirs: z.array(z.string()).default([]),
+    /** cortex#2097 — dedicated per-stack workspace dir; dispatch's cwd fallback when no allowedDirs/dirRestrictions resolve one (a bare stack). Optional; `~` expands. Absent ⇒ canonical default `~/.local/share/metafactory/cortex/<slug>/workspace` (see `canonicalWorkspaceDir` in `../data-path`). */
+    workspaceDir: z.string().optional(),
   }),
 
   attachments: z.object({

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1563,6 +1563,15 @@ export const ClaudeConfigSchema = z.object({
   }).optional(),
   allowedDirs: z.array(z.string()).default([]),
   readOnlyDirs: z.array(z.string()).default([]),
+  /**
+   * cortex#2097 — dedicated per-stack workspace dir. Dispatch's cwd fallback
+   * when NO dir resolves (`dirRestrictions`/`allowedDirs` all empty — a bare
+   * stack), so an unconfigured stack's CC session never inherits the daemon's
+   * own cwd (`$HOME` / the cortex repo). Optional; `~` expands. Absent ⇒ the
+   * canonical default `~/.local/share/metafactory/cortex/<slug>/workspace`
+   * (see `canonicalWorkspaceDir` in `../data-path`).
+   */
+  workspaceDir: z.string().optional(),
 });
 
 export type ClaudeConfig = z.infer<typeof ClaudeConfigSchema>;

--- a/src/services/ai.meta-factory.cortex.stack.plist
+++ b/src/services/ai.meta-factory.cortex.stack.plist
@@ -12,7 +12,7 @@
         <string>__CONFIG_PATH__</string>
     </array>
     <key>WorkingDirectory</key>
-    <string>__CORTEX_DIR__</string>
+    <string>__WORKSPACE_DIR__</string>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>


### PR DESCRIPTION
Closes #2097. Epic arc#312 Wave 1 Lane C — community-reported security finding (dispatched CC sessions inherited the daemon's cwd: `$HOME` on Linux, the cortex install repo on macOS).

## What ships

- `canonicalWorkspaceDir(slug)` → `~/.local/share/metafactory/cortex/<slug>/workspace` (new `src/common/data-path.ts` helper)
- `claude.workspaceDir` (optional) in both config schemas (MIRROR-sync test green)
- **Dispatch fallback**: bare stacks (no configured dirs) now dispatch into the workspace dir (created 0700, appended to `allowedDirs`) instead of inheriting the daemon cwd
- **Scaffold**: `stack create --apply` creates the dir + documents the key in `system.yaml`
- **macOS plist**: `WorkingDirectory` now points at the workspace dir (new render token), not the cortex repo — the dir is mkdir'd at render time so launchd never chdirs into a missing path
- Tests: 4 new dispatch-handler cases (bare-stack fallback, default slug, configured-dirs regression, `~` expansion), schema round-trip, plist fail-on-old, + a genuine fixture regression caught and fixed in the xdg-migration guard e2e

## Also fixed in passing

A **pre-existing test-isolation gap**: three test files exercised dispatch/scaffold with no `$HOME` sandbox and wrote into the real home dir. Isolated properly (repo rule: tests never touch real `~/`); verified zero new real-home writes on a full re-run.

## Verification

tsc 0 · lint 0 errors · targeted suites 374/374 · full suite 9935 pass / 12 fail — all 12 **byte-identical on clean origin/main** (this machine's known non-hermetic set), zero regressions.

## Open point for the principal (stop-and-ask from the issue)

Existing stacks get the workspace dir organically at first dispatch (the fallback self-creates). No explicit postupgrade migration step was added — confirm that's sufficient or ask for one.

Trust-path lane: adversarial review running in parallel; merge blocked on both gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
