### PR TITLE
feat(substrates): API-P1.4 — normalized error to dispatch lifecycle mapping + back-pressure

### DIFF
--- a/src/common/inference/registry.ts
+++ b/src/common/inference/registry.ts
@@ -22,8 +22,13 @@
 // passes the schema-validated secret REFERENCE (`apiKey` / `headers.*`, each an
 // `env:NAME` ref) straight through to the factory on the untouched provider
 // config. It does NOT import or call `resolveSecretRef`, and places NO resolved
-// secret value on any object. Resolution stays at REQUEST time inside the
-// provider (the only correct place — see secret-ref.ts). Credentials belong in
+// secret value on any object — that invariant is the registry's own and holds.
+// Resolution happens one layer out, in the injected FACTORY, at provider-
+// CONSTRUCTION time (the shipped provider constructors take a literal key — see
+// `substrates/api-agent/provider-factories.ts`), which `resolveProfile` triggers
+// on a provider's first build. Since the boot pre-flight ({@link
+// InferenceRegistry.validateAll} in `startCortex`) resolves every profile at
+// startup, that is BOOT for every configured provider. Credentials belong in
 // the `apiKey` / `headers` reference fields ONLY; the profile `options` bag is an
 // opaque provider-knob escape hatch that cortex never inspects and never resolves
 // secrets from — never route a credential through `options`.
@@ -46,9 +51,19 @@ export type ModelClass = InferenceProfile["modelClass"];
  * entry. Injected per `protocol` (dependency injection): API-P1.3 wires the real
  * `AnthropicMessagesProvider` / `OpenAICompatibleProvider` constructors; tests
  * wire fakes. The `config` passed in still carries the secret REFERENCES
- * (`apiKey` / `headers.*` as `env:NAME`) untouched — the factory hands them to
- * the provider, which resolves them at REQUEST time. The factory MUST NOT
- * resolve or persist a secret value.
+ * (`apiKey` / `headers.*` as `env:NAME`) untouched — the REGISTRY never resolves
+ * them. A factory whose provider constructor needs a literal key (both shipped
+ * P1.3 providers do) resolves the reference here, at construction, via
+ * `resolveSecretRef`; a factory whose provider can defer should. Either way the
+ * factory MUST NOT persist a resolved secret: never write it back onto the
+ * `config` object it was handed, and never log it. A resolved value belongs on
+ * the provider instance alone.
+ *
+ * Construction — and therefore any such resolution — is triggered by
+ * `resolveProfile`, which the boot pre-flight ({@link
+ * InferenceRegistry.validateAll}) runs for EVERY profile at startup. A factory
+ * that resolves eagerly will therefore throw at BOOT on an unset env var; the
+ * registry catches that and reports `provider-instantiation-failed`.
  */
 export type ProviderFactory = (input: {
   /** The provider's key in `inference.providers` — becomes the provider id. */
@@ -121,7 +136,11 @@ export type ProfileResolution =
  * provider bundles, failing closed on every unresolvable case.
  *
  * Provider instances are created LAZILY on first resolve and cached by provider
- * key, so profiles sharing a provider reuse one instance.
+ * key, so profiles sharing a provider reuse one instance. Note that "first
+ * resolve" is BOOT in the daemon: {@link InferenceRegistry.validateAll} runs as
+ * a startup pre-flight over every profile, so every configured provider is built
+ * (and its secret reference resolved by the factory) at boot — not on first
+ * dispatch.
  */
 export class InferenceRegistry {
   private readonly config: InferenceConfig;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3701,6 +3701,21 @@ export async function startCortex(
   const inferenceRegistry = createInferenceRegistry(
     config.inference ?? { providers: {}, profiles: {} },
   );
+  // API-P1.4 — pre-flight EVERY inference profile at boot (design §"fail at
+  // config load"). An unresolvable profile (unknown provider, no factory for
+  // its protocol) surfaces HERE, loudly, rather than lurking until the first
+  // `substrate: api-agent` dispatch. Kept NON-FATAL: the api-agent harness
+  // already fails closed per-dispatch on the same conditions, and one bad
+  // profile must not take down a daemon serving unrelated claude-code agents —
+  // so this reports (stderr, one line per profile) and boot continues. Empty
+  // `inference` config ⇒ no profiles ⇒ no output.
+  for (const err of inferenceRegistry.validateAll()) {
+    process.stderr.write(
+      `[boot/inference] inference profile "${err.profileName}" does not resolve ` +
+        `(${err.code}): ${err.message} — any \`substrate: api-agent\` agent bound ` +
+        `to it will fail closed at dispatch.\n`,
+    );
+  }
 
   const sharedDispatchListenerOpts = {
     runtime,

--- a/src/substrates/api-agent/__tests__/error-mapping.test.ts
+++ b/src/substrates/api-agent/__tests__/error-mapping.test.ts
@@ -1,0 +1,111 @@
+// API-P1.4 (issue #2064) — unit coverage for the `ProviderErrorKind` → dispatch
+// outcome table. Proves EVERY kind maps to a defined outcome, that the transient
+// kinds are back-pressure (carry `retryAfterMs` when known) and the rest are not,
+// and that the `not_now` reason detail is built from the kind alone (secret-free).
+
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderErrorKind } from "../../../common/inference/errors";
+import {
+  PROVIDER_ERROR_KIND_OUTCOME,
+  shapeProviderFailure,
+} from "../error-mapping";
+
+// The full closed set, spelled out independently of the table so a kind added to
+// the type (and the table) without updating this list fails the exhaustiveness
+// assertion below.
+const ALL_KINDS: ProviderErrorKind[] = [
+  "authentication",
+  "authorization",
+  "rate_limit",
+  "overloaded",
+  "invalid_request",
+  "unsupported_capability",
+  "content_filter",
+  "timeout",
+  "unavailable",
+  "malformed_response",
+];
+
+const BACK_PRESSURE_KINDS: ProviderErrorKind[] = [
+  "rate_limit",
+  "overloaded",
+  "unavailable",
+  "timeout",
+];
+const NON_RETRYABLE_KINDS: ProviderErrorKind[] = ALL_KINDS.filter(
+  (k) => !BACK_PRESSURE_KINDS.includes(k),
+);
+
+describe("api-agent error-mapping · ProviderErrorKind → dispatch outcome (#2064)", () => {
+  test("the table is exhaustive over every ProviderErrorKind", () => {
+    const tableKinds = Object.keys(PROVIDER_ERROR_KIND_OUTCOME).sort();
+    expect(tableKinds).toEqual([...ALL_KINDS].sort());
+  });
+
+  test("every kind maps to a defined `failed` outcome (never undefined)", () => {
+    for (const kind of ALL_KINDS) {
+      const shape = shapeProviderFailure({ errorKind: kind, retryable: true });
+      // No provider-error kind maps to `aborted` — that is the cancellation
+      // path's outcome, not a provider error's.
+      expect(shape.outcome).toBe("failed");
+    }
+  });
+
+  test("back-pressure kinds are retryable and surface `retryAfterMs` when known", () => {
+    for (const kind of BACK_PRESSURE_KINDS) {
+      const shape = shapeProviderFailure({
+        errorKind: kind,
+        retryable: true,
+        retryAfterMs: 2500,
+      });
+      expect(shape.retryable).toBe(true);
+      expect(shape.retryAfterMs).toBe(2500);
+      expect(shape.reason).toEqual({
+        kind: "not_now",
+        detail: `provider back-pressure (${kind})`,
+        retry_after_ms: 2500,
+      });
+    }
+  });
+
+  test("a back-pressure kind WITHOUT a hint still emits `not_now`, no retry_after_ms", () => {
+    for (const kind of BACK_PRESSURE_KINDS) {
+      const shape = shapeProviderFailure({ errorKind: kind, retryable: true });
+      expect(shape.retryable).toBe(true);
+      expect(shape.retryAfterMs).toBeUndefined();
+      expect(shape.reason).toEqual({
+        kind: "not_now",
+        detail: `provider back-pressure (${kind})`,
+      });
+    }
+  });
+
+  test("non-retryable kinds carry NO retryAfterMs and NO back-pressure reason", () => {
+    for (const kind of NON_RETRYABLE_KINDS) {
+      // Even if a provider mis-set `retryable: true` / supplied a hint, the
+      // table's classification is authoritative and refuses the hint.
+      const shape = shapeProviderFailure({
+        errorKind: kind,
+        retryable: true,
+        retryAfterMs: 9999,
+      });
+      expect(shape.retryable).toBe(false);
+      expect(shape.retryAfterMs).toBeUndefined();
+      expect(shape.reason).toBeUndefined();
+    }
+  });
+
+  test("the `not_now` detail is derived from the kind alone (no injected text)", () => {
+    const shape = shapeProviderFailure({
+      errorKind: "rate_limit",
+      retryable: true,
+      retryAfterMs: 1000,
+    });
+    // Deterministic, kind-only string — nothing provider-authored can reach it.
+    expect(shape.reason?.kind).toBe("not_now");
+    if (shape.reason?.kind === "not_now") {
+      expect(shape.reason.detail).toBe("provider back-pressure (rate_limit)");
+    }
+  });
+});

--- a/src/substrates/api-agent/__tests__/harness.test.ts
+++ b/src/substrates/api-agent/__tests__/harness.test.ts
@@ -407,6 +407,138 @@ describe("provider contract · api-agent-harness (live, #2063)", () => {
   });
 });
 
+// ── API-P1.4 · normalized error → lifecycle mapping + back-pressure (#2064) ────
+describe("api-agent-harness · error→lifecycle mapping + back-pressure (#2064)", () => {
+  test("a rate-limit (429 + retry-after) → failed with a not_now back-pressure hint", async () => {
+    server.enqueue({
+      status: 429,
+      headers: { "retry-after": "3" },
+      chunks: [{ data: '{"error":{"message":"slow-down-should-not-leak"}}' }],
+    });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1);
+    const t = terminals[0];
+    expect(t?.type).toBe("dispatch.task.failed");
+    // Diagnostic fields carried onto the lifecycle envelope.
+    expect(t?.payload.provider_error_kind).toBe("rate_limit");
+    expect(t?.payload.retryable).toBe(true);
+    expect(t?.payload.retry_after_ms).toBe(3000);
+    // Back-pressure reason mirrors the dispatch-listener `not_now` shape.
+    expect(t?.payload.reason).toEqual({
+      kind: "not_now",
+      detail: "provider back-pressure (rate_limit)",
+      retry_after_ms: 3000,
+    });
+    // Redacted summary only — no raw body, no key.
+    const summary = String(t?.payload.error_summary);
+    expect(summary).not.toContain("slow-down-should-not-leak");
+    expect(summary).not.toContain(API_KEY);
+  });
+
+  test("a 503 → unavailable failed with back-pressure, even without a retry-after hint", async () => {
+    server.enqueue({ status: 503, chunks: [{ data: '{"error":{"message":"down"}}' }] });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    const t = terminalsOf(envs)[0];
+    expect(t?.type).toBe("dispatch.task.failed");
+    expect(t?.payload.provider_error_kind).toBe("unavailable");
+    expect(t?.payload.retryable).toBe(true);
+    // No provider-supplied hint → no retry_after_ms surfaced, but still not_now.
+    expect(t?.payload.retry_after_ms).toBeUndefined();
+    expect((t?.payload.reason as { kind: string } | undefined)?.kind).toBe("not_now");
+  });
+
+  test("a non-retryable auth failure (401) carries NO retry hint and NO reason", async () => {
+    server.enqueue({ status: 401, chunks: [{ data: '{"error":{"message":"nope"}}' }] });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    const t = terminalsOf(envs)[0];
+    expect(t?.type).toBe("dispatch.task.failed");
+    expect(t?.payload.provider_error_kind).toBe("authentication");
+    expect(t?.payload.retryable).toBe(false);
+    expect(t?.payload.retry_after_ms).toBeUndefined();
+    expect(t?.payload.reason).toBeUndefined();
+  });
+
+  test("SECRET LEAK GUARD — no key/header/raw-body in the envelope or captured request path", async () => {
+    // A retryable failure whose scripted body carries a decoy secret + the API
+    // key. The emitted envelope must carry ONLY the redacted summary + numeric
+    // diagnostics — never the key, the retry-after header value verbatim as a
+    // secret, or the raw body.
+    server.enqueue({
+      status: 429,
+      headers: { "retry-after": "2", "x-secret-header": API_KEY },
+      chunks: [{ data: `{"error":{"message":"leak-me ${API_KEY}"}}` }],
+    });
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+
+    const serialized = JSON.stringify(envs);
+    expect(serialized).not.toContain(API_KEY);
+    expect(serialized).not.toContain("leak-me");
+    expect(serialized).not.toContain("x-secret-header");
+    // The retry hint IS present as a normalized number (2s → 2000ms) — proving
+    // we surface the hint without echoing the raw header string.
+    const t = terminalsOf(envs)[0];
+    expect(t?.payload.retry_after_ms).toBe(2000);
+  });
+
+  test("mid-stream (post-200) provider error → exactly ONE terminal, carrying diagnostics", async () => {
+    // A committed 200 then an in-stream error frame the openai parser normalizes.
+    const payload =
+      contentChunk("partial ") +
+      sse({ error: { type: "server_error", code: "internal", message: "boom-should-not-leak" } });
+    server.enqueue({ status: 200, headers: SSE_HEADERS, chunks: [{ data: payload }] });
+
+    const envs = await drain(makeHarness().dispatch(makeRequest()));
+    expect(startedOf(envs)).toHaveLength(1);
+    const terminals = terminalsOf(envs);
+    expect(terminals).toHaveLength(1); // one-terminal invariant holds post-200
+    expect(terminals[0]?.type).toBe("dispatch.task.failed");
+    // A normalized in-stream error carries its kind diagnostic; body stays out.
+    expect(terminals[0]?.payload.provider_error_kind).toBeDefined();
+    expect(String(terminals[0]?.payload.error_summary)).not.toContain(
+      "boom-should-not-leak",
+    );
+  });
+});
+
+// ── API-P1.4 · boot pre-flight (validateAll surfaces bad profiles at load) ─────
+describe("api-agent boot pre-flight · createInferenceRegistry().validateAll (#2064)", () => {
+  test("a fully-resolvable inference config pre-flights with zero errors", () => {
+    const config = InferenceConfigSchema.parse({
+      providers: {
+        test: {
+          protocol: "openai-chat-completions",
+          baseUrl: `${server.url}/v1`,
+          apiKey: "env:TEST_KEY",
+        },
+      },
+      profiles: {
+        fast: { provider: "test", model: "test-model", modelClass: "any" },
+      },
+    });
+    const registry = createInferenceRegistry(config, { env: TEST_ENV });
+    expect(registry.validateAll()).toEqual([]);
+  });
+
+  // NOTE: structural failures (unknown profile / missing provider) are rejected
+  // earlier, by `InferenceConfigSchema` at config-load, so they never reach
+  // `validateAll`. What the boot pre-flight adds on top of the schema is the
+  // resolve-time class — `no-factory-for-protocol` / `provider-instantiation-
+  // failed` — exercised directly against injected fakes in
+  // `common/inference/__tests__/registry.test.ts`. Here we prove the REAL
+  // factory composition boot uses pre-flights clean.
+  test("an empty inference config pre-flights clean (no api-agent profiles)", () => {
+    const registry = createInferenceRegistry(
+      { providers: {}, profiles: {} },
+      { env: TEST_ENV },
+    );
+    expect(registry.validateAll()).toEqual([]);
+  });
+});
+
 // ── claude-code NON-REGRESSION (resolver selection unchanged) ──────────────────
 describe("harness resolver — substrate selection (api-agent + non-regression)", () => {
   const deps = {

--- a/src/substrates/api-agent/agent-loop.ts
+++ b/src/substrates/api-agent/agent-loop.ts
@@ -24,10 +24,13 @@
 // the underlying HTTP connection — no leaked sockets.
 //
 // PROVIDER ERROR SEAM (D2 — providers YIELD an `{type:"error"}` event, never
-// throw): the loop consumes that event and maps it to a `failed` outcome
-// carrying ONLY the redacted `ProviderError.summary` — never raw detail, headers,
-// or secrets. A provider that nonetheless rejects `next()` (contract violation)
-// is caught and collapsed to a fixed, secret-free `failed` summary.
+// throw): the loop consumes that event and reduces it to a `failed` outcome
+// carrying ONLY the redacted `ProviderError.summary` PLUS the normalized
+// secret-free facts (kind, retryability, `retryAfterMs`) the harness needs for
+// the API-P1.4 error-kind→lifecycle mapping + back-pressure — never raw detail,
+// headers, or secrets. A provider that nonetheless rejects `next()` (contract
+// violation) is caught and collapsed to a fixed, secret-free `failed` summary
+// (no `providerError` facts — a rejection is not a normalized error).
 //
 // NO TOOLS (D5): Phase 1 is text-only. If a provider emits a `tool_call.*` event
 // the loop IGNORES it (never executes anything) — tool execution is Phase 3.
@@ -38,7 +41,7 @@ import type {
   ModelProvider,
   ModelRequest,
 } from "../../common/inference/types";
-import type { ProviderError } from "../../common/inference/errors";
+import type { ProviderError, ProviderErrorKind } from "../../common/inference/errors";
 
 /** Token accounting accumulated from the provider's `usage` event. */
 export interface AgentLoopUsage {
@@ -65,6 +68,18 @@ export type AgentLoopOutcome =
       /** REDACTED summary only — never raw provider detail or secrets. */
       summary: string;
       providerRequestId?: string;
+      /**
+       * API-P1.4 — the normalized-provider-error facts, present ONLY when this
+       * failure came from a yielded provider `error` event (not a cortex-side
+       * timeout / stream fault). The harness maps these onto the lifecycle
+       * envelope's diagnostic fields + back-pressure hint. Carries the normalized
+       * kind + numeric retry hint ONLY — never the raw body, headers, or secrets.
+       */
+      providerError?: {
+        errorKind: ProviderErrorKind;
+        retryable: boolean;
+        retryAfterMs?: number;
+      };
     }
   | { kind: "aborted"; reason: string };
 
@@ -171,14 +186,22 @@ function errorOutcome(
   accumulatedRequestId: string | undefined,
 ): AgentLoopOutcome {
   // Prefer the error's own provider request id for correlation; fall back to any
-  // id seen earlier in the stream. API-P1.4 refines the error-kind→lifecycle
-  // mapping (e.g. rate_limit back-pressure); here every provider error is a
-  // `failed` terminal carrying ONLY the redacted summary.
+  // id seen earlier in the stream. API-P1.4 — carry the normalized kind +
+  // retryability + retry hint alongside the redacted summary so the harness can
+  // map the kind onto the lifecycle outcome + back-pressure. Only these
+  // SECRET-FREE facts cross the seam — never the raw body, headers, or key.
   const requestId = error.providerRequestId ?? accumulatedRequestId;
   return {
     kind: "failed",
     summary: error.summary,
     ...(requestId !== undefined ? { providerRequestId: requestId } : {}),
+    providerError: {
+      errorKind: error.kind,
+      retryable: error.retryable,
+      ...(error.retryAfterMs !== undefined
+        ? { retryAfterMs: error.retryAfterMs }
+        : {}),
+    },
   };
 }
 

--- a/src/substrates/api-agent/error-mapping.ts
+++ b/src/substrates/api-agent/error-mapping.ts
@@ -1,0 +1,128 @@
+// API-P1.4 (epic #2055, Phase 1) — normalized `ProviderError` → dispatch
+// lifecycle mapping + back-pressure. Design §"Error normalization",
+// §"Policy, sovereignty, and economics".
+//
+// This is the AUTHORITATIVE table: every `ProviderErrorKind` maps to a defined
+// dispatch outcome, and the transient/back-pressure kinds additionally carry a
+// `retryAfterMs` hint. It refines the BASIC P1.3 mapping (every provider error →
+// a plain `failed`) into the full table the issue specifies.
+//
+// KEY DECISIONS (mirrors the established back-pressure shape in
+// `runner/dispatch-listener.ts`, where admission rate-exhaustion emits a
+// `dispatch.task.failed { reason: { kind: "not_now", retry_after_ms } }`):
+//
+//   - Every `ProviderErrorKind` is a `failed` terminal. There is NO provider-
+//     error kind that maps to `aborted` — `aborted` is reserved for the
+//     abort-signal (cancellation / shutdown) path, which the agent loop yields
+//     directly. Rate exhaustion is TRANSIENT, not a `term`/abort; the
+//     dispatch-listener precedent is explicit on this.
+//   - The four transient kinds (`rate_limit` / `overloaded` / `unavailable` /
+//     `timeout`) are BACK-PRESSURE: they carry a `not_now` reason and surface
+//     `retryAfterMs` when the provider supplied one. The other six kinds are
+//     non-retryable: no `retryAfterMs`, no back-pressure reason.
+//
+// SECRET-SAFE by construction. This module only ever reads the normalized kind +
+// the numeric `retryAfterMs`; it never touches the raw provider body, headers,
+// or key material. The human-readable `not_now.detail` is built from the kind
+// alone, so nothing an attacker controls can reach the lifecycle envelope here.
+
+import type { ProviderErrorKind } from "../../common/inference/errors";
+import type { DispatchTaskFailedReason } from "../../bus/dispatch-events";
+
+/** The dispatch outcome a normalized provider error maps to. */
+export type ProviderErrorOutcome = "failed" | "aborted";
+
+/**
+ * The authoritative `ProviderErrorKind` → dispatch outcome table (issue #2064).
+ * Exhaustive over every kind — a new kind added to `ProviderErrorKind` fails
+ * compilation here until it is classified, so the mapping can never silently
+ * fall through to an undefined outcome.
+ *
+ * `backPressure: true` ⇒ transient/retryable: emit a `not_now` reason and
+ * surface `retryAfterMs` when known. `backPressure: false` ⇒ non-retryable:
+ * a plain `failed` terminal, no retry hint.
+ */
+export const PROVIDER_ERROR_KIND_OUTCOME: Record<
+  ProviderErrorKind,
+  { readonly outcome: ProviderErrorOutcome; readonly backPressure: boolean }
+> = {
+  // Non-retryable — a plain `failed` terminal, no back-pressure.
+  authentication: { outcome: "failed", backPressure: false },
+  authorization: { outcome: "failed", backPressure: false },
+  invalid_request: { outcome: "failed", backPressure: false },
+  unsupported_capability: { outcome: "failed", backPressure: false },
+  content_filter: { outcome: "failed", backPressure: false },
+  malformed_response: { outcome: "failed", backPressure: false },
+  // Transient / back-pressure — `failed` + `not_now` reason + `retryAfterMs`.
+  rate_limit: { outcome: "failed", backPressure: true },
+  overloaded: { outcome: "failed", backPressure: true },
+  unavailable: { outcome: "failed", backPressure: true },
+  timeout: { outcome: "failed", backPressure: true },
+};
+
+/**
+ * The normalized-provider-error facts the agent loop forwards to the harness for
+ * lifecycle shaping. A subset of {@link ProviderError} — deliberately NOT the
+ * whole error, so the raw body / headers / summary-with-detail never travel this
+ * seam. (The redacted `summary` rides its own outcome field.)
+ */
+export interface ProviderFailureInput {
+  readonly errorKind: ProviderErrorKind;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
+}
+
+/**
+ * The lifecycle-envelope shaping a normalized provider error resolves to. The
+ * harness stamps these onto the `dispatch.task.failed` envelope's diagnostic
+ * fields.
+ */
+export interface ProviderFailureShape {
+  /** The dispatch outcome — always `failed` for a provider error (see header). */
+  readonly outcome: ProviderErrorOutcome;
+  /** The normalized kind, stamped as a `provider_error_kind` diagnostic. */
+  readonly errorKind: ProviderErrorKind;
+  /** Whether a retry could plausibly succeed — the table's classification. */
+  readonly retryable: boolean;
+  /** Provider-advised retry delay — present ONLY for back-pressure kinds with a known hint. */
+  readonly retryAfterMs?: number;
+  /** A `not_now` back-pressure reason for the transient kinds; omitted otherwise. */
+  readonly reason?: DispatchTaskFailedReason;
+}
+
+/**
+ * Map a normalized provider error onto its dispatch-lifecycle shape (issue
+ * #2064). Table-driven: the kind alone decides retryability and back-pressure,
+ * so a provider that mis-set `retryable` cannot flip the classification. The
+ * `retryAfterMs` hint is carried through verbatim for back-pressure kinds only.
+ */
+export function shapeProviderFailure(
+  input: ProviderFailureInput,
+): ProviderFailureShape {
+  const spec = PROVIDER_ERROR_KIND_OUTCOME[input.errorKind];
+  if (spec.backPressure) {
+    return {
+      outcome: spec.outcome,
+      errorKind: input.errorKind,
+      retryable: true,
+      ...(input.retryAfterMs !== undefined
+        ? { retryAfterMs: input.retryAfterMs }
+        : {}),
+      reason: {
+        kind: "not_now",
+        // Built from the kind ALONE — no provider-authored text, so this string
+        // is secret-free by construction.
+        detail: `provider back-pressure (${input.errorKind})`,
+        ...(input.retryAfterMs !== undefined
+          ? { retry_after_ms: input.retryAfterMs }
+          : {}),
+      },
+    };
+  }
+  return {
+    outcome: spec.outcome,
+    errorKind: input.errorKind,
+    retryable: false,
+    // Non-retryable: no `retryAfterMs`, no back-pressure reason.
+  };
+}

--- a/src/substrates/api-agent/harness.ts
+++ b/src/substrates/api-agent/harness.ts
@@ -40,12 +40,14 @@ import {
   createDispatchTaskFailedEvent,
   createDispatchTaskStartedEvent,
   type DispatchEventSource,
+  type DispatchTaskFailedReason,
 } from "../../bus/dispatch-events";
 import {
   truncateDispatchErrorSummary,
   truncateDispatchResultSummary,
 } from "../../bus/dispatch-lifecycle-summary";
 import { runAgentLoop, type AgentLoopOutcome, type AgentLoopUsage } from "./agent-loop";
+import { shapeProviderFailure, type ProviderFailureShape } from "./error-mapping";
 
 // Q6 defaults (design §"Streaming and lifecycle") — the same two-cap model the
 // substrate protocol documents on `DispatchRequest.timeoutMs` / `inactivityMs`.
@@ -146,6 +148,38 @@ function stampUsage(
               ? { cache_read_tokens: usage.cacheReadTokens }
               : {}),
           }
+        : {}),
+      ...(providerRequestId !== undefined
+        ? { provider_request_id: providerRequestId }
+        : {}),
+    },
+  };
+}
+
+/**
+ * API-P1.4 — widen a `dispatch.task.failed` envelope's payload with the
+ * normalized provider-error diagnostics (`provider_error_kind`, `retryable`,
+ * `retry_after_ms`, `provider_request_id`). Uses the same additional-payload-
+ * property mechanism `stampUsage` rides (the myelin schema admits extra payload
+ * keys), so it widens the diagnostic surface without a wire-grammar change.
+ *
+ * SECRET-SAFE: every value comes from the normalized {@link ProviderFailureShape}
+ * (kind + numeric hint) or the redacted request id — never the raw provider
+ * body, headers, or key material.
+ */
+function stampFailureDiagnostics(
+  env: Envelope,
+  shape: ProviderFailureShape,
+  providerRequestId: string | undefined,
+): Envelope {
+  return {
+    ...env,
+    payload: {
+      ...env.payload,
+      provider_error_kind: shape.errorKind,
+      retryable: shape.retryable,
+      ...(shape.retryAfterMs !== undefined
+        ? { retry_after_ms: shape.retryAfterMs }
         : {}),
       ...(providerRequestId !== undefined
         ? { provider_request_id: providerRequestId }
@@ -329,6 +363,7 @@ export class ApiAgentHarness implements SessionHarness {
     startedAt: Date,
     correlationId: string,
     errorSummary: string,
+    reason?: DispatchTaskFailedReason,
   ): Envelope {
     return createDispatchTaskFailedEvent({
       source: this.source,
@@ -338,6 +373,7 @@ export class ApiAgentHarness implements SessionHarness {
       startedAt,
       failedAt: new Date(),
       errorSummary: truncateDispatchErrorSummary(errorSummary),
+      ...(reason !== undefined ? { reason } : {}),
     });
   }
 
@@ -377,13 +413,25 @@ export class ApiAgentHarness implements SessionHarness {
           reason: outcome.reason,
         });
       case "failed":
-      default:
-        return this.buildFailed(
-          req,
-          startedAt,
-          correlationId,
-          outcome.summary,
-        );
+      default: {
+        // API-P1.4 — a failure from a normalized provider `error` event carries
+        // its kind: shape it onto the full lifecycle table (back-pressure hint
+        // for the transient kinds) and stamp the redacted diagnostics. A
+        // cortex-side failure (wall-clock / inactivity timeout, stream fault,
+        // early-exit) has no `providerError` and stays a plain `failed` terminal.
+        if (outcome.providerError !== undefined) {
+          const shape = shapeProviderFailure(outcome.providerError);
+          const env = this.buildFailed(
+            req,
+            startedAt,
+            correlationId,
+            outcome.summary,
+            shape.reason,
+          );
+          return stampFailureDiagnostics(env, shape, outcome.providerRequestId);
+        }
+        return this.buildFailed(req, startedAt, correlationId, outcome.summary);
+      }
     }
   }
 }

--- a/src/substrates/api-agent/provider-factories.ts
+++ b/src/substrates/api-agent/provider-factories.ts
@@ -8,11 +8,23 @@
 // REFERENCES (`apiKey` / `headers.*` as `env:NAME`) intact. The shipped provider
 // constructors (`AnthropicMessagesProvider` / `OpenAICompatibleProvider`) take a
 // LITERAL key, so the factory resolves the reference via `resolveSecretRef` at
-// construction time — which the registry does LAZILY on first `resolveProfile`,
-// so an unused provider with an unset env var never resolves (and never throws).
+// PROVIDER-CONSTRUCTION time — inside `InferenceRegistry.resolveProfile`, the
+// first time a given provider is built (instances are then cached).
+//
+// TIMING (API-P1.4): that construction happens at BOOT, not on first dispatch.
+// The boot pre-flight (`inferenceRegistry.validateAll()` in `startCortex`)
+// resolves EVERY configured profile at startup, so every configured provider's
+// secret is resolved then — including providers no agent currently uses. The
+// intended consequence: an unset/empty `env:NAME` surfaces as a boot stderr line
+// (`resolveSecretRef` throws `SecretRefResolutionError`; the registry catches it
+// and reports that profile as `provider-instantiation-failed`) instead of lying
+// dormant until the first dispatch. Reported, not fatal — boot continues, and
+// the api-agent harness still fails closed per-dispatch on the same condition.
+//
 // The resolved value lives on the provider instance only; it is never written
 // back onto config and never logged (both providers keep it out of every error,
-// event, and log line).
+// event, and log line) — and the resolution error names the env VAR only, never
+// a value.
 
 import type {
   ProviderFactory,


### PR DESCRIPTION
Closes #2064 · Part of epic #2055 · Phase 1 — final slice. Normalized error → dispatch lifecycle mapping + back-pressure.

Adds `src/substrates/api-agent/error-mapping.ts` — the authoritative, table-driven kind→outcome map, refining P1.3's basic "all errors → failed".

| ProviderErrorKind | Outcome | retryable | retry hint |
|---|---|---|---|
| authentication / authorization / invalid_request / unsupported_capability / content_filter / malformed_response | failed | false | — |
| rate_limit / overloaded / unavailable / timeout | failed | true | when the provider supplied one, + a transient back-pressure reason |
| cancellation / shutdown | aborted | — | — |

The table is `Record<ProviderErrorKind, …>`, so a new kind fails compilation until classified, and a provider that mis-sets its own `retryable` cannot flip the classification. Cortex-side wall-clock/inactivity limits stay plain `failed` (D1 cortex-owned, distinct from the provider `timeout` kind).

**Deviation to review:** the issue text allowed retryable kinds → `failed`/`aborted`; this routes ALL provider errors → `failed` and reserves `aborted` for the cancellation/abort-signal path, mirroring the dispatch-listener precedent that back-pressure is transient and never an abort. Reviewer should rule on this.

**Secret hygiene:** the only fields crossing the loop→harness seam are the normalized kind, the numeric retry hint, the redacted summary, and the request id — never a raw body, headers, or key material. The back-pressure detail is built from the kind alone. A dedicated leak-guard test scripts a rate-limited response whose body and headers both embed a credential, then asserts the serialized envelopes contain none of it while the normalized numeric retry hint still surfaces.

Also closes a P1.3 review nit: wires the registry's `validateAll()` boot pre-flight in `startCortex` (design-aligned "fail at config load"), non-fatal — one bad profile must not crash a daemon serving unrelated claude-code agents; the harness still fails closed per-dispatch.

Verification: `bun test src/substrates/api-agent` 34/0; `bun test src/runner` 902/0 (non-regression); `bunx tsc --noEmit` exit 0; eslint clean; vocab-clean. Shared `contract.ts` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)