### PR TITLE
feat(quickstart): L3 — cortex quickstart, env-contract one-command first install (cortex#2094)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-config-write.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-config-write.test.ts
@@ -56,6 +56,26 @@ describe("writeNetworksGuarded", () => {
     expect(backups.length).toBe(1);
   });
 
+  test("a re-write's backup carries the file's actual mode (0600 once key-clamped), never a bare-default 0644", () => {
+    writeFileSync(path, "policy:\n  federated:\n    networks: []\n");
+    writeNetworksGuarded(path, [net()], { backupLabel: "rotate-key" }); // clamps to 0600 (key present)
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+
+    // A second write (e.g. key rotation) — the file is ALREADY 0600 and
+    // already carries a real payload_key; its backup is a snapshot of that
+    // key-bearing file taken BEFORE this write, and must inherit the same
+    // 0600, not the umask-default a bare `writeFileSync(backupPath, text)`
+    // would otherwise leave it at.
+    const rotated = net({ payload_key: Buffer.alloc(32, 1).toString("base64"), payload_key_id: "metafactory/k3" });
+    writeNetworksGuarded(path, [rotated], { backupLabel: "rotate-key" });
+
+    const backups = readdirSync(tmp).filter((f) => f.includes(".pre-rotate-key-") && f.endsWith(".bak"));
+    expect(backups.length).toBeGreaterThanOrEqual(1);
+    for (const b of backups) {
+      expect(statSync(join(tmp, b)).mode & 0o777).toBe(0o600);
+    }
+  });
+
   test("REFUSES a malformed (wrong-length) payload_key BEFORE any fs mutation", () => {
     const before = "policy:\n  federated:\n    networks: []\n";
     writeFileSync(path, before);

--- a/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
@@ -326,6 +326,32 @@ describe("patchSurfacesYaml", () => {
     const entriesAfterSecond = readdirSync(dir);
     expect(entriesAfterSecond.length).toBe(countBefore);
   });
+
+  test("re-run backup is 0600, never the umask-default 0644 — even though it carries the live token from a PRIOR run", () => {
+    // The exact scenario the "fix one env var and re-run" flow hits: run 1
+    // sets the real token; run 2 only changes guildId (the token is
+    // unchanged). At run 2, `originalText` (what gets backed up) is the
+    // ALREADY-patched file from run 1 — it carries the real token. The
+    // backup must inherit the file's 0600 mode, not fall back to whatever
+    // the process umask would otherwise leave a fresh file at.
+    const dir = freshDir();
+    const path = seed(dir);
+    const first = { token: "MY-REAL-BOT-TOKEN", guildId: "111", agentChannelId: "222", logChannelId: "333" };
+    patchSurfacesYaml(path, first);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+
+    const second = { ...first, guildId: "999" }; // token unchanged, one field changed
+    const result = patchSurfacesYaml(path, second);
+    expect(result.changed).toBe(true);
+    expect(result.backupPath).toBeDefined();
+
+    const backupPath = result.backupPath!;
+    expect(statSync(backupPath).mode & 0o777).toBe(0o600);
+    // The backup DOES legitimately carry the token (it's a snapshot of the
+    // token-bearing file as it stood before this edit) — the fix is the file
+    // MODE being restrictive, not stripping the content from the backup.
+    expect(readFileSync(backupPath, "utf-8")).toContain("MY-REAL-BOT-TOKEN");
+  });
 });
 
 describe("patchStackYaml", () => {

--- a/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
@@ -143,7 +143,11 @@ describe("validateEnvContract — shape violations", () => {
 
   test("a 19-digit snowflake (realistic Discord id length) is valid shape", () => {
     const env = validEnv();
-    env.CTX_MY_DISCORD_ID = "1234567890123456789";
+    // Repeated-digit — the confidentiality-gate's platform-snowflake pattern
+    // (17-20 digit run) allow-lists all-same-digit values as an obvious
+    // placeholder; a sequential run like "123456789…" is NOT allow-listed and
+    // trips the gate even though it's just as clearly synthetic.
+    env.CTX_MY_DISCORD_ID = "5555555555555555555";
     const result = validateEnvContract(env);
     expect(result.ok).toBe(true);
   });

--- a/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
@@ -1,0 +1,444 @@
+/**
+ * cortex#2094 (L3) — pure-logic tests for `quickstart-lib.ts`.
+ *
+ * Covers the env-contract validation matrix, the nats .conf renderer, the
+ * guarded comment-preserving YAML patch (incl. idempotency — a second patch
+ * with the SAME values must be byte-identical, no write), the healthy-boot
+ * gate line-matcher, and — the non-negotiable one — that a set secret value
+ * NEVER appears anywhere in what `validateEnvContract`/`renderEnvTable`
+ * return, even though the secret gates `ok`.
+ *
+ * Temp-dir isolated for every fs-touching test; never touches real
+ * ~/.config or ~/.claude.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, statSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  CTX_REQUIRED_KEYS,
+  daemonLogPath,
+  evaluateHealthyBootGate,
+  gatePassed,
+  natsConfPath,
+  nkeyBasenameForSlug,
+  patchStackYaml,
+  patchSurfacesYaml,
+  patchSystemNatsPort,
+  renderEnvTable,
+  renderNatsConf,
+  validateEnvContract,
+} from "../quickstart-lib";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "c2094-quickstart-lib-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+/** A fully valid env — every test mutates a shallow copy of this. */
+function validEnv(): NodeJS.ProcessEnv {
+  return {
+    CTX_PRINCIPAL: "andreas",
+    CTX_SLUG: "work",
+    CTX_NATS_PORT: "4222",
+    CTX_NATS_MON: "8222",
+    CTX_GUILD_ID: "111111111111111111",
+    CTX_CHANNEL_ID: "222222222222222222",
+    CTX_LOG_CHANNEL_ID: "333333333333333333",
+    CTX_MY_DISCORD_ID: "444444444444444444",
+    CTX_DISCORD_TOKEN: "THE-REAL-SECRET-TOKEN-VALUE",
+  };
+}
+
+const SECRET = "THE-REAL-SECRET-TOKEN-VALUE";
+
+// =============================================================================
+// env-validation matrix
+// =============================================================================
+
+describe("validateEnvContract — the happy path", () => {
+  test("a fully valid env validates ok with every value present", () => {
+    const result = validateEnvContract(validEnv());
+    expect(result.ok).toBe(true);
+    expect(result.values?.CTX_SLUG).toBe("work");
+    expect(result.values?.CTX_PRINCIPAL).toBe("andreas");
+  });
+
+  test("CLAUDE_CODE_OAUTH_TOKEN absent does NOT block ok (optional on native hosts)", () => {
+    const env = validEnv();
+    delete env.CLAUDE_CODE_OAUTH_TOKEN;
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(true);
+    expect(result.secrets.find((s) => s.key === "CLAUDE_CODE_OAUTH_TOKEN")?.status).toBe("missing");
+  });
+});
+
+describe("validateEnvContract — missing required keys", () => {
+  for (const key of CTX_REQUIRED_KEYS) {
+    test(`missing ${key} → not ok, reported as missing`, () => {
+      const env = validEnv();
+      Reflect.deleteProperty(env, key);
+      const result = validateEnvContract(env);
+      expect(result.ok).toBe(false);
+      expect(result.values).toBeUndefined();
+      const check = result.checks.find((c) => c.key === key);
+      expect(check?.ok).toBe(false);
+      expect(check?.reason).toBe("missing");
+    });
+  }
+
+  test("CTX_DISCORD_TOKEN missing → not ok (it gates, unlike the oauth token)", () => {
+    const env = validEnv();
+    delete env.CTX_DISCORD_TOKEN;
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("validateEnvContract — shape violations", () => {
+  test("CTX_SLUG uppercase → invalid shape", () => {
+    const env = validEnv();
+    env.CTX_SLUG = "Work";
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((c) => c.key === "CTX_SLUG")?.ok).toBe(false);
+  });
+
+  test("CTX_PRINCIPAL with underscore → invalid shape (stricter than slug)", () => {
+    const env = validEnv();
+    env.CTX_PRINCIPAL = "an_dreas";
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("CTX_NATS_PORT non-numeric → invalid shape", () => {
+    const env = validEnv();
+    env.CTX_NATS_PORT = "not-a-port";
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((c) => c.key === "CTX_NATS_PORT")?.reason).toContain("port");
+  });
+
+  test("CTX_NATS_PORT out of range (>65535) → invalid shape", () => {
+    const env = validEnv();
+    env.CTX_NATS_PORT = "99999";
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("CTX_GUILD_ID non-numeric → invalid shape (a Discord snowflake is digits only)", () => {
+    const env = validEnv();
+    env.CTX_GUILD_ID = "not-a-snowflake";
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((c) => c.key === "CTX_GUILD_ID")?.reason).toContain("snowflake");
+  });
+
+  test("a 19-digit snowflake (realistic Discord id length) is valid shape", () => {
+    const env = validEnv();
+    env.CTX_MY_DISCORD_ID = "1234567890123456789";
+    const result = validateEnvContract(env);
+    expect(result.ok).toBe(true);
+  });
+});
+
+// =============================================================================
+// secret non-echo — the non-negotiable one
+// =============================================================================
+
+describe("secret hygiene — CTX_DISCORD_TOKEN never echoed", () => {
+  test("validateEnvContract's result never carries the token value anywhere", () => {
+    const result = validateEnvContract(validEnv());
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(SECRET);
+    // The secrets bucket must carry only the status enum, never a `value` field.
+    const tokenEntry = result.secrets.find((s) => s.key === "CTX_DISCORD_TOKEN");
+    expect(tokenEntry).toEqual({ key: "CTX_DISCORD_TOKEN", status: "set" });
+  });
+
+  test("renderEnvTable's rendered text never contains the token value", () => {
+    const result = validateEnvContract(validEnv());
+    const table = renderEnvTable(result);
+    expect(table).not.toContain(SECRET);
+    expect(table).toContain("CTX_DISCORD_TOKEN: set");
+  });
+
+  test("renderEnvTable reports missing without ever having carried a value", () => {
+    const env = validEnv();
+    delete env.CTX_DISCORD_TOKEN;
+    const table = renderEnvTable(validateEnvContract(env));
+    expect(table).toContain("CTX_DISCORD_TOKEN: missing");
+    expect(table).not.toContain(SECRET);
+  });
+});
+
+// =============================================================================
+// nats conf renderer
+// =============================================================================
+
+describe("renderNatsConf / natsConfPath", () => {
+  test("matches the Appendix-A shape (§4)", () => {
+    const conf = renderNatsConf({
+      slug: "work",
+      principal: "andreas",
+      port: "4223",
+      monitorPort: "8223",
+      natsDir: "/home/andreas/.config/nats",
+    });
+    expect(conf).toContain("server_name: work-andreas");
+    expect(conf).toContain("listen: 127.0.0.1:4223");
+    expect(conf).toContain("http: 127.0.0.1:8223");
+    expect(conf).toContain("store_dir: /home/andreas/.config/nats/work-jetstream");
+    expect(conf).toContain("domain: work-andreas");
+  });
+
+  test("natsConfPath joins natsDir + <slug>.conf", () => {
+    expect(natsConfPath("/x/nats", "work")).toBe("/x/nats/work.conf");
+  });
+});
+
+// =============================================================================
+// nkey basename derivation (mirrors postupgrade.sh)
+// =============================================================================
+
+describe("nkeyBasenameForSlug", () => {
+  test("meta-factory → cortex (the historical single-file default)", () => {
+    expect(nkeyBasenameForSlug("meta-factory")).toBe("cortex");
+  });
+  test("any other slug → cortex-<slug>", () => {
+    expect(nkeyBasenameForSlug("work")).toBe("cortex-work");
+  });
+});
+
+// =============================================================================
+// Guarded YAML patch — idempotency (the "second run: zero mutations" guarantee)
+// =============================================================================
+
+const SURFACES_FIXTURE = `# =============================================================================
+# surfaces/surfaces.yaml — the shared surface-gateway binding map (IAW CFG.c)
+# =============================================================================
+surfaces:
+  discord:
+    - agent: assistant
+      stack: andreas/work
+      binding:
+        token: "<REPLACE_ME>"            # the bot token (chmod 600 the file)
+        guildId: "<REPLACE_ME>"
+        agentChannelId: "<REPLACE_ME>"
+        logChannelId: "<REPLACE_ME>"
+`;
+
+const STACK_FIXTURE = `# =============================================================================
+# stacks/work.yaml — this stack's per-deployment layer
+# =============================================================================
+principal:
+  id: andreas
+  displayName: andreas
+  discordId: "<REPLACE_ME>"   # your numeric Discord snowflake
+
+stack:
+  id: andreas/work
+  nkey_seed_path: ~/.config/nats/cortex-work.nk
+  nkey_pub: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+policy:
+  principals:
+    - id: assistant
+      home_principal: andreas
+      home_stack: andreas/work
+      platform_ids: {}
+    - id: andreas
+      home_principal: andreas
+      home_stack: andreas/work
+      platform_ids:
+        discord:
+          - "<REPLACE_ME>"            # your numeric Discord id
+`;
+
+const SYSTEM_FIXTURE = `# =============================================================================
+# system.yaml — the cross-cutting machine / substrate layer
+# =============================================================================
+nats:
+  url: nats://127.0.0.1:4222   # review host:port for your NATS server (default: local 4222)
+  name: cortex-work
+`;
+
+describe("patchSurfacesYaml", () => {
+  function seed(dir: string): string {
+    const path = join(dir, "surfaces.yaml");
+    writeFileSync(path, SURFACES_FIXTURE, { mode: 0o600 });
+    return path;
+  }
+
+  test("first patch writes the real values and preserves the section banner", () => {
+    const dir = freshDir();
+    const path = seed(dir);
+    const result = patchSurfacesYaml(path, {
+      token: "MY-REAL-BOT-TOKEN",
+      guildId: "111",
+      agentChannelId: "222",
+      logChannelId: "333",
+    });
+    expect(result.changed).toBe(true);
+    const text = readFileSync(path, "utf-8");
+    expect(text).toContain("the shared surface-gateway binding map");
+    expect(text).toContain('token: "MY-REAL-BOT-TOKEN"');
+    expect(text).toContain('guildId: "111"');
+    // the file was born 0600 (scaffold birth) — the patch must preserve that.
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test("a second patch with the SAME values is a byte-identical no-op", () => {
+    const dir = freshDir();
+    const path = seed(dir);
+    const opts = { token: "MY-REAL-BOT-TOKEN", guildId: "111", agentChannelId: "222", logChannelId: "333" };
+    patchSurfacesYaml(path, opts);
+    const afterFirst = readFileSync(path, "utf-8");
+    const mtimeAfterFirst = statSync(path).mtimeMs;
+
+    const second = patchSurfacesYaml(path, opts);
+    expect(second.changed).toBe(false);
+    expect(readFileSync(path, "utf-8")).toBe(afterFirst);
+    expect(statSync(path).mtimeMs).toBe(mtimeAfterFirst); // untouched — no write happened at all
+  });
+
+  test("a backup file is created only when a write actually happens", () => {
+    const dir = freshDir();
+    const path = seed(dir);
+    const opts = { token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" };
+    patchSurfacesYaml(path, opts);
+    const entriesAfterFirst = readdirSync(dir);
+    expect(entriesAfterFirst.some((f) => f.includes(".pre-quickstart-surfaces-"))).toBe(true);
+
+    const countBefore = entriesAfterFirst.length;
+    patchSurfacesYaml(path, opts); // no-op — must NOT create a second backup
+    const entriesAfterSecond = readdirSync(dir);
+    expect(entriesAfterSecond.length).toBe(countBefore);
+  });
+});
+
+describe("patchStackYaml", () => {
+  test("sets principal.discordId AND the human principals[] entry's platform_ids.discord[0]", () => {
+    const dir = freshDir();
+    mkdirSync(join(dir, "work"), { recursive: true });
+    const path = join(dir, "work", "stacks-work.yaml");
+    writeFileSync(path, STACK_FIXTURE, { mode: 0o600 });
+    // pointerConfigPath validation is skipped by pointing "pointerPath" at a
+    // path that doesn't exist — validateConfigLoads then fails closed, which
+    // this test asserts is surfaced via composeErrors rather than silently
+    // dropped, without needing a full config-split fixture tree.
+    const result = patchStackYaml(path, join(dir, "does-not-exist.yaml"), {
+      principal: "andreas",
+      discordId: "999888777",
+    });
+    expect(result.changed).toBe(true);
+    const text = readFileSync(path, "utf-8");
+    expect(text).toContain('discordId: "999888777"');
+    // exactly one occurrence in policy.principals[] (the human entry) — the
+    // agent entry (id: assistant) has platform_ids: {} and must stay untouched.
+    expect((text.match(/999888777/g) ?? []).length).toBe(2); // principal.discordId + platform_ids.discord[0]
+    expect(text).toContain("platform_ids: {}"); // the agent entry, untouched
+  });
+
+  test("idempotent: second patch with the same discordId is a no-op", () => {
+    const dir = freshDir();
+    const path = join(dir, "stack.yaml");
+    writeFileSync(path, STACK_FIXTURE, { mode: 0o600 });
+    const opts = { principal: "andreas", discordId: "999888777" };
+    patchStackYaml(path, join(dir, "no-pointer.yaml"), opts);
+    const after = readFileSync(path, "utf-8");
+    const second = patchStackYaml(path, join(dir, "no-pointer.yaml"), opts);
+    expect(second.changed).toBe(false);
+    expect(readFileSync(path, "utf-8")).toBe(after);
+  });
+
+  test("throws when no policy.principals[] entry matches the principal id", () => {
+    const dir = freshDir();
+    const path = join(dir, "stack.yaml");
+    writeFileSync(path, STACK_FIXTURE, { mode: 0o600 });
+    expect(() =>
+      patchStackYaml(path, join(dir, "no-pointer.yaml"), { principal: "nobody", discordId: "1" }),
+    ).toThrow();
+    // Must have restored the original — a thrown patch never leaves a half-write.
+    expect(readFileSync(path, "utf-8")).toBe(STACK_FIXTURE);
+  });
+});
+
+describe("patchSystemNatsPort", () => {
+  test("rewrites nats.url's port and preserves the trailing comment", () => {
+    const dir = freshDir();
+    const path = join(dir, "system.yaml");
+    writeFileSync(path, SYSTEM_FIXTURE, { mode: 0o600 });
+    const result = patchSystemNatsPort(path, "4223");
+    expect(result.changed).toBe(true);
+    const text = readFileSync(path, "utf-8");
+    expect(text).toContain("url: nats://127.0.0.1:4223");
+    expect(text).toContain("# review host:port for your NATS server");
+  });
+
+  test("idempotent: re-patching the same port is a no-op", () => {
+    const dir = freshDir();
+    const path = join(dir, "system.yaml");
+    writeFileSync(path, SYSTEM_FIXTURE, { mode: 0o600 });
+    patchSystemNatsPort(path, "4223");
+    const after = readFileSync(path, "utf-8");
+    const second = patchSystemNatsPort(path, "4223");
+    expect(second.changed).toBe(false);
+    expect(readFileSync(path, "utf-8")).toBe(after);
+  });
+});
+
+// =============================================================================
+// healthy-boot gate (§5)
+// =============================================================================
+
+describe("evaluateHealthyBootGate / gatePassed", () => {
+  test("undefined log (not written yet) → every line unmatched", () => {
+    const lines = evaluateHealthyBootGate(undefined);
+    expect(lines.every((l) => !l.matched)).toBe(true);
+    expect(gatePassed(lines, true)).toBe(false);
+  });
+
+  test("all five §5 substrings present + healthz ok → gate passes", () => {
+    const log = [
+      "Stack: andreas/work",
+      "connected to nats://127.0.0.1:4222",
+      "policy-engine active — principals=2",
+      "discord adapter started (… Guild: 111)",
+      "connected as Bot#0001",
+    ].join("\n");
+    const lines = evaluateHealthyBootGate(log);
+    expect(lines.every((l) => l.matched)).toBe(true);
+    expect(gatePassed(lines, true)).toBe(true);
+  });
+
+  test("healthz false still fails the gate even with all log lines present", () => {
+    const log = "Stack: x\nconnected to nats\npolicy-engine active\nconnected as Bot\nGuild: 1";
+    const lines = evaluateHealthyBootGate(log);
+    expect(gatePassed(lines, false)).toBe(false);
+  });
+
+  test("one missing line fails the gate", () => {
+    const log = "Stack: x\nconnected to nats\npolicy-engine active\nconnected as Bot"; // no Guild:
+    const lines = evaluateHealthyBootGate(log);
+    expect(gatePassed(lines, true)).toBe(false);
+    expect(lines.find((l) => l.label === "Guild:")?.matched).toBe(false);
+  });
+});
+
+// =============================================================================
+// daemonLogPath
+// =============================================================================
+
+test("daemonLogPath matches §5's target path shape", () => {
+  expect(daemonLogPath("/home/andreas", "work")).toBe(
+    "/home/andreas/.local/state/metafactory/cortex/logs/cortex-work.log",
+  );
+});

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -1,0 +1,570 @@
+/**
+ * cortex#2094 (L3) — `cortex quickstart` CLI dispatcher tests.
+ *
+ * Exercises the full 8-step orchestration through `dispatchQuickstart` with
+ * an INJECTED fake `QuickstartPorts` bundle (never a real `systemctl` /
+ * `loginctl` / `claude` spawn, never a real HTTP call, never a real
+ * wall-clock wait in the gate poll loop — `gate.sleep`/`gate.now` are a fake
+ * deterministic clock). Steps 3-5 (nats conf / scaffold / config patch) do
+ * real fs I/O against a fresh tmp `--config-dir`/`--nats-dir` per test —
+ * NEVER the real `~/.config/cortex`.
+ *
+ * `$HOME` is sandboxed for the whole file (mirrors `stack-cli.test.ts`):
+ * `stack create --apply`'s workspace-dir creation (cortex#2097) resolves off
+ * `homedir()`, not `--config-dir`, so it must be redirected too.
+ *
+ * Covers: preflight failure modes (incl. the cortex#2068 auth-failure
+ * message reuse), env-contract gating, nats-conf write/refuse/--force,
+ * scaffold + idempotent re-run, the injectable systemd seam (unit files
+ * missing / enable failure / happy path, all on a FAKED "linux"
+ * `process.platform` — never a real systemd host), the gate's bounded-wait
+ * timeout, and — end to end — that the Discord bot token NEVER appears
+ * anywhere in `stdout` across a full run, and that a second run mutates
+ * NOTHING (a full before/after fs snapshot of the config + nats trees).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  rmSync,
+  existsSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { dispatchQuickstart } from "../quickstart";
+import type {
+  CommandResult,
+  GatePort,
+  PreflightPorts,
+  ProvisionPort,
+  QuickstartPorts,
+  ServicePort,
+} from "../quickstart-ports";
+
+const SECRET_TOKEN = "THE-REAL-DISCORD-BOT-TOKEN-VALUE-abc123";
+
+// =============================================================================
+// $HOME sandbox (cortex#2097 workspace-dir creation resolves off homedir())
+// =============================================================================
+
+let sandboxHome: string;
+let savedHome: string | undefined;
+beforeAll(() => {
+  savedHome = process.env.HOME;
+  sandboxHome = mkdtempSync(join(tmpdir(), "c2094-quickstart-home-"));
+  process.env.HOME = sandboxHome;
+});
+afterAll(() => {
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
+  rmSync(sandboxHome, { recursive: true, force: true });
+});
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "c2094-quickstart-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+// =============================================================================
+// process.platform sandbox — Linux-only step 7 is exercised via a FAKED
+// platform value, never a real systemd host.
+// =============================================================================
+
+// `dispatchQuickstart` is async — step 7's `process.platform` read happens
+// well after several `await`s, so the override must stay in place across the
+// WHOLE awaited call, not just the synchronous call-setup. Restoring in a
+// non-awaited `finally` (the naive version) resets `platform` before step 7
+// ever runs.
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const orig = process.platform;
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", { value: orig, configurable: true });
+  }
+}
+
+// =============================================================================
+// CTX_* env sandbox
+// =============================================================================
+
+const CTX_KEYS = [
+  "CTX_PRINCIPAL",
+  "CTX_SLUG",
+  "CTX_NATS_PORT",
+  "CTX_NATS_MON",
+  "CTX_GUILD_ID",
+  "CTX_CHANNEL_ID",
+  "CTX_LOG_CHANNEL_ID",
+  "CTX_MY_DISCORD_ID",
+  "CTX_DISCORD_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+] as const;
+
+function withEnv<T>(env: Partial<Record<(typeof CTX_KEYS)[number], string>>, fn: () => Promise<T>): Promise<T> {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of CTX_KEYS) saved[k] = process.env[k];
+  for (const k of CTX_KEYS) Reflect.deleteProperty(process.env, k);
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  return fn().finally(() => {
+    for (const k of CTX_KEYS) {
+      if (saved[k] === undefined) Reflect.deleteProperty(process.env, k);
+      else process.env[k] = saved[k];
+    }
+  });
+}
+
+function validCtxEnv(overrides: Partial<Record<(typeof CTX_KEYS)[number], string>> = {}): Record<string, string> {
+  return {
+    CTX_PRINCIPAL: "andreas",
+    CTX_SLUG: "work",
+    CTX_NATS_PORT: "4222",
+    CTX_NATS_MON: "8222",
+    CTX_GUILD_ID: "111111111111111111",
+    CTX_CHANNEL_ID: "222222222222222222",
+    CTX_LOG_CHANNEL_ID: "333333333333333333",
+    CTX_MY_DISCORD_ID: "444444444444444444",
+    CTX_DISCORD_TOKEN: SECRET_TOKEN,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Fake ports
+// =============================================================================
+
+const FULL_HEALTHY_LOG = [
+  "Stack: andreas/work",
+  "connected to nats://127.0.0.1:4222",
+  "policy-engine active — principals=2",
+  "discord adapter started (… Guild: 111111111111111111)",
+  "connected as Bot#0001",
+].join("\n");
+
+interface FakeOverrides {
+  which?: (bin: string) => string | undefined;
+  claudeVersion?: () => CommandResult;
+  lingerStatus?: () => "yes" | "no" | "unknown";
+  unitFileExists?: (unit: string) => boolean;
+  daemonReload?: () => CommandResult;
+  enableNow?: (units: string[]) => CommandResult;
+  provisionSeed?: () => CommandResult;
+  readLog?: () => string | undefined;
+  fetchHealthz?: () => Promise<boolean>;
+}
+
+function fakePorts(overrides: FakeOverrides = {}): QuickstartPorts {
+  let clock = 0;
+  const preflight: PreflightPorts = {
+    which: overrides.which ?? ((bin) => `/usr/bin/${bin}`),
+    claudeVersion: overrides.claudeVersion ?? (() => ({ exitCode: 0, stdout: "2.1.0", stderr: "" })),
+    lingerStatus: overrides.lingerStatus ?? (() => "yes"),
+  };
+  const service: ServicePort = {
+    unitFileExists: overrides.unitFileExists ?? (() => true),
+    daemonReload: overrides.daemonReload ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
+    enableNow: overrides.enableNow ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
+  };
+  const provision: ProvisionPort = {
+    provisionSeed: overrides.provisionSeed ?? (() => ({ exitCode: 0, stdout: "  ⊘ NKey already exists — reusing\n", stderr: "" })),
+  };
+  const gate: GatePort = {
+    readLog: overrides.readLog ?? (() => FULL_HEALTHY_LOG),
+    fetchHealthz: overrides.fetchHealthz ?? (() => Promise.resolve(true)),
+    sleep: (ms: number) => {
+      clock += ms;
+      return Promise.resolve();
+    },
+    now: () => clock,
+  };
+  return { preflight, service, provision, gate };
+}
+
+/** Recursive snapshot of every file's size + mtime under `dirs` — used to
+ *  prove a re-run mutates NOTHING (cortex#2094 acceptance criteria). */
+function snapshotTree(dirs: string[]): Record<string, { size: number; mtimeMs: number }> {
+  const out: Record<string, { size: number; mtimeMs: number }> = {};
+  const walk = (dir: string): void => {
+    if (!existsSync(dir)) return;
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full);
+      else out[full] = { size: st.size, mtimeMs: st.mtimeMs };
+    }
+  };
+  for (const d of dirs) walk(d);
+  return out;
+}
+
+// =============================================================================
+// --help / usage
+// =============================================================================
+
+describe("dispatchQuickstart — usage", () => {
+  test("--help → exit 0, describes the 8 steps", async () => {
+    const res = await dispatchQuickstart(["--help"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex quickstart");
+    expect(res.stdout).toContain("CTX_PRINCIPAL");
+  });
+
+  test("unknown flag → exit 2", async () => {
+    const res = await dispatchQuickstart(["--bogus"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("unknown flag: --bogus");
+  });
+
+  test("--config-dir with no value → exit 2", async () => {
+    const res = await dispatchQuickstart(["--config-dir"]);
+    expect(res.exitCode).toBe(2);
+  });
+});
+
+// =============================================================================
+// Step 1 — preflight
+// =============================================================================
+
+describe("dispatchQuickstart — step 1 preflight", () => {
+  test("bun missing on PATH → exit 1, stops before env validation", async () => {
+    const res = await withEnv({}, () =>
+      dispatchQuickstart([], () => fakePorts({ which: (bin) => (bin === "bun" ? undefined : `/usr/bin/${bin}`) })),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("bun on PATH");
+    // never reached step 2 — no env-contract table printed.
+    expect(res.stdout).not.toContain("Validate env contract");
+  });
+
+  test("claude missing on PATH → exit 1, actionable install hint", async () => {
+    const res = await withEnv({}, () =>
+      dispatchQuickstart([], () => fakePorts({ which: (bin) => (bin === "claude" ? undefined : `/usr/bin/${bin}`) })),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("claude on PATH — install Claude Code first");
+  });
+
+  test("claude present but auth expired → cortex#2068 message verbatim", async () => {
+    const res = await withEnv({}, () =>
+      dispatchQuickstart([], () =>
+        fakePorts({
+          claudeVersion: () => ({
+            exitCode: 1,
+            stdout: "",
+            stderr: "Error: OAuth token has expired. Please run `claude login` to re-authenticate.",
+          }),
+        }),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("the host's authentication has expired");
+    expect(res.stdout).toContain("run `claude` in a terminal");
+  });
+
+  test("nats-server missing on PATH → exit 1", async () => {
+    const res = await withEnv({}, () =>
+      dispatchQuickstart([], () => fakePorts({ which: (bin) => (bin === "nats-server" ? undefined : `/usr/bin/${bin}`) })),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("nats-server on PATH");
+  });
+
+  test("Linux + linger disabled → exit 1, prints the exact sudo command", async () => {
+    const savedUser = process.env.USER;
+    process.env.USER = "andreas";
+    try {
+      const res = await withPlatform("linux", () =>
+        withEnv({}, () => dispatchQuickstart([], () => fakePorts({ lingerStatus: () => "no" }))),
+      );
+      expect(res.exitCode).toBe(1);
+      expect(res.stdout).toContain('sudo loginctl enable-linger "andreas"');
+    } finally {
+      if (savedUser === undefined) delete process.env.USER;
+      else process.env.USER = savedUser;
+    }
+  });
+
+  test("Linux + linger status unknown → soft warning only, proceeds past preflight", async () => {
+    const res = await withPlatform("linux", () =>
+      withEnv({}, () => dispatchQuickstart([], () => fakePorts({ lingerStatus: () => "unknown" }))),
+    );
+    // env is empty in this test → step 2 fails (exit 2), proving step 1 passed.
+    expect(res.exitCode).toBe(2);
+    expect(res.stdout).toContain("linger status unknown");
+  });
+
+  test("macOS host never checks linger at all", async () => {
+    const res = await withPlatform("darwin", () =>
+      withEnv({}, () => dispatchQuickstart([], () => fakePorts())),
+    );
+    expect(res.stdout).not.toContain("linger");
+  });
+});
+
+// =============================================================================
+// Step 2 — env contract (integration-level; the full matrix is in
+// quickstart-lib.test.ts)
+// =============================================================================
+
+describe("dispatchQuickstart — step 2 env contract", () => {
+  test("no CTX_* set at all → exit 2 with the table, preflight already passed", async () => {
+    const res = await withEnv({}, () => dispatchQuickstart([], () => fakePorts()));
+    expect(res.exitCode).toBe(2);
+    expect(res.stdout).toContain("✓ bun on PATH");
+    expect(res.stdout).toContain("✗ CTX_SLUG: missing");
+  });
+
+  test("CTX_DISCORD_TOKEN missing → exit 2 (it gates, never silently proceeds)", async () => {
+    const env = validCtxEnv();
+    delete (env as Record<string, string | undefined>).CTX_DISCORD_TOKEN;
+    const res = await withEnv(env, () => dispatchQuickstart([], () => fakePorts()));
+    expect(res.exitCode).toBe(2);
+    expect(res.stdout).toContain("CTX_DISCORD_TOKEN: missing");
+  });
+});
+
+// =============================================================================
+// Step 3 — nats conf write / refuse / --force
+// =============================================================================
+
+describe("dispatchQuickstart — step 3 nats conf", () => {
+  test("a hand-written DIFFERENT .conf is refused without --force, and left untouched", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const confPath = join(natsDir, "work.conf");
+    writeFileSync(confPath, "# a principal's hand-tuned conf\nlisten: 127.0.0.1:9999\n");
+
+    const res = await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("refusing to overwrite without --force");
+    expect(readFileSync(confPath, "utf-8")).toContain("a principal's hand-tuned conf");
+  });
+
+  test("--force overwrites a differing .conf", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const confPath = join(natsDir, "work.conf");
+    writeFileSync(confPath, "# stale\nlisten: 127.0.0.1:9999\n");
+
+    const res = await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--force"], () => fakePorts()),
+    );
+    // step 3 itself must succeed (may still fail later steps — that's fine,
+    // this test only asserts the conf got overwritten).
+    expect(res.stdout).toContain("overwritten (--force)");
+    expect(readFileSync(confPath, "utf-8")).toContain("listen: 127.0.0.1:4222");
+  });
+});
+
+// =============================================================================
+// Step 7 — the injectable systemd seam (FAKED "linux", never a real host)
+// =============================================================================
+
+describe("dispatchQuickstart — step 7 services (injected, faked platform)", () => {
+  test("missing L1 unit files → exit 1, names cortex#2071 as the dependency", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () => fakePorts({ unitFileExists: () => false }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("REQUIRES cortex#2071");
+  });
+
+  test("enable --now failure surfaces systemctl's stderr and exits 1", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              enableNow: () => ({ exitCode: 1, stdout: "", stderr: "Failed to enable unit: Unit not found." }),
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("Unit not found");
+  });
+
+  test("--skip-services bypasses the whole step even on a faked Linux platform", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--skip-services"],
+          () => fakePorts({ unitFileExists: () => false }), // would fail step 7 if NOT skipped
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("--skip-services passed");
+  });
+});
+
+// =============================================================================
+// Step 8 — bounded-wait gate timeout (fake deterministic clock, no real wait)
+// =============================================================================
+
+describe("dispatchQuickstart — step 8 gate", () => {
+  test("gate never satisfied → times out at the configured window, exit 1", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(
+        ["--config-dir", configDir, "--nats-dir", natsDir, "--gate-timeout-ms", "5000"],
+        () => fakePorts({ readLog: () => undefined, fetchHealthz: () => Promise.resolve(false) }),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("timed out after 5000ms");
+    expect(res.stdout).toContain("✗ Stack:");
+    expect(res.stdout).toContain("✗ nats /healthz");
+  });
+});
+
+// =============================================================================
+// End to end — happy path, secret non-echo, and idempotent re-run
+// =============================================================================
+
+describe("dispatchQuickstart — end to end (macOS: step 7 auto-skips)", () => {
+  test("a full run succeeds, patches the scaffold, and NEVER echoes the token", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex quickstart: complete");
+    // the non-negotiable one: the real token value never appears in ANY
+    // output this whole run produced (stdout + stderr).
+    expect(res.stdout).not.toContain(SECRET_TOKEN);
+    expect(res.stderr).not.toContain(SECRET_TOKEN);
+
+    const surfaces = readFileSync(join(configDir, "work", "surfaces", "surfaces.yaml"), "utf-8");
+    expect(surfaces).toContain(`token: "${SECRET_TOKEN}"`); // the FILE carries it — only stdout/stderr must not
+    const stack = readFileSync(join(configDir, "work", "stacks", "work.yaml"), "utf-8");
+    expect(stack).toContain('discordId: "444444444444444444"');
+    expect(existsSync(join(natsDir, "work.conf"))).toBe(true);
+  });
+
+  test("a second run against the same state mutates NOTHING (checksum both trees)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const run = () =>
+      withPlatform("darwin", () =>
+        withEnv(validCtxEnv(), () =>
+          dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+        ),
+      );
+
+    const first = await run();
+    expect(first.exitCode).toBe(0);
+
+    const before = snapshotTree([configDir, natsDir]);
+    const second = await run();
+    expect(second.exitCode).toBe(0);
+    const after = snapshotTree([configDir, natsDir]);
+
+    expect(after).toEqual(before);
+    // Every step reported a skip/verified outcome, not a fresh write.
+    expect(second.stdout).toContain("already up to date (skip)");
+    expect(second.stdout).toContain("already exists with matching identity");
+    expect(second.stdout).not.toContain(SECRET_TOKEN);
+  });
+
+  test("re-running with a DIFFERENT principal for the same slug is refused, not silently accepted", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const first = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+      ),
+    );
+    expect(first.exitCode).toBe(0);
+
+    const second = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv({ CTX_PRINCIPAL: "someone-else" }), () =>
+        // --force: a different principal also renders a different nats .conf
+        // (server_name/domain embed the principal) — force past step 3 so
+        // this test isolates step 4's identity-mismatch refusal.
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--force"], () => fakePorts()),
+      ),
+    );
+    expect(second.exitCode).toBe(1);
+    expect(second.stdout).toContain("does not match the expected");
+  });
+});
+
+// =============================================================================
+// End to end — Linux happy path (faked platform + injected systemd seam)
+// =============================================================================
+
+describe("dispatchQuickstart — end to end (faked Linux, step 7 exercised)", () => {
+  test("full run through services + gate on a faked Linux host", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("systemctl --user daemon-reload");
+    expect(res.stdout).toContain("systemctl --user enable --now nats@work cortex@work");
+    expect(res.stdout).not.toContain(SECRET_TOKEN);
+  });
+});
+
+// =============================================================================
+// --json envelope
+// =============================================================================
+
+describe("dispatchQuickstart — --json", () => {
+  test("failure envelope carries no secret and reports the failing step", async () => {
+    const res = await withEnv({}, () => dispatchQuickstart(["--json"], () => fakePorts()));
+    expect(res.exitCode).toBe(2);
+    const parsed = JSON.parse(res.stdout) as { status: string; error?: { reason: string } };
+    expect(parsed.status).toBe("error");
+    expect(parsed.error?.reason).toBe("2. Validate env contract");
+    expect(res.stdout).not.toContain(SECRET_TOKEN);
+  });
+
+  test("success envelope on a full run", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--json"], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as { status: string };
+    expect(parsed.status).toBe("ok");
+    expect(res.stdout).not.toContain(SECRET_TOKEN);
+  });
+});

--- a/src/cli/cortex/commands/network-config-write.ts
+++ b/src/cli/cortex/commands/network-config-write.ts
@@ -133,11 +133,17 @@ export function writeNetworksGuarded(
   mkdirSync(dirname(path), { recursive: true });
 
   // (2) Timestamped backup (only when a file existed — a fresh file is removed on
-  // failure instead).
+  // failure instead). The backup carries the file's CURRENT content — which, when
+  // a network entry already carries a payload_key from an earlier write, means the
+  // backup carries that secret too. Written at the file's own mode from creation
+  // (and re-chmodded, umask-proof) so a secret-bearing config never produces a
+  // world-readable backup — `originalMode` is always defined here (`existed` guards
+  // this branch, and `originalMode` is only ever `undefined` when `!existed`).
   let backupPath: string | undefined;
-  if (existed && originalText !== undefined) {
+  if (existed && originalText !== undefined && originalMode !== undefined) {
     backupPath = `${path}.pre-${backupLabel}-${backupStamp()}.bak`;
-    writeFileSync(backupPath, originalText, "utf-8");
+    writeFileSync(backupPath, originalText, { encoding: "utf-8", mode: originalMode });
+    chmodSync(backupPath, originalMode);
   }
 
   // (3) Atomic write, then (4) re-parse verify the networks round-trip. Any parse

--- a/src/cli/cortex/commands/quickstart-adapters.ts
+++ b/src/cli/cortex/commands/quickstart-adapters.ts
@@ -1,0 +1,182 @@
+/**
+ * `cortex quickstart` — LIVE adapters (cortex#2094, L3).
+ *
+ * Wires real `PATH` resolution, real subprocess spawns, and real HTTP into
+ * the {@link QuickstartPorts} the orchestrator (`quickstart.ts`) depends on.
+ * Constructed only on a real `cortex quickstart` invocation; tests inject
+ * fakes (`quickstart-lib.test.ts` / `quickstart.test.ts`) and never reach
+ * this file — no real `systemctl`/`loginctl` exists on the macOS dev/CI hosts
+ * these tests run on.
+ *
+ * Every spawn is wrapped so a missing binary or a spawn-level failure (EACCES,
+ * ENOENT racing a PATH check) surfaces as a `CommandResult` with a synthetic
+ * non-zero exit code, never an uncaught throw — a preflight/service check
+ * failing is an ordinary, expected outcome for quickstart, not a bug.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import type {
+  CommandResult,
+  GatePort,
+  PreflightPorts,
+  ProvisionPort,
+  ServicePort,
+} from "./quickstart-ports";
+
+// =============================================================================
+// Shared spawn helper
+// =============================================================================
+
+/** Run `cmd` synchronously, capturing stdout/stderr. Never throws — a spawn
+ *  failure (missing binary, EACCES) is reported as `exitCode: 127` with the
+ *  error message on `stderr`, matching the shell convention for "command not
+ *  found" so callers can treat every path uniformly. */
+function runSync(cmd: string[]): CommandResult {
+  try {
+    const r = Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe" });
+    return {
+      exitCode: r.exitCode,
+      stdout: r.stdout.toString("utf-8"),
+      stderr: r.stderr.toString("utf-8"),
+    };
+  } catch (err) {
+    return {
+      exitCode: 127,
+      stdout: "",
+      stderr: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// =============================================================================
+// Preflight
+// =============================================================================
+
+export function buildPreflightPorts(): PreflightPorts {
+  return {
+    which(bin: string): string | undefined {
+      return Bun.which(bin) ?? undefined;
+    },
+    claudeVersion(): CommandResult {
+      return runSync(["claude", "--version"]);
+    },
+    lingerStatus(user: string): "yes" | "no" | "unknown" {
+      if (process.platform !== "linux") return "unknown";
+      const r = runSync(["loginctl", "show-user", user, "-p", "Linger"]);
+      if (r.exitCode !== 0) return "unknown";
+      // Output shape: a single line `Linger=yes` / `Linger=no`.
+      const m = /Linger=(yes|no)/.exec(r.stdout);
+      return m?.[1] === "yes" || m?.[1] === "no" ? m[1] : "unknown";
+    },
+  };
+}
+
+// =============================================================================
+// Service (systemd user units, Linux only)
+// =============================================================================
+
+/** Where L1 (cortex#2071) renders the two template units. Mirrors the path
+ *  Appendix A (README-AGENTS.md) documents. */
+function systemdUserUnitDir(): string {
+  return join(homedir(), ".config", "systemd", "user");
+}
+
+export function buildServicePort(): ServicePort {
+  return {
+    unitFileExists(unitTemplate: string): boolean {
+      return existsSync(join(systemdUserUnitDir(), unitTemplate));
+    },
+    daemonReload(): CommandResult {
+      return runSync(["systemctl", "--user", "daemon-reload"]);
+    },
+    enableNow(units: string[]): CommandResult {
+      return runSync(["systemctl", "--user", "enable", "--now", ...units]);
+    },
+  };
+}
+
+// =============================================================================
+// Provision (stack signing identity)
+// =============================================================================
+
+/** Repo root, resolved from THIS file's location (mirrors `release.ts`'s
+ *  `projectRoot()` — `src/cli/cortex/commands/` is 4 levels under root). */
+function repoRoot(): string {
+  return join(import.meta.dir, "..", "..", "..", "..");
+}
+
+export function buildProvisionPort(): ProvisionPort {
+  return {
+    provisionSeed(stackConfigPath: string, nkeyBasename: string): CommandResult {
+      // The SAME entry postupgrade.sh sources — invoked as a one-shot bash
+      // call rather than re-implementing seed generation / the G3 nkey_pub
+      // write-back in TypeScript. `set -e` so a mid-script failure (e.g. the
+      // config-backup `cp` failing) surfaces as a non-zero exit instead of
+      // silently continuing.
+      const scriptPath = join(repoRoot(), "scripts", "lib", "stack-identity-provision.sh");
+      const shellCmd = [
+        `source ${shellQuote(scriptPath)}`,
+        `provision_stack_identity ${shellQuote(stackConfigPath)} ${shellQuote(nkeyBasename)}`,
+      ].join("\n");
+      return runSync(["bash", "-c", shellCmd]);
+    },
+  };
+}
+
+/** Minimal single-quote shell escaping for the two path/basename arguments
+ *  passed into the `bash -c` script above. Both come from THIS process's own
+ *  resolved config paths / slug-derived basenames — never from the untrusted
+ *  CTX_* env directly — but quoting defensively costs nothing. */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+// =============================================================================
+// Gate (bounded healthy-boot wait)
+// =============================================================================
+
+export function buildGatePort(): GatePort {
+  return {
+    readLog(logPath: string): string | undefined {
+      if (!existsSync(logPath)) return undefined;
+      try {
+        return readFileSync(logPath, "utf-8");
+      } catch (_err) {
+        // Racing rotation / permission blip — treat as "not readable yet",
+        // the poll loop retries on the next tick. Safe to ignore.
+        return undefined;
+      }
+    },
+    async fetchHealthz(url: string, timeoutMs: number): Promise<boolean> {
+      try {
+        const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+        return res.ok;
+      } catch (_err) {
+        return false;
+      }
+    },
+    sleep(ms: number): Promise<void> {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    },
+    now(): number {
+      return Date.now();
+    },
+  };
+}
+
+export function buildQuickstartPorts(): {
+  preflight: PreflightPorts;
+  service: ServicePort;
+  provision: ProvisionPort;
+  gate: GatePort;
+} {
+  return {
+    preflight: buildPreflightPorts(),
+    service: buildServicePort(),
+    provision: buildProvisionPort(),
+    gate: buildGatePort(),
+  };
+}

--- a/src/cli/cortex/commands/quickstart-lib.ts
+++ b/src/cli/cortex/commands/quickstart-lib.ts
@@ -301,8 +301,12 @@ function backupStamp(): string {
 
 function atomicWriteFileSync(path: string, contents: string, mode: number): void {
   const tmpPath = `${path}.tmp`;
-  writeFileSync(tmpPath, contents, "utf-8");
-  chmodSync(tmpPath, mode); // create mode is umask-masked; re-chmod before the rename.
+  // Pass `mode` at creation (closes the window where a secret-bearing tmp
+  // file would otherwise sit at the umask default between create and chmod)
+  // AND re-chmod after (umask can still mask the creation-time mode — belt-
+  // and-braces, mirrors network-config-write.ts's atomicWriteFileSync).
+  writeFileSync(tmpPath, contents, { encoding: "utf-8", mode });
+  chmodSync(tmpPath, mode);
   renameSync(tmpPath, path);
 }
 
@@ -339,8 +343,17 @@ export function patchYamlGuarded(
     return { changed: false };
   }
 
+  // The backup carries the SAME content as the file being patched — which,
+  // on a re-run where the token/discordId was already set by an EARLIER
+  // quickstart run, means the backup carries the live secret too. Every
+  // patched file here is born 0600 (stack.ts's scaffold); write the backup
+  // at that mode from creation (and re-chmod, umask-proof) so it never has a
+  // world-readable window — the same treatment atomicWriteFileSync gives the
+  // main file, applied here because the backup is an equally secret-bearing
+  // copy, not a throwaway.
   const backupPath = `${path}.pre-${backupLabel}-${backupStamp()}.bak`;
-  writeFileSync(backupPath, originalText, "utf-8");
+  writeFileSync(backupPath, originalText, { encoding: "utf-8", mode: originalMode });
+  chmodSync(backupPath, originalMode);
 
   try {
     atomicWriteFileSync(path, nextText, originalMode);

--- a/src/cli/cortex/commands/quickstart-lib.ts
+++ b/src/cli/cortex/commands/quickstart-lib.ts
@@ -1,0 +1,502 @@
+/**
+ * `cortex quickstart` — pure logic + guarded config-write (cortex#2094, L3).
+ *
+ * Collapses the validated Debian runbook (README-AGENTS.md Appendix A + §5,
+ * merged PR#2090) into ONE idempotent command driven by the DD-L5 env
+ * contract (arc `design/linux-host-support.md`, arc#309). This module holds
+ * everything that does NOT need an injected port (`quickstart-ports.ts`):
+ *
+ *   - the `CTX_*` env-contract validation matrix (§2 of the issue)
+ *   - the Appendix-A `.conf` renderer (§4/A.1)
+ *   - the guarded, comment-preserving YAML patch for the three formerly-manual
+ *     edits (§5): `surfaces/surfaces.yaml`, `stacks/<slug>.yaml`,
+ *     `system/system.yaml`
+ *   - the §5 healthy-boot gate line-matcher
+ *
+ * Config-file I/O here is real `fs` (mirrors `stack.ts` / `network-config-
+ * write.ts` — config reads/writes are NOT behind an injected port in this
+ * codebase; only external processes/network calls are, via
+ * `quickstart-ports.ts`). Tests point every path at a tmp dir.
+ *
+ * The YAML patcher follows `network-config-write.ts`'s `writeNetworksGuarded`
+ * pattern verbatim: `parseDocument` + `setIn` (comments survive — proven
+ * against the REAL scaffold output cortex#2094 verification, not assumed),
+ * a timestamped backup, an atomic temp+rename write, and a re-parse
+ * round-trip check that restores the original on any mismatch. New here:
+ * a NO-OP short-circuit when the desired value is already in place — the
+ * `yaml` library's `parseDocument().toString()` is not perfectly
+ * byte-identical to hand-written source on the FIRST parse (it normalizes
+ * some comment spacing), but it IS a stable fixed point after that first
+ * pass — so re-running quickstart against an already-patched file reads,
+ * re-serializes, and compares BYTE-IDENTICAL, and the write is skipped
+ * entirely. That is what makes "second run: zero file mutations"
+ * (cortex#2094 acceptance criteria) hold.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { join } from "path";
+import { parseDocument } from "yaml";
+
+import { validateConfigLoads } from "../../../common/config/validate-on-write";
+
+// =============================================================================
+// Env contract (DD-L5)
+// =============================================================================
+
+/** Every non-secret `CTX_*` key quickstart requires. */
+export const CTX_REQUIRED_KEYS = [
+  "CTX_PRINCIPAL",
+  "CTX_SLUG",
+  "CTX_NATS_PORT",
+  "CTX_NATS_MON",
+  "CTX_GUILD_ID",
+  "CTX_CHANNEL_ID",
+  "CTX_LOG_CHANNEL_ID",
+  "CTX_MY_DISCORD_ID",
+] as const;
+export type CtxRequiredKey = (typeof CTX_REQUIRED_KEYS)[number];
+
+/**
+ * The two secret env vars. NEVER echoed — every table/report built from
+ * {@link validateEnvContract} carries only `"set" | "missing"` for these,
+ * never the value (cortex#2094 acceptance criteria: "Secret values never
+ * appear in stdout, stderr, or logs").
+ *
+ * `CLAUDE_CODE_OAUTH_TOKEN` is optional even when present in the schema
+ * below — "optional on native hosts where `claude` login exists" (the issue
+ * body): quickstart's step 1 preflight already confirms `claude` is
+ * authenticated via its OWN credential store, so this var is only load-
+ * bearing for a headless/container host with no interactive login. It is
+ * validated for SHAPE (non-empty when present) but never REQUIRED.
+ */
+export const CTX_SECRET_KEYS = ["CTX_DISCORD_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
+export type CtxSecretKey = (typeof CTX_SECRET_KEYS)[number];
+
+// Mirrors stack.ts's SLUG_RE / PRINCIPAL_ID_RE (the `cortex stack create`
+// grammar) — not exported from that module, so duplicated here rather than
+// widen stack.ts's surface for a one-line regex. Keep in sync if that
+// grammar ever changes.
+const SLUG_RE = /^[a-z][a-z0-9_-]*$/;
+const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
+/** Discord snowflakes are unsigned 64-bit integers rendered as decimal
+ *  strings — too large for `Number` to round-trip safely, so validated as a
+ *  digit-string, never parsed to a JS number. */
+const SNOWFLAKE_RE = /^[0-9]{1,20}$/;
+const PORT_RE = /^[0-9]{1,5}$/;
+
+/** One required key's validation verdict. */
+export interface CtxKeyCheck {
+  key: CtxRequiredKey;
+  /** `undefined` when missing entirely (distinct from present-but-invalid). */
+  value?: string;
+  ok: boolean;
+  /** Present only when `!ok` — the shape rule that failed. */
+  reason?: string;
+}
+
+/** One secret key's presence verdict — value NEVER carried here. */
+export interface CtxSecretCheck {
+  key: CtxSecretKey;
+  status: "set" | "missing";
+}
+
+export interface EnvValidationResult {
+  ok: boolean;
+  checks: CtxKeyCheck[];
+  secrets: CtxSecretCheck[];
+  /** Convenience: the typed values, only present when `ok`. Callers still
+   *  must not log `secrets` values — this map never carries the secret keys. */
+  values?: Record<CtxRequiredKey, string>;
+}
+
+/**
+ * Validate the full `CTX_*` env contract against `env` (normally
+ * `process.env`). Never throws. `ok === false` ⇒ caller exits 2 with a table
+ * of what's missing/invalid (cortex#2094 §2 + acceptance criteria).
+ */
+export function validateEnvContract(env: NodeJS.ProcessEnv): EnvValidationResult {
+  const checks: CtxKeyCheck[] = CTX_REQUIRED_KEYS.map((key) => {
+    const raw = env[key];
+    if (raw === undefined || raw.length === 0) {
+      return { key, ok: false, reason: "missing" };
+    }
+    const shape = shapeCheck(key, raw);
+    return shape.ok
+      ? { key, value: raw, ok: true }
+      : { key, value: raw, ok: false, reason: shape.reason };
+  });
+
+  const secrets: CtxSecretCheck[] = CTX_SECRET_KEYS.map((key) => ({
+    key,
+    status: env[key] !== undefined && env[key].length > 0 ? "set" : "missing",
+  }));
+
+  // CTX_DISCORD_TOKEN gates `ok` (§5 needs a real token to patch into
+  // surfaces.yaml — a quickstart run that "succeeds" with a placeholder
+  // token would leave the daemon unable to connect) even though it is
+  // validated PRESENCE-ONLY here and never enters `checks`/`values` — it
+  // must never carry a value into anything that gets echoed or table-
+  // rendered. CLAUDE_CODE_OAUTH_TOKEN does NOT gate `ok` — it is optional on
+  // a native host with an existing `claude` login (step 1 already confirmed
+  // that); only a headless/container consumer needs it.
+  const discordTokenSet = secrets.some((s) => s.key === "CTX_DISCORD_TOKEN" && s.status === "set");
+  const ok = checks.every((c) => c.ok) && discordTokenSet;
+  // `c.value` is always set when `c.ok` (validateEnvContract's own
+  // construction above never emits `ok: true` without `value`) — TS can't
+  // narrow that across the `.map`, so fall back to "" rather than an
+  // assertion (`as`/`!` are both banned here); the fallback is unreachable
+  // in practice since this whole branch is gated on `checks.every(ok)`.
+  const values = checks.every((c) => c.ok)
+    ? (Object.fromEntries(checks.map((c) => [c.key, c.value ?? ""])) as Record<CtxRequiredKey, string>)
+    : undefined;
+
+  return values !== undefined ? { ok, checks, secrets, values } : { ok, checks, secrets };
+}
+
+/** Per-key shape rule. Extracted from {@link validateEnvContract} so the
+ *  matrix is independently testable per key. */
+function shapeCheck(key: CtxRequiredKey, value: string): { ok: boolean; reason?: string } {
+  switch (key) {
+    case "CTX_PRINCIPAL":
+      return PRINCIPAL_ID_RE.test(value)
+        ? { ok: true }
+        : { ok: false, reason: "must be lowercase alphanumeric + hyphen, letter-prefixed" };
+    case "CTX_SLUG":
+      return SLUG_RE.test(value)
+        ? { ok: true }
+        : { ok: false, reason: "must be lowercase alphanumeric + hyphen/underscore, letter-prefixed" };
+    case "CTX_NATS_PORT":
+    case "CTX_NATS_MON":
+      return PORT_RE.test(value) && Number(value) > 0 && Number(value) <= 65535
+        ? { ok: true }
+        : { ok: false, reason: "must be a numeric port (1-65535)" };
+    case "CTX_GUILD_ID":
+    case "CTX_CHANNEL_ID":
+    case "CTX_LOG_CHANNEL_ID":
+    case "CTX_MY_DISCORD_ID":
+      return SNOWFLAKE_RE.test(value)
+        ? { ok: true }
+        : { ok: false, reason: "must be a numeric Discord snowflake" };
+  }
+}
+
+/** Render the validation result as a human-readable ✓/✗ table. Never prints
+ *  a secret VALUE — only `set`/`missing` for the two secret keys. */
+export function renderEnvTable(result: EnvValidationResult): string {
+  const lines: string[] = ["env contract (CTX_*):"];
+  for (const c of result.checks) {
+    const mark = c.ok ? "✓" : "✗";
+    const detail = c.ok ? (c.value ?? "") : (c.reason ?? "missing");
+    lines.push(`  ${mark} ${c.key}: ${detail}`);
+  }
+  for (const s of result.secrets) {
+    // CTX_DISCORD_TOKEN gates `ok` (see validateEnvContract) — missing is a
+    // hard ✗, matching the required checks above. CLAUDE_CODE_OAUTH_TOKEN is
+    // always optional — missing is a soft ○, never a failure mark.
+    const gates = s.key === "CTX_DISCORD_TOKEN";
+    const mark = s.status === "set" ? "✓" : gates ? "✗" : "○";
+    lines.push(`  ${mark} ${s.key}: ${s.status}`);
+  }
+  return lines.join("\n");
+}
+
+// =============================================================================
+// nats conf (§4 / A.1 shape)
+// =============================================================================
+
+export interface NatsConfInputs {
+  slug: string;
+  principal: string;
+  port: string;
+  monitorPort: string;
+  /** `~/.config/nats` by default — overridable for `--nats-dir` / tests. */
+  natsDir: string;
+}
+
+/** `<natsDir>/<slug>.conf` — the file quickstart writes/verifies. */
+export function natsConfPath(natsDir: string, slug: string): string {
+  return join(natsDir, `${slug}.conf`);
+}
+
+/** Byte-for-byte the shape README-AGENTS.md §4 documents (jetstream
+ *  store_dir under the SAME `natsDir`, `<slug>-jetstream`). */
+export function renderNatsConf(inputs: NatsConfInputs): string {
+  const { slug, principal, port, monitorPort, natsDir } = inputs;
+  return `server_name: ${slug}-${principal}
+listen: 127.0.0.1:${port}
+http: 127.0.0.1:${monitorPort}
+jetstream {
+  store_dir: ${join(natsDir, `${slug}-jetstream`)}
+  max_mem: 64mb
+  max_file: 1gb
+  domain: ${slug}-${principal}
+}
+`;
+}
+
+// =============================================================================
+// Seed provisioning basename (mirrors postupgrade.sh's derivation)
+// =============================================================================
+
+/** `meta-factory` → `cortex` (the historical single-file default stack);
+ *  everything else → `cortex-<slug>`. Verbatim mirror of postupgrade.sh's
+ *  inline `if [ "${slug}" = "meta-factory" ]` branch. */
+export function nkeyBasenameForSlug(slug: string): string {
+  return slug === "meta-factory" ? "cortex" : `cortex-${slug}`;
+}
+
+// =============================================================================
+// Config paths (config-split layout — mirrors stack-lib.ts's discoverStacks)
+// =============================================================================
+
+export function stackTargetDir(configDir: string, slug: string): string {
+  return join(configDir, slug);
+}
+export function pointerConfigPath(configDir: string, slug: string): string {
+  return join(stackTargetDir(configDir, slug), `${slug}.yaml`);
+}
+export function stackAgentConfigPath(configDir: string, slug: string): string {
+  return join(stackTargetDir(configDir, slug), "stacks", `${slug}.yaml`);
+}
+export function surfacesConfigPath(configDir: string, slug: string): string {
+  return join(stackTargetDir(configDir, slug), "surfaces", "surfaces.yaml");
+}
+export function systemConfigPath(configDir: string, slug: string): string {
+  return join(stackTargetDir(configDir, slug), "system", "system.yaml");
+}
+
+// =============================================================================
+// Guarded YAML patch (mirrors network-config-write.ts's writeNetworksGuarded)
+// =============================================================================
+
+export interface PatchResult {
+  /** `false` when the desired value(s) were already in place — no write, no
+   *  backup, the file's mtime/bytes are untouched. */
+  changed: boolean;
+  backupPath?: string;
+}
+
+/** Timestamped suffix for the pre-write backup — same shape as
+ *  `network-config-write.ts`'s `backupStamp`. */
+function backupStamp(): string {
+  const now = new Date();
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  return [
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+    "T",
+    pad(now.getHours()),
+    pad(now.getMinutes()),
+    pad(now.getSeconds()),
+  ].join("");
+}
+
+function atomicWriteFileSync(path: string, contents: string, mode: number): void {
+  const tmpPath = `${path}.tmp`;
+  writeFileSync(tmpPath, contents, "utf-8");
+  chmodSync(tmpPath, mode); // create mode is umask-masked; re-chmod before the rename.
+  renameSync(tmpPath, path);
+}
+
+/**
+ * Apply `mutate` to a `parseDocument()` of `path`'s current contents, and
+ * write back ONLY if the result differs from what's already on disk.
+ * Preserves comments (proven against the real scaffold shape — see this
+ * file's header). Backs up before writing, writes atomically, re-parses to
+ * verify `verify(doc)` holds post-write, and restores the original on any
+ * failure — the same guard shape `writeNetworksGuarded` uses, generalized
+ * over an arbitrary mutation instead of one hardcoded to
+ * `policy.federated.networks`.
+ *
+ * Throws (with the original restored) on a verify failure. Callers wrap this
+ * in their own try/catch to turn that into a clean step failure.
+ */
+export function patchYamlGuarded(
+  path: string,
+  backupLabel: string,
+  mutate: (doc: ReturnType<typeof parseDocument>) => void,
+  verify: (doc: ReturnType<typeof parseDocument>) => boolean,
+): PatchResult {
+  if (!existsSync(path)) {
+    throw new Error(`cannot patch ${path}: file does not exist`);
+  }
+  const originalText = readFileSync(path, "utf-8");
+  const originalMode = statSync(path).mode & 0o777;
+
+  const doc = parseDocument(originalText);
+  mutate(doc);
+  const nextText = doc.toString();
+
+  if (nextText === originalText) {
+    return { changed: false };
+  }
+
+  const backupPath = `${path}.pre-${backupLabel}-${backupStamp()}.bak`;
+  writeFileSync(backupPath, originalText, "utf-8");
+
+  try {
+    atomicWriteFileSync(path, nextText, originalMode);
+    const reparsed = parseDocument(readFileSync(path, "utf-8"));
+    if (!verify(reparsed)) {
+      throw new Error("patched file failed round-trip verification");
+    }
+  } catch (err) {
+    atomicWriteFileSync(path, originalText, originalMode);
+    throw new Error(
+      `guarded YAML patch failed for ${path} — restored original (backup ${backupPath}): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err },
+    );
+  }
+
+  return { changed: true, backupPath };
+}
+
+/** Find the index of the `policy.principals[]` entry whose `id` equals
+ *  `principalId` — the human principal's entry (distinct from the agent's
+ *  own entry, index 0 in the scaffold). Returns -1 when not found (a config
+ *  that doesn't match the scaffold shape quickstart itself wrote — callers
+ *  treat that as an error, not a silent skip). */
+export function findPrincipalEntryIndex(
+  doc: ReturnType<typeof parseDocument>,
+  principalId: string,
+): number {
+  const seq = doc.getIn(["policy", "principals"], true) as
+    | { items: { get: (k: string) => unknown }[] }
+    | undefined;
+  if (seq === undefined) return -1;
+  return seq.items.findIndex((item) => item.get("id") === principalId);
+}
+
+/** Patch `stacks/<slug>.yaml`: `principal.discordId` +
+ *  `policy.principals[<human>].platform_ids.discord[0]`. Also re-validates
+ *  the composed whole via `validateConfigLoads(pointerPath)` post-write (FS-7
+ *  discipline) — surfaced to the caller as part of the result so a
+ *  composition-only failure (rare; each individual write already round-trip
+ *  verifies itself) is reported rather than silently accepted. */
+export function patchStackYaml(
+  path: string,
+  pointerPath: string,
+  opts: { principal: string; discordId: string },
+): PatchResult & { composeErrors?: string[] } {
+  const result = patchYamlGuarded(
+    path,
+    "quickstart-stack",
+    (doc) => {
+      doc.setIn(["principal", "discordId"], opts.discordId);
+      const idx = findPrincipalEntryIndex(doc, opts.principal);
+      if (idx === -1) {
+        throw new Error(
+          `stacks/${opts.principal}.yaml: no policy.principals[] entry with id "${opts.principal}" — not the scaffold shape quickstart expects`,
+        );
+      }
+      doc.setIn(["policy", "principals", idx, "platform_ids", "discord", 0], opts.discordId);
+    },
+    (doc) => {
+      const idx = findPrincipalEntryIndex(doc, opts.principal);
+      if (idx === -1) return false;
+      return (
+        doc.getIn(["principal", "discordId"]) === opts.discordId &&
+        doc.getIn(["policy", "principals", idx, "platform_ids", "discord", 0]) === opts.discordId
+      );
+    },
+  );
+  if (!result.changed) return result;
+  const validation = validateConfigLoads(pointerPath);
+  return validation.ok ? result : { ...result, composeErrors: validation.errors };
+}
+
+/** Patch `surfaces/surfaces.yaml`: the sole `surfaces.discord[0].binding`
+ *  entry the scaffold writes (`stack-lib.ts`'s `surfacesYaml`). */
+export function patchSurfacesYaml(
+  path: string,
+  opts: { token: string; guildId: string; agentChannelId: string; logChannelId: string },
+): PatchResult {
+  return patchYamlGuarded(
+    path,
+    "quickstart-surfaces",
+    (doc) => {
+      doc.setIn(["surfaces", "discord", 0, "binding", "token"], opts.token);
+      doc.setIn(["surfaces", "discord", 0, "binding", "guildId"], opts.guildId);
+      doc.setIn(["surfaces", "discord", 0, "binding", "agentChannelId"], opts.agentChannelId);
+      doc.setIn(["surfaces", "discord", 0, "binding", "logChannelId"], opts.logChannelId);
+    },
+    (doc) =>
+      doc.getIn(["surfaces", "discord", 0, "binding", "token"]) === opts.token &&
+      doc.getIn(["surfaces", "discord", 0, "binding", "guildId"]) === opts.guildId &&
+      doc.getIn(["surfaces", "discord", 0, "binding", "agentChannelId"]) === opts.agentChannelId &&
+      doc.getIn(["surfaces", "discord", 0, "binding", "logChannelId"]) === opts.logChannelId,
+  );
+}
+
+/** Patch `system/system.yaml`'s `nats.url` port. Callers skip calling this
+ *  entirely when `CTX_NATS_PORT === "4222"` (the scaffold's own default —
+ *  nothing to change), matching the issue's "if CTX_NATS_PORT ≠ 4222" gate. */
+export function patchSystemNatsPort(path: string, port: string): PatchResult {
+  const url = `nats://127.0.0.1:${port}`;
+  return patchYamlGuarded(
+    path,
+    "quickstart-system",
+    (doc) => {
+      doc.setIn(["nats", "url"], url);
+    },
+    (doc) => doc.getIn(["nats", "url"]) === url,
+  );
+}
+
+// =============================================================================
+// Healthy-boot gate (§5)
+// =============================================================================
+
+/** The exact five substrings README-AGENTS.md §5's grep -E alternation
+ *  matches, in the order it lists them. */
+export const HEALTHY_BOOT_PATTERNS: readonly { label: string; pattern: RegExp }[] = [
+  { label: "Stack:", pattern: /Stack:/ },
+  { label: "connected to nats", pattern: /connected to nats/ },
+  { label: "policy-engine active", pattern: /policy-engine active/ },
+  { label: "connected as", pattern: /connected as/ },
+  { label: "Guild:", pattern: /Guild:/ },
+];
+
+export interface GateLineResult {
+  label: string;
+  matched: boolean;
+}
+
+/** Evaluate the §5 healthy-boot gate against the daemon log text.
+ *  `logText === undefined` (log not written yet) ⇒ every line is unmatched. */
+export function evaluateHealthyBootGate(logText: string | undefined): GateLineResult[] {
+  return HEALTHY_BOOT_PATTERNS.map(({ label, pattern }) => ({
+    label,
+    matched: logText !== undefined && pattern.test(logText),
+  }));
+}
+
+export function renderGateTable(lines: GateLineResult[], healthzOk: boolean): string {
+  const rows = lines.map((l) => `  ${l.matched ? "✓" : "✗"} ${l.label}`);
+  rows.push(`  ${healthzOk ? "✓" : "✗"} nats /healthz`);
+  return ["healthy-boot gate:", ...rows].join("\n");
+}
+
+export function gatePassed(lines: GateLineResult[], healthzOk: boolean): boolean {
+  return healthzOk && lines.every((l) => l.matched);
+}
+
+// =============================================================================
+// Misc path helper
+// =============================================================================
+
+/** `~/.local/state/metafactory/cortex/logs/cortex-<slug>.log` — the path §5's
+ *  grep targets. */
+export function daemonLogPath(home: string, slug: string): string {
+  return join(home, ".local", "state", "metafactory", "cortex", "logs", `cortex-${slug}.log`);
+}

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -1,0 +1,123 @@
+/**
+ * `cortex quickstart` — injected-dependency seams (cortex#2094, L3).
+ *
+ * Mirrors the `network-doctor-ports.ts` / `network-ping-ports.ts` pattern: the
+ * orchestrator (`quickstart-lib.ts` + `quickstart.ts`) is written against these
+ * PORTS; the live adapters (`quickstart-adapters.ts`) wire real `PATH` lookups,
+ * real subprocess spawns (`claude --version`, `loginctl`, `systemctl`, the
+ * provisioning shell script), and real HTTP (`/healthz`). Tests inject fakes
+ * that never touch a real PATH, spawn a real process, or open a real socket —
+ * load-bearing on macOS dev machines, where `systemctl`/`loginctl` don't exist
+ * at all.
+ *
+ * Every port method is synchronous or returns a plain awaited value (no
+ * streaming) — quickstart is a short, linear, one-shot CLI run, not a
+ * long-lived supervisor; there is no need for the richer `Spawn`/watchdog
+ * shape `process-runner.ts` uses for detached bus-triggered jobs.
+ */
+
+// =============================================================================
+// Shared result shape
+// =============================================================================
+
+/** Outcome of a synchronous subprocess run. Never throws on a non-zero exit —
+ *  callers branch on `exitCode`; a thrown port method means the subprocess
+ *  could not even be spawned (binary missing, EACCES, …). */
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+// =============================================================================
+// Preflight — step 1 (all read-only)
+// =============================================================================
+
+export interface PreflightPorts {
+  /** Resolve a binary on `PATH`. Returns the resolved path, or `undefined`
+   *  when not found. Never throws. */
+  which(bin: string): string | undefined;
+  /** Spawn `claude --version` and capture the result. Only called when
+   *  `which("claude")` already resolved — a missing binary is reported by
+   *  `which` alone, not by attempting to spawn it. */
+  claudeVersion(): CommandResult;
+  /**
+   * Linux-only: `loginctl show-user "<user>" -p Linger` — whether the user's
+   * systemd session survives logout (REQUIRED for `systemctl --user` units to
+   * keep running after an SSH session ends). `"unknown"` when the check could
+   * not run (e.g. `loginctl` missing) — quickstart treats that as a soft
+   * warning, not a hard preflight failure, since it can only be conclusively
+   * verified on a systemd host anyway.
+   */
+  lingerStatus(user: string): "yes" | "no" | "unknown";
+}
+
+// =============================================================================
+// Service — step 7 (systemd user units, Linux only)
+// =============================================================================
+
+/**
+ * The injectable systemd seam. NEVER exercised on macOS in production
+ * (quickstart's orchestrator skips the whole step off `process.platform`) —
+ * this interface exists so a test can inject a fake systemctl and assert the
+ * exact invocations quickstart makes, without a real systemd on the test
+ * host (arc's L2 pattern, referenced in cortex#2094's acceptance criteria).
+ */
+export interface ServicePort {
+  /** Absolute path a systemd user unit named `unit` would be rendered at —
+   *  used to confirm L1 (cortex#2071) already rendered `nats@.service` /
+   *  `cortex@.service` before quickstart tries to enable an instance of them.
+   *  Read-only existence probe; never renders a unit itself (out of scope —
+   *  see cortex#2094 "explicitly out of scope"). */
+  unitFileExists(unitTemplate: string): boolean;
+  /** `systemctl --user daemon-reload`. */
+  daemonReload(): CommandResult;
+  /** `systemctl --user enable --now <units...>`. */
+  enableNow(units: string[]): CommandResult;
+}
+
+// =============================================================================
+// Provision — step 6 (stack signing identity)
+// =============================================================================
+
+/**
+ * The SAME entry point `postupgrade.sh` uses (`provision_stack_identity`,
+ * `scripts/lib/stack-identity-provision.sh`) — quickstart does not
+ * reimplement seed generation or the G3 nkey_pub write-back, it invokes the
+ * one existing, already-idempotent shell helper. `stdout`/`stderr` here are
+ * the helper's own human-readable progress log (never a secret — the seed
+ * itself is never printed by that script).
+ */
+export interface ProvisionPort {
+  provisionSeed(stackConfigPath: string, nkeyBasename: string): CommandResult;
+}
+
+// =============================================================================
+// Gate — step 8 (bounded healthy-boot wait)
+// =============================================================================
+
+export interface GatePort {
+  /** Read the daemon log file. `undefined` when it doesn't exist yet (the
+   *  daemon hasn't written anything, or hasn't started). Never throws. */
+  readLog(logPath: string): string | undefined;
+  /** GET `<url>/healthz` with a bounded timeout. `true` only on a 2xx
+   *  response; any failure (unreachable, timeout, non-2xx) is `false`. */
+  fetchHealthz(url: string, timeoutMs: number): Promise<boolean>;
+  /** Injectable sleep — tests pass a no-op/near-instant version so the
+   *  bounded-wait poll loop doesn't actually block for real wall-clock time. */
+  sleep(ms: number): Promise<void>;
+  /** Injectable clock — `Date.now` in production, a controllable counter in
+   *  tests, so the poll loop's deadline arithmetic is deterministic. */
+  now(): number;
+}
+
+// =============================================================================
+// The ports bundle
+// =============================================================================
+
+export interface QuickstartPorts {
+  preflight: PreflightPorts;
+  service: ServicePort;
+  provision: ProvisionPort;
+  gate: GatePort;
+}

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -494,7 +494,11 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
   const natsUnit = ports.service.unitFileExists("nats@.service");
   const cortexUnit = ports.service.unitFileExists("cortex@.service");
   if (!natsUnit || !cortexUnit) {
-    lines.push("  ✗ systemd template units not found under ~/.config/systemd/user/");
+    // The actual check above reads via ports.service.unitFileExists(), whose
+    // live adapter (quickstart-adapters.ts's systemdUserUnitDir()) resolves
+    // the real path off homedir()+join() — this string is a human-facing
+    // diagnostic only, never a runtime path.
+    lines.push("  ✗ systemd template units not found under ~/.config/systemd/user/"); // xdg-audit:allow(user-facing diagnostic naming the canonical systemd user-unit dir — not a runtime path write; cortex#2094)
     lines.push(
       "    quickstart REQUIRES cortex#2071 (L1) — run `arc install`/`arc upgrade cortex` first to render nats@.service + cortex@.service",
     );

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -1,0 +1,729 @@
+#!/usr/bin/env bun
+/**
+ * `cortex quickstart` — L3 (cortex#2094): env-contract driven one-command
+ * first install (Debian).
+ *
+ * Collapses the validated Debian runbook (README-AGENTS.md Appendix A + §5,
+ * merged PR#2090 — itself crediting the community gist it's based on) into
+ * ONE idempotent command, driven entirely by the DD-L5 `CTX_*` env contract
+ * (arc `design/linux-host-support.md`, arc#309):
+ *
+ *   set -a; . ./cortex.env; set +a; cortex quickstart
+ *
+ * Eight numbered steps, each printing a ✓/✗ table before the next one runs.
+ * The WHOLE run is re-runnable without damage — every step is designed to
+ * be a no-op (skip/verified) on a config that's already in the desired
+ * state, so a principal can re-run this after fixing one env var without
+ * fear of clobbering anything already wired up.
+ *
+ *   1. Preflight        — bun/claude/nats-server on PATH, claude authenticated,
+ *                          Linux linger enabled. All read-only.
+ *   2. Validate env      — every required CTX_* present + shape-checked.
+ *   3. nats conf         — write ~/.config/nats/$CTX_SLUG.conf (skip if
+ *                          byte-identical; refuse a DIFFERENT existing file
+ *                          without --force).
+ *   4. Scaffold          — `cortex stack create` (or verify+skip if the
+ *                          stack already exists with matching identity).
+ *   5. Patch configs     — the three formerly-manual edits, guarded +
+ *                          comment-preserving (quickstart-lib.ts).
+ *   6. Seed provisioning — the SAME entry postupgrade.sh uses.
+ *   7. Services          — Linux: systemd user units (L1, cortex#2071
+ *                          REQUIRED — declared as a hard dependency, not
+ *                          re-implemented here). macOS: arc handles launchd;
+ *                          skip.
+ *   8. Gate              — the §5 healthy-boot grep table + nats /healthz,
+ *                          bounded wait.
+ *
+ * Explicitly OUT OF SCOPE (cortex#2094): rendering the systemd units
+ * (cortex#2071 — quickstart REQUIRES it merged, checked in step 7); the
+ * container entrypoint (a future L4 issue calls INTO this command, not the
+ * reverse); Discord bot creation / invite flow (irreducibly manual — the
+ * Developer Portal has no API for it; quickstart only validates the
+ * resulting ids via the env contract).
+ *
+ * Secret hygiene (non-negotiable, cortex#2094 acceptance criteria):
+ * `CTX_DISCORD_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` values NEVER reach stdout,
+ * stderr, or any error message — every place quickstart reports on them
+ * prints only `"set" | "missing"` (see `quickstart-lib.ts`'s
+ * `validateEnvContract` / `renderEnvTable`, which structurally keep those two
+ * keys out of any value-carrying field).
+ *
+ * Exit codes: 0 success (or a fully-idempotent no-op re-run) · 1 operational
+ * failure (a step's precondition failed, or a step itself failed) · 2 usage
+ * error (bad flag) or a missing/malformed env contract.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname } from "path";
+
+import { discoverStacks } from "./stack-lib";
+import { dispatchStack } from "./stack";
+import { CliArgsError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { type ExitResult } from "./_shared/exit-result";
+
+import { CC_AUTH_FAILURE_MESSAGE, isCcAuthFailure } from "../../../runner/cc-failure-classifier";
+import type { CCSessionResult } from "../../../runner/cc-session";
+import { resolveConfigDir } from "../../../common/config/config-path";
+
+import { buildQuickstartPorts } from "./quickstart-adapters";
+import type { QuickstartPorts } from "./quickstart-ports";
+import {
+  daemonLogPath,
+  evaluateHealthyBootGate,
+  gatePassed,
+  natsConfPath,
+  nkeyBasenameForSlug,
+  patchStackYaml,
+  patchSurfacesYaml,
+  patchSystemNatsPort,
+  pointerConfigPath,
+  renderEnvTable,
+  renderGateTable,
+  renderNatsConf,
+  stackAgentConfigPath,
+  stackTargetDir,
+  surfacesConfigPath,
+  systemConfigPath,
+  validateEnvContract,
+  type EnvValidationResult,
+} from "./quickstart-lib";
+
+export { type ExitResult } from "./_shared/exit-result";
+
+// =============================================================================
+// Injectable ports factory (mirrors network.ts's *PortsFactory convention)
+// =============================================================================
+
+/** Production omits this — the live adapters. Tests pass a fake bundle so
+ *  quickstart's CLI-level tests never spawn a real `systemctl`/`loginctl`/
+ *  `claude`, never hit a real `/healthz`, and never wait real wall-clock
+ *  time in the gate's poll loop. */
+export type QuickstartPortsFactory = () => QuickstartPorts;
+const DEFAULT_QUICKSTART_PORTS_FACTORY: QuickstartPortsFactory = buildQuickstartPorts;
+
+/** Bounded wait window for step 8's gate poll loop (cortex#2094: "30s-120s
+ *  bounded wait"). Overridable via `--gate-timeout-ms` (tests + an unusually
+ *  slow first boot). */
+export const DEFAULT_GATE_TIMEOUT_MS = 60_000;
+const GATE_POLL_INTERVAL_MS = 3_000;
+
+// =============================================================================
+// Flags
+// =============================================================================
+
+interface QuickstartFlags {
+  configDir?: string;
+  natsDir?: string;
+  force: boolean;
+  json: boolean;
+  skipServices: boolean;
+  gateTimeoutMs: number;
+  help: boolean;
+}
+
+/** quickstart takes no subcommand (it's a single, env-driven verb) — a small
+ *  hand-rolled flag parser rather than `parseSubcommandArgs` (built for the
+ *  `<subcommand> <flags>` shape `stack`/`network` use). */
+function parseQuickstartArgs(argv: string[]): QuickstartFlags {
+  const flags: QuickstartFlags = {
+    force: false,
+    json: false,
+    skipServices: false,
+    gateTimeoutMs: DEFAULT_GATE_TIMEOUT_MS,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--config-dir":
+        flags.configDir = requireValue(argv, ++i, "--config-dir");
+        break;
+      case "--nats-dir":
+        flags.natsDir = requireValue(argv, ++i, "--nats-dir");
+        break;
+      case "--gate-timeout-ms": {
+        const raw = requireValue(argv, ++i, "--gate-timeout-ms");
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw new CliArgsError("quickstart", `--gate-timeout-ms must be a positive number, got "${raw}"`);
+        }
+        flags.gateTimeoutMs = n;
+        break;
+      }
+      case "--force":
+        flags.force = true;
+        break;
+      case "--json":
+        flags.json = true;
+        break;
+      // Linux-only step 7 is already a clean no-op on macOS (checked via
+      // `process.platform`); this flag exists for CI/tests that want to
+      // exercise steps 1-6+8 without a systemd host at all.
+      case "--skip-services":
+        flags.skipServices = true;
+        break;
+      case "--help":
+      case "-h":
+        flags.help = true;
+        break;
+      default:
+        throw new CliArgsError("quickstart", `unknown flag: ${a}`);
+    }
+  }
+  return flags;
+}
+
+function requireValue(argv: string[], idx: number, flag: string): string {
+  const v = argv[idx];
+  if (v === undefined || v.startsWith("--")) {
+    throw new CliArgsError("quickstart", `${flag} requires a value`);
+  }
+  return v;
+}
+
+// =============================================================================
+// Step result + report accumulation
+// =============================================================================
+
+interface StepReport {
+  name: string;
+  ok: boolean;
+  lines: string[];
+}
+
+function step(name: string, ok: boolean, lines: string[]): StepReport {
+  return { name, ok, lines };
+}
+
+function renderReport(reports: StepReport[]): string {
+  const out: string[] = [];
+  for (const r of reports) {
+    out.push(`── ${r.name} ${r.ok ? "✓" : "✗"} ──`);
+    for (const l of r.lines) out.push(l);
+    out.push("");
+  }
+  return out.join("\n");
+}
+
+// =============================================================================
+// Step 1 — preflight
+// =============================================================================
+
+function runPreflight(ports: QuickstartPorts): StepReport {
+  const lines: string[] = [];
+  let ok = true;
+
+  const bun = ports.preflight.which("bun");
+  lines.push(`  ${bun !== undefined ? "✓" : "✗"} bun on PATH${bun !== undefined ? ` (${bun})` : ""}`);
+  if (bun === undefined) ok = false;
+
+  const claudePath = ports.preflight.which("claude");
+  if (claudePath === undefined) {
+    lines.push("  ✗ claude on PATH — install Claude Code first (https://claude.com/claude-code)");
+    ok = false;
+  } else {
+    const versionResult = ports.preflight.claudeVersion();
+    if (versionResult.exitCode === 0) {
+      lines.push(`  ✓ claude authenticated (${claudePath})`);
+    } else {
+      // cortex#2068 — reuse the shared classifier's signature match instead
+      // of re-deriving auth-failure regexes here. `claudeVersion()` doesn't
+      // return a real CCSessionResult (there's no dispatched session), so a
+      // minimal shape carrying only the fields `isCcAuthFailure` reads is
+      // built here — never echoing anything beyond claude's own CLI output.
+      const fakeResult: CCSessionResult = {
+        success: false,
+        response: versionResult.stdout,
+        stderr: versionResult.stderr,
+        exitCode: versionResult.exitCode,
+        durationMs: 0,
+      };
+      if (isCcAuthFailure(fakeResult)) {
+        lines.push(`  ✗ claude not authenticated`);
+        lines.push(`    ${CC_AUTH_FAILURE_MESSAGE}`);
+      } else {
+        lines.push(`  ✗ claude --version failed (exit ${String(versionResult.exitCode)})`);
+        if (versionResult.stderr.trim().length > 0) {
+          lines.push(`    ${versionResult.stderr.trim()}`);
+        }
+      }
+      ok = false;
+    }
+  }
+
+  const natsServer = ports.preflight.which("nats-server");
+  lines.push(`  ${natsServer !== undefined ? "✓" : "✗"} nats-server on PATH${natsServer !== undefined ? ` (${natsServer})` : ""}`);
+  if (natsServer === undefined) ok = false;
+
+  if (process.platform === "linux") {
+    const user = process.env.USER;
+    const linger = user !== undefined ? ports.preflight.lingerStatus(user) : "unknown";
+    if (linger === "yes") {
+      lines.push("  ✓ systemd linger enabled");
+    } else if (linger === "no") {
+      const target = user !== undefined ? `"${user}"` : '"$USER"';
+      lines.push("  ✗ systemd linger disabled — services stop the moment your SSH session ends");
+      lines.push(`    fix: sudo loginctl enable-linger ${target}`);
+      ok = false;
+    } else {
+      lines.push("  ○ systemd linger status unknown (loginctl unavailable — verify manually)");
+    }
+  }
+
+  return step("1. Preflight", ok, lines);
+}
+
+// =============================================================================
+// Step 2 — env contract
+// =============================================================================
+
+function runEnvValidation(): { report: StepReport; result: EnvValidationResult } {
+  const result = validateEnvContract(process.env);
+  const lines = renderEnvTable(result).split("\n").slice(1); // drop the "env contract (CTX_*):" header — the step name is already the header
+  return { report: step("2. Validate env contract", result.ok, lines), result };
+}
+
+// =============================================================================
+// Step 3 — nats conf
+// =============================================================================
+
+function runNatsConf(opts: {
+  slug: string;
+  principal: string;
+  port: string;
+  monitorPort: string;
+  natsDir: string;
+  force: boolean;
+}): StepReport {
+  const path = natsConfPath(opts.natsDir, opts.slug);
+  const desired = renderNatsConf({
+    slug: opts.slug,
+    principal: opts.principal,
+    port: opts.port,
+    monitorPort: opts.monitorPort,
+    natsDir: opts.natsDir,
+  });
+
+  if (existsSync(path)) {
+    const existing = readFileSync(path, "utf-8");
+    if (existing === desired) {
+      return step("3. nats conf", true, [`  ✓ ${path} already up to date (skip)`]);
+    }
+    if (!opts.force) {
+      return step("3. nats conf", false, [
+        `  ✗ ${path} exists and differs from the expected contents`,
+        `    refusing to overwrite without --force (a hand-edited or differently-configured .conf is preserved by default)`,
+      ]);
+    }
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, desired, "utf-8");
+    return step("3. nats conf", true, [`  ✓ ${path} overwritten (--force)`]);
+  }
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, desired, "utf-8");
+  return step("3. nats conf", true, [`  ✓ ${path} written`]);
+}
+
+// =============================================================================
+// Step 4 — scaffold
+// =============================================================================
+
+async function runScaffold(opts: {
+  slug: string;
+  principal: string;
+  configDir: string;
+}): Promise<StepReport> {
+  const create = await dispatchStack([
+    "create",
+    opts.slug,
+    "--principal",
+    opts.principal,
+    "--apply",
+    "--config-dir",
+    opts.configDir,
+  ]);
+
+  if (create.exitCode === 0) {
+    return step("4. Scaffold", true, [`  ✓ stack "${opts.slug}" created under ${opts.configDir}`]);
+  }
+
+  // Idempotency: `stack create` refuses a dir collision. That's expected on
+  // a re-run — verify the ALREADY-discovered stack's identity actually
+  // matches this env's CTX_PRINCIPAL/CTX_SLUG (a structural check, not a
+  // string-match on create's error text) before treating it as a skip.
+  const targetDir = stackTargetDir(opts.configDir, opts.slug);
+  if (existsSync(targetDir)) {
+    const discovered = discoverStacks(opts.configDir).find((s) => s.slugLocator === opts.slug);
+    const expectedStackId = `${opts.principal}/${opts.slug}`;
+    if (discovered?.stackId === expectedStackId) {
+      return step("4. Scaffold", true, [
+        `  ✓ stack "${opts.slug}" already exists with matching identity (${expectedStackId}) — skip`,
+      ]);
+    }
+    return step("4. Scaffold", false, [
+      `  ✗ ${targetDir} exists but its stack.id ("${discovered?.stackId ?? "(unreadable)"}") does not match the expected "${expectedStackId}"`,
+      `    this is a pre-existing, differently-identified stack at the CTX_SLUG path — resolve manually before re-running quickstart`,
+    ]);
+  }
+
+  return step("4. Scaffold", false, [
+    `  ✗ cortex stack create failed:`,
+    ...create.stderr.split("\n").filter((l) => l.length > 0).map((l) => `    ${l}`),
+  ]);
+}
+
+// =============================================================================
+// Step 5 — patch configs from env
+// =============================================================================
+
+function runPatchConfigs(opts: {
+  slug: string;
+  principal: string;
+  configDir: string;
+  natsPort: string;
+  discordToken: string;
+  guildId: string;
+  channelId: string;
+  logChannelId: string;
+  myDiscordId: string;
+}): StepReport {
+  const lines: string[] = [];
+  let ok = true;
+
+  try {
+    const surfacesResult = patchSurfacesYaml(surfacesConfigPath(opts.configDir, opts.slug), {
+      token: opts.discordToken,
+      guildId: opts.guildId,
+      agentChannelId: opts.channelId,
+      logChannelId: opts.logChannelId,
+    });
+    lines.push(
+      `  ✓ surfaces/surfaces.yaml ${surfacesResult.changed ? "patched (token set — never echoed)" : "already up to date (skip)"}`,
+    );
+  } catch (err) {
+    lines.push(`  ✗ surfaces/surfaces.yaml patch failed: ${errMsg(err)}`);
+    ok = false;
+  }
+
+  try {
+    const pointerPath = pointerConfigPath(opts.configDir, opts.slug);
+    const stackResult = patchStackYaml(stackAgentConfigPath(opts.configDir, opts.slug), pointerPath, {
+      principal: opts.principal,
+      discordId: opts.myDiscordId,
+    });
+    if (stackResult.composeErrors !== undefined) {
+      lines.push(`  ✗ stacks/${opts.slug}.yaml patched, but the composed config failed validation:`);
+      for (const e of stackResult.composeErrors) lines.push(`    ${e}`);
+      ok = false;
+    } else {
+      lines.push(
+        `  ✓ stacks/${opts.slug}.yaml ${stackResult.changed ? "patched (discordId set)" : "already up to date (skip)"}`,
+      );
+    }
+  } catch (err) {
+    lines.push(`  ✗ stacks/${opts.slug}.yaml patch failed: ${errMsg(err)}`);
+    ok = false;
+  }
+
+  // system/system.yaml's nats.url only needs a patch when the port differs
+  // from the scaffold's own default (4222) — cortex#2094's explicit gate.
+  if (opts.natsPort !== "4222") {
+    try {
+      const systemResult = patchSystemNatsPort(systemConfigPath(opts.configDir, opts.slug), opts.natsPort);
+      lines.push(
+        `  ✓ system/system.yaml ${systemResult.changed ? `patched (nats.url port → ${opts.natsPort})` : "already up to date (skip)"}`,
+      );
+    } catch (err) {
+      lines.push(`  ✗ system/system.yaml patch failed: ${errMsg(err)}`);
+      ok = false;
+    }
+  } else {
+    lines.push("  ✓ system/system.yaml nats.url — CTX_NATS_PORT is the default (4222); no patch needed");
+  }
+
+  return step("5. Patch configs from env", ok, lines);
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// =============================================================================
+// Step 6 — seed provisioning
+// =============================================================================
+
+function runSeedProvisioning(ports: QuickstartPorts, opts: { slug: string; configDir: string }): StepReport {
+  const nkeyBasename = nkeyBasenameForSlug(opts.slug);
+  const result = ports.provision.provisionSeed(stackAgentConfigPath(opts.configDir, opts.slug), nkeyBasename);
+  // scripts/lib/stack-identity-provision.sh is documented best-effort (its
+  // own header: "Exit code: always 0") — a non-zero here means the SHELL
+  // invocation itself failed (bash missing, the script unreadable), not a
+  // provisioning outcome. Either way this step never blocks progression to
+  // services/gate: an unsigned stack still boots (with a boot-time WARNING),
+  // which is exactly the degrade path the script itself documents.
+  const lines = result.stdout
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => `  ${l.trim()}`);
+  if (result.exitCode !== 0) {
+    lines.push(`  ⚠ provisioning script exited ${String(result.exitCode)} — continuing (stack will boot unsigned)`);
+    if (result.stderr.trim().length > 0) lines.push(`    ${result.stderr.trim()}`);
+  }
+  return step("6. Seed provisioning", true, lines.length > 0 ? lines : ["  ✓ nothing to do"]);
+}
+
+// =============================================================================
+// Step 7 — services (Linux only)
+// =============================================================================
+
+function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean }): StepReport {
+  if (opts.skip) {
+    return step("7. Services", true, ["  ○ --skip-services passed — skipping"]);
+  }
+  if (process.platform !== "linux") {
+    return step("7. Services", true, ["  ○ non-Linux host — launchd is handled by arc; skip"]);
+  }
+
+  const lines: string[] = [];
+  let ok = true;
+
+  // L1 (cortex#2071) REQUIRED, not re-implemented here — an install without
+  // it has no template units to enable an instance of.
+  const natsUnit = ports.service.unitFileExists("nats@.service");
+  const cortexUnit = ports.service.unitFileExists("cortex@.service");
+  if (!natsUnit || !cortexUnit) {
+    lines.push("  ✗ systemd template units not found under ~/.config/systemd/user/");
+    lines.push(
+      "    quickstart REQUIRES cortex#2071 (L1) — run `arc install`/`arc upgrade cortex` first to render nats@.service + cortex@.service",
+    );
+    return step("7. Services", false, lines);
+  }
+
+  const reload = ports.service.daemonReload();
+  if (reload.exitCode !== 0) {
+    lines.push(`  ✗ systemctl --user daemon-reload failed: ${reload.stderr.trim()}`);
+    return step("7. Services", false, lines);
+  }
+  lines.push("  ✓ systemctl --user daemon-reload");
+
+  const enable = ports.service.enableNow([`nats@${opts.slug}`, `cortex@${opts.slug}`]);
+  if (enable.exitCode !== 0) {
+    lines.push(`  ✗ systemctl --user enable --now nats@${opts.slug} cortex@${opts.slug} failed: ${enable.stderr.trim()}`);
+    ok = false;
+  } else {
+    lines.push(`  ✓ systemctl --user enable --now nats@${opts.slug} cortex@${opts.slug}`);
+  }
+
+  return step("7. Services", ok, lines);
+}
+
+// =============================================================================
+// Step 8 — healthy-boot gate
+// =============================================================================
+
+async function runGate(
+  ports: QuickstartPorts,
+  opts: { slug: string; monitorPort: string; timeoutMs: number },
+): Promise<StepReport> {
+  const logPath = daemonLogPath(process.env.HOME ?? "", opts.slug);
+  const healthzUrl = `http://127.0.0.1:${opts.monitorPort}/healthz`;
+  const deadline = ports.gate.now() + opts.timeoutMs;
+
+  for (;;) {
+    const logText = ports.gate.readLog(logPath);
+    const gateLines = evaluateHealthyBootGate(logText);
+    const healthzOk = await ports.gate.fetchHealthz(healthzUrl, 3_000);
+    if (gatePassed(gateLines, healthzOk)) {
+      return step("8. Healthy-boot gate", true, [renderGateTable(gateLines, healthzOk)]);
+    }
+    if (ports.gate.now() >= deadline) {
+      return step("8. Healthy-boot gate", false, [
+        renderGateTable(gateLines, healthzOk),
+        `  (timed out after ${String(opts.timeoutMs)}ms waiting on ${logPath})`,
+      ]);
+    }
+    await ports.gate.sleep(GATE_POLL_INTERVAL_MS);
+  }
+}
+
+// =============================================================================
+// Orchestrator
+// =============================================================================
+
+export async function dispatchQuickstart(
+  argv: string[],
+  // cortex#2094 — injectable ports factory so quickstart's CLI tests drive
+  // fake preflight/service/provision/gate ports (no real systemctl/loginctl/
+  // claude spawn, no real HTTP, no real wall-clock wait). Production omits
+  // it → the live adapters.
+  portsFactory: QuickstartPortsFactory = DEFAULT_QUICKSTART_PORTS_FACTORY,
+): Promise<ExitResult> {
+  let flags: QuickstartFlags;
+  try {
+    flags = parseQuickstartArgs(argv);
+  } catch (err) {
+    if (err instanceof CliArgsError) {
+      return { exitCode: 2, stdout: "", stderr: `cortex quickstart: ${err.message}\n${topLevelHelp()}` };
+    }
+    throw err;
+  }
+
+  if (flags.help) {
+    return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
+  }
+
+  const ports = portsFactory();
+  const configDir = flags.configDir ?? resolveConfigDir();
+  const natsDir = flags.natsDir ?? "~/.config/nats";
+  const reports: StepReport[] = [];
+
+  // --- 1. Preflight ----------------------------------------------------------
+  const preflight = runPreflight(ports);
+  reports.push(preflight);
+  if (!preflight.ok) {
+    return finish(reports, 1, flags.json);
+  }
+
+  // --- 2. Validate env contract ------------------------------------------------
+  const { report: envReport, result: env } = runEnvValidation();
+  reports.push(envReport);
+  if (!env.ok || env.values === undefined) {
+    return finish(reports, 2, flags.json);
+  }
+  const v = env.values;
+
+  // --- 3. nats conf ------------------------------------------------------------
+  const natsConfReport = runNatsConf({
+    slug: v.CTX_SLUG,
+    principal: v.CTX_PRINCIPAL,
+    port: v.CTX_NATS_PORT,
+    monitorPort: v.CTX_NATS_MON,
+    natsDir,
+    force: flags.force,
+  });
+  reports.push(natsConfReport);
+  if (!natsConfReport.ok) {
+    return finish(reports, 1, flags.json);
+  }
+
+  // --- 4. Scaffold ---------------------------------------------------------
+  const scaffoldReport = await runScaffold({ slug: v.CTX_SLUG, principal: v.CTX_PRINCIPAL, configDir });
+  reports.push(scaffoldReport);
+  if (!scaffoldReport.ok) {
+    return finish(reports, 1, flags.json);
+  }
+
+  // --- 5. Patch configs from env ---------------------------------------------
+  // process.env access for the two secrets happens HERE ONLY, scoped to this
+  // one call — never stored in a variable that a later step's log line could
+  // accidentally interpolate.
+  const patchReport = runPatchConfigs({
+    slug: v.CTX_SLUG,
+    principal: v.CTX_PRINCIPAL,
+    configDir,
+    natsPort: v.CTX_NATS_PORT,
+    discordToken: process.env.CTX_DISCORD_TOKEN ?? "",
+    guildId: v.CTX_GUILD_ID,
+    channelId: v.CTX_CHANNEL_ID,
+    logChannelId: v.CTX_LOG_CHANNEL_ID,
+    myDiscordId: v.CTX_MY_DISCORD_ID,
+  });
+  reports.push(patchReport);
+  if (!patchReport.ok) {
+    return finish(reports, 1, flags.json);
+  }
+
+  // --- 6. Seed provisioning ---------------------------------------------------
+  const provisionReport = runSeedProvisioning(ports, { slug: v.CTX_SLUG, configDir });
+  reports.push(provisionReport);
+
+  // --- 7. Services -------------------------------------------------------------
+  const servicesReport = runServices(ports, { slug: v.CTX_SLUG, skip: flags.skipServices });
+  reports.push(servicesReport);
+  if (!servicesReport.ok) {
+    return finish(reports, 1, flags.json);
+  }
+
+  // --- 8. Healthy-boot gate -----------------------------------------------------
+  const gateReport = await runGate(ports, {
+    slug: v.CTX_SLUG,
+    monitorPort: v.CTX_NATS_MON,
+    timeoutMs: flags.gateTimeoutMs,
+  });
+  reports.push(gateReport);
+  if (!gateReport.ok) {
+    return finish(reports, 1, flags.json);
+  }
+
+  return finish(reports, 0, flags.json);
+}
+
+function finish(reports: StepReport[], exitCode: number, json: boolean): ExitResult {
+  if (json) {
+    const allOk = reports.every((r) => r.ok);
+    const envelope = allOk
+      ? envelopeOk(
+          reports.map((r) => ({ step: r.name, ok: "true" })),
+          {},
+        )
+      : envelopeError(
+          reports.find((r) => !r.ok)?.name ?? "unknown step failed",
+          { steps: JSON.stringify(reports.map((r) => ({ step: r.name, ok: r.ok }))) },
+        );
+    return { exitCode, stdout: renderJson(envelope), stderr: "" };
+  }
+  const text = renderReport(reports);
+  return exitCode === 0
+    ? { exitCode, stdout: `${text}cortex quickstart: complete ✓\n`, stderr: "" }
+    : { exitCode, stdout: text, stderr: "" };
+}
+
+// =============================================================================
+// Help
+// =============================================================================
+
+function topLevelHelp(): string {
+  return `cortex quickstart — env-contract driven one-command first install (cortex#2094, L3)
+
+Usage:
+  set -a; . ./cortex.env; set +a; cortex quickstart [options]
+
+Runs the validated Debian runbook (README-AGENTS.md Appendix A + §5) as ONE
+idempotent command: preflight → validate env → nats conf → scaffold → patch
+configs from env → seed provisioning → services → healthy-boot gate.
+
+Requires (env, DD-L5 contract): CTX_PRINCIPAL, CTX_SLUG, CTX_NATS_PORT,
+CTX_NATS_MON, CTX_GUILD_ID, CTX_CHANNEL_ID, CTX_LOG_CHANNEL_ID,
+CTX_MY_DISCORD_ID, CTX_DISCORD_TOKEN. Optional: CLAUDE_CODE_OAUTH_TOKEN
+(native hosts with an existing \`claude\` login don't need it).
+
+Flags:
+  --config-dir <path>     Config dir (default: the resolved cortex config dir).
+  --nats-dir <path>       NATS material dir (default: ~/.config/nats).
+  --force                 Allow step 3 to overwrite a DIFFERENT existing
+                          .conf file (default: refuse).
+  --skip-services         Skip step 7 (systemd) entirely — for CI/tests
+                          without a systemd host.
+  --gate-timeout-ms <n>   Step 8's bounded wait (default: ${String(DEFAULT_GATE_TIMEOUT_MS)}).
+  --json                  Emit a { status, items, data, error } envelope.
+
+Requires cortex#2071 (L1 — systemd unit rendering) merged; declared as a hard
+dependency, checked (not re-implemented) in step 7.
+
+Secret hygiene: CTX_DISCORD_TOKEN / CLAUDE_CODE_OAUTH_TOKEN values are NEVER
+printed — every report shows only "set" / "missing" for those two keys.
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+if (import.meta.main) {
+  const result = await dispatchQuickstart(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -326,6 +326,7 @@ import { dispatchOffer } from "./cli/cortex/commands/offer";
 import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
 import { dispatchRelease } from "./cli/cortex/commands/release";
 import { dispatchStack } from "./cli/cortex/commands/stack";
+import { dispatchQuickstart } from "./cli/cortex/commands/quickstart";
 import { dispatchPlugin } from "./cli/cortex/commands/plugin";
 import { dispatchConfig } from "./cli/cortex/commands/config";
 import { dispatchCreds } from "./cli/cortex/commands/creds";
@@ -6722,6 +6723,25 @@ if (import.meta.main) {
     .helpOption(false)
     .action(async (args: string[]) => {
       const result = await dispatchStack(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  // cortex#2094 (L3) — env-contract driven one-command first install. Same
+  // passthrough shape as `stack`/`network`: `dispatchQuickstart` owns its own
+  // flag parsing (there is no subcommand — quickstart is a single, env-driven
+  // verb), so commander hands it the raw remaining argv untouched. Does not
+  // boot the daemon itself — step 7 hands that off to `systemctl --user`.
+  program
+    .command("quickstart")
+    .description("Env-contract driven one-command first install (preflight → validate → scaffold → services → gate)")
+    .argument("[args...]", "quickstart flags (see `cortex quickstart --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchQuickstart(args);
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
       process.exit(result.exitCode);


### PR DESCRIPTION
Closes #2094. Epic arc#312 Wave 2 — the L3 quickstart: the validated Debian runbook collapsed into one idempotent command driven by Vincent's `CTX_*` env contract.

## What ships

New `cortex quickstart` subcommand (registered in `src/cortex.ts` like `stack`/`network`), 8-step orchestration behind **injectable ports** (mirrors the existing `network-doctor-ports`/`-adapters` pattern):

preflight (bun/claude/nats-server on PATH; claude-auth via the cortex#2068 classifier; Linux linger check with the exact sudo command) → env-contract validation → nats `.conf` write/refuse/`--force` → scaffold via `dispatchStack(create)` with idempotent re-run detection (`discoverStacks`, not error-string matching) → **comment-preserving** YAML patch of surfaces/stacks/system → seed provisioning (shells into the same `stack-identity-provision.sh` postupgrade uses) → systemd services (Linux-only, injectable, requires the merged L1 units) → §5 healthy-boot gate (bounded poll, fake clock in tests).

## Trust-path properties (tested)

- **Secret hygiene:** `CTX_DISCORD_TOKEN`/`CLAUDE_CODE_OAUTH_TOKEN` never enter the validator's values — only a `set`/`missing` bucket. Tests assert the literal secret never appears in `JSON.stringify(result)`, the env table, or end-to-end `stdout`/`stderr` (incl. `--json`).
- **Idempotency:** CLI test runs `dispatchQuickstart` twice, snapshots `{size, mtimeMs}` of every file under both trees, asserts deep equality — zero mutation, proven not assumed.
- **Comment preservation:** verified empirically against real scaffold output — reaches a stable fixed point after a one-time cosmetic normalization; reuses `writeNetworksGuarded`'s backup→atomic-write→reparse-verify→restore shape.

61 tests pass (37 lib + 24 CLI), tsc clean, lint clean.

## Decisions / flags for review

- **CTX_DISCORD_TOKEN made required** (gates, exit 2 if missing) since surfaces.yaml needs a real token; `CLAUDE_CODE_OAUTH_TOKEN` fully optional (presence-checked, never gates, never consumed — it's for a headless/container consumer, L4 scope). Orchestrator-accepted as the sensible default; easy to relax later.
- Residual (from the executor, for the adversarial pass): the `claude --version` auth check is a best-effort proxy per the issue (—version usually doesn't need auth); seed-provisioning bash shell-out is faked in tests (real exercise deferred to CI systemd job per the issue); `unitFileExists` checks the literal L1 unit names.

Trust-path lane: CI + adversarial review (secret handling + config writes) both gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
