### PR TITLE
fix(inference): API-2114 — profile maxOutputTokens + options reach the provider (were silently discarded)

### DIFF
--- a/docs/design-api-model-provider-support.md
+++ b/docs/design-api-model-provider-support.md
@@ -285,6 +285,63 @@ runtime:
     - research
 ```
 
+#### `maxOutputTokens` — and what omitting it means
+
+`maxOutputTokens` is the principal's declared cost/length bound. It reaches the
+wire as `max_tokens` on both protocols. (It was accepted by the schema and read
+by both providers but never populated in between for the whole of Phase 1 —
+silently discarding the bound; issue #2114 wired the middle of that chain and
+pins it with wire-body tests.)
+
+It is optional, but **what omission means is per protocol** — the two APIs
+disagree on whether the field is required, so cortex cannot make this uniform:
+
+| Protocol | Profile omits `maxOutputTokens` |
+|---|---|
+| `anthropic-messages` | The API **requires** `max_tokens`, so cortex sends a declared default: `DEFAULT_MAX_OUTPUT_TOKENS` = **4096** (exported from `src/providers/anthropic/messages-provider.ts`; overridable per provider instance via `defaultMaxOutputTokens`). |
+| `openai-chat-completions` | The field is **omitted entirely**; the target server's own default applies and cortex bounds nothing. |
+
+A profile that states `maxOutputTokens` always wins on both. **Prefer stating
+it** — as the examples above do. Omitting it does not mean "unbounded"; it means
+the bound is chosen by the provider adapter's default or by the remote server,
+not by the principal.
+
+#### `options` — the namespaced escape hatch
+
+`options` is a single bag of opaque provider-only knobs keyed by provider
+namespace (Q5). A provider merges **only its own namespace** onto its wire body:
+
+```yaml
+profiles:
+  claude-sonnet:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    maxOutputTokens: 8192
+    modelClass: frontier
+    options:
+      anthropic:            # → merged onto the Anthropic wire body
+        top_k: 40
+      openai:               # → inert here; a foreign namespace is never read
+        temperature: 0.2
+```
+
+Portable behaviour must not depend on anything under `options`.
+
+**Precedence against core fields is currently asymmetric** — the two adapters
+merge the bag in opposite order:
+
+- `anthropic-messages` merges the bag **first**, then the core fields
+  (`model`, `max_tokens`, `stream`, `system`, `messages`) — so core **wins** and
+  `options.anthropic` cannot override the profile's `maxOutputTokens`.
+- `openai-chat-completions` merges the bag **last** — so `options.openai` **can**
+  override core fields, including `max_tokens`.
+
+Both are as-shipped in Phase 1 and pinned by test. The asymmetry is a known wart
+rather than a designed behaviour: an `options` entry that overrides the
+principal's declared bound on one protocol but not the other is a footgun, and
+converging both on "core wins" is worth a follow-up decision. Until then, do not
+set core fields via `options`.
+
 Do not reuse `agent.runtime.model`: that field currently selects the model used
 by the Sage review engine. `inferenceProfile` names a resolved operational
 profile rather than embedding a provider and model at every agent.

--- a/src/common/inference/__tests__/registry.test.ts
+++ b/src/common/inference/__tests__/registry.test.ts
@@ -131,6 +131,60 @@ describe("InferenceRegistry.resolveProfile — happy path", () => {
     expect(profile.provider.id).toBe("anthropic");
   });
 
+  // ── #2114: the resolved bundle must CARRY the principal's knobs ───────────
+  // These were absent from `ResolvedProfile` for a full epic, so the harness had
+  // nothing to copy onto the `ModelRequest` and both fields were silently
+  // discarded. The end-to-end proof is the wire-body suite in
+  // `src/substrates/api-agent/__tests__/harness.test.ts`; these pin the seam.
+
+  test("carries maxOutputTokens + options from config onto the resolved bundle (#2114)", () => {
+    const spy = makeFactorySpy();
+    const config = InferenceConfigSchema.parse({
+      providers: {
+        anthropic: {
+          protocol: "anthropic-messages",
+          baseUrl: "https://api.anthropic.example/v1",
+          apiKey: "env:ANTHROPIC_API_KEY",
+        },
+      },
+      profiles: {
+        bounded: {
+          provider: "anthropic",
+          model: "claude-sonnet-4",
+          modelClass: "frontier",
+          maxOutputTokens: 8192,
+          options: { anthropic: { top_k: 40 } },
+        },
+      },
+    });
+    const registry = new InferenceRegistry(config, {
+      "anthropic-messages": spy.factory,
+    });
+
+    const result = registry.resolveProfile("bounded");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.profile.maxOutputTokens).toBe(8192);
+    expect(result.profile.options).toEqual({ anthropic: { top_k: 40 } });
+  });
+
+  test("omits maxOutputTokens + options from the bundle when the profile omits them (#2114)", () => {
+    const spy = makeFactorySpy();
+    const registry = new InferenceRegistry(baseConfig(), {
+      "anthropic-messages": spy.factory,
+    });
+
+    const result = registry.resolveProfile("frontier-eu");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    // Absent, not `undefined`-valued: the harness spreads these conditionally,
+    // and each provider then applies its own documented omission behaviour.
+    expect(result.profile).not.toHaveProperty("maxOutputTokens");
+    expect(result.profile).not.toHaveProperty("options");
+  });
+
   test("caches the provider instance across resolves of the same provider", () => {
     const spy = makeFactorySpy();
     const config = InferenceConfigSchema.parse({

--- a/src/common/inference/inference-config-schema.ts
+++ b/src/common/inference/inference-config-schema.ts
@@ -104,7 +104,20 @@ export const InferenceProfileSchema = z
     provider: z.string().min(1),
     /** Provider-neutral model id. */
     model: z.string().min(1),
-    /** Upper bound on generated tokens. Optional. */
+    /**
+     * Upper bound on generated tokens — the principal's declared cost/length
+     * bound. Reaches the wire as `max_tokens` on BOTH protocols (issue #2114).
+     *
+     * Optional, and what omission means is PER PROTOCOL (it is not uniform,
+     * because the two APIs differ on whether the field is required):
+     *   - `anthropic-messages`: the API REQUIRES `max_tokens`, so cortex sends
+     *     its declared default — `DEFAULT_MAX_OUTPUT_TOKENS` (4096) in
+     *     `src/providers/anthropic/messages-provider.ts`.
+     *   - `openai-chat-completions`: the field is omitted entirely and the
+     *     target server's own default applies (cortex bounds nothing).
+     *
+     * Prefer stating it. Omitting it means the bound is someone else's choice.
+     */
     maxOutputTokens: z.number().int().positive().optional(),
     /** Policy: the egress class this profile is permitted. */
     modelClass: z.enum(["local-only", "frontier", "any"]),

--- a/src/common/inference/registry.ts
+++ b/src/common/inference/registry.ts
@@ -33,7 +33,11 @@
 // opaque provider-knob escape hatch that cortex never inspects and never resolves
 // secrets from — never route a credential through `options`.
 
-import type { ProviderCapabilities, ModelProvider } from "./types";
+import type {
+  ProviderCapabilities,
+  ModelProvider,
+  ProviderOptions,
+} from "./types";
 import type {
   InferenceConfig,
   InferenceProvider,
@@ -92,6 +96,27 @@ export interface ResolvedProfile {
   readonly modelClass: ModelClass;
   /** Policy: declared data-residency label (from config), when set. */
   readonly dataResidency?: string;
+  /**
+   * Upper bound on generated tokens, from the profile config, when set. The
+   * principal's declared cost/length bound: the harness copies it onto every
+   * `ModelRequest` this profile builds, and each provider puts it on the wire
+   * (`max_tokens`). Omitted here ⇒ omitted from the request ⇒ each provider
+   * applies its OWN documented fallback (Anthropic: its
+   * `defaultMaxOutputTokens`, since the Messages API requires `max_tokens`;
+   * OpenAI-compatible: the field is omitted and the server's default applies).
+   *
+   * Carrying this on the resolved bundle is load-caring: it was missing here
+   * for a full epic, which silently discarded the bound (issue #2114).
+   */
+  readonly maxOutputTokens?: number;
+  /**
+   * The Q5 namespaced escape hatch, from the profile config, when set. Opaque
+   * provider-only knobs keyed by provider namespace (e.g. `anthropic`); the
+   * harness passes them through untouched and each provider merges ONLY its own
+   * namespace onto the wire — a foreign namespace is inert by construction.
+   * Portable behaviour must NOT depend on anything here.
+   */
+  readonly options?: ProviderOptions;
 }
 
 /** The reasons a profile can fail to resolve. All fail closed. */
@@ -225,6 +250,14 @@ export class InferenceRegistry {
         ...(profile.dataResidency !== undefined
           ? { dataResidency: profile.dataResidency }
           : {}),
+        // Carry the principal's declared bound + escape hatch onto the resolved
+        // bundle. Dropping them here is what made both fields inert (#2114):
+        // the schema accepted them and both providers read them, but nothing
+        // populated the middle of the chain.
+        ...(profile.maxOutputTokens !== undefined
+          ? { maxOutputTokens: profile.maxOutputTokens }
+          : {}),
+        ...(profile.options !== undefined ? { options: profile.options } : {}),
       },
     };
   }

--- a/src/providers/anthropic/messages-provider.ts
+++ b/src/providers/anthropic/messages-provider.ts
@@ -28,7 +28,27 @@ import { mapAnthropicMessagesStream } from "./stream-parser";
 
 const DEFAULT_BASE_URL = "https://api.anthropic.com";
 const DEFAULT_ANTHROPIC_VERSION = "2023-06-01";
-const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+/**
+ * The `max_tokens` cortex sends when a profile omits `maxOutputTokens` (issue
+ * #2114).
+ *
+ * WHY A DEFAULT EXISTS AT ALL — and only here. The Anthropic Messages API makes
+ * `max_tokens` a REQUIRED body field: omitting it is a 400, so cortex cannot
+ * pass the omission through the way the OpenAI-compatible adapter can (there
+ * the field is simply left off and the server's own default applies). Some
+ * value must be chosen; the only question is whether it is chosen silently.
+ *
+ * It is therefore DECLARED, not silent: exported and named so the value is
+ * greppable, assertable from a test, and documented in the design's
+ * §Configuration table rather than buried as a magic number at a call site.
+ * Overridable per provider instance via `defaultMaxOutputTokens`.
+ *
+ * A profile that states `maxOutputTokens` always wins — this constant applies
+ * ONLY to profiles that omit it. Prefer stating the bound explicitly in the
+ * profile: it is the principal's declared cost/length bound, and 4096 is a
+ * conservative floor well below what current Anthropic models support.
+ */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
 
 /** Constructor options for {@link AnthropicMessagesProvider}. */
 export interface AnthropicMessagesProviderOptions {

--- a/src/substrates/api-agent/__tests__/harness.test.ts
+++ b/src/substrates/api-agent/__tests__/harness.test.ts
@@ -29,6 +29,7 @@ import type {
 } from "../../../common/substrates/types";
 import { ApiAgentHarness } from "../harness";
 import { createInferenceRegistry } from "../provider-factories";
+import { DEFAULT_MAX_OUTPUT_TOKENS } from "../../../providers/anthropic/messages-provider";
 import { DefaultHarnessResolver } from "../../../runner/harness-resolver";
 import type { AgentRuntime } from "../../../common/types/cortex-config";
 
@@ -576,5 +577,204 @@ describe("harness resolver — substrate selection (api-agent + non-regression)"
       capabilities: [],
     };
     expect(resolver.resolve(agent, undefined).id).toBe("api-agent");
+  });
+});
+
+// ── Profile → WIRE BODY · maxOutputTokens + options (issue #2114) ─────────────
+//
+// WHY THESE ASSERT ON THE CAPTURED WIRE BODY AND NOT THE `ModelRequest`
+// ---------------------------------------------------------------------
+// `maxOutputTokens` and `options` were accepted by the schema and read by BOTH
+// providers, yet reached NEITHER wire for the whole of Phase 1: `ResolvedProfile`
+// did not carry them, so `buildModelRequest` never set them. Each end looked
+// correct in isolation, and every test profile omitted both fields — so nothing
+// failed. A unit assertion on the request OBJECT would not have caught it
+// either: only bytes on the wire prove the whole chain
+// (config → schema → registry → harness → provider → HTTP body) is connected.
+//
+// These drive a REAL harness against the fake server and assert on
+// `server.requests[0].body`. They are the pin: revert the population in
+// `registry.ts` or `harness.ts` and they fail.
+describe("profile → wire body · maxOutputTokens + options (#2114)", () => {
+  /** The single captured request's parsed JSON body. */
+  const wireBody = (): Record<string, unknown> => {
+    expect(server.requests).toHaveLength(1);
+    return JSON.parse(server.requests[0]?.body ?? "{}") as Record<string, unknown>;
+  };
+
+  /**
+   * Drive one dispatch through a harness whose single profile is built from
+   * `profile`. `protocol` selects the adapter (default: openai-chat-completions)
+   * and is stripped before the profile is parsed.
+   */
+  async function dispatchWithProfile(
+    profile: Record<string, unknown> = {},
+  ): Promise<void> {
+    const { protocol = "openai-chat-completions", ...profileFields } = profile;
+    const config = InferenceConfigSchema.parse({
+      providers: {
+        test: { protocol, baseUrl: `${server.url}/v1`, apiKey: "env:TEST_KEY" },
+      },
+      profiles: {
+        fast: {
+          provider: "test",
+          model: "test-model",
+          modelClass: "any",
+          ...profileFields,
+        },
+      },
+    });
+    const harness = new ApiAgentHarness({
+      source: SOURCE,
+      registry: createInferenceRegistry(config, { env: TEST_ENV }),
+      inferenceProfile: "fast",
+    });
+    await drain(harness.dispatch(makeRequest()));
+  }
+
+  /** One Anthropic-wire SSE frame (`event:`/`data:` + blank line). */
+  const aFrame = (event: string, data: unknown): string =>
+    `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+  /** A minimal well-formed Anthropic stream, so the dispatch completes cleanly. */
+  const enqueueAnthropicOk = (): void => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [
+        {
+          data:
+            aFrame("message_start", {
+              type: "message_start",
+              message: {
+                id: "msg_1",
+                role: "assistant",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            }) +
+            aFrame("content_block_delta", {
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "ok" },
+            }) +
+            aFrame("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn" },
+              usage: { output_tokens: 2 },
+            }) +
+            aFrame("message_stop", { type: "message_stop" }),
+        },
+      ],
+    });
+  };
+
+  /** A minimal well-formed OpenAI-compatible stream. */
+  const enqueueOpenAiOk = (): void => {
+    server.enqueue({
+      status: 200,
+      headers: SSE_HEADERS,
+      chunks: [{ data: contentChunk("ok") + finishChunk("stop") + DONE }],
+    });
+  };
+
+  // ── The bound reaches BOTH wires ─────────────────────────────────────────
+
+  test("maxOutputTokens: N → max_tokens: N on the ANTHROPIC wire body", async () => {
+    enqueueAnthropicOk();
+    await dispatchWithProfile({ protocol: "anthropic-messages", maxOutputTokens: 8192 });
+
+    expect(wireBody().max_tokens).toBe(8192);
+  });
+
+  test("maxOutputTokens: N → max_tokens: N on the OPENAI-COMPATIBLE wire body", async () => {
+    enqueueOpenAiOk();
+    await dispatchWithProfile({ maxOutputTokens: 8192 });
+
+    expect(wireBody().max_tokens).toBe(8192);
+  });
+
+  // ── Documented behaviour when the profile OMITS the bound ────────────────
+  // Asymmetric ON PURPOSE: the two APIs disagree on whether `max_tokens` is
+  // required. Both halves are pinned so neither drifts into the other's rule.
+
+  test("omitted maxOutputTokens → Anthropic sends its declared default (the API requires max_tokens)", async () => {
+    enqueueAnthropicOk();
+    await dispatchWithProfile({ protocol: "anthropic-messages" });
+
+    // The Messages API rejects a body with no `max_tokens`, so cortex cannot
+    // pass the omission through — it sends the exported, documented default
+    // rather than a magic number invented at the call site.
+    expect(wireBody().max_tokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+    expect(DEFAULT_MAX_OUTPUT_TOKENS).toBe(4096);
+  });
+
+  test("omitted maxOutputTokens → OpenAI-compatible omits max_tokens entirely (server default applies)", async () => {
+    enqueueOpenAiOk();
+    await dispatchWithProfile();
+
+    // Omission is legal here, so cortex bounds nothing rather than inventing a
+    // bound the principal never declared.
+    expect(wireBody()).not.toHaveProperty("max_tokens");
+  });
+
+  // ── options: own namespace lands, foreign namespace is inert ─────────────
+
+  test("options under the provider's OWN namespace reach that provider's wire body", async () => {
+    enqueueOpenAiOk();
+    await dispatchWithProfile({ options: { openai: { temperature: 0.2, top_p: 0.9 } } });
+
+    const body = wireBody();
+    expect(body.temperature).toBe(0.2);
+    expect(body.top_p).toBe(0.9);
+  });
+
+  test("options under a FOREIGN namespace never reach the wire body", async () => {
+    enqueueOpenAiOk();
+    // `anthropic` is foreign to the openai adapter: inert, and its keys must not
+    // leak onto the wire under any name (nor as a nested `anthropic` object).
+    await dispatchWithProfile({
+      options: { anthropic: { top_k: 40 }, openai: { temperature: 0.5 } },
+    });
+
+    const body = wireBody();
+    expect(body).not.toHaveProperty("top_k");
+    expect(body).not.toHaveProperty("anthropic");
+    expect(body.temperature).toBe(0.5); // the own-namespace bag still lands
+  });
+
+  test("options under the anthropic namespace reach the ANTHROPIC wire body only", async () => {
+    enqueueAnthropicOk();
+    await dispatchWithProfile({
+      protocol: "anthropic-messages",
+      maxOutputTokens: 8192,
+      options: { anthropic: { top_k: 40 }, openai: { temperature: 0.5 } },
+    });
+
+    const body = wireBody();
+    expect(body.top_k).toBe(40);
+    expect(body).not.toHaveProperty("temperature"); // foreign namespace inert
+    expect(body).not.toHaveProperty("openai");
+    // Anthropic merges the bag FIRST, so core fields win: the declared bound
+    // survives the escape hatch.
+    expect(body.max_tokens).toBe(8192);
+  });
+
+  // ── Combined regression pin ─────────────────────────────────────────────
+
+  test("regression: a profile's bound AND its options both reach the wire (both were silently dropped)", async () => {
+    enqueueOpenAiOk();
+    await dispatchWithProfile({
+      maxOutputTokens: 1234,
+      options: { openai: { temperature: 0.7 } },
+    });
+
+    const body = wireBody();
+    // The exact pair the bug dropped. BEFORE the fix the captured body was:
+    //   {"model":"test-model","messages":[…],"stream":true,
+    //    "stream_options":{"include_usage":true}}
+    // — no max_tokens, no temperature.
+    expect(body.max_tokens).toBe(1234);
+    expect(body.temperature).toBe(0.7);
+    expect(body.model).toBe("test-model");
   });
 });

--- a/src/substrates/api-agent/harness.ts
+++ b/src/substrates/api-agent/harness.ts
@@ -26,7 +26,10 @@ import { randomUUID } from "crypto";
 
 import { isUuidLoose } from "../../common/types/uuid";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
-import type { InferenceRegistry } from "../../common/inference/registry";
+import type {
+  InferenceRegistry,
+  ResolvedProfile,
+} from "../../common/inference/registry";
 import type { ModelMessage, ModelRequest } from "../../common/inference/types";
 import type {
   Capability,
@@ -102,22 +105,37 @@ function unsupportedCapabilityReason(req: DispatchRequest): string | undefined {
 }
 
 /**
- * Build a normalized {@link ModelRequest} FROM THE DISPATCH REQUEST. Phase 1
- * rebuilds the "conversation" from the request alone (no ConversationStore —
- * that's Phase 2): the persona/system becomes `instructions`, and the prompt
- * becomes the single user turn. Text only (D5/Phase 1).
+ * Build a normalized {@link ModelRequest} FROM THE DISPATCH REQUEST plus the
+ * RESOLVED PROFILE. Phase 1 rebuilds the "conversation" from the request alone
+ * (no ConversationStore — that's Phase 2): the persona/system becomes
+ * `instructions`, and the prompt becomes the single user turn. Text only
+ * (D5/Phase 1).
+ *
+ * The profile contributes the principal's declared knobs: `model`, the
+ * `maxOutputTokens` bound, and the namespaced `options` escape hatch. It takes
+ * the WHOLE {@link ResolvedProfile} rather than cherry-picked fields on purpose
+ * — cherry-picking `model` alone is precisely how `maxOutputTokens`/`options`
+ * stayed silently unpopulated for a full epic (issue #2114) despite the schema
+ * accepting them and both providers reading them.
  */
-function buildModelRequest(req: DispatchRequest, model: string): ModelRequest {
+function buildModelRequest(
+  req: DispatchRequest,
+  profile: ResolvedProfile,
+): ModelRequest {
   const messages: ModelMessage[] = [
     { role: "user", content: [{ type: "text", text: req.prompt }] },
   ];
   const instructions = req.persona?.content;
   return {
-    model,
+    model: profile.model,
     ...(instructions !== undefined && instructions !== ""
       ? { instructions }
       : {}),
     messages,
+    ...(profile.maxOutputTokens !== undefined
+      ? { maxOutputTokens: profile.maxOutputTokens }
+      : {}),
+    ...(profile.options !== undefined ? { options: profile.options } : {}),
   };
 }
 
@@ -258,7 +276,7 @@ export class ApiAgentHarness implements SessionHarness {
     }
     const resolved = resolution.profile;
 
-    const request = buildModelRequest(req, resolved.model);
+    const request = buildModelRequest(req, resolved);
 
     // One controller per dispatch, tracked for shutdown-driven cancellation.
     const controller = new AbortController();


### PR DESCRIPTION
Closes #2114 · Epic #2055. Fixes a silent-discard bug found by the Step 5 close-out audit.

`profile.maxOutputTokens` and `profile.options` were accepted by the schema and read by both providers, but nothing populated the middle — so a principal's declared cost/length bound was inert.

**Wire body, before → after** (probe: profile with `maxOutputTokens: 8192` + an `options` namespace entry):

```
BEFORE: {"model":"test-model","messages":[…],"stream":true,"stream_options":{"include_usage":true}}
AFTER:  {…,"stream_options":{"include_usage":true},"max_tokens":8192,"temperature":0.2}
```

Changes:
- `ResolvedProfile` carries `maxOutputTokens` + `options`; the resolve path populates them.
- `buildModelRequest` now takes the **whole** `ResolvedProfile` rather than cherry-picking `model`. Cherry-picking is the bug's own mechanism — passing the bundle removes the failure mode instead of patching this instance of it.
- Anthropic's previously-hardcoded fallback is now an exported, documented, test-pinned `DEFAULT_MAX_OUTPUT_TOKENS`.

**Omitted `maxOutputTokens` — kept optional, made explicit.** The protocols can't be symmetric: Anthropic's Messages API *requires* `max_tokens` (omitting is a 400), so a value must be chosen; OpenAI-compatible omission is legal. So Anthropic sends the documented default; OpenAI omits and defers to the server. Schema optionality unchanged; per-protocol semantics documented in the schema and the design doc.

**Tests are mutation-checked.** Since the point is that the original tests missed this: reverting the registry population fails 6 of 8. The other 2 are omission-behaviour tests that correctly don't depend on that path. All assert on the **captured wire body** (`server.requests[0].body`), never on the request object — asserting the object is what let this slip.

Known wart pinned, not fixed here (follow-up filed): Anthropic merges the options bag first (core wins), OpenAI merges it last — so an `options` entry can override the declared bound on OpenAI-compat only.

Verification: `bunx tsc --noEmit` exit 0; lint 0 errors on changed files; `src/substrates/api-agent` + `src/providers` + `src/common/inference` → 95 pass / 0 fail; `src/runner` non-regression → 902 pass / 0 fail; vocab-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)