### PR TITLE
feat(policy): per-principal MCP grants — tool.mcp* capability namespace + MCP Guard hook (#2111)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -82,6 +82,14 @@ provides:
     # reference the installed absolute path.
     - source: src/runner/hooks/skill-guard.hook.ts
       target: ~/.claude/hooks/CortexSkillGuard.hook.ts
+    # cortex#2111 — per-principal MCP grant PreToolUse hook. Same posture as
+    # the Skill Guard above: symlink ONLY (no `hooks:` entry) so it is NEVER
+    # registered in the principal's GLOBAL settings.json — it would otherwise
+    # gate the principal's own MCP tools. It is registered PER-SESSION in the
+    # curated `--settings` file (session-settings.ts, matcher `mcp__.*`) for
+    # bot sessions whose policy decision carried an MCP grant list.
+    - source: src/runner/hooks/mcp-guard.hook.ts
+      target: ~/.claude/hooks/CortexMcpGuard.hook.ts
     # cortex#1676: deliberately NO `hooks/lib` symlink under ~/.claude. Hook
     # files import their lib modules with paths relative to their own file
     # (e.g. `./lib/...`, or `../../taps/cc-events/hooks/lib/...` for

--- a/docs/design-policy-cutover.md
+++ b/docs/design-policy-cutover.md
@@ -150,6 +150,7 @@ Adapter resolves inbound `message.author.id` → principal via reverse lookup. I
 Reserved capability ids:
 - `keyword.chat`, `keyword.async`, `keyword.team` — replace `features[]`
 - `tool.<lowercase-tool-name>` — granted means tool is allowed; absent means denied. `disallowedTools: ["Bash"]` migrates to: omit `tool.bash` from the role's capabilities.
+- `tool.mcp` / `tool.mcp.<server>` / `tool.mcp.<server>.<toolname>` — cortex#2111: the MCP namespace (`mcp__*` CC tools). INVERSE default of the CC tools above: MCP names are not enumerable at build time (they depend on which servers the host connected), so deny-by-omission via the inventory can never reach them — instead the whole namespace is **deny-by-default** and these capabilities are explicit grants (`tool.mcp` = everything; `tool.mcp.<server>` = every tool of one server; `tool.mcp.<server>.<toolname>` = one tool; all lowercase). `operator` principals hold the implicit full grant. Enforced by the MCP Guard PreToolUse hook (matcher `mcp__.*`) registered in the curated session settings, plus a `--strict-mcp-config` structural backstop for zero-grant principals. The 14-tool inventory semantics are untouched.
 - `operator` — special capability granted only to the operator role. Used by adapter to short-circuit DM gating (operator-role principal gets full access).
 - `dispatch.<agent_id>` — already used by dispatch-listener.ts:718, unchanged.
 

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -75,8 +75,30 @@ export interface AccessDecision {
     async: boolean;
     team: boolean;
   };
-  /** Disallowed MCP tools for this user */
+  /**
+   * Disallowed Claude Code tools for this sender — the inversion of their
+   * `tool.*` capability grants against `CLAUDE_TOOL_INVENTORY`. CC tools
+   * only: `mcp__*` names never appear here (not enumerable at build time —
+   * see `mcpGrants` below, cortex#2111).
+   */
   toolRestrictions?: string[];
+  /**
+   * cortex#2111 — per-principal MCP grants, in the MCP Guard pattern grammar
+   * (`"*"` = whole namespace | `"<server>"` | `"<server>.<tool>"`, lowercase).
+   * Derived from `tool.mcp*` capabilities by `deriveMcpGrants` (a principal
+   * holding the reserved short-circuit capability ⇒ `["*"]`).
+   *
+   * Semantics of PRESENCE vs ABSENCE (load-bearing):
+   *   - present (even `[]`) — a policy-resolved decision: the MCP namespace
+   *     is DENY-BY-DEFAULT for this session. The dispatch-handler threads the
+   *     list to the CC session, which registers the MCP Guard PreToolUse hook
+   *     (matcher `mcp__.*`) with exactly these grants; `[]` additionally arms
+   *     the `--strict-mcp-config` structural backstop (no servers load).
+   *   - absent — a path that never went through `resolvePolicyAccess`
+   *     (review pipeline, dev consumer, direct CLI); existing behaviour is
+   *     unchanged there.
+   */
+  mcpGrants?: string[];
   /**
    * cortex#1167 — EXPLICIT tool ALLOWLIST. When present and non-empty, the CC
    * session is confined to exactly these tools (anything else, including every

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -501,6 +501,8 @@ export class DispatchHandler extends EventEmitter {
     allowedTools?: string[];
     /** cortex#710 — per-skill grant list (see InboundChatDispatchPublishOpts). */
     allowedSkills: string[] | undefined;
+    /** cortex#2111 — per-principal MCP grant list (see InboundChatDispatchPublishOpts). */
+    mcpGrants?: string[];
     timeoutMs: number | undefined;
     cwd: string | undefined;
     additionalArgs: string[] | undefined;
@@ -1000,10 +1002,24 @@ export class DispatchHandler extends EventEmitter {
         : undefined;
       const principal = msg.authorName;
 
+      // cortex#2111 — per-principal MCP grants. Defined (even []) on every
+      // policy-resolved decision; the CC session registers the MCP Guard
+      // PreToolUse hook with exactly this list (deny-by-default over the
+      // `mcp__*` namespace, which CLAUDE_TOOL_INVENTORY inversion can never
+      // reach). Threaded to all dispatch paths below.
+      const mcpGrants = access.mcpGrants;
+
       // WEB-2 / B1 — per-agent --strict-mcp-config. Computed alongside
       // effectiveDisallowed so all dispatch paths (bus sync, direct sync,
       // async, team) carry it uniformly via the effectiveAdditionalArgs param.
-      const effectiveAdditionalArgs = targetAgent?.strictMcpConfig === true
+      // cortex#2111 — a principal with ZERO MCP grants gets the same
+      // structural flag: no MCP servers load at all for their session (the
+      // MCP Guard hook stays armed as the in-session backstop). A principal
+      // with partial grants must NOT get the flag — their granted servers
+      // have to load; the hook enforces the per-server/per-tool boundary.
+      const strictMcp = targetAgent?.strictMcpConfig === true ||
+        mcpGrants?.length === 0;
+      const effectiveAdditionalArgs = strictMcp
         ? [...this.config.claude.additionalArgs, "--strict-mcp-config"]
         : this.config.claude.additionalArgs;
 
@@ -1029,6 +1045,10 @@ export class DispatchHandler extends EventEmitter {
           // applies {broad Skill allow + gate hook} for grants, default-deny
           // otherwise. `access.allowedSkills` is undefined → field omitted.
           allowedSkills: skillGrants,
+          // cortex#2111 — carry the per-principal MCP grant list so the
+          // runner harness arms the MCP Guard (deny-by-default over mcp__*).
+          // undefined → field omitted (non-policy behaviour unchanged).
+          mcpGrants,
           timeoutMs: this.config.claude.timeoutMs,
           cwd: effectiveCwd,
           additionalArgs: effectiveAdditionalArgs,
@@ -1057,13 +1077,13 @@ export class DispatchHandler extends EventEmitter {
       // 12. Route by mode
       switch (parsed.mode) {
         case "async":
-          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs);
+          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants);
           break;
         case "team":
-          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs);
+          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants);
           break;
         default:
-          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs);
+          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants);
           break;
       }
     } catch (error) {
@@ -1105,6 +1125,8 @@ export class DispatchHandler extends EventEmitter {
     allowedTools?: string[],
     /** WEB-2 / B1 — pre-computed effective additionalArgs (may include --strict-mcp-config). */
     additionalArgs?: string[],
+    /** cortex#2111 — per-principal MCP grants (defined ⇒ deny-by-default over mcp__*). */
+    mcpGrants?: string[],
   ): Promise<void> {
     const target = this.targetFromMsg(adapter, msg);
 
@@ -1146,6 +1168,9 @@ export class DispatchHandler extends EventEmitter {
       allowedTools: allowedTools ?? this.config.claude.allowedTools,
       disallowedTools,
       ...(allowedSkills !== undefined && { allowedSkills }),
+      // cortex#2111 — arm the MCP Guard when the policy decision carried a
+      // grant list (defined ⇒ deny-by-default over mcp__*).
+      ...(mcpGrants !== undefined && { mcpGrants }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       cwd,
       bashAllowlist,
@@ -1467,6 +1492,8 @@ export class DispatchHandler extends EventEmitter {
     allowedTools?: string[],
     /** WEB-2 / B1 — pre-computed effective additionalArgs (may include --strict-mcp-config). */
     additionalArgs?: string[],
+    /** cortex#2111 — per-principal MCP grants (defined ⇒ deny-by-default over mcp__*). */
+    mcpGrants?: string[],
   ): Promise<void> {
     const taskId = `task-${randomUUID()}`;
 
@@ -1489,6 +1516,9 @@ export class DispatchHandler extends EventEmitter {
       allowedTools: allowedTools ?? this.config.claude.allowedTools,
       disallowedTools,
       ...(allowedSkills !== undefined && { allowedSkills }),
+      // cortex#2111 — arm the MCP Guard when the policy decision carried a
+      // grant list (defined ⇒ deny-by-default over mcp__*).
+      ...(mcpGrants !== undefined && { mcpGrants }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       cwd,
       project: groveProject,
@@ -1605,6 +1635,8 @@ export class DispatchHandler extends EventEmitter {
     allowedTools?: string[],
     /** WEB-2 / B1 — pre-computed effective additionalArgs (may include --strict-mcp-config). */
     additionalArgs?: string[],
+    /** cortex#2111 — per-principal MCP grants (defined ⇒ deny-by-default over mcp__*). */
+    mcpGrants?: string[],
   ): Promise<void> {
     const taskId = `team-${randomUUID()}`;
 
@@ -1628,6 +1660,9 @@ export class DispatchHandler extends EventEmitter {
       allowedTools: allowedTools ?? this.config.claude.allowedTools,
       disallowedTools,
       ...(allowedSkills !== undefined && { allowedSkills }),
+      // cortex#2111 — every team-member session inherits the invoking
+      // principal's MCP grant list (defined ⇒ deny-by-default over mcp__*).
+      ...(mcpGrants !== undefined && { mcpGrants }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       timeoutMs: this.config.claude.asyncTimeoutMs,
       bashGuardDisabled,

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -47,6 +47,16 @@ export interface InboundChatDispatchPublishOpts {
    * (it grants nothing — see bus-inbound-sink.ts).
    */
   allowedSkills: string[] | undefined;
+  /**
+   * cortex#2111 — per-principal MCP grant list, emitted as `mcp_grants` on
+   * the payload. `undefined` → omit (non-policy path; runner behaviour
+   * unchanged). Present (even `[]`) → the runner arms the MCP Guard
+   * PreToolUse hook with exactly these patterns (`"*"` | `"<server>"` |
+   * `"<server>.<tool>"`) — deny-by-default over the `mcp__*` namespace.
+   * Emitted even for `[]` (explicit no-MCP) so the runner can distinguish
+   * "no decision" (field absent) from "decided: no MCP".
+   */
+  mcpGrants?: string[];
   timeoutMs: number | undefined;
   cwd: string | undefined;
   additionalArgs: string[] | undefined;
@@ -279,6 +289,12 @@ export async function publishInboundChatDispatchEnvelope(
     // distinguish "no decision" (field absent) from "decided: no skills".
     ...(opts.allowedSkills !== undefined && {
       allowed_skills: opts.allowedSkills,
+    }),
+    // cortex#2111 — carry the per-principal MCP grant list when the source
+    // decided one. Emitted even for `[]` (explicit no-MCP) so the runner can
+    // distinguish "no decision" (field absent) from "decided: deny all MCP".
+    ...(opts.mcpGrants !== undefined && {
+      mcp_grants: opts.mcpGrants,
     }),
     ...(opts.allowedDirs.length > 0 && { allowed_dirs: opts.allowedDirs }),
     ...(opts.timeoutMs !== undefined && { timeout_ms: opts.timeoutMs }),

--- a/src/common/policy/__tests__/resolve-access.test.ts
+++ b/src/common/policy/__tests__/resolve-access.test.ts
@@ -12,6 +12,7 @@ import { DID_RE } from "@the-metafactory/myelin/identity";
 import {
   resolvePolicyAccess,
   anonOnboardingAccess,
+  deriveMcpGrants,
   PUBLIC_ORIGINATOR_DID,
   isOperatorPrincipal,
 } from "../resolve-access";
@@ -618,5 +619,108 @@ describe("resolvePolicyAccess — facilitator-role: pylon locked-out as sender (
     expect(engine.check("luna", { capability: "dispatch.pylon", sovereignty }).allow).toBe(true);
     // pylon cannot dispatch to anything (not registered)
     expect(engine.check("pylon", { capability: "dispatch.luna", sovereignty }).allow).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#2111 — per-principal MCP grants (`tool.mcp*` capability namespace)
+// ---------------------------------------------------------------------------
+
+describe("deriveMcpGrants — capability → grant-pattern derivation (cortex#2111)", () => {
+  test("operator gets the implicit full grant regardless of capabilities", () => {
+    expect(deriveMcpGrants([], true)).toEqual(["*"]);
+    expect(deriveMcpGrants(undefined, true)).toEqual(["*"]);
+    expect(deriveMcpGrants(["keyword.chat"], true)).toEqual(["*"]);
+  });
+
+  test("bare tool.mcp grants the whole namespace", () => {
+    expect(deriveMcpGrants(["keyword.chat", "tool.mcp"], false)).toEqual(["*"]);
+  });
+
+  test("server + tool capabilities map to their patterns", () => {
+    expect(
+      deriveMcpGrants(
+        ["keyword.chat", "tool.mcp.gdrive", "tool.mcp.jira.search_issues", "tool.read"],
+        false,
+      ),
+    ).toEqual(["gdrive", "jira.search_issues"]);
+  });
+
+  test("no mcp capabilities → empty (deny-all)", () => {
+    expect(deriveMcpGrants(["keyword.chat", "tool.read", "tool.bash"], false)).toEqual([]);
+    expect(deriveMcpGrants(undefined, false)).toEqual([]);
+  });
+
+  test("patterns are lowercased and deduped", () => {
+    expect(
+      deriveMcpGrants(["tool.mcp.GDrive", "tool.mcp.gdrive"], false),
+    ).toEqual(["gdrive"]);
+  });
+
+  test("a capability that merely PREFIXES tool.mcp (e.g. tool.mcpfoo) does not grant", () => {
+    expect(deriveMcpGrants(["tool.mcpfoo"], false)).toEqual([]);
+  });
+});
+
+describe("resolvePolicyAccess — mcpGrants on the decision (cortex#2111)", () => {
+  test("non-operator principal with NO tool.mcp capabilities gets mcpGrants: [] (deny-all)", () => {
+    const result = resolvePolicyAccess({
+      msg: msg({ authorId: "555555555555555555" }),
+      ...buildHarness(USER_POLICY),
+    });
+    expect(result.allowed).toBe(true);
+    // PRESENT and EMPTY — presence arms the deny-by-default downstream.
+    expect(result.mcpGrants).toEqual([]);
+  });
+
+  test("operator principal gets the implicit full grant", () => {
+    const result = resolvePolicyAccess({
+      msg: msg({ authorId: "666666666666666666" }),
+      ...buildHarness(OPERATOR_POLICY),
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.mcpGrants).toEqual(["*"]);
+  });
+
+  test("non-operator with explicit tool.mcp.* capabilities gets exactly those grants", () => {
+    const policy: Policy = {
+      principals: [
+        {
+          id: "martin",
+          home_principal: "andreas",
+          home_stack: "andreas/manda",
+          role: ["chat-user"],
+          trust: [],
+          platform_ids: { discord: ["444444444444444444"] },
+        },
+      ],
+      roles: [
+        {
+          id: "chat-user",
+          capabilities: [
+            "keyword.chat",
+            "tool.read",
+            "tool.mcp.gdrive",
+            "tool.mcp.jira.search_issues",
+          ],
+        },
+      ],
+    };
+    const result = resolvePolicyAccess({
+      msg: msg({ authorId: "444444444444444444" }),
+      ...buildHarness(policy),
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.mcpGrants).toEqual(["gdrive", "jira.search_issues"]);
+    // The asymmetric-principal scenario from the issue: withholding tool.bash
+    // IS still enforced via toolRestrictions…
+    expect(result.toolRestrictions).toContain("Bash");
+    // …and now the MCP surface is confined too (not the wider principal's).
+    expect(result.mcpGrants).not.toContain("*");
+  });
+
+  test("anonOnboardingAccess carries mcpGrants: [] (deny-all belt-and-braces)", () => {
+    const decision = anonOnboardingAccess(msg());
+    expect(decision.mcpGrants).toEqual([]);
   });
 });

--- a/src/common/policy/__tests__/resolve-access.test.ts
+++ b/src/common/policy/__tests__/resolve-access.test.ts
@@ -13,6 +13,7 @@ import {
   resolvePolicyAccess,
   anonOnboardingAccess,
   deriveMcpGrants,
+  intersectMcpGrants,
   PUBLIC_ORIGINATOR_DID,
   isOperatorPrincipal,
 } from "../resolve-access";
@@ -722,5 +723,39 @@ describe("resolvePolicyAccess — mcpGrants on the decision (cortex#2111)", () =
   test("anonOnboardingAccess carries mcpGrants: [] (deny-all belt-and-braces)", () => {
     const decision = anonOnboardingAccess(msg());
     expect(decision.mcpGrants).toEqual([]);
+  });
+});
+
+describe("intersectMcpGrants — wire may narrow, never widen (cortex#2111 MAJOR fix)", () => {
+  test("wildcard wire claim collapses to the authoritative list", () => {
+    // Attack A from the adversarial review: a peer sends ["*"] — the
+    // executing stack's own policy is the ceiling.
+    expect(intersectMcpGrants(["*"], ["gdrive"])).toEqual(["gdrive"]);
+    expect(intersectMcpGrants(["*"], [])).toEqual([]);
+  });
+
+  test("wire may narrow a server grant to a single tool", () => {
+    expect(intersectMcpGrants(["gdrive.read_file"], ["gdrive"])).toEqual([
+      "gdrive.read_file",
+    ]);
+  });
+
+  test("disjoint sets intersect to empty (deny-all)", () => {
+    expect(intersectMcpGrants(["jira"], ["gdrive"])).toEqual([]);
+  });
+
+  test("authoritative wildcard yields the wire list unchanged", () => {
+    expect(intersectMcpGrants(["gdrive", "jira.search"], ["*"])).toEqual([
+      "gdrive",
+      "jira.search",
+    ]);
+  });
+
+  test("both wildcard → wildcard", () => {
+    expect(intersectMcpGrants(["*"], ["*"])).toEqual(["*"]);
+  });
+
+  test("dedupes overlapping contributions", () => {
+    expect(intersectMcpGrants(["gdrive", "*"], ["gdrive"])).toEqual(["gdrive"]);
   });
 });

--- a/src/common/policy/__tests__/resolve-access.test.ts
+++ b/src/common/policy/__tests__/resolve-access.test.ts
@@ -759,3 +759,15 @@ describe("intersectMcpGrants — wire may narrow, never widen (cortex#2111 MAJOR
     expect(intersectMcpGrants(["gdrive", "*"], ["gdrive"])).toEqual(["gdrive"]);
   });
 });
+
+describe("deriveMcpGrants — single-arg form derives the short-circuit from the set", () => {
+  test("capability set carrying the reserved short-circuit → full grant", () => {
+    expect(deriveMcpGrants(["keyword.chat", "operator"])).toEqual(["*"]);
+  });
+
+  test("without it → normal derivation", () => {
+    expect(deriveMcpGrants(["keyword.chat", "tool.mcp.gdrive"])).toEqual(["gdrive"]);
+    expect(deriveMcpGrants(["keyword.chat"])).toEqual([]);
+    expect(deriveMcpGrants(undefined)).toEqual([]);
+  });
+});

--- a/src/common/policy/resolve-access.ts
+++ b/src/common/policy/resolve-access.ts
@@ -193,6 +193,49 @@ export function anonOnboardingAccess(
 }
 
 /**
+ * cortex#2111 (adversarial-review MAJOR) — does grant pattern `p` cover
+ * pattern `q`? `"*"` covers everything; `"<server>"` covers itself and
+ * every `"<server>.<tool>"`; a tool pattern covers only itself.
+ */
+function mcpGrantCovers(p: string, q: string): boolean {
+  return p === MCP_GRANT_WILDCARD || p === q || q.startsWith(`${p}.`);
+}
+
+/** The full-namespace grant pattern (`deriveMcpGrants`'s `["*"]`). */
+export const MCP_GRANT_WILDCARD = "*";
+
+/**
+ * Intersect two MCP grant-pattern sets: the result allows a tool iff BOTH
+ * sets allow it. Used by the runner to combine the wire-supplied grant list
+ * with the EXECUTING stack's own policy-derived list, so a remote
+ * dispatcher can NARROW its session's MCP surface but never WIDEN it past
+ * what local policy grants the originator (the cortex#127
+ * receiving-stack-authoritative model applied to MCP).
+ *
+ * Pattern-set intersection: for every pair `(a, b)` keep the NARROWER
+ * pattern when one covers the other (`"*"` ∩ X = X; `"srv"` ∩ `"srv.tool"`
+ * = `"srv.tool"`; disjoint pairs contribute nothing). Deduped, stable
+ * order (a-major). Exported for unit tests.
+ */
+export function intersectMcpGrants(
+  a: readonly string[],
+  b: readonly string[],
+): string[] {
+  const out: string[] = [];
+  for (const pa of a) {
+    for (const pb of b) {
+      const narrower = mcpGrantCovers(pa, pb)
+        ? pb
+        : mcpGrantCovers(pb, pa)
+          ? pa
+          : undefined;
+      if (narrower !== undefined && !out.includes(narrower)) out.push(narrower);
+    }
+  }
+  return out;
+}
+
+/**
  * Authorise an inbound platform message via the PolicyEngine. Returns an
  * `AccessDecision` the adapter passes back to MessageRouter.
  *

--- a/src/common/policy/resolve-access.ts
+++ b/src/common/policy/resolve-access.ts
@@ -76,12 +76,20 @@ export const MCP_CAPABILITY_PREFIX = "tool.mcp";
  * - Otherwise, every `tool.mcp.<rest>` capability contributes `<rest>`.
  *
  * Exported for unit tests.
+ *
+ * @param isOperator pass the engine-checked short-circuit result when the
+ *   caller already has it (resolvePolicyAccess). Omit to derive it from
+ *   the capability set itself (the runner's gate decision carries the
+ *   reserved capability in-band) — keeps the literal inside this
+ *   carved-out module.
  */
 export function deriveMcpGrants(
   capabilities: readonly string[] | undefined,
-  isOperator: boolean,
+  isOperator?: boolean,
 ): string[] {
-  if (isOperator) return ["*"];
+  const operator =
+    isOperator ?? capabilities?.includes("operator") ?? false;
+  if (operator) return ["*"];
   if (capabilities === undefined) return [];
   const grants: string[] = [];
   for (const cap of capabilities) {

--- a/src/common/policy/resolve-access.ts
+++ b/src/common/policy/resolve-access.ts
@@ -40,6 +40,61 @@ import {
 } from "./policy-gate";
 
 /**
+ * cortex#2111 — the capability prefix that carries per-principal MCP grants.
+ *
+ * `CLAUDE_TOOL_INVENTORY` deny-by-omission can never reach `mcp__*` tools:
+ * MCP names are not enumerable at build time (they depend on which servers
+ * the operator connected in `~/.claude/settings.json`, per-host, changing
+ * without a cortex release). So the `mcp` namespace is DENY-BY-DEFAULT with
+ * explicit grants, expressed as capabilities on roles:
+ *
+ *   - `tool.mcp`                      — the whole MCP namespace
+ *   - `tool.mcp.<server>`             — every tool of one server
+ *   - `tool.mcp.<server>.<toolname>`  — a single tool
+ *
+ * (all lowercase, per the `tool.<lowercase>` convention of
+ * `docs/design-policy-cutover.md` §5.2). Enforcement is the Cortex MCP Guard
+ * PreToolUse hook (`src/runner/hooks/mcp-guard.hook.ts`) plus a structural
+ * `--strict-mcp-config` backstop when a principal has NO grants at all —
+ * see the dispatch-handler. The 14-tool CC inventory and its
+ * allow-by-default semantics are untouched.
+ */
+export const MCP_CAPABILITY_PREFIX = "tool.mcp";
+
+/**
+ * Derive the normalized MCP grant list for a principal from their effective
+ * capability set. Returns patterns in the grammar the MCP Guard hook
+ * consumes (`"*"` | `"<server>"` | `"<server>.<tool>"`), deduped, in
+ * capability-set iteration order.
+ *
+ * - `operator` principals get the full namespace (`["*"]`): the operator is
+ *   the stack's home principal / trust root (features + `trusted` already
+ *   short-circuit on it) and pre-#2111 stacks relied on allow-by-default —
+ *   this keeps single-principal stacks working with zero config change while
+ *   the deny-by-default lands for everyone else.
+ * - A bare `tool.mcp` capability also grants the full namespace.
+ * - Otherwise, every `tool.mcp.<rest>` capability contributes `<rest>`.
+ *
+ * Exported for unit tests.
+ */
+export function deriveMcpGrants(
+  capabilities: readonly string[] | undefined,
+  isOperator: boolean,
+): string[] {
+  if (isOperator) return ["*"];
+  if (capabilities === undefined) return [];
+  const grants: string[] = [];
+  for (const cap of capabilities) {
+    if (cap === MCP_CAPABILITY_PREFIX) return ["*"];
+    if (cap.startsWith(`${MCP_CAPABILITY_PREFIX}.`)) {
+      const rest = cap.slice(MCP_CAPABILITY_PREFIX.length + 1).toLowerCase();
+      if (rest.length > 0 && !grants.includes(rest)) grants.push(rest);
+    }
+  }
+  return grants;
+}
+
+/**
  * Inputs the adapter passes to {@link resolvePolicyAccess}. The engine +
  * index + registry are populated from the parsed `policy:` block; when the
  * deployment hasn't declared a policy (or declares one with no
@@ -124,6 +179,9 @@ export function anonOnboardingAccess(
     allowedTools: allowlist,
     // Belt-and-braces deny-list backstop: the full known inventory.
     toolRestrictions: [...CLAUDE_TOOL_INVENTORY],
+    // cortex#2111 — zero MCP grants: arms the MCP Guard deny-by-default (and
+    // the --strict-mcp-config backstop) on top of the allowlist confinement.
+    mcpGrants: [],
     bashGuard: true,
     trusted: false,
     anonPrincipal: true,
@@ -189,8 +247,22 @@ export function resolvePolicyAccess(input: ResolvePolicyAccessInput): AccessDeci
   }
 
   const sovereignty = defaultPolicySovereignty();
-  const allow = (capability: string): boolean =>
-    engine.check(principalId, { capability, sovereignty }).allow;
+  // cortex#2111 — an ALLOWED engine decision carries the principal's full
+  // effective capability set. Harvest it from the first allow so the MCP
+  // grant derivation below reads the same ground truth the checks used
+  // (no second resolution path, no drift). Any allowed access implies at
+  // least one allowed check (keyword.* or operator), so on every path that
+  // reaches the allowed return the set has been captured.
+  let effectiveCapabilities: readonly string[] | undefined;
+  const allow = (capability: string): boolean => {
+    const decision = engine.check(principalId, { capability, sovereignty });
+    // The allow-branch of PolicyDecision always carries `capabilities`
+    // (discriminated union) — no undefined check needed.
+    if (decision.allow) {
+      effectiveCapabilities = decision.capabilities;
+    }
+    return decision.allow;
+  };
 
   const features = {
     chat: allow("keyword.chat"),
@@ -245,6 +317,11 @@ export function resolvePolicyAccess(input: ResolvePolicyAccessInput): AccessDeci
       ? { chat: true, async: true, team: true }
       : features,
     ...(toolRestrictions.length > 0 && { toolRestrictions }),
+    // cortex#2111 — ALWAYS present on a policy-resolved allow (empty array =
+    // no MCP at all). Presence of the field is what arms the MCP Guard
+    // deny-by-default downstream; legacy/non-policy paths that never set it
+    // keep their existing behaviour.
+    mcpGrants: deriveMcpGrants(effectiveCapabilities, isOperator),
     ...(allowedDirs !== undefined && { dirRestrictions: allowedDirs }),
     ...(allowedSkills !== undefined && { allowedSkills }),
     bashGuard,

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -389,6 +389,23 @@ export interface DispatchRequest {
    */
   allowedSkills?: string[];
   /**
+   * cortex#2111 — per-principal MCP grant list. Distinct from `tools`: MCP
+   * tool names (`mcp__*`) are not enumerable at build time (they depend on
+   * which servers the host has connected), so they can never appear in the
+   * inventory-inverted deny list; the namespace is gated by the MCP Guard
+   * PreToolUse hook instead.
+   *
+   * Semantics, mirroring `AccessDecision.mcpGrants`:
+   *   - `undefined` → no decision carried; the harness leaves MCP behaviour
+   *     unchanged (no MCP hook registered).
+   *   - `[]` → explicit deny-all: the guard denies every `mcp__*` call.
+   *   - `[...]` → allow exactly the covered servers/tools (patterns
+   *     `"*"` | `"<server>"` | `"<server>.<tool>"`, lowercase).
+   *
+   * Non-CC harnesses (bus-peer, future) ignore this field.
+   */
+  mcpGrants?: string[];
+  /**
    * Pluggable context bundle. The runner attaches whatever the agent's
    * trigger source produced (Discord message history, GitHub PR diffs,
    * attachments, environment hints). The harness handles whichever

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -964,6 +964,15 @@ export const AgentSchema = z.object({
    * remain accessible even when all 14 known CC tools appear in
    * `agentDisallowedTools`. Mirrors grill.ts's `--strict-mcp-config` flag.
    * Default `false`/absent.
+   *
+   * NOTE this is AGENT-level (all-or-nothing for every sender). Since
+   * cortex#2111 the PRINCIPAL-level control is the `tool.mcp*` capability
+   * namespace on policy roles: `mcp__*` is deny-by-default per principal
+   * with explicit grants (`tool.mcp` | `tool.mcp.<server>` |
+   * `tool.mcp.<server>.<tool>`), enforced by the MCP Guard PreToolUse hook
+   * plus a `--strict-mcp-config` backstop for zero-grant principals. This
+   * flag remains for structural airgaps that must hold regardless of who
+   * asks (e.g. zero-tool facilitator agents).
    */
   strictMcpConfig: z.boolean().optional(),
   /**

--- a/src/gateway/__tests__/bus-inbound-sink.test.ts
+++ b/src/gateway/__tests__/bus-inbound-sink.test.ts
@@ -181,6 +181,25 @@ describe("BusInboundSink", () => {
     expect(opts.disallowedTools).toEqual(["Skill"]);
   });
 
+  // ── Test 3b: fail-closed MCP deny on the gateway path (cortex#2111) ──────────
+  //
+  // The MCP twin of Test 3: no deny rule can reach un-enumerable `mcp__*`
+  // names, so an OMITTED mcpGrants would leave the bound stack's session
+  // with every MCP tool available by default. The gateway grants nothing —
+  // it must emit the EXPLICIT empty grant list, which makes the runner
+  // register the MCP Guard hook in deny-all mode + add --strict-mcp-config.
+
+  test("emits mcpGrants: [] (fail-closed MCP deny-all, cortex#2111)", async () => {
+    const { sink, calls } = makeSink();
+    await sink.publish(makeDecision(), makeMsg());
+    const opts = calls[0];
+    if (opts === undefined) throw new Error("expected publishFn to have been called");
+
+    // PRESENT and EMPTY — presence is what arms the deny-by-default; an
+    // absent field would mean "no decision" (allow-by-default, the #2111 gap).
+    expect(opts.mcpGrants).toEqual([]);
+  });
+
   // ── Test 4: taskId is non-empty ──────────────────────────────────────────────
 
   test("taskId is non-empty on each call", async () => {

--- a/src/gateway/bus-inbound-sink.ts
+++ b/src/gateway/bus-inbound-sink.ts
@@ -190,6 +190,16 @@ export class BusInboundSink implements GatewayInboundSink {
       // bound stack's harness would then apply the hook-based grant exactly
       // as the per-stack dispatch path does. Until then: no skills, by design.
       allowedSkills: undefined,
+      // cortex#2111 — the same fail-closed posture for the MCP namespace.
+      // The gateway is a thin demux that grants NOTHING; an omitted
+      // `mcpGrants` would leave the bound stack's session with mcp__* tools
+      // AVAILABLE BY DEFAULT (no deny rule can reach un-enumerable MCP
+      // names — the exact #2111 gap, and the MCP twin of the bare `Skill`
+      // hole above). Explicit empty list → the runner registers the MCP
+      // Guard hook in deny-all mode + adds --strict-mcp-config. If/when a
+      // gateway binding is given an explicit MCP grant set, THIS is the
+      // field to populate.
+      mcpGrants: [],
       // Optional opts — the gateway does not own these; the bound stack applies
       // its own policy and session context.
       resumeSessionId: undefined,

--- a/src/runner/__tests__/cc-session-isolation.test.ts
+++ b/src/runner/__tests__/cc-session-isolation.test.ts
@@ -397,3 +397,40 @@ describe("CCSession — per-principal MCP grants (cortex#2111)", () => {
     }
   });
 });
+
+  test("M3: settingsIsolation OFF + PARTIAL grants → strict flag (fail-closed, no hook possible)", () => {
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        settingsIsolation: false,
+        mcpGrants: ["gdrive"],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+      // No curated settings on the non-isolated path → the hook can't
+      // register, so fine-grained enforcement is impossible. Denying the
+      // granted server too beats granting the whole namespace.
+      expect(calls[0]!.cmd).toContain("--strict-mcp-config");
+    } finally {
+      restore();
+    }
+  });
+
+  test("M3: settingsIsolation OFF + FULL grant ('*') → no strict flag (nothing to confine)", () => {
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        settingsIsolation: false,
+        mcpGrants: ["*"],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+      expect(calls[0]!.cmd).not.toContain("--strict-mcp-config");
+    } finally {
+      restore();
+    }
+  });

--- a/src/runner/__tests__/cc-session-isolation.test.ts
+++ b/src/runner/__tests__/cc-session-isolation.test.ts
@@ -257,3 +257,143 @@ describe("CCSession — isolation opt-out (principal-as-self)", () => {
     }
   });
 });
+
+describe("CCSession — per-principal MCP grants (cortex#2111)", () => {
+  /**
+   * Snapshot the curated `--settings` file AT SPAWN TIME — the spy throw
+   * triggers CCSession's catch path, which cleans the temp dir (same
+   * pattern as captureSpawnWithSettings above).
+   */
+  function captureSpawnMcp(): {
+    calls: (Captured & { settings: unknown })[];
+    restore: () => void;
+  } {
+    const calls: (Captured & { settings: unknown })[] = [];
+    const spy = spyOn(Bun, "spawn").mockImplementation(((
+      cmd: string[],
+      opts: { env: Record<string, string> },
+    ) => {
+      const idx = cmd.indexOf("--settings");
+      const settings =
+        idx > -1 ? JSON.parse(readFileSync(cmd[idx + 1]!, "utf8")) : undefined;
+      calls.push({ cmd, env: opts.env, settings });
+      throw new Error("spawn intercepted by test");
+    }) as unknown as typeof Bun.spawn);
+    return { calls, restore: () => spy.mockRestore() };
+  }
+
+  const mcpEntry = (settings: unknown) =>
+    (settings as { hooks: { PreToolUse: { matcher?: string; hooks: { command: string }[] }[] } })
+      .hooks.PreToolUse.find((e) => e.matcher === "mcp__.*");
+
+  test("defined mcpGrants → CORTEX_MCP_GRANTS env + MCP Guard hook in curated settings", () => {
+    const { calls, restore } = captureSpawnMcp();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        claudeDir: "/fake/.claude",
+        mcpGrants: ["gdrive", "jira.search_issues"],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      const { cmd, env, settings } = calls[0]!;
+      // Env: grant list rides CORTEX_MCP_GRANTS, atomically with the hook.
+      expect(env.CORTEX_MCP_GRANTS).toBe('["gdrive","jira.search_issues"]');
+      // Curated settings file registers the MCP Guard under mcp__.*.
+      const mcp = mcpEntry(settings);
+      expect(mcp).toBeDefined();
+      expect(mcp!.hooks[0]!.command).toContain("CortexMcpGuard.hook.ts");
+      // Partial grants must NOT add the structural strict flag — granted
+      // servers have to load; the hook enforces the boundary.
+      expect(cmd).not.toContain("--strict-mcp-config");
+    } finally {
+      restore();
+    }
+  });
+
+  test("EMPTY mcpGrants → deny-all: hook + env + --strict-mcp-config backstop", () => {
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        claudeDir: "/fake/.claude",
+        mcpGrants: [],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      const { cmd, env } = calls[0]!;
+      expect(env.CORTEX_MCP_GRANTS).toBe("[]");
+      expect(cmd).toContain("--strict-mcp-config");
+      // No double-append when the caller already supplied the flag is
+      // covered by the dedupe test below.
+    } finally {
+      restore();
+    }
+  });
+
+  test("EMPTY mcpGrants + caller-supplied strict flag → no duplicate", () => {
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        claudeDir: "/fake/.claude",
+        mcpGrants: [],
+        additionalArgs: ["--strict-mcp-config"],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      const { cmd } = calls[0]!;
+      expect(cmd.filter((a) => a === "--strict-mcp-config").length).toBe(1);
+    } finally {
+      restore();
+    }
+  });
+
+  test("UNDEFINED mcpGrants → no env, no hook, no strict flag (behaviour unchanged)", () => {
+    const { calls, restore } = captureSpawnMcp();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        claudeDir: "/fake/.claude",
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      const { cmd, env, settings } = calls[0]!;
+      expect(env.CORTEX_MCP_GRANTS).toBeUndefined();
+      expect(cmd).not.toContain("--strict-mcp-config");
+      expect(mcpEntry(settings)).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("settingsIsolation OFF + empty grants → strict flag STILL applied (not gated on isolate)", () => {
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        settingsIsolation: false,
+        mcpGrants: [],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      const { cmd } = calls[0]!;
+      // No curated settings (no hook) on the non-isolated path, so the
+      // structural flag is the only line of defence — it must survive.
+      expect(cmd).toContain("--strict-mcp-config");
+      expect(cmd.indexOf("--settings")).toBe(-1);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -123,6 +123,61 @@ describe("buildCuratedSettings — per-skill grant hook (cortex#710)", () => {
   });
 });
 
+describe("buildCuratedSettings — per-principal MCP guard hook (cortex#2111)", () => {
+  interface Curated {
+    hooks: Record<string, { matcher?: string; hooks: { command: string }[] }[]>;
+  }
+
+  const mcpHook = (s: Curated) =>
+    s.hooks.PreToolUse!.find((e) => e.matcher === "mcp__.*");
+
+  test("UNDEFINED mcpGrants → no MCP hook (non-policy path, behaviour unchanged)", () => {
+    const s = buildCuratedSettings("/fake/.claude", undefined, undefined) as unknown as Curated;
+    expect(mcpHook(s)).toBeUndefined();
+  });
+
+  test("EMPTY mcpGrants ([]) STILL registers the hook — deny-all is a decision", () => {
+    // Asymmetry with skills is deliberate: an empty skill list is covered by
+    // the `Skill` deny rule, but NO deny rule can reach un-enumerable mcp__*
+    // names — the hook IS the deny (cortex#2111).
+    const s = buildCuratedSettings("/fake/.claude", undefined, []) as unknown as Curated;
+    const entry = mcpHook(s);
+    expect(entry).toBeDefined();
+    expect(entry!.hooks[0]!.command).toMatch(/\/hooks\/CortexMcpGuard\.hook\.ts$/);
+  });
+
+  test("WITH grants → MCP Guard hook registered under the mcp__.* matcher", () => {
+    const s = buildCuratedSettings("/fake/.claude", undefined, ["gdrive"]) as unknown as Curated;
+    expect(mcpHook(s)).toBeDefined();
+  });
+
+  test("grant patterns are NOT baked into the settings file (they ride the env var)", () => {
+    const s = buildCuratedSettings("/fake/.claude", undefined, ["gdrive", "jira.search"]);
+    expect(JSON.stringify(s)).not.toContain("gdrive");
+  });
+
+  test("skill + mcp hooks coexist independently", () => {
+    const s = buildCuratedSettings("/fake/.claude", ["code-review"], []) as unknown as Curated;
+    expect(s.hooks.PreToolUse!.find((e) => e.matcher === "Skill")).toBeDefined();
+    expect(mcpHook(s)).toBeDefined();
+    expect(s.hooks.PreToolUse!.find((e) => e.matcher === "Bash")).toBeDefined();
+  });
+
+  test("createIsolatedSettings threads mcpGrants into the written file", () => {
+    const iso = createIsolatedSettings("/fake/.claude", undefined, []);
+    try {
+      const written = JSON.parse(readFileSync(iso.settingsPath, "utf8"));
+      const mcp = written.hooks.PreToolUse.find(
+        (e: { matcher?: string }) => e.matcher === "mcp__.*",
+      );
+      expect(mcp).toBeDefined();
+      expect(mcp.hooks[0].command).toContain("CortexMcpGuard.hook.ts");
+    } finally {
+      iso.cleanup();
+    }
+  });
+});
+
 describe("createIsolatedSettings — materialised file + args", () => {
   test("writes a settings file and emits the isolation args", () => {
     const iso = createIsolatedSettings("/fake/.claude");

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -123,6 +123,13 @@ export interface AgentTeamOpts {
    * skill overrides are out of scope; the whole team shares the grant set.
    */
   allowedSkills?: string[];
+  /**
+   * cortex#2111 — per-principal MCP grant list, propagated to ALL team
+   * sessions (moderator + participants + synthesis) so a granted team
+   * inherits the MCP Guard deny-by-default like any other session.
+   * Undefined → no MCP hook (non-policy path, behaviour unchanged).
+   */
+  mcpGrants?: string[];
   allowedDirs?: string[];
   timeoutMs?: number;
   /** Bash guard config — propagated to all team sessions (moderator + participants) */
@@ -589,6 +596,7 @@ export class AgentTeam extends EventEmitter {
       allowedTools: this.opts.allowedTools,
       disallowedTools: this.opts.disallowedTools,
       ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
+      ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
       allowedDirs: this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
@@ -710,6 +718,7 @@ export class AgentTeam extends EventEmitter {
       allowedTools: config.allowedTools ?? this.opts.allowedTools,
       disallowedTools: config.disallowedTools ?? this.opts.disallowedTools,
       ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
+      ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
       allowedDirs: config.dirs ?? this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
@@ -890,6 +899,7 @@ export class AgentTeam extends EventEmitter {
       allowedTools: this.opts.allowedTools,
       disallowedTools: this.opts.disallowedTools,
       ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
+      ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
       allowedDirs: this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -241,6 +241,20 @@ export class CCSession extends EventEmitter {
     // guard (deny-all), unlike skills where empty skips the hook.
     const mcpGrants = this.opts.mcpGrants;
     const hasMcpGuard = isolate && mcpGrants !== undefined;
+    // cortex#2111 — structural backstop, CENTRALIZED here so every
+    // construction path gets it (dispatch-handler direct paths, the bus
+    // harness, agent-team, gateway-published envelopes): a session whose
+    // policy decision granted ZERO MCP patterns loads no MCP servers at
+    // all. Deduped against caller-supplied args (the dispatch-handler also
+    // appends it for agent-level strictMcpConfig). Deliberately NOT gated
+    // on `isolate`: even a non-isolated session must not fail open when a
+    // deny-all MCP decision was made.
+    const strictMcpArgs =
+      mcpGrants !== undefined &&
+      mcpGrants.length === 0 &&
+      !(this.opts.additionalArgs ?? []).includes("--strict-mcp-config")
+        ? ["--strict-mcp-config"]
+        : [];
     const isolationArgs: string[] = [];
     if (isolate) {
       this.isolatedSettings = createIsolatedSettings(
@@ -287,6 +301,7 @@ export class CCSession extends EventEmitter {
         "--verbose",
         "--output-format", "stream-json",
         ...isolationArgs,
+        ...strictMcpArgs,
         ...(this.opts.additionalArgs ?? []),
       ],
     };

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -13,6 +13,7 @@ import {
   createIsolatedSettings,
   scopeSessionEnv,
   CORTEX_SKILL_GRANTS_ENV,
+  CORTEX_MCP_GRANTS_ENV,
   type IsolatedSettings,
 } from "./session-settings";
 
@@ -89,6 +90,26 @@ export interface CCSessionOpts {
    * principal's full skill set and does not register the gate.
    */
   allowedSkills?: string[];
+  /**
+   * cortex#2111 — per-principal MCP grant list for this session, in the MCP
+   * Guard pattern grammar (`"*"` | `"<server>"` | `"<server>.<tool>"`,
+   * lowercase). When DEFINED (including `[]`), the curated settings file
+   * registers the MCP Guard PreToolUse hook (matcher `mcp__.*`) and this
+   * list is passed to it via the `CORTEX_MCP_GRANTS` env var — any `mcp__*`
+   * invocation not covered by a pattern is denied. `[]` means NO MCP at all
+   * (the dispatch path additionally appends `--strict-mcp-config` for that
+   * case, so un-granted servers don't even load).
+   *
+   * When `undefined`, no MCP hook is registered — a path that never went
+   * through `resolvePolicyAccess` keeps existing (allow-by-default)
+   * behaviour.
+   *
+   * Only honoured when `settingsIsolation` is on (the default) — the hook
+   * lives in the curated settings file. A principal-as-self session
+   * (`settingsIsolation:false`) runs as the home principal with their own
+   * settings; that principal holds the implicit full grant anyway.
+   */
+  mcpGrants?: string[];
 }
 
 export interface CCSessionResult {
@@ -213,11 +234,19 @@ export class CCSession extends EventEmitter {
     const skillGrants = this.opts.allowedSkills;
     const hasSkillGrants =
       isolate && skillGrants !== undefined && skillGrants.length > 0;
+    // cortex#2111 — per-principal MCP grants. Defined (even []) → curated
+    // settings register the MCP Guard hook AND the grant list is exported to
+    // it via env. The two MUST move together (same atomicity contract as the
+    // skill pair above). Note `!== undefined` — an EMPTY list still arms the
+    // guard (deny-all), unlike skills where empty skips the hook.
+    const mcpGrants = this.opts.mcpGrants;
+    const hasMcpGuard = isolate && mcpGrants !== undefined;
     const isolationArgs: string[] = [];
     if (isolate) {
       this.isolatedSettings = createIsolatedSettings(
         this.opts.claudeDir ?? `${homedir()}/.claude`,
         skillGrants,
+        mcpGrants,
       );
       isolationArgs.push(...this.isolatedSettings.args);
     }
@@ -283,6 +312,14 @@ export class CCSession extends EventEmitter {
       // is not a CLAUDE_* var so scoping passes it through regardless.
       ...(hasSkillGrants && {
         [CORTEX_SKILL_GRANTS_ENV]: JSON.stringify(skillGrants),
+      }),
+      // cortex#2111 — pass the MCP grant list to the MCP Guard hook. Only set
+      // when the curated settings actually registered the hook (hasMcpGuard),
+      // so the env var and the hook move atomically. The hook itself treats a
+      // missing var as deny-all, so even a registration-without-env bug fails
+      // CLOSED, never open.
+      ...(hasMcpGuard && {
+        [CORTEX_MCP_GRANTS_ENV]: JSON.stringify(mcpGrants),
       }),
     };
 

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -249,8 +249,20 @@ export class CCSession extends EventEmitter {
     // appends it for agent-level strictMcpConfig). Deliberately NOT gated
     // on `isolate`: even a non-isolated session must not fail open when a
     // deny-all MCP decision was made.
+    // Adversarial-review M3 — the flag fires in TWO confinement cases:
+    //   1. ZERO grants (any isolation mode): no MCP at all.
+    //   2. PARTIAL grants on a NON-ISOLATED session: the guard hook lives
+    //      in the curated settings file, which a non-isolated session
+    //      doesn't load — so fine-grained enforcement is impossible there.
+    //      Denying the granted servers too (fail-closed) beats silently
+    //      granting the whole namespace (fail-open). Full grant ("*")
+    //      needs no confinement.
+    const mcpConfinementRequired =
+      mcpGrants !== undefined &&
+      (mcpGrants.length === 0 ||
+        (!isolate && !mcpGrants.includes("*")));
     const strictMcpArgs =
-      mcpGrants?.length === 0 &&
+      mcpConfinementRequired &&
       this.opts.additionalArgs?.includes("--strict-mcp-config") !== true
         ? ["--strict-mcp-config"]
         : [];

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -250,9 +250,8 @@ export class CCSession extends EventEmitter {
     // on `isolate`: even a non-isolated session must not fail open when a
     // deny-all MCP decision was made.
     const strictMcpArgs =
-      mcpGrants !== undefined &&
-      mcpGrants.length === 0 &&
-      !(this.opts.additionalArgs ?? []).includes("--strict-mcp-config")
+      mcpGrants?.length === 0 &&
+      this.opts.additionalArgs?.includes("--strict-mcp-config") !== true
         ? ["--strict-mcp-config"]
         : [];
     const isolationArgs: string[] = [];

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -2140,14 +2140,12 @@ async function handleDispatchEnvelope(
   // belt-and-braces fallback derives from `undefined` → `[]` (deny-all),
   // never allow.
   {
-    // TS narrows `gatedCapabilities` to non-nullish here: it is assigned on
-    // the gate's allow path and every deny path returns before this point.
-    // (deriveMcpGrants would still map undefined → [] = deny-all, never
-    // allow, if a future refactor broke that invariant.)
-    const authoritative = deriveMcpGrants(
-      gatedCapabilities,
-      gatedCapabilities.includes("operator"),
-    );
+    // `gatedCapabilities` is assigned on the gate's allow path and every
+    // deny path returns before this point; deriveMcpGrants maps undefined
+    // → [] = deny-all (never allow) if a future refactor broke that. The
+    // reserved short-circuit capability is detected INSIDE deriveMcpGrants
+    // (single-arg form) — the literal stays in the carved-out policy module.
+    const authoritative = deriveMcpGrants(gatedCapabilities);
     req.mcpGrants =
       req.mcpGrants === undefined
         ? authoritative

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -111,6 +111,7 @@ import { extractAgentIdFromDid } from "../common/policy/did";
 // limiting) + the anonymous public principal id it fails closed for.
 import type { AdmissionGate, AdmissionLease } from "../bus/admission";
 import { PUBLIC_PRINCIPAL_ID } from "../common/policy/factory";
+import { deriveMcpGrants, intersectMcpGrants } from "../common/policy/resolve-access";
 import { isUuid } from "../common/types/uuid";
 // M3 (cortex#1241, ADR-0019) — verify-then-decrypt the sealed dispatch payload.
 import { readMarker, NetworkKeyring } from "../common/crypto/payload-encryption";
@@ -1810,6 +1811,12 @@ async function handleDispatchEnvelope(
   // leave it `undefined` so the engine skips the federation branch.
   const sourceNetwork = extractSourceNetwork(envelope, subject, federatedNetworksById);
   let gatedPrincipal: Principal | undefined;
+  // cortex#2111 (adversarial-review MAJOR) — the EXECUTING stack's own
+  // policy-derived capability set for the originator, captured from the
+  // gate decision below so the MCP grant injection after
+  // buildDispatchRequest() can be RECEIVING-STACK-AUTHORITATIVE (the #127
+  // bash-allowlist model) instead of trusting the wire.
+  let gatedCapabilities: readonly string[] | undefined;
   // R26 P1 (cortex#1371) — in-flight admission lease, acquired by the
   // admission gate below (only when `max_concurrent` tiers are configured)
   // and released in the `finally` around the harness drain: the harness
@@ -1983,6 +1990,7 @@ async function handleDispatchEnvelope(
       decision.capability,
     );
     gatedPrincipal = decision.principal;
+    gatedCapabilities = decision.capabilities;
 
     // R26 P1 (cortex#1371) — ADMISSION GATE (enforcement point 1, design
     // §4.2). Runs AFTER the policy allow and BEFORE harness construction:
@@ -2113,6 +2121,37 @@ async function handleDispatchEnvelope(
       runtime.bashGuardDisabled = bashGuardDisabled;
     }
     req.runtime = runtime;
+  }
+
+  // cortex#2111 (adversarial-review MAJOR) — RECEIVING-STACK-AUTHORITATIVE
+  // MCP grants, the #127 model applied to the MCP namespace. The wire's
+  // `mcp_grants` is a REMOTE claim: a federated peer (or a pre-#2111 /
+  // crafted publisher) could send `["*"]` to self-grant the executing
+  // host's whole MCP surface, or OMIT the field to land in the
+  // allow-by-default no-hook path. Neither may stand. The EXECUTING
+  // stack's own policy decision for the originator (captured at the gate
+  // above) is the authority:
+  //   - wire ABSENT  → authoritative list wholesale (closes the omission
+  //     fail-open: every policy-gated dispatch now carries a defined list,
+  //     so the MCP Guard always arms).
+  //   - wire PRESENT → intersect(wire, authoritative): a source may NARROW
+  //     its session's MCP surface, never widen it past local policy.
+  // `gatedCapabilities` is always set on the allow path; the
+  // belt-and-braces fallback derives from `undefined` → `[]` (deny-all),
+  // never allow.
+  {
+    // TS narrows `gatedCapabilities` to non-nullish here: it is assigned on
+    // the gate's allow path and every deny path returns before this point.
+    // (deriveMcpGrants would still map undefined → [] = deny-all, never
+    // allow, if a future refactor broke that invariant.)
+    const authoritative = deriveMcpGrants(
+      gatedCapabilities,
+      gatedCapabilities.includes("operator"),
+    );
+    req.mcpGrants =
+      req.mcpGrants === undefined
+        ? authoritative
+        : intersectMcpGrants(req.mcpGrants, authoritative);
   }
 
   // API-P0.5 (#2060, D3) — harness selection lives in the HarnessResolver

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -237,6 +237,12 @@ export interface DispatchTaskReceivedPayload {
    * grant exactly those skills via the Skill Guard PreToolUse hook.
    */
   allowed_skills?: string[];
+  /**
+   * cortex#2111 — per-principal MCP grant list. `undefined` → no MCP hook
+   * (behaviour unchanged); `[]` → deny every `mcp__*` tool; `[...]` → allow
+   * exactly the covered servers/tools via the MCP Guard PreToolUse hook.
+   */
+  mcp_grants?: string[];
   allowed_dirs?: string[];
   timeout_ms?: number;
   cwd?: string;
@@ -1276,6 +1282,11 @@ function buildDispatchRequest(
     // Omitted when the payload didn't carry it (→ harness default-deny).
     ...(payload.allowed_skills !== undefined && {
       allowedSkills: payload.allowed_skills,
+    }),
+    // cortex#2111 — per-principal MCP grants ride `mcp_grants`. Omitted when
+    // the payload didn't carry it (→ harness leaves MCP behaviour unchanged).
+    ...(payload.mcp_grants !== undefined && {
+      mcpGrants: payload.mcp_grants,
     }),
     context: hasEnvContext ? [{ kind: "env", data: envContext }] : [],
     agent: {

--- a/src/runner/hooks/__tests__/mcp-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/mcp-guard.hook.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the Cortex MCP Guard PreToolUse hook (cortex#2111).
+ *
+ * Two layers, mirroring skill-guard.hook.test.ts:
+ *   - PURE logic (parseMcpGrantList / parseMcpToolName / decideMcp) — the
+ *     name-parsing + allow/deny decision, exercised directly.
+ *   - PROCESS behaviour — spawn the hook with a PreToolUse payload on stdin
+ *     and assert the exit code + stdout decision:
+ *       * granted server/tool → exit 0, {"continue":true}
+ *       * un-granted mcp__* tool → exit 2, structured PreToolUse deny
+ *       * no/empty/malformed grant list → deny (fail-closed)
+ *       * empty/malformed payload → deny (fail-closed)
+ *       * non-mcp tool name → pass-through allow (not this hook's namespace)
+ */
+
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+import {
+  parseMcpGrantList,
+  parseMcpToolName,
+  decideMcp,
+  MCP_GRANT_ALL,
+} from "../mcp-guard.hook";
+
+const HOOK_PATH = join(import.meta.dir, "..", "mcp-guard.hook.ts");
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+}
+
+/** Run the hook with a tool-call payload on stdin + a grant-list env. */
+function runHook(
+  payload: Record<string, unknown> | string,
+  grants: string | undefined,
+): RunResult {
+  // Build a clean env: start from process.env, drop any inherited grant var,
+  // then apply this test's value (undefined → unset).
+  const merged: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && k !== "CORTEX_MCP_GRANTS") merged[k] = v;
+  }
+  if (grants !== undefined) merged.CORTEX_MCP_GRANTS = grants;
+
+  const input = typeof payload === "string" ? payload : JSON.stringify(payload);
+  const result = spawnSync("bun", [HOOK_PATH], {
+    encoding: "utf-8",
+    input,
+    env: merged,
+  });
+  return { status: result.status, stdout: result.stdout };
+}
+
+// ---------------------------------------------------------------------------
+// Pure logic
+// ---------------------------------------------------------------------------
+
+describe("parseMcpGrantList — fail-closed parsing", () => {
+  test("parses a JSON array of grant patterns", () => {
+    expect(parseMcpGrantList('["gdrive","jira.search_issues"]')).toEqual([
+      "gdrive",
+      "jira.search_issues",
+    ]);
+  });
+
+  test("undefined env → empty (deny-all)", () => {
+    expect(parseMcpGrantList(undefined)).toEqual([]);
+  });
+
+  test("empty string → empty (deny-all)", () => {
+    expect(parseMcpGrantList("")).toEqual([]);
+  });
+
+  test("malformed JSON → empty (deny-all, never widens access)", () => {
+    expect(parseMcpGrantList("not json")).toEqual([]);
+  });
+
+  test("non-array JSON → empty (deny-all)", () => {
+    expect(parseMcpGrantList('{"server":"gdrive"}')).toEqual([]);
+    expect(parseMcpGrantList('"gdrive"')).toEqual([]);
+  });
+
+  test("filters non-string members", () => {
+    expect(parseMcpGrantList('["gdrive",42,null,"*"]')).toEqual(["gdrive", "*"]);
+  });
+});
+
+describe("parseMcpToolName — (server, tool) split", () => {
+  test("splits mcp__<server>__<tool>", () => {
+    expect(parseMcpToolName("mcp__gdrive__read_file")).toEqual({
+      server: "gdrive",
+      tool: "read_file",
+    });
+  });
+
+  test("lowercases both segments", () => {
+    expect(parseMcpToolName("mcp__Claude_ai_Google_Drive__ReadFile")).toEqual({
+      server: "claude_ai_google_drive",
+      tool: "readfile",
+    });
+  });
+
+  test("preserves a double underscore INSIDE the tool name", () => {
+    expect(parseMcpToolName("mcp__srv__ns__op")).toEqual({
+      server: "srv",
+      tool: "ns__op",
+    });
+  });
+
+  test("server-only name (no tool segment) parses with empty tool", () => {
+    expect(parseMcpToolName("mcp__gdrive")).toEqual({ server: "gdrive", tool: "" });
+  });
+
+  test("non-mcp tool → null", () => {
+    expect(parseMcpToolName("Bash")).toBeNull();
+    expect(parseMcpToolName("Read")).toBeNull();
+  });
+
+  test("bare prefix / empty server → null", () => {
+    expect(parseMcpToolName("mcp__")).toBeNull();
+    expect(parseMcpToolName("mcp____tool")).toBeNull();
+  });
+});
+
+describe("decideMcp — allow/deny decision", () => {
+  test("wildcard grant allows any mcp tool", () => {
+    expect(decideMcp("mcp__gdrive__read_file", [MCP_GRANT_ALL]).allow).toBe(true);
+    expect(decideMcp("mcp__anything__at_all", ["*"]).allow).toBe(true);
+  });
+
+  test("server grant allows every tool of that server only", () => {
+    expect(decideMcp("mcp__gdrive__read_file", ["gdrive"]).allow).toBe(true);
+    expect(decideMcp("mcp__gdrive__delete_file", ["gdrive"]).allow).toBe(true);
+    expect(decideMcp("mcp__jira__search", ["gdrive"]).allow).toBe(false);
+  });
+
+  test("tool grant allows exactly that tool", () => {
+    const grants = ["jira.search_issues"];
+    expect(decideMcp("mcp__jira__search_issues", grants).allow).toBe(true);
+    expect(decideMcp("mcp__jira__create_issue", grants).allow).toBe(false);
+    expect(decideMcp("mcp__gdrive__search_issues", grants).allow).toBe(false);
+  });
+
+  test("matching is case-insensitive on the tool-name side", () => {
+    expect(decideMcp("mcp__GDrive__Read_File", ["gdrive.read_file"]).allow).toBe(true);
+  });
+
+  test("empty grants deny every mcp tool (deny-by-default)", () => {
+    const d = decideMcp("mcp__gdrive__read_file", []);
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("mcp__gdrive__read_file");
+    expect(d.reason).toContain("tool.mcp.gdrive");
+  });
+
+  test("non-mcp tool passes through (not this hook's namespace)", () => {
+    expect(decideMcp("Bash", []).allow).toBe(true);
+    expect(decideMcp("Read", []).allow).toBe(true);
+  });
+
+  test("server-only invocation is allowed by server grant, denied otherwise", () => {
+    expect(decideMcp("mcp__gdrive", ["gdrive"]).allow).toBe(true);
+    expect(decideMcp("mcp__gdrive", ["jira"]).allow).toBe(false);
+    // An empty tool segment must NOT match a `server.` pattern.
+    expect(decideMcp("mcp__gdrive", ["gdrive."]).allow).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Process behaviour
+// ---------------------------------------------------------------------------
+
+describe("mcp-guard hook process — enforcement", () => {
+  test("granted server → exit 0 + continue", () => {
+    const r = runHook({ tool_name: "mcp__gdrive__read_file" }, '["gdrive"]');
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout)).toEqual({ continue: true });
+  });
+
+  test("wildcard grant → exit 0 + continue", () => {
+    const r = runHook({ tool_name: "mcp__anything__tool" }, '["*"]');
+    expect(r.status).toBe(0);
+  });
+
+  test("un-granted server → exit 2 + structured deny", () => {
+    const r = runHook({ tool_name: "mcp__jira__search" }, '["gdrive"]');
+    expect(r.status).toBe(2);
+    const out = JSON.parse(r.stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("mcp__jira__search");
+  });
+
+  test("no grant env → deny-all (fail-closed)", () => {
+    const r = runHook({ tool_name: "mcp__gdrive__read_file" }, undefined);
+    expect(r.status).toBe(2);
+  });
+
+  test("empty grant list → deny-all", () => {
+    const r = runHook({ tool_name: "mcp__gdrive__read_file" }, "[]");
+    expect(r.status).toBe(2);
+  });
+
+  test("malformed grant env → deny-all (fail-closed)", () => {
+    const r = runHook({ tool_name: "mcp__gdrive__read_file" }, "not json");
+    expect(r.status).toBe(2);
+  });
+
+  test("empty stdin payload → deny (fail-closed)", () => {
+    const r = runHook("", '["*"]');
+    expect(r.status).toBe(2);
+  });
+
+  test("malformed stdin payload → deny (fail-closed)", () => {
+    const r = runHook("{not json", '["*"]');
+    expect(r.status).toBe(2);
+  });
+
+  test("payload without tool_name → deny (fail-closed)", () => {
+    const r = runHook({ session_id: "s1" }, '["*"]');
+    expect(r.status).toBe(2);
+  });
+
+  test("non-mcp tool name → pass-through allow", () => {
+    const r = runHook({ tool_name: "Bash" }, "[]");
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout)).toEqual({ continue: true });
+  });
+});

--- a/src/runner/hooks/__tests__/mcp-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/mcp-guard.hook.test.ts
@@ -158,6 +158,14 @@ describe("decideMcp — allow/deny decision", () => {
     expect(decideMcp("Read", []).allow).toBe(true);
   });
 
+  test("M2: in-namespace but UNPARSEABLE names are DENIED even with a wildcard grant", () => {
+    // `mcp__` / `mcp____tool` parse to null but sit inside the namespace the
+    // matcher fired on — unattributable ⇒ fail-closed, never pass-through.
+    expect(decideMcp("mcp__", ["*"]).allow).toBe(false);
+    expect(decideMcp("mcp____tool", ["*"]).allow).toBe(false);
+    expect(decideMcp("mcp__", []).allow).toBe(false);
+  });
+
   test("server-only invocation is allowed by server grant, denied otherwise", () => {
     expect(decideMcp("mcp__gdrive", ["gdrive"]).allow).toBe(true);
     expect(decideMcp("mcp__gdrive", ["jira"]).allow).toBe(false);

--- a/src/runner/hooks/mcp-guard.hook.ts
+++ b/src/runner/hooks/mcp-guard.hook.ts
@@ -114,9 +114,24 @@ export function decideMcp(
 ): { allow: boolean; reason?: string } {
   const parsed = parseMcpToolName(toolName);
   if (parsed === null) {
-    // Not an mcp__* tool — not ours to gate (Claude Code fires this hook on
-    // the `mcp__.*` matcher, but if it over-matches, pass through: every
-    // non-MCP tool has its own confinement via toolRestrictions/allowlist).
+    // Adversarial-review M2 — split the two null cases; only ONE may pass:
+    //   (a) name does NOT start with `mcp__` → genuinely not ours to gate
+    //       (matcher over-match; the tool has its own confinement via
+    //       toolRestrictions/allowlist). Pass through.
+    //   (b) name IS in the `mcp__` namespace but unparseable (empty server
+    //       segment, e.g. `mcp__` / `mcp____tool`) → we cannot attribute it
+    //       to a server, and the namespace is allow-by-default at the
+    //       permission layer. Fail CLOSED — never let an unattributable
+    //       in-namespace name through.
+    if (toolName.startsWith(MCP_TOOL_PREFIX)) {
+      return {
+        allow: false,
+        reason:
+          `[Cortex MCP Guard] Blocked MCP tool "${toolName}": in the ` +
+          `mcp__ namespace but not parseable into a (server, tool) pair — ` +
+          `denying to stay fail-closed (cortex#2111).`,
+      };
+    }
     return { allow: true };
   }
   const { server, tool } = parsed;

--- a/src/runner/hooks/mcp-guard.hook.ts
+++ b/src/runner/hooks/mcp-guard.hook.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+/**
+ * Cortex MCP Guard — PreToolUse hook for the `mcp__*` tool namespace
+ * (cortex#2111 — TRUST-PATH/security).
+ *
+ * ## Why a hook (and not the tool inventory)
+ *
+ * `resolvePolicyAccess` confines CC tools by inverting a principal's
+ * `tool.*` grants against `CLAUDE_TOOL_INVENTORY` — deny-by-omission over an
+ * enumerable, build-time-pinned set of 14 names. MCP tool names are NOT
+ * enumerable at build time: they depend on which servers the host has
+ * connected in `~/.claude/settings.json`, per-host, changing without a
+ * cortex release. No inventory inversion can ever cover `mcp__*` (cortex#2111
+ * — structural, not a lag). You cannot deny-by-omission a name you cannot
+ * enumerate — but you CAN deny a namespace and require an explicit grant.
+ *
+ * This hook is that namespace gate: registered in the curated `--settings`
+ * file under PreToolUse matcher `mcp__.*` (hooks run BEFORE permission rules;
+ * a blocking hook beats allow-by-default), it denies every `mcp__*` invocation
+ * that is not covered by the session's grant list.
+ *
+ * ## Grant grammar
+ *
+ * The grant list reaches this hook via the `CORTEX_MCP_GRANTS` env var (a
+ * JSON array, set by `cc-session.ts` — same layering as `CORTEX_SKILL_GRANTS`).
+ * Entries are lowercase patterns derived from `tool.mcp*` policy capabilities
+ * (see `deriveMcpGrants` in `src/common/policy/resolve-access.ts`):
+ *
+ *   - `"*"`               — the whole MCP namespace (from `tool.mcp`, or the
+ *                           reserved short-circuit capability)
+ *   - `"<server>"`        — every tool of one server (from `tool.mcp.<server>`)
+ *   - `"<server>.<tool>"` — a single tool (from `tool.mcp.<server>.<tool>`)
+ *
+ * A CC tool name `mcp__<server>__<tool>` matches a grant when the grant is
+ * `"*"`, equals `<server>`, or equals `<server>.<tool>` (all compared
+ * lowercase — mirrors the `tool.<lowercase>` capability convention).
+ *
+ * ## Deny behaviour
+ *
+ * Doubly fail-closed, mirroring skill-guard.hook.ts:
+ *   1. Emits Claude Code's structured PreToolUse deny decision on stdout so
+ *      the reason surfaces to the agent and the Cortex→Discord relay.
+ *   2. Exits with code **2** — a hard block even for a CLI that ignores
+ *      structured hook output.
+ *
+ * ## Fail-closed posture
+ *
+ * If `CORTEX_MCP_GRANTS` is absent or malformed, the grant list is empty →
+ * every `mcp__*` tool is denied. An empty/unparseable stdin payload is a
+ * deny (we cannot identify the tool; `mcp__*` is allow-by-default at the
+ * permission layer, so passing through would fail OPEN — the exact
+ * cortex#710 lesson). A non-`mcp__*` tool name is a pass-through allow:
+ * this hook only governs the MCP namespace.
+ */
+
+interface HookInput {
+  session_id?: string;
+  tool_name?: string;
+}
+
+/** The CC tool-name prefix that marks an MCP server tool. */
+const MCP_TOOL_PREFIX = "mcp__";
+
+/** Grant entry that opens the whole MCP namespace. */
+export const MCP_GRANT_ALL = "*";
+
+/**
+ * Parse the per-session grant list from `CORTEX_MCP_GRANTS` (JSON array of
+ * lowercase pattern strings). Returns `[]` (deny-all) on absence or malformed
+ * input — fail-closed. Exported for unit tests.
+ */
+export function parseMcpGrantList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s): s is string => typeof s === "string");
+  } catch {
+    // Malformed grant list — fail closed (deny all). A bad env value must
+    // never widen access.
+    return [];
+  }
+}
+
+/**
+ * Split a CC MCP tool name into its (server, tool) pair, lowercased.
+ * `mcp__gdrive__read_file` → `{ server: "gdrive", tool: "read_file" }`.
+ * Server names may contain single underscores (`claude_ai_Google_Drive`);
+ * the separator is the DOUBLE underscore, so the server is the first
+ * `__`-delimited segment and the tool is the remainder (re-joined, so a
+ * tool name that itself contains `__` survives). Returns `null` when the
+ * name is not an `mcp__*` tool or has no server segment. Exported for unit
+ * tests.
+ */
+export function parseMcpToolName(
+  toolName: string,
+): { server: string; tool: string } | null {
+  if (!toolName.startsWith(MCP_TOOL_PREFIX)) return null;
+  const rest = toolName.slice(MCP_TOOL_PREFIX.length);
+  if (rest.length === 0) return null;
+  const segments = rest.split("__");
+  const server = segments[0]?.toLowerCase() ?? "";
+  if (server.length === 0) return null;
+  return { server, tool: segments.slice(1).join("__").toLowerCase() };
+}
+
+/**
+ * Decide allow/deny for an MCP tool invocation given the grant list. Pure —
+ * exported for unit tests.
+ */
+export function decideMcp(
+  toolName: string,
+  grants: string[],
+): { allow: boolean; reason?: string } {
+  const parsed = parseMcpToolName(toolName);
+  if (parsed === null) {
+    // Not an mcp__* tool — not ours to gate (Claude Code fires this hook on
+    // the `mcp__.*` matcher, but if it over-matches, pass through: every
+    // non-MCP tool has its own confinement via toolRestrictions/allowlist).
+    return { allow: true };
+  }
+  const { server, tool } = parsed;
+  const granted =
+    grants.includes(MCP_GRANT_ALL) ||
+    grants.includes(server) ||
+    (tool.length > 0 && grants.includes(`${server}.${tool}`));
+  if (granted) return { allow: true };
+  return {
+    allow: false,
+    reason:
+      `[Cortex MCP Guard] Blocked MCP tool "${toolName}": server "${server}"` +
+      `${tool.length > 0 ? ` / tool "${tool}"` : ""} is not in this ` +
+      `session's MCP grant list [${grants.map((g) => `"${g}"`).join(", ")}]. ` +
+      `MCP tools are deny-by-default per principal (cortex#2111). Ask the ` +
+      `principal to grant \`tool.mcp.${server}\` (whole server) or ` +
+      `\`tool.mcp.${server}.${tool || "<tool>"}\` (single tool) on a role ` +
+      `this sender holds in policy.roles[].capabilities[].`,
+  };
+}
+
+/** Emit the pass-through decision (mirrors skill-guard.hook.ts). */
+function allow(): void {
+  console.log(JSON.stringify({ continue: true }));
+}
+
+/**
+ * Emit Claude Code's structured PreToolUse *deny* decision. The
+ * `permissionDecisionReason` surfaces back to the agent + the Cortex→Discord
+ * relay (mirrors skill-guard.hook.ts / bash-guard.hook.ts).
+ */
+function deny(reason: string): void {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+}
+
+/**
+ * Read the PreToolUse payload from stdin to EOF, bounded by a hang-stop cap.
+ * On the cap firing we throw and the caller fails CLOSED (deny) — never
+ * allow. Same posture (and rationale) as skill-guard.hook.ts: `mcp__*` is
+ * allow-by-default at the permission layer, so an abandoned read that fell
+ * through to `allow()` would run an un-identified MCP tool.
+ */
+const STDIN_READ_CAP_MS = 5_000;
+
+async function readStdin(): Promise<string> {
+  const timedOut = Symbol("timedOut");
+  let capTimer: ReturnType<typeof setTimeout> | undefined;
+  const outcome = await Promise.race([
+    Bun.stdin.text(),
+    new Promise<typeof timedOut>((r) => {
+      capTimer = setTimeout(() => {
+        r(timedOut);
+      }, STDIN_READ_CAP_MS);
+    }),
+  ]);
+  if (capTimer !== undefined) clearTimeout(capTimer);
+  if (outcome === timedOut) {
+    throw new Error("mcp-guard: stdin read exceeded cap before EOF");
+  }
+  return outcome;
+}
+
+async function main(): Promise<void> {
+  let input: HookInput;
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) {
+      // Empty payload: we cannot identify the tool, and the namespace is
+      // allow-by-default at the permission layer. Fail CLOSED.
+      deny(
+        "[Cortex MCP Guard] Blocked: empty PreToolUse input — could not " +
+          "identify the MCP tool; denying to stay fail-closed.",
+      );
+      process.exit(2);
+    }
+    input = JSON.parse(raw) as HookInput;
+  } catch {
+    deny(
+      "[Cortex MCP Guard] Blocked: could not parse the PreToolUse input — " +
+        "denying to stay fail-closed.",
+    );
+    process.exit(2);
+  }
+
+  const toolName = input.tool_name;
+  if (typeof toolName !== "string" || toolName.length === 0) {
+    // A payload with no tool name: cannot attribute the call. The matcher
+    // only fires on mcp__* names, so an unattributable payload here is a
+    // capture failure, not a non-MCP call. Fail CLOSED.
+    deny(
+      "[Cortex MCP Guard] Blocked: PreToolUse input carries no tool_name — " +
+        "denying to stay fail-closed.",
+    );
+    process.exit(2);
+  }
+
+  const grants = parseMcpGrantList(process.env.CORTEX_MCP_GRANTS);
+  const decision = decideMcp(toolName, grants);
+
+  if (decision.allow) {
+    allow();
+    return;
+  }
+
+  // Write the deny decision FIRST (surfaces the reason), then exit 2 so the
+  // block is enforced even by a CLI that ignores structured hook output.
+  deny(decision.reason ?? "[Cortex MCP Guard] Blocked.");
+  process.exit(2);
+}
+
+// Only execute the gate when run AS a script (the production hook path) —
+// same import.meta.main guard (and rationale) as skill-guard.hook.ts, so
+// unit tests can import the pure helpers without triggering the stdin read.
+if (import.meta.main) {
+  main().catch(() => {
+    // An unexpected failure in the gate must fail CLOSED, not open.
+    deny(
+      "[Cortex MCP Guard] Blocked: internal hook error — denying to stay " +
+        "fail-closed.",
+    );
+    process.exit(2);
+  });
+}

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -162,6 +162,19 @@ export const CORTEX_PRESERVED_CLAUDE_ENV = new Set<string>([
 export const CORTEX_SKILL_GRANTS_ENV = "CORTEX_SKILL_GRANTS";
 
 /**
+ * Env var carrying the per-session **MCP grant list** to the MCP Guard
+ * PreToolUse hook (cortex#2111). Value is a JSON array of lowercase grant
+ * patterns (`"*"` | `"<server>"` | `"<server>.<tool>"` — see
+ * `deriveMcpGrants` in `src/common/policy/resolve-access.ts`). The hook
+ * (`mcp-guard.hook.ts`, matcher `mcp__.*`) DENIES any `mcp__*` invocation
+ * not covered by a pattern; absent/malformed env → deny-all (fail-closed).
+ *
+ * Set on the child env by `cc-session.ts`, layered AFTER `scopeSessionEnv`
+ * — exactly the {@link CORTEX_SKILL_GRANTS_ENV} pattern.
+ */
+export const CORTEX_MCP_GRANTS_ENV = "CORTEX_MCP_GRANTS";
+
+/**
  * Build the curated settings object cortex spawns bot sessions under.
  *
  * Contains ONLY cortex's own hooks (resolved to the installed symlink
@@ -186,15 +199,35 @@ export const CORTEX_SKILL_GRANTS_ENV = "CORTEX_SKILL_GRANTS";
  * session is either {broad `Skill` allow + this gate hook} or {no `Skill`
  * tool}, never the broken {`Skill(name)` allow + bare `Skill` deny}.
  *
+ * ## MCP gating (cortex#2111)
+ *
+ * When `mcpGrants` is DEFINED (including `[]`), the session came from a
+ * policy-resolved decision and the `mcp__*` namespace is deny-by-default:
+ * we register the **MCP Guard** PreToolUse hook (matcher `mcp__.*`), which
+ * denies any MCP invocation not covered by the grant list. The list reaches
+ * the hook via the {@link CORTEX_MCP_GRANTS_ENV} env var on the child (set
+ * by cc-session.ts, atomically with this registration). Note the asymmetry
+ * with skills: an EMPTY skill-grant list skips the hook (the `Skill` deny
+ * rule covers it), but an empty MCP grant list still REGISTERS the hook —
+ * there is no inventory-based deny rule that can reach `mcp__*` names
+ * (that's the whole #2111 gap), so the hook IS the deny.
+ *
+ * When `mcpGrants` is `undefined` (a path that never went through
+ * `resolvePolicyAccess` — review pipeline, dev consumer), no MCP hook is
+ * registered and existing behaviour is unchanged.
+ *
  * @param claudeDir Absolute path to the cortex-owned `.claude` dir holding
  *   the installed hook symlinks. Defaults to `${HOME}/.claude`.
  * @param skillGrants Per-session skill grant list. Non-empty → register the
  *   Skill Guard hook. Undefined/empty → no Skill hook (default-deny lives
  *   in the caller's `disallowedTools`).
+ * @param mcpGrants Per-session MCP grant list (cortex#2111). Defined →
+ *   register the MCP Guard hook (deny-by-default over `mcp__*`).
  */
 export function buildCuratedSettings(
   claudeDir: string,
   skillGrants?: readonly string[],
+  mcpGrants?: readonly string[],
 ): Record<string, unknown> {
   const hook = (name: string) => ({
     type: "command",
@@ -209,6 +242,12 @@ export function buildCuratedSettings(
   ];
   if (skillGrants !== undefined && skillGrants.length > 0) {
     preToolUse.push({ matcher: "Skill", hooks: [hook("CortexSkillGuard.hook.ts")] });
+  }
+  // cortex#2111 — defined mcpGrants (even []) arms the namespace gate. The
+  // matcher is a regex: every tool name starting `mcp__` routes through the
+  // guard.
+  if (mcpGrants !== undefined) {
+    preToolUse.push({ matcher: "mcp__.*", hooks: [hook("CortexMcpGuard.hook.ts")] });
   }
 
   // Mirrors src/settings/cortex-hooks.json (the reference fallback) but
@@ -257,16 +296,21 @@ export interface IsolatedSettings {
  *   the curated file registers the Skill Guard PreToolUse hook; the caller
  *   must ALSO broadly allow the `Skill` tool and set the
  *   {@link CORTEX_SKILL_GRANTS_ENV} env var. Undefined/empty → no Skill hook.
+ * @param mcpGrants Per-session MCP grant list (cortex#2111). Defined (even
+ *   `[]`) → the curated file registers the MCP Guard PreToolUse hook and the
+ *   caller must set the {@link CORTEX_MCP_GRANTS_ENV} env var. Undefined →
+ *   no MCP hook (non-policy path, behaviour unchanged).
  */
 export function createIsolatedSettings(
   claudeDir: string,
   skillGrants?: readonly string[],
+  mcpGrants?: readonly string[],
 ): IsolatedSettings {
   const dir = mkdtempSync(join(tmpdir(), "cortex-session-"));
   const settingsPath = join(dir, "settings.json");
   writeFileSync(
     settingsPath,
-    JSON.stringify(buildCuratedSettings(claudeDir, skillGrants), null, 2),
+    JSON.stringify(buildCuratedSettings(claudeDir, skillGrants, mcpGrants), null, 2),
     {
       mode: 0o600,
     },

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -363,6 +363,16 @@ export class ClaudeCodeHarness implements SessionHarness {
       if (!disallowedTools.includes("Skill")) disallowedTools.push("Skill");
     }
 
+    // cortex#2111 — per-principal MCP grants. Pass-through: a DEFINED list
+    // (even []) makes cc-session register the MCP Guard PreToolUse hook
+    // (matcher `mcp__.*`) with exactly these patterns and export them via
+    // CORTEX_MCP_GRANTS — deny-by-default over the un-enumerable `mcp__*`
+    // namespace. `undefined` → no hook, existing behaviour (a request that
+    // never went through resolvePolicyAccess).
+    if (req.mcpGrants !== undefined) {
+      opts.mcpGrants = [...req.mcpGrants];
+    }
+
     if (allowedTools.length > 0) {
       opts.allowedTools = allowedTools;
     }

--- a/src/surface-sdk/generated/surface-sdk.d.ts
+++ b/src/surface-sdk/generated/surface-sdk.d.ts
@@ -92,8 +92,30 @@ export interface AccessDecision {
 		async: boolean;
 		team: boolean;
 	};
-	/** Disallowed MCP tools for this user */
+	/**
+	 * Disallowed Claude Code tools for this sender — the inversion of their
+	 * `tool.*` capability grants against `CLAUDE_TOOL_INVENTORY`. CC tools
+	 * only: `mcp__*` names never appear here (not enumerable at build time —
+	 * see `mcpGrants` below, cortex#2111).
+	 */
 	toolRestrictions?: string[];
+	/**
+	 * cortex#2111 — per-principal MCP grants, in the MCP Guard pattern grammar
+	 * (`"*"` = whole namespace | `"<server>"` | `"<server>.<tool>"`, lowercase).
+	 * Derived from `tool.mcp*` capabilities by `deriveMcpGrants` (a principal
+	 * holding the reserved short-circuit capability ⇒ `["*"]`).
+	 *
+	 * Semantics of PRESENCE vs ABSENCE (load-bearing):
+	 *   - present (even `[]`) — a policy-resolved decision: the MCP namespace
+	 *     is DENY-BY-DEFAULT for this session. The dispatch-handler threads the
+	 *     list to the CC session, which registers the MCP Guard PreToolUse hook
+	 *     (matcher `mcp__.*`) with exactly these grants; `[]` additionally arms
+	 *     the `--strict-mcp-config` structural backstop (no servers load).
+	 *   - absent — a path that never went through `resolvePolicyAccess`
+	 *     (review pipeline, dev consumer, direct CLI); existing behaviour is
+	 *     unchanged there.
+	 */
+	mcpGrants?: string[];
 	/**
 	 * cortex#1167 — EXPLICIT tool ALLOWLIST. When present and non-empty, the CC
 	 * session is confined to exactly these tools (anything else, including every


### PR DESCRIPTION
Closes #2111.

## The gap

`resolvePolicyAccess` confines tools by inverting `tool.*` grants against `CLAUDE_TOOL_INVENTORY` (14 build-time names). `mcp__*` names are **not enumerable at build time** (they depend on which servers the host connected — per-host, changing without a cortex release), so deny-by-omission can never reach them: on any stack with asymmetric principals, the narrower principal silently inherited the full MCP surface of the wider one. Withholding `tool.bash` bought nothing against MCP (issue's `andreas/manda` scenario).

## The fix — issue option 1 (preferred)

**`mcp` becomes a first-class capability namespace, deny-by-default with explicit grant.** You cannot allowlist what you cannot enumerate, but you can deny a namespace and require an explicit grant.

### Capability grammar (design-policy-cutover §5.2, updated)

| Capability | Grants |
|---|---|
| `tool.mcp` | the whole MCP namespace |
| `tool.mcp.<server>` | every tool of one server |
| `tool.mcp.<server>.<toolname>` | a single tool |

Principals holding the reserved short-circuit capability get the implicit full grant (`["*"]`) — **existing single-principal stacks keep working with zero config change**; deny-by-default lands for everyone else. The 14-tool CC inventory and its allow-by-default semantics are untouched.

### Mechanism (the cortex#710 pattern — a permission rule can't express this)

1. **Resolution** — `resolvePolicyAccess` harvests the effective capability set from the engine's allow decision (no second resolution path) and emits `AccessDecision.mcpGrants`. Present-even-empty on every policy-resolved allow; **absent** on paths that never went through policy (review pipeline, dev consumer) → behaviour unchanged there.
2. **Enforcement** — new **MCP Guard PreToolUse hook** (`mcp-guard.hook.ts`, matcher `mcp__.*`), registered in the curated `--settings` file whenever `mcpGrants` is defined; grants ride `CORTEX_MCP_GRANTS` (atomically with registration, the #706 lesson). Doubly fail-closed: structured deny + exit 2; missing/malformed env → deny-all; empty/unparseable payload → deny (the #710 fail-open lesson, applied from day one).
3. **Structural backstop** — zero-grant principals additionally get `--strict-mcp-config`: un-granted servers don't even load. Partial-grant principals must NOT get the flag (their granted servers have to load); the hook enforces the boundary.

Note the deliberate asymmetry with skills: an **empty** skill list skips the hook (the `Skill` deny rule covers it); an **empty** MCP list still registers the hook — no deny rule can reach un-enumerable `mcp__*` names, so the hook IS the deny. Pinned in tests.

### Threading (all dispatch paths)

bus payload `mcp_grants` (publisher → listener → `DispatchRequest.mcpGrants` → CC harness) · direct sync/async/team · AgentTeam member sessions (moderator + participants + synthesis) · anon open-onboarding gets `mcpGrants: []` belt-and-braces. `arc-manifest.yaml` installs `CortexMcpGuard.hook.ts` **symlink-only** (never global settings), same posture as the Skill Guard.

### Out of scope (per issue)

Resource-level scoping within an MCP server (the resource owner's authorization to enforce). Per-principal `session_config` overrides of MCP grants (roles compose; can follow if needed).

## Tests

- `mcp-guard.hook.test.ts` — pure logic (grant parsing fail-closed matrix, `(server, tool)` split incl. `__`-in-tool + case folding) + **process enforcement** (spawned hook: granted → exit 0; un-granted/no-env/malformed-env/empty-payload → exit 2 structured deny; non-mcp name → pass-through).
- `resolve-access.test.ts` — `deriveMcpGrants` derivation (implicit full grant, bare `tool.mcp`, server/tool patterns, dedupe+lowercase, `tool.mcpfoo` non-grant), `mcpGrants` on decisions incl. **the issue's asymmetric-principal scenario** (Bash restricted AND MCP confined), anon path.
- `session-settings.test.ts` — registration matrix (undefined → no hook; `[]` → hook; grants → hook), grants-not-baked-into-file, skill+mcp coexistence, `createIsolatedSettings` threading.

Full suite: 10,047 pass / 0 new failures (12 pre-existing failures reproduce identically on clean `main` — machine-local env, filing separately). `tsc` 0, lint 0 errors, vocab ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9wp7h9ThsZpMgpqSrCpWc
