### PR TITLE
feat(systemd): L1 uninstall — remove rendered units on arc remove (marker-guarded) (cortex#2093)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -139,6 +139,12 @@ scripts:
   postinstall: ./scripts/postinstall.sh
   preupgrade: ./scripts/preupgrade.sh
   postupgrade: ./scripts/postupgrade.sh
+  # cortex#2093: L1 rollback — disables + removes rendered systemd user units
+  # (cortex#2071) before `arc remove cortex` tears down symlinks/repo. Fires
+  # via arc's `scripts.preremove` hook (arc/src/commands/remove.ts step 1,
+  # arc#138) — the first thing `arc remove` does, non-aborting on failure.
+  # No-ops on Darwin / systemd-less hosts.
+  preremove: ./scripts/preremove.sh
 
 # Dependencies — cortex#79 pins arc >= 0.25.0. That's the release that
 # ships the stable `arc.nats.v1` JSON contract on the four `arc nats *`

--- a/scripts/__tests__/systemd-remove-e2e.test.ts
+++ b/scripts/__tests__/systemd-remove-e2e.test.ts
@@ -1,0 +1,151 @@
+// Real end-to-end coverage for scripts/lib/systemd-remove.sh against an
+// ACTUAL systemd --user session (cortex#2093, the L1 rollback half of
+// cortex#2071's systemd-render-e2e.test.ts): render → enable --now → remove
+// (disable + delete + reload) → assert `systemctl --user list-unit-files`
+// no longer lists either unit — the exact verification recipe from the issue.
+//
+// Deliberately split out of systemd-remove.test.ts (fully mocked, safe
+// anywhere) for the same reason systemd-render-e2e.test.ts is split from
+// systemd-render.test.ts: the running systemd --user MANAGER resolves its
+// unit search path from ITS OWN startup environment, not from whatever
+// $HOME this test process exports, so a scratch-HOME trick cannot isolate
+// this test the way it isolates the mocked one.
+//
+// Runs ONLY in the dedicated `systemd-e2e` CI job (cortex#2092), gated on
+// SYSTEMD_E2E=1 — identical gate to systemd-render-e2e.test.ts, for the
+// identical reason (must never leak into the plain Test job, must never run
+// unattended against a real developer's Linux desktop). The "systemd-e2e" in
+// this file's describe/test names is what the CI job's
+// `--test-name-pattern systemd-e2e` picks up; no separate CI wiring needed.
+//
+// Every mutation this test makes to the real $HOME is backed up before and
+// restored in `finally`, mirroring systemd-render-e2e.test.ts's backup()
+// helper exactly.
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const RENDER_LIB = join(REPO_ROOT, "scripts", "lib", "systemd-render.sh");
+const REMOVE_LIB = join(REPO_ROOT, "scripts", "lib", "systemd-remove.sh");
+
+function sh(cmd: string, args: string[]) {
+  return spawnSync(cmd, args, { encoding: "utf8" });
+}
+
+function hasSystemdUserSession(): boolean {
+  if (process.platform !== "linux") return false;
+  const probe = sh("systemctl", ["--user", "show-environment"]);
+  return probe.status === 0;
+}
+
+// Same opt-in gate as systemd-render-e2e.test.ts — see file header.
+const RUN_E2E = process.env.SYSTEMD_E2E === "1" && hasSystemdUserSession();
+
+const SLUG = "e2e2093";
+const HOME_DIR = homedir();
+const UNIT_DIR = join(HOME_DIR, ".config", "systemd", "user");
+const LOCAL_BIN = join(HOME_DIR, ".local", "bin");
+const WORKSPACE_DIR = join(HOME_DIR, ".local", "share", "metafactory", "cortex", SLUG);
+const NATS_LOGS_DIR = join(HOME_DIR, ".local", "state", "nats", "logs");
+const CORTEX_LOGS_DIR = join(HOME_DIR, ".local", "state", "metafactory", "cortex", "logs");
+
+function listUnitFiles(): string {
+  const res = sh("systemctl", ["--user", "list-unit-files"]);
+  return res.stdout;
+}
+
+// Backs up path (rename aside) if it already exists, returning a restore
+// function — byte-identical helper to systemd-render-e2e.test.ts's backup().
+function backup(path: string): () => void {
+  if (!existsSync(path)) {
+    return () => rmSync(path, { force: true, recursive: true });
+  }
+  const savedAt = `${path}.systemd-e2e-backup`;
+  renameSync(path, savedAt);
+  return () => {
+    rmSync(path, { force: true, recursive: true });
+    renameSync(savedAt, path);
+  };
+}
+
+describe("systemd-e2e: real render + enable + remove (cortex#2093)", () => {
+  test.skipIf(!RUN_E2E)("render → enable --now nats@/cortex@ → remove → list-unit-files empty", () => {
+    mkdirSync(LOCAL_BIN, { recursive: true });
+    mkdirSync(UNIT_DIR, { recursive: true });
+
+    const restoreFns: Array<() => void> = [];
+    restoreFns.push(backup(join(UNIT_DIR, "nats@.service")));
+    restoreFns.push(backup(join(UNIT_DIR, "cortex@.service")));
+    restoreFns.push(backup(WORKSPACE_DIR));
+
+    // Stub nats-server/cortex — same real-long-running-process approach as
+    // systemd-render-e2e.test.ts, so enable --now has something real to mark
+    // active without needing an actual NATS server or a linked cortex CLI.
+    for (const name of ["nats-server", "cortex"]) {
+      const p = join(LOCAL_BIN, name);
+      restoreFns.push(backup(p));
+      writeFileSync(p, "#!/bin/sh\nexec sleep infinity\n");
+      chmodSync(p, 0o755);
+    }
+
+    const configDir = mkdtempSync(join(tmpdir(), "cortex-systemd-remove-e2e-config-"));
+    mkdirSync(join(configDir, SLUG, "system"), { recursive: true });
+    writeFileSync(join(configDir, SLUG, `${SLUG}.yaml`), "");
+    writeFileSync(join(configDir, SLUG, "system", "system.yaml"), "");
+
+    mkdirSync(CORTEX_LOGS_DIR, { recursive: true });
+
+    try {
+      // 1. Render + enable — the exact precondition state removal must clean
+      //    up (mirrors what a real `arc install cortex` + `systemctl --user
+      //    enable --now` sequence leaves behind).
+      const render = sh("bash", ["-c", `source "${RENDER_LIB}" && render_cortex_systemd_units "${REPO_ROOT}" "${UNIT_DIR}" "${configDir}"`]);
+      if (render.status !== 0) throw new Error(`render_cortex_systemd_units failed:\n${render.stdout}${render.stderr}`);
+
+      const enableNats = sh("systemctl", ["--user", "enable", "--now", `nats@${SLUG}`]);
+      if (enableNats.status !== 0) throw new Error(`enable nats@${SLUG} failed:\n${enableNats.stdout}${enableNats.stderr}`);
+      const enableCortex = sh("systemctl", ["--user", "enable", "--now", `cortex@${SLUG}`]);
+      if (enableCortex.status !== 0) throw new Error(`enable cortex@${SLUG} failed:\n${enableCortex.stdout}${enableCortex.stderr}`);
+
+      const activeBefore = sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]);
+      expect(activeBefore.status).toBe(0);
+
+      // 2. The actual thing under test: remove_cortex_systemd_units — the
+      //    exact function scripts/preremove.sh calls on `arc remove cortex`.
+      const remove = sh("bash", ["-c", `source "${REMOVE_LIB}" && remove_cortex_systemd_units "${UNIT_DIR}" "${configDir}"`]);
+      if (remove.status !== 0) throw new Error(`remove_cortex_systemd_units failed:\n${remove.stdout}${remove.stderr}`);
+
+      // 3. Acceptance criterion, verbatim from the issue: the enabled
+      //    instance is stopped, both template files are gone, and
+      //    `list-unit-files | grep -E "cortex@|nats@"` has nothing left.
+      const activeAfter = sh("systemctl", ["--user", "is-active", "--quiet", `cortex@${SLUG}`]);
+      expect(activeAfter.status).not.toBe(0);
+      expect(existsSync(join(UNIT_DIR, "nats@.service"))).toBe(false);
+      expect(existsSync(join(UNIT_DIR, "cortex@.service"))).toBe(false);
+
+      const unitFiles = listUnitFiles();
+      expect(unitFiles).not.toMatch(/cortex@|nats@/);
+    } finally {
+      // Belt-and-braces: if the assertions above failed before remove ran
+      // (or remove itself failed), make sure the e2e instances are never
+      // left running before we restore/replace the unit files underneath
+      // them.
+      sh("systemctl", ["--user", "disable", "--now", `cortex@${SLUG}`]);
+      sh("systemctl", ["--user", "disable", "--now", `nats@${SLUG}`]);
+      for (const restore of restoreFns.reverse()) restore();
+      sh("systemctl", ["--user", "daemon-reload"]);
+      rmSync(configDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Documents the skip reason in CI output when the gate isn't satisfied — same
+// rationale as systemd-render-e2e.test.ts's afterAll.
+afterAll(() => {
+  if (!RUN_E2E) {
+    console.log("systemd-e2e: skipped (requires SYSTEMD_E2E=1 + a live systemd --user session — see file header)");
+  }
+});

--- a/scripts/__tests__/systemd-remove.sh
+++ b/scripts/__tests__/systemd-remove.sh
@@ -1,0 +1,334 @@
+#!/bin/bash
+# cortex#2093 (L1 rollback, closing the gap cortex#2071 left open) — unit
+# tests for scripts/lib/systemd-remove.sh: marker-guarded file deletion
+# (unmarked files survive byte-identical), instance disable ordering
+# (disabled/stopped BEFORE any file is deleted), the Darwin/systemd-less
+# no-ops, daemon-reload-only-on-change, and `set -e` survival of a failing
+# systemctl call.
+#
+# Tests run entirely in a scratch $HOME; no live ~/.config/systemd/user or
+# systemctl/loginctl is touched — both are mocked via PATH override, same
+# pattern as scripts/__tests__/systemd-render.sh. `uname` is ALSO mocked so
+# the Linux-only remove path is exercised regardless of the host actually
+# running this suite.
+#
+# Run:
+#   bash scripts/__tests__/systemd-remove.sh
+#
+# Exit code: 0 = all pass, non-zero = failure count.
+
+set -euo pipefail
+
+# ─── Test harness ─────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+pass() { printf '  ✓ %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass "${label}"
+  else
+    fail "${label}: expected «${expected}» got «${actual}»"
+  fi
+}
+
+assert_true() {
+  local label="$1"; shift
+  if "$@"; then pass "${label}"; else fail "${label}"; fi
+}
+
+assert_false() {
+  local label="$1"; shift
+  if "$@"; then fail "${label}"; else pass "${label}"; fi
+}
+
+assert_file_exists() {
+  local label="$1" path="$2"
+  if [ -f "${path}" ]; then pass "${label}"; else fail "${label}: not found: ${path}"; fi
+}
+
+assert_file_missing() {
+  local label="$1" path="$2"
+  if [ ! -e "${path}" ]; then pass "${label}"; else fail "${label}: still present: ${path}"; fi
+}
+
+assert_grep_file() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "${needle}" "${file}"; then pass "${label}"; else fail "${label}"; fi
+}
+
+# ─── Fixtures ─────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "${TMPHOME}"' EXIT
+export HOME="${TMPHOME}"
+
+# Source AFTER HOME is set — same convention as systemd-render.sh's suite.
+# shellcheck source=scripts/lib/systemd-remove.sh
+source "${SCRIPT_DIR}/lib/systemd-remove.sh"
+
+MARKER="# rendered-by: cortex systemd-render v1"
+
+# Mock bin dir: uname (force "Linux"), systemctl (trace log + controllable
+# disable/daemon-reload failure injection). `timeout` itself is NOT mocked —
+# same rationale as systemd-render.sh's suite.
+MOCK_BIN="${TMPHOME}/mock-bin"
+mkdir -p "${MOCK_BIN}"
+
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Linux"
+EOF
+chmod +x "${MOCK_BIN}/uname"
+
+export SYSTEMCTL_LOG="${TMPHOME}/systemctl.log"
+# FAIL_DISABLE_UNITS="unit1 unit2" → `disable --now <unit>` exits 1 iff <unit> is listed
+# (simulates "not loaded"/"not found" — the tolerate-and-log-per-unit case).
+# FAIL_DAEMON_RELOAD=1 → `daemon-reload` exits 1 (simulates a wedged/unavailable bus).
+cat > "${MOCK_BIN}/systemctl" <<'EOF'
+#!/bin/sh
+printf 'systemctl %s\n' "$*" >> "${SYSTEMCTL_LOG:-/dev/null}"
+if [ "$1" = "--user" ] && [ "$2" = "disable" ] && [ "$3" = "--now" ]; then
+  unit="$4"
+  for u in ${FAIL_DISABLE_UNITS:-}; do
+    [ "$u" = "$unit" ] && exit 1
+  done
+  exit 0
+fi
+if [ "$1" = "--user" ] && [ "$2" = "daemon-reload" ]; then
+  [ "${FAIL_DAEMON_RELOAD:-0}" = "1" ] && exit 1
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "${MOCK_BIN}/systemctl"
+
+export PATH="${MOCK_BIN}:${PATH}"
+
+reset_unit_dir() {
+  UNIT_DIR="${TMPHOME}/unit-dir"
+  rm -rf "${UNIT_DIR}"
+  mkdir -p "${UNIT_DIR}"
+}
+
+render_marked_units() {
+  { printf '%s\n' "${MARKER}"; printf '[Unit]\nDescription=nats template\n'; } > "${UNIT_DIR}/nats@.service"
+  { printf '%s\n' "${MARKER}"; printf '[Unit]\nDescription=cortex template\n'; } > "${UNIT_DIR}/cortex@.service"
+}
+
+# Config-dir fixture with two discoverable stacks (same shape systemd-
+# render.sh's suite uses — dir-layout marker <slug>/system/system.yaml).
+CONFIG_DIR="${TMPHOME}/config"
+mkdir -p "${CONFIG_DIR}/work/system" "${CONFIG_DIR}/halden/system"
+: > "${CONFIG_DIR}/work/work.yaml"
+: > "${CONFIG_DIR}/work/system/system.yaml"
+: > "${CONFIG_DIR}/halden/halden.yaml"
+: > "${CONFIG_DIR}/halden/system/system.yaml"
+
+EMPTY_CONFIG_DIR="${TMPHOME}/empty-config"
+mkdir -p "${EMPTY_CONFIG_DIR}"
+
+export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
+mkdir -p "${SYSTEMD_HOST_MARKER}"
+
+# ─── Section 1: disable_cortex_systemd_instances ──────────────────
+printf '\n=== disable_cortex_systemd_instances ===\n'
+
+: > "${SYSTEMCTL_LOG}"
+DISABLE_OUT="$(disable_cortex_systemd_instances "${CONFIG_DIR}")"
+assert_eq "both stacks' cortex@ instances disabled" "2" \
+  "$(grep -c '^systemctl --user disable --now cortex@' "${SYSTEMCTL_LOG}")"
+assert_eq "both stacks' nats@ instances disabled" "2" \
+  "$(grep -c '^systemctl --user disable --now nats@' "${SYSTEMCTL_LOG}")"
+assert_eq "cortex@work is disabled" "1" \
+  "$(grep -c '^systemctl --user disable --now cortex@work$' "${SYSTEMCTL_LOG}")"
+assert_eq "cortex@halden is disabled" "1" \
+  "$(grep -c '^systemctl --user disable --now cortex@halden$' "${SYSTEMCTL_LOG}")"
+if printf '%s' "${DISABLE_OUT}" | grep -qF "cortex@work disabled"; then
+  pass "disable success is logged"
+else
+  fail "disable success is logged"
+fi
+
+# Tolerate not-loaded/not-found: one unit fails, the others still proceed and
+# are logged individually — never a single all-or-nothing failure.
+export FAIL_DISABLE_UNITS="cortex@halden"
+: > "${SYSTEMCTL_LOG}"
+set +e
+DISABLE_OUT2="$(disable_cortex_systemd_instances "${CONFIG_DIR}")"
+DISABLE_RC=$?
+set -e
+assert_eq "a not-loaded unit does not abort the loop" "0" "${DISABLE_RC}"
+assert_grep_file "the not-loaded unit is logged per-unit, not silently swallowed" \
+  <(printf '%s' "${DISABLE_OUT2}") "cortex@halden not loaded/not found"
+assert_eq "nats@halden is still attempted despite cortex@halden failing" "1" \
+  "$(grep -c '^systemctl --user disable --now nats@halden$' "${SYSTEMCTL_LOG}")"
+assert_eq "the OTHER stack (work) is still disabled" "1" \
+  "$(grep -c '^systemctl --user disable --now cortex@work$' "${SYSTEMCTL_LOG}")"
+unset FAIL_DISABLE_UNITS
+
+# `set -e` caller survival (mirrors preremove.sh's own shebang).
+export FAIL_DISABLE_UNITS="cortex@work nats@work cortex@halden nats@halden"
+SETE_OUT="$(mktemp)"
+set +e
+bash -c "set -e; source '${SCRIPT_DIR}/lib/systemd-remove.sh'; disable_cortex_systemd_instances '${CONFIG_DIR}'; echo SCRIPT_COMPLETED" > "${SETE_OUT}" 2>&1
+SETE_RC=$?
+set -e
+assert_eq "a 'set -e' caller completes despite every disable failing" "0" "${SETE_RC}"
+assert_grep_file "the caller ran past every guarded disable call" "${SETE_OUT}" "SCRIPT_COMPLETED"
+rm -f "${SETE_OUT}"
+unset FAIL_DISABLE_UNITS
+
+# No discoverable stacks → clean no-op.
+: > "${SYSTEMCTL_LOG}"
+assert_true "no stacks → clean no-op" disable_cortex_systemd_instances "${EMPTY_CONFIG_DIR}"
+assert_eq "no stacks → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
+
+# ─── Section 2: remove_cortex_systemd_unit_files — marker guard ───
+printf '\n=== remove_cortex_systemd_unit_files ===\n'
+
+reset_unit_dir
+render_marked_units
+: > "${SYSTEMCTL_LOG}"
+remove_cortex_systemd_unit_files "${UNIT_DIR}"
+assert_file_missing "marked nats@.service removed" "${UNIT_DIR}/nats@.service"
+assert_file_missing "marked cortex@.service removed" "${UNIT_DIR}/cortex@.service"
+assert_eq "two files removed → exactly 1 daemon-reload call" "1" \
+  "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}")"
+
+# Nothing to remove → zero daemon-reload calls.
+reset_unit_dir
+: > "${SYSTEMCTL_LOG}"
+remove_cortex_systemd_unit_files "${UNIT_DIR}"
+assert_eq "no files present → zero daemon-reload calls" "0" \
+  "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}" || true)"
+
+# Hand-authored-unit protection (mirrors systemd-render.sh's own regression
+# guard): a dst WITHOUT the marker must survive byte-identical, and must NOT
+# count toward the reload-gating change counter.
+reset_unit_dir
+HAND_REF="$(mktemp)"
+cat > "${HAND_REF}" <<'EOF'
+[Unit]
+Description=My own hand-authored cortex unit, please do not touch
+EOF
+cp "${HAND_REF}" "${UNIT_DIR}/cortex@.service"
+: > "${SYSTEMCTL_LOG}"
+HAND_WARN="$(mktemp)"
+remove_cortex_systemd_unit_files "${UNIT_DIR}" 2>"${HAND_WARN}"
+assert_true "hand-authored dst is byte-identical after remove (never touched)" \
+  cmp -s "${HAND_REF}" "${UNIT_DIR}/cortex@.service"
+assert_grep_file "hand-authored dst → warns it was left untouched" "${HAND_WARN}" \
+  "exists without the cortex systemd-render marker"
+assert_eq "hand-authored-only dst → zero daemon-reload calls (nothing this fn owns changed)" "0" \
+  "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}" || true)"
+rm -f "${HAND_WARN}" "${HAND_REF}"
+
+# Mixed: one marked (removed), one hand-authored (untouched) — still exactly
+# one reload, gated on the marked file actually changing.
+reset_unit_dir
+render_marked_units
+cat > "${UNIT_DIR}/cortex@.service" <<'EOF'
+[Unit]
+Description=hand-authored, no marker
+EOF
+: > "${SYSTEMCTL_LOG}"
+remove_cortex_systemd_unit_files "${UNIT_DIR}"
+assert_file_missing "marked nats@.service removed" "${UNIT_DIR}/nats@.service"
+assert_file_exists "unmarked cortex@.service survives" "${UNIT_DIR}/cortex@.service"
+assert_eq "mixed marked/unmarked → exactly 1 daemon-reload call (for the one real change)" "1" \
+  "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}")"
+
+# A failing daemon-reload must not abort the caller (mirrors systemd-render's
+# BLOCKER 2 guard on the render side).
+reset_unit_dir
+render_marked_units
+export FAIL_DAEMON_RELOAD=1
+RELOAD_ERR="$(mktemp)"
+set +e
+remove_cortex_systemd_unit_files "${UNIT_DIR}" 2>"${RELOAD_ERR}"
+RELOAD_RC=$?
+set -e
+assert_eq "remove_cortex_systemd_unit_files returns 0 even when daemon-reload fails" "0" "${RELOAD_RC}"
+assert_grep_file "failing daemon-reload is warned, not silently swallowed" "${RELOAD_ERR}" \
+  "daemon-reload failed"
+assert_file_missing "units were still removed despite the reload failure" "${UNIT_DIR}/cortex@.service"
+rm -f "${RELOAD_ERR}"
+unset FAIL_DAEMON_RELOAD
+
+# ─── Section 3: remove_cortex_systemd_units — orchestration + ordering ─
+printf '\n=== remove_cortex_systemd_units (orchestration) ===\n'
+
+# Darwin → no-op, nothing touched, zero systemctl calls.
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Darwin"
+EOF
+reset_unit_dir
+render_marked_units
+: > "${SYSTEMCTL_LOG}"
+remove_cortex_systemd_units "${UNIT_DIR}" "${CONFIG_DIR}"
+assert_file_exists "Darwin → nats@.service left untouched" "${UNIT_DIR}/nats@.service"
+assert_file_exists "Darwin → cortex@.service left untouched" "${UNIT_DIR}/cortex@.service"
+assert_eq "Darwin → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
+
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Linux"
+EOF
+
+# systemd-less Linux host → no-op.
+export SYSTEMD_HOST_MARKER="${TMPHOME}/no-such-run-systemd-system"
+rm -rf "${HOME}/.config/systemd/user"
+reset_unit_dir
+render_marked_units
+: > "${SYSTEMCTL_LOG}"
+remove_cortex_systemd_units "${UNIT_DIR}" "${CONFIG_DIR}"
+assert_file_exists "systemd-less Linux → nats@.service left untouched" "${UNIT_DIR}/nats@.service"
+assert_eq "systemd-less Linux → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
+export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
+mkdir -p "${SYSTEMD_HOST_MARKER}"
+
+# Real systemd Linux host, marked units + live-looking stacks → instances
+# disabled BEFORE any file is deleted (ordering is the acceptance criterion),
+# both files removed, exactly one reload.
+reset_unit_dir
+render_marked_units
+: > "${SYSTEMCTL_LOG}"
+remove_cortex_systemd_units "${UNIT_DIR}" "${CONFIG_DIR}"
+assert_file_missing "cortex@.service removed" "${UNIT_DIR}/cortex@.service"
+assert_file_missing "nats@.service removed" "${UNIT_DIR}/nats@.service"
+assert_eq "exactly one daemon-reload" "1" \
+  "$(grep -c '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}")"
+# Ordering: every disable line must appear BEFORE the daemon-reload line —
+# i.e. instances are stopped before the template files (and the reload that
+# follows their removal) happen.
+LAST_DISABLE_LINE=$(grep -n '^systemctl --user disable --now' "${SYSTEMCTL_LOG}" | tail -1 | cut -d: -f1)
+RELOAD_LINE=$(grep -n '^systemctl --user daemon-reload$' "${SYSTEMCTL_LOG}" | head -1 | cut -d: -f1)
+if [ "${LAST_DISABLE_LINE}" -lt "${RELOAD_LINE}" ]; then
+  pass "every instance is disabled before the daemon-reload that follows file removal"
+else
+  fail "instance disable did not precede file removal/reload"
+fi
+
+# Full user-authored-survives-byte-identical acceptance check.
+reset_unit_dir
+HAND_REF2="$(mktemp)"
+cat > "${HAND_REF2}" <<'EOF'
+[Unit]
+Description=principal's hand-authored cortex@.service, predates the renderer
+EOF
+cp "${HAND_REF2}" "${UNIT_DIR}/cortex@.service"
+: > "${SYSTEMCTL_LOG}"
+remove_cortex_systemd_units "${UNIT_DIR}" "${CONFIG_DIR}"
+assert_true "hand-authored unit survives full remove_cortex_systemd_units, byte-identical" \
+  cmp -s "${HAND_REF2}" "${UNIT_DIR}/cortex@.service"
+rm -f "${HAND_REF2}"
+
+# ─── Results ──────────────────────────────────────────────────────
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/scripts/__tests__/systemd-remove.test.ts
+++ b/scripts/__tests__/systemd-remove.test.ts
@@ -1,0 +1,27 @@
+// bun-test wrapper for scripts/__tests__/systemd-remove.sh so the systemd
+// unit removal (marker-guarded delete, instance disable, daemon-reload —
+// cortex#2093) is gated by CI's `bun test`, not just runnable by hand.
+// Mirrors systemd-render.test.ts's pattern (spawn the shell suite, assert
+// exit 0).
+//
+// The shell suite runs entirely in a scratch $HOME with mocked uname/
+// systemctl — no live ~/.config/systemd/user or systemd session is touched,
+// so this runs identically on the Linux CI runner and a macOS dev box.
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SUITE = join(REPO_ROOT, "scripts", "__tests__", "systemd-remove.sh");
+
+describe("systemd-remove shell suite (cortex#2093)", () => {
+  test("marker-guarded delete/instance-disable-ordering/no-ops pass (exit 0)", () => {
+    const res = spawnSync("bash", [SUITE], { cwd: REPO_ROOT, encoding: "utf8" });
+    const out = `${res.stdout}${res.stderr}`;
+    // Surface the shell suite's own trace when it fails so the failing case is
+    // visible in the bun-test output.
+    if (res.status !== 0) throw new Error(`shell suite failed (exit ${res.status}):\n${out}`);
+    expect(res.status).toBe(0);
+    expect(out).toContain("0 failed");
+  });
+});

--- a/scripts/lib/systemd-remove.sh
+++ b/scripts/lib/systemd-remove.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Cortex systemd user-unit removal — L1 rollback half of systemd-render.sh
+# (cortex#2093, closing the gap cortex#2071 deliberately left open: rendering
+# a unit is not enough, `arc remove cortex` must also tear it down cleanly).
+#
+# Without this, `arc remove cortex` on Linux would leave enabled instances
+# (cortex@<slug>, nats@<slug>) pointing at a deleted install — restart-
+# looping under `Restart=on-failure` every boot, and the two template unit
+# files orphaned in ~/.config/systemd/user/ forever.
+#
+# Usage (in the calling script):
+#   source "${SCRIPT_DIR}/lib/systemd-remove.sh"
+#   remove_cortex_systemd_units "${UNIT_DIR}" "${CONFIG_DIR}"
+#
+# Functions never write outside ${UNIT_DIR} — no repo files, no state trees.
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# systemd-render.sh provides SYSTEMD_UNIT_MARKER, systemd_host_detected, and
+# run_with_timeout (and transitively sources plist-render.sh for
+# discover_stack_slugs) — the removal side reuses every one of these rather
+# than forking its own copy, so the two halves of the marker contract can
+# never drift apart. Sourcing here (rather than relying on the caller to have
+# sourced it already) lets this file be sourced standalone (tests do exactly
+# that).
+# shellcheck source=scripts/lib/systemd-render.sh
+source "${LIB_DIR}/systemd-render.sh"
+
+# Disable + stop every discovered stack's cortex@<slug> and nats@<slug>
+# instances, tolerating "not loaded" / "not found" (a stack that was
+# scaffolded but never enabled, or a unit already stopped by hand) — this is
+# best-effort cleanup, not a precondition the remove can fail on.
+#
+# Each unit gets its OWN `systemctl --user disable --now` call (rather than
+# passing both units to one invocation) so a failure on one never masks the
+# other, and each result is logged individually — the same per-unit
+# granularity render_systemd_unit uses on the render side.
+#
+# `&& echo ok || echo not-loaded` per call is `set -e`-safe: per bash's
+# documented exemption, a command that is not the LAST element of an AND-OR
+# list does not trigger `set -e` on failure (mirrors the guarded calls
+# throughout systemd-render.sh, e.g. render_cortex_systemd_units' daemon-
+# reload guard).
+#
+# Args: $1 CONFIG_DIR — cortex config dir (stacks are discovered from here)
+disable_cortex_systemd_instances() {
+  local config_dir="$1"
+  local slug unit
+  while IFS= read -r slug; do
+    [ -z "${slug}" ] && continue
+    for unit in "cortex@${slug}" "nats@${slug}"; do
+      if run_with_timeout systemctl --user disable --now "${unit}" >/dev/null 2>&1; then
+        echo "  ✓ ${unit} disabled"
+      else
+        echo "  ⊘ ${unit} not loaded/not found — nothing to disable"
+      fi
+    done
+  done < <(discover_stack_slugs "${config_dir}")
+}
+
+# Delete the two rendered TEMPLATE unit files from UNIT_DIR — IFF each one
+# still carries the render side's marker header. A marker-less file (hand-
+# authored, or externally managed — see render_systemd_unit's docstring in
+# systemd-render.sh) is left completely untouched: never deleted, warned
+# about instead. The marker is the ONLY ownership signal this function
+# trusts, mirroring render_systemd_unit's own rule exactly — removal must
+# never be more aggressive than render was conservative.
+#
+# Runs `systemctl --user daemon-reload` at most once, and only when at least
+# one file was actually deleted — same "reload only on change" discipline as
+# the render side. Guarded the same way (a failing reload warns, never
+# aborts the caller).
+#
+# Args: $1 UNIT_DIR — typically ${HOME}/.config/systemd/user
+remove_cortex_systemd_unit_files() {
+  local unit_dir="$1"
+  local unit dst removed=0
+  for unit in nats@.service cortex@.service; do
+    dst="${unit_dir}/${unit}"
+    if [ ! -f "${dst}" ]; then
+      echo "  ⊘ ${unit} not present — nothing to remove"
+      continue
+    fi
+    if [ "$(sed -n '1p' "${dst}" 2>/dev/null)" != "${SYSTEMD_UNIT_MARKER}" ]; then
+      echo "  ⊘ ${unit} exists without the cortex systemd-render marker — leaving it untouched (hand-authored or externally managed; delete it yourself if it should go)" >&2
+      continue
+    fi
+    rm -f "${dst}"
+    removed=$((removed + 1))
+    echo "  ✓ ${unit} removed"
+  done
+
+  if [ "${removed}" -gt 0 ]; then
+    if run_with_timeout systemctl --user daemon-reload; then
+      echo "  ✓ systemd user daemon reloaded (${removed} unit file(s) removed)"
+    else
+      echo "  ⚠ systemctl --user daemon-reload failed (bus unavailable or timed out) — the daemon may still list the removed unit(s) until the next successful reload; re-run \`systemctl --user daemon-reload\` manually" >&2
+    fi
+  fi
+}
+
+# Full L1 rollback: disable every discovered instance, THEN delete the
+# marker-guarded template files, then reload — in that order, so systemd
+# never has a live unit pointing at a file that's already gone.
+#
+# Never aborts the caller: mirrors render_cortex_systemd_units' contract
+# exactly (scripts/preremove.sh runs under `set -e`, same as postinstall.sh/
+# postupgrade.sh, and an unguarded failure here must not abort `arc remove`).
+#
+# No-ops (silently, exit 0) on Darwin and on a systemd-less host — see
+# systemd_host_detected() in systemd-render.sh. A host that never rendered
+# these units (systemd_host_detected false, or UNIT_DIR never existed) has
+# nothing to clean up either way.
+#
+# Args: $1 UNIT_DIR   — typically ${HOME}/.config/systemd/user
+#       $2 CONFIG_DIR — cortex config dir, for stack discovery
+remove_cortex_systemd_units() {
+  local unit_dir="$1"
+  local config_dir="$2"
+
+  if [ "$(uname)" = "Darwin" ]; then
+    return 0
+  fi
+  if ! systemd_host_detected; then
+    return 0
+  fi
+
+  disable_cortex_systemd_instances "${config_dir}"
+  remove_cortex_systemd_unit_files "${unit_dir}"
+}

--- a/scripts/preremove.sh
+++ b/scripts/preremove.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+# Cortex preremove — tear down rendered systemd units before `arc remove
+# cortex` deletes symlinks/repo (cortex#2093, the L1 rollback half of
+# cortex#2071).
+#
+# Fires via arc's `scripts.preremove` hook (arc/src/commands/remove.ts step
+# 1, arc#138): the FIRST thing arc does on `arc remove`, before any symlink
+# or repo teardown — so this script's own lib files are still on disk when
+# it runs — and non-aborting on failure (a wedged --user D-Bus session must
+# not block the rest of the uninstall).
+#
+# No-ops cleanly on Darwin and on a systemd-less host (see
+# systemd_host_detected in scripts/lib/systemd-render.sh) — same guards as
+# the renderer this undoes.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# plist-render.sh provides resolve_config_dir. Sourced explicitly (though
+# systemd-remove.sh also pulls it in transitively via systemd-render.sh) to
+# match postinstall.sh's convention of naming every lib this script depends
+# on directly.
+# shellcheck source=scripts/lib/plist-render.sh
+source "${SCRIPT_DIR}/lib/plist-render.sh"
+# shellcheck source=scripts/lib/systemd-remove.sh
+source "${SCRIPT_DIR}/lib/systemd-remove.sh"
+
+# XDG wave-4 (cortex#1869): resolve the active config dir the SAME way
+# postinstall/postupgrade do, so stack discovery here sees the same stacks
+# the renderer saw.
+CONFIG_DIR="$(resolve_config_dir)"
+UNIT_DIR="${HOME}/.config/systemd/user"  # xdg-audit:allow(L1 rollback target dir (cortex#2093) — mirrors postinstall.sh/postupgrade.sh's UNIT_DIR entry, the canonical systemd user-unit search path; remove_cortex_systemd_units is the programmatic resolver this pattern otherwise asks for)
+
+echo "Running Cortex preremove..."
+remove_cortex_systemd_units "${UNIT_DIR}" "${CONFIG_DIR}"
+echo "✓ Cortex preremove complete"


### PR DESCRIPTION
Closes #2093. Epic arc#312 — completes L1 (the render side shipped in #2103; this is the teardown half I mis-tracked as already done).

Wires `scripts.preremove` (arc#138 — fires first on `arc remove`, non-aborting; confirmed in arc `types.ts:474` + `remove.ts:254`) → `remove_cortex_systemd_units`:
1. disable+stop every discovered `cortex@<slug>` / `nats@<slug>` (per-unit, tolerant of not-loaded, individually logged),
2. THEN delete template files **only if they carry the render side's marker** — a marker-less/hand-authored unit survives byte-identical (mirrors `render_systemd_unit` exactly),
3. THEN a single guarded `daemon-reload`.

Reuses `systemd-render.sh`'s marker constant + `run_with_timeout` + host-detect (no fork). No-op on Darwin/systemd-less.

Tests: 36/36 mocked shell suite (marker guard, disable-before-delete ordering, Darwin/systemd-less no-op, set-e survival) + a real-systemctl e2e gated to the dedicated CI job (name auto-picked by the existing pattern). xdg-audit GATE PASS (one inline allow), lint + tsc clean.

Trust-path lane: live systemd-e2e (this PR) + adversarial review both gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
