### PR TITLE
feat(substrates): config-driven, substrate-agnostic config-home

### DIFF
--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -29,7 +29,6 @@ import { buildPrompt } from "../runner/prompt-builder";
 import { scanPrompt } from "../runner/prompt-filter";
 import { renderFilterRejection } from "../adapters/filter-rejection";
 import { CCSession, type CCSessionOpts, type CCSessionResult } from "../runner/cc-session";
-import { resolveConfigHomeEnv } from "../common/substrates/config-home";
 import type {
   CCSessionFactory,
   CCSessionLike,
@@ -301,17 +300,7 @@ export class DispatchHandler extends EventEmitter {
         });
     this.runtime = opts.runtime;
     this.systemEventSource = opts.systemEventSource;
-    // Default factory injects the claude-code config-home (from the deployment
-    // `substrates:` block) unless the caller already set it. `this.config` is
-    // read at call time (the closure runs at dispatch), so ordering here is
-    // safe. Tests injecting their own factory opt out entirely.
-    this.ccSessionFactory =
-      opts.ccSessionFactory ??
-      ((sessionOpts) =>
-        new CCSession({
-          configHomeEnv: resolveConfigHomeEnv("claude-code", this.config.substrates),
-          ...sessionOpts,
-        }));
+    this.ccSessionFactory = opts.ccSessionFactory ?? ((sessionOpts) => new CCSession(sessionOpts));
     this.retryMaxAttempts = opts.retry?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
     this.retryMaxTotalMs = opts.retry?.maxTotalMs ?? DEFAULT_RETRY_MAX_TOTAL_MS;
     this.stack = opts.stack;
@@ -1516,10 +1505,6 @@ export class DispatchHandler extends EventEmitter {
     await adapter.postResponse(replyTarget, "On it — I'll report back when done.");
 
     const session = new CCSession({
-      // Config-home (e.g. CLAUDE_CONFIG_DIR → ~/.claude-soma) from the
-      // deployment `substrates:` block; set post-scope in cc-session so it
-      // survives isolation. See common/substrates/config-home.ts.
-      configHomeEnv: resolveConfigHomeEnv("claude-code", this.config.substrates),
       prompt,
       channel: channel,
       network: network,

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -29,6 +29,7 @@ import { buildPrompt } from "../runner/prompt-builder";
 import { scanPrompt } from "../runner/prompt-filter";
 import { renderFilterRejection } from "../adapters/filter-rejection";
 import { CCSession, type CCSessionOpts, type CCSessionResult } from "../runner/cc-session";
+import { resolveConfigHomeEnv } from "../common/substrates/config-home";
 import type {
   CCSessionFactory,
   CCSessionLike,
@@ -300,7 +301,17 @@ export class DispatchHandler extends EventEmitter {
         });
     this.runtime = opts.runtime;
     this.systemEventSource = opts.systemEventSource;
-    this.ccSessionFactory = opts.ccSessionFactory ?? ((sessionOpts) => new CCSession(sessionOpts));
+    // Default factory injects the claude-code config-home (from the deployment
+    // `substrates:` block) unless the caller already set it. `this.config` is
+    // read at call time (the closure runs at dispatch), so ordering here is
+    // safe. Tests injecting their own factory opt out entirely.
+    this.ccSessionFactory =
+      opts.ccSessionFactory ??
+      ((sessionOpts) =>
+        new CCSession({
+          configHomeEnv: resolveConfigHomeEnv("claude-code", this.config.substrates),
+          ...sessionOpts,
+        }));
     this.retryMaxAttempts = opts.retry?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
     this.retryMaxTotalMs = opts.retry?.maxTotalMs ?? DEFAULT_RETRY_MAX_TOTAL_MS;
     this.stack = opts.stack;
@@ -1505,6 +1516,10 @@ export class DispatchHandler extends EventEmitter {
     await adapter.postResponse(replyTarget, "On it — I'll report back when done.");
 
     const session = new CCSession({
+      // Config-home (e.g. CLAUDE_CONFIG_DIR → ~/.claude-soma) from the
+      // deployment `substrates:` block; set post-scope in cc-session so it
+      // survives isolation. See common/substrates/config-home.ts.
+      configHomeEnv: resolveConfigHomeEnv("claude-code", this.config.substrates),
       prompt,
       channel: channel,
       network: network,

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -1110,6 +1110,11 @@ function loadCortexShape(
     // matter what the principal declared in system.yaml. Silently, too: with no
     // profiles the boot pre-flight has nothing to report.
     inference: cortexConfig.inference,
+    // Per-substrate config-home block — carry through so dispatched sessions
+    // resolve credentials/projects against the declared home (e.g. a Soma-
+    // backed ~/.claude-soma). On AgentConfigSchema too, so the strip-by-default
+    // parse below keeps it. See common/substrates/config-home.ts.
+    ...(cortexConfig.substrates !== undefined && { substrates: cortexConfig.substrates }),
     ...(cortexConfig.nats !== undefined && { nats: cortexConfig.nats }),
   };
 

--- a/src/common/substrates/__tests__/config-home.test.ts
+++ b/src/common/substrates/__tests__/config-home.test.ts
@@ -6,6 +6,7 @@ import {
   resolveConfigHomeEnv,
   setActiveSubstrates,
   activeConfigHomeEnv,
+  configHomeSpawnEnv,
 } from "../config-home";
 import { AgentRuntimeSchema } from "../../types/cortex-config";
 
@@ -119,6 +120,51 @@ describe("active substrates chokepoint (setActiveSubstrates / activeConfigHomeEn
   test("returns undefined for a substrate absent from the active set", () => {
     setActiveSubstrates({ codex: { configHome: "/x" } });
     expect(activeConfigHomeEnv("claude-code")).toBeUndefined();
+  });
+});
+
+// These guard the two spawn wrappers (mc endpoint-resolver, sage-runner) whose
+// own bodies are injection-seam defaults tests never execute — the logic lives
+// here precisely so it CAN be asserted.
+describe("configHomeSpawnEnv — spawn env for a substrate's binary", () => {
+  afterEach(() => setActiveSubstrates(undefined));
+
+  test("returns undefined when no config home is declared (caller omits env → inherit)", () => {
+    setActiveSubstrates(undefined);
+    expect(configHomeSpawnEnv("claude-code", { PATH: "/usr/bin" })).toBeUndefined();
+  });
+
+  test("layers the config home on top of the base env, preserving it", () => {
+    setActiveSubstrates({ "claude-code": { configHome: "/Users/x/.claude-soma" } });
+    const env = configHomeSpawnEnv("claude-code", { PATH: "/usr/bin", GITHUB_TOKEN: "t" });
+    expect(env?.CLAUDE_CONFIG_DIR).toBe("/Users/x/.claude-soma");
+    // sage relies on inherited gh auth — the base env must survive.
+    expect(env?.PATH).toBe("/usr/bin");
+    expect(env?.GITHUB_TOKEN).toBe("t");
+  });
+
+  test("drops undefined base-env values rather than stringifying them", () => {
+    setActiveSubstrates({ "claude-code": { configHome: "/home" } });
+    const env = configHomeSpawnEnv("claude-code", { PATH: "/usr/bin", NOPE: undefined });
+    expect("NOPE" in (env ?? {})).toBe(false);
+  });
+
+  // The codex regression: a site that hardcodes "claude-code" leaves a codex
+  // deployment on its vendor default — the exact bug class this module exists
+  // to kill. Resolution must follow the substrate actually being run.
+  test("resolves per-substrate: codex gets CODEX_HOME, not CLAUDE_CONFIG_DIR", () => {
+    setActiveSubstrates({
+      "claude-code": { configHome: "/claude/home" },
+      codex: { configHome: "/codex/home" },
+    });
+    const env = configHomeSpawnEnv("codex", { PATH: "/usr/bin" });
+    expect(env?.CODEX_HOME).toBe("/codex/home");
+    expect(env?.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  test("returns undefined for a substrate with no config-home env var (pi-dev)", () => {
+    setActiveSubstrates({ "pi-dev": { configHome: "/x" } });
+    expect(configHomeSpawnEnv("pi-dev", { PATH: "/usr/bin" })).toBeUndefined();
   });
 });
 

--- a/src/common/substrates/__tests__/config-home.test.ts
+++ b/src/common/substrates/__tests__/config-home.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  SUBSTRATE_CONFIG_HOME_ENV,
+  SubstratesSchema,
+  resolveConfigHomeEnv,
+} from "../config-home";
+
+describe("SUBSTRATE_CONFIG_HOME_ENV — translation table", () => {
+  test("maps known substrates to their config-home env var", () => {
+    expect(SUBSTRATE_CONFIG_HOME_ENV["claude-code"]).toBe("CLAUDE_CONFIG_DIR");
+    expect(SUBSTRATE_CONFIG_HOME_ENV.codex).toBe("CODEX_HOME");
+  });
+
+  test("has no entry for substrates without a config-home var", () => {
+    expect(SUBSTRATE_CONFIG_HOME_ENV["pi-dev"]).toBeUndefined();
+  });
+});
+
+describe("SubstratesSchema — validation", () => {
+  test("accepts a per-substrate configHome map", () => {
+    const parsed = SubstratesSchema.parse({
+      "claude-code": { configHome: "/Users/x/.claude-soma" },
+      codex: { configHome: "/Users/x/.codex" },
+    });
+    expect(parsed["claude-code"]?.configHome).toBe("/Users/x/.claude-soma");
+  });
+
+  test("rejects an unknown key inside a substrate block (strict)", () => {
+    expect(() =>
+      SubstratesSchema.parse({ "claude-code": { configHome: "/x", bogus: 1 } }),
+    ).toThrow();
+  });
+
+  test("accepts an empty substrate block (no configHome)", () => {
+    expect(() => SubstratesSchema.parse({ "claude-code": {} })).not.toThrow();
+  });
+});
+
+describe("resolveConfigHomeEnv", () => {
+  const savedHome = process.env.HOME;
+  beforeEach(() => {
+    process.env.HOME = "/Users/tester";
+  });
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+  });
+
+  test("resolves claude-code to CLAUDE_CONFIG_DIR + absolute value", () => {
+    const got = resolveConfigHomeEnv("claude-code", {
+      "claude-code": { configHome: "/Users/x/.claude-soma" },
+    });
+    expect(got).toEqual({ name: "CLAUDE_CONFIG_DIR", value: "/Users/x/.claude-soma" });
+  });
+
+  test("resolves codex to CODEX_HOME", () => {
+    const got = resolveConfigHomeEnv("codex", { codex: { configHome: "/Users/x/.codex" } });
+    expect(got).toEqual({ name: "CODEX_HOME", value: "/Users/x/.codex" });
+  });
+
+  test("expands a leading ~/", () => {
+    const got = resolveConfigHomeEnv("claude-code", {
+      "claude-code": { configHome: "~/.claude-soma" },
+    });
+    expect(got?.value).toBe("/Users/tester/.claude-soma");
+  });
+
+  test("expands ${HOME}", () => {
+    const got = resolveConfigHomeEnv("claude-code", {
+      "claude-code": { configHome: "${HOME}/.claude-soma" },
+    });
+    expect(got?.value).toBe("/Users/tester/.claude-soma");
+  });
+
+  test("returns undefined when the substrate has no declared configHome", () => {
+    expect(resolveConfigHomeEnv("claude-code", { codex: { configHome: "/x" } })).toBeUndefined();
+    expect(resolveConfigHomeEnv("claude-code", {})).toBeUndefined();
+    expect(resolveConfigHomeEnv("claude-code", undefined)).toBeUndefined();
+  });
+
+  test("returns undefined for a substrate with no config-home env var", () => {
+    // pi-dev has a configHome declared but no known env var → nothing to set.
+    expect(
+      resolveConfigHomeEnv("pi-dev", { "pi-dev": { configHome: "/x" } }),
+    ).toBeUndefined();
+  });
+});

--- a/src/common/substrates/__tests__/config-home.test.ts
+++ b/src/common/substrates/__tests__/config-home.test.ts
@@ -1,9 +1,13 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
   SUBSTRATE_CONFIG_HOME_ENV,
+  SUBSTRATE_IDS,
   SubstratesSchema,
   resolveConfigHomeEnv,
+  setActiveSubstrates,
+  activeConfigHomeEnv,
 } from "../config-home";
+import { AgentRuntimeSchema } from "../../types/cortex-config";
 
 describe("SUBSTRATE_CONFIG_HOME_ENV — translation table", () => {
   test("maps known substrates to their config-home env var", () => {
@@ -83,5 +87,66 @@ describe("resolveConfigHomeEnv", () => {
     expect(
       resolveConfigHomeEnv("pi-dev", { "pi-dev": { configHome: "/x" } }),
     ).toBeUndefined();
+  });
+});
+
+describe("SUBSTRATE_IDS ↔ AgentRuntimeSchema.substrate (drift guard)", () => {
+  test("the local id tuple matches the config substrate enum exactly", () => {
+    // config-home.ts keeps a local copy (leaf module, no schema-import cycle);
+    // this fails CI if the two ever drift — e.g. a substrate added to the schema
+    // but not here (which would silently reject a valid `substrates:` key).
+    const enumOptions = AgentRuntimeSchema.shape.substrate.unwrap().options;
+    expect([...SUBSTRATE_IDS].sort()).toEqual([...enumOptions].sort());
+  });
+});
+
+describe("active substrates chokepoint (setActiveSubstrates / activeConfigHomeEnv)", () => {
+  afterEach(() => setActiveSubstrates(undefined));
+
+  test("activeConfigHomeEnv reads the process-wide substrates set at boot", () => {
+    setActiveSubstrates({ "claude-code": { configHome: "/Users/x/.claude-soma" } });
+    expect(activeConfigHomeEnv("claude-code")).toEqual({
+      name: "CLAUDE_CONFIG_DIR",
+      value: "/Users/x/.claude-soma",
+    });
+  });
+
+  test("returns undefined when nothing is set", () => {
+    setActiveSubstrates(undefined);
+    expect(activeConfigHomeEnv("claude-code")).toBeUndefined();
+  });
+
+  test("returns undefined for a substrate absent from the active set", () => {
+    setActiveSubstrates({ codex: { configHome: "/x" } });
+    expect(activeConfigHomeEnv("claude-code")).toBeUndefined();
+  });
+});
+
+describe("expandHome edge cases (via resolveConfigHomeEnv)", () => {
+  const savedHome = process.env.HOME;
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+  });
+
+  test("leaves an absolute path unchanged", () => {
+    process.env.HOME = "/Users/tester";
+    expect(
+      resolveConfigHomeEnv("claude-code", { "claude-code": { configHome: "/abs/.claude" } })?.value,
+    ).toBe("/abs/.claude");
+  });
+
+  test("does NOT expand $HOMEDIR (word boundary)", () => {
+    process.env.HOME = "/Users/tester";
+    expect(
+      resolveConfigHomeEnv("claude-code", { "claude-code": { configHome: "$HOMEDIR/x" } })?.value,
+    ).toBe("$HOMEDIR/x");
+  });
+
+  test("returns the tilde path unchanged when HOME is empty (no root-relative rewrite)", () => {
+    process.env.HOME = "";
+    expect(
+      resolveConfigHomeEnv("claude-code", { "claude-code": { configHome: "~/.claude-soma" } })?.value,
+    ).toBe("~/.claude-soma");
   });
 });

--- a/src/common/substrates/config-home.ts
+++ b/src/common/substrates/config-home.ts
@@ -26,10 +26,11 @@
 import { z } from "zod/v4";
 
 /**
- * Config-facing substrate ids. Mirrors the `substrate` enum on
+ * Config-facing substrate ids. MUST stay in sync with the `substrate` enum on
  * `AgentRuntimeSchema` (cortex-config.ts). Kept as a local tuple so this file
- * stays a leaf (no config-schema import cycle); keep the two lists in sync when
- * a new substrate lands.
+ * stays a leaf (no config-schema import cycle); a drift-guard test
+ * (`config-home.test.ts`) asserts the two lists match so an addition to one
+ * without the other fails CI rather than silently rejecting a valid substrate.
  */
 export const SUBSTRATE_IDS = [
   "claude-code",
@@ -37,6 +38,7 @@ export const SUBSTRATE_IDS = [
   "pi-dev",
   "cursor",
   "custom",
+  "api-agent",
 ] as const;
 
 export type SubstrateId = (typeof SUBSTRATE_IDS)[number];
@@ -85,12 +87,22 @@ export const SubstratesSchema = z.partialRecord(
 
 export type SubstratesConfig = z.infer<typeof SubstratesSchema>;
 
-/** Expand a leading `~`/`~/` and `$HOME`/`${HOME}` using `process.env.HOME`. */
+/**
+ * Expand a leading `~`/`~/` and `${HOME}`/`$HOME` using `process.env.HOME`.
+ * If `HOME` is unset/empty a tilde/`$HOME` path can't be resolved to an
+ * absolute location, so the input is returned UNCHANGED (never silently
+ * rewritten to a root-relative `/.foo`) — the caller/substrate then fails on a
+ * clearly-wrong path rather than on a plausible-but-wrong one. `$HOME` only
+ * matches at a word boundary so `$HOMEDIR` is left intact.
+ */
 function expandHome(p: string): string {
   const home = process.env.HOME ?? "";
+  if (!home && (p === "~" || p.startsWith("~/") || /\$\{HOME\}|\$HOME\b/.test(p))) {
+    return p;
+  }
   if (p === "~") return home;
   if (p.startsWith("~/")) return home + p.slice(1);
-  return p.replace(/\$\{HOME\}|\$HOME/g, home);
+  return p.replace(/\$\{HOME\}|\$HOME\b/g, home);
 }
 
 /**
@@ -110,4 +122,36 @@ export function resolveConfigHomeEnv(
   const name = SUBSTRATE_CONFIG_HOME_ENV[substrate];
   if (!name) return undefined;
   return { name, value: expandHome(configHome) };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process-level active substrates — the single chokepoint.
+//
+// Every claude-code session cortex spawns must resolve against the SAME config
+// home, but sessions are constructed at several scattered sites (chat/async
+// dispatch, the autonomous dev-loop, PR review, agent-team members). Rather than
+// thread `configHomeEnv` through every opts-builder — where a newly-added path
+// can silently forget it and fall back to the vendor-default credential (which
+// then expires independently) — the daemon sets the active `substrates:` block
+// ONCE at boot (and on config reload), and the single spawn site (cc-session.ts)
+// reads it. Set-once / read-at-spawn: no dispatch path can miss it.
+// ─────────────────────────────────────────────────────────────────────────────
+let activeSubstrates: SubstratesConfig | undefined;
+
+/** Set the process-wide `substrates:` config. Called at daemon boot + reload. */
+export function setActiveSubstrates(substrates: SubstratesConfig | undefined): void {
+  activeSubstrates = substrates;
+}
+
+/**
+ * Resolve the config-home env var for `substrate` from the process-wide
+ * `substrates:` config set by {@link setActiveSubstrates}. Returns `undefined`
+ * when nothing was set, the substrate declared no `configHome`, or the substrate
+ * has no known config-home env var — the caller then leaves the child on its
+ * default home. This is the read side of the single chokepoint (cc-session).
+ */
+export function activeConfigHomeEnv(
+  substrate: SubstrateId,
+): { name: string; value: string } | undefined {
+  return resolveConfigHomeEnv(substrate, activeSubstrates);
 }

--- a/src/common/substrates/config-home.ts
+++ b/src/common/substrates/config-home.ts
@@ -1,0 +1,113 @@
+/**
+ * Substrate config-home resolution — the "adapter translates" seam for where
+ * a substrate keeps its config + auth.
+ *
+ * **The core concept.** Every agent-execution substrate (Claude Code, Codex,
+ * Gemini, …) has a notion of a *config home*: the directory holding its
+ * settings, projects, and — critically — its credential store. Relocating that
+ * home is how a deployment points a substrate at, e.g., a Soma-backed profile
+ * instead of the vendor default. Each substrate exposes exactly ONE env var for
+ * this (Claude Code: `CLAUDE_CONFIG_DIR`; Codex: `CODEX_HOME`; …).
+ *
+ * **Why this module exists.** Cortex core must never hardcode a single
+ * substrate's env var (`CLAUDE_CONFIG_DIR`) into an isolation allowlist or a
+ * session builder — that bakes one substrate's concept into substrate-neutral
+ * code. Instead, the deployment declares a substrate-neutral `configHome` path
+ * per substrate (the `substrates:` config block), and this table translates it
+ * to the concrete env var the substrate reads. Cortex asks the table; the table
+ * owns the vendor-specific knowledge.
+ *
+ * **Leaf module.** Depends only on `zod`. It defines its own substrate-id tuple
+ * (mirroring `AgentRuntimeSchema.substrate` in `cortex-config.ts`) rather than
+ * importing the config schema, so both config schemas can import THIS without a
+ * cycle.
+ */
+
+import { z } from "zod/v4";
+
+/**
+ * Config-facing substrate ids. Mirrors the `substrate` enum on
+ * `AgentRuntimeSchema` (cortex-config.ts). Kept as a local tuple so this file
+ * stays a leaf (no config-schema import cycle); keep the two lists in sync when
+ * a new substrate lands.
+ */
+export const SUBSTRATE_IDS = [
+  "claude-code",
+  "codex",
+  "pi-dev",
+  "cursor",
+  "custom",
+] as const;
+
+export type SubstrateId = (typeof SUBSTRATE_IDS)[number];
+
+/**
+ * The translation table: substrate → the single env var it reads to relocate
+ * its config/auth home. Absent entry = "this substrate has no config-home env
+ * var cortex knows about" (e.g. `pi-dev`, a direct API call with no CLI home).
+ * Fill entries in as harnesses land.
+ */
+export const SUBSTRATE_CONFIG_HOME_ENV: Partial<Record<SubstrateId, string>> = {
+  "claude-code": "CLAUDE_CONFIG_DIR",
+  codex: "CODEX_HOME",
+};
+
+/**
+ * Per-substrate config block. `configHome` is a substrate-NEUTRAL path — the
+ * translation to a concrete env var is this module's job, not the config's.
+ */
+export const SubstrateConfigSchema = z
+  .object({
+    /**
+     * Absolute path (or `~/…` / `${HOME}/…`) to the substrate's config + auth
+     * home. When set, the runner exports the substrate's config-home env var
+     * (see {@link SUBSTRATE_CONFIG_HOME_ENV}) on every session it spawns for
+     * that substrate — so dispatched sessions resolve credentials/projects
+     * against this home instead of the vendor default.
+     */
+    configHome: z.string().min(1).optional(),
+  })
+  .strict();
+
+/**
+ * Deployment/stack-level `substrates:` map — keyed by substrate id, each value
+ * a {@link SubstrateConfigSchema}. All keys optional: a deployment declares only
+ * the substrates whose home it wants to relocate.
+ */
+// `partialRecord` (not `record`): a deployment declares ONLY the substrates
+// whose home it relocates — every key is optional. Plain `z.record` over an
+// enum would demand all substrate ids be present and reject a block that lists
+// just `claude-code`.
+export const SubstratesSchema = z.partialRecord(
+  z.enum(SUBSTRATE_IDS),
+  SubstrateConfigSchema,
+);
+
+export type SubstratesConfig = z.infer<typeof SubstratesSchema>;
+
+/** Expand a leading `~`/`~/` and `$HOME`/`${HOME}` using `process.env.HOME`. */
+function expandHome(p: string): string {
+  const home = process.env.HOME ?? "";
+  if (p === "~") return home;
+  if (p.startsWith("~/")) return home + p.slice(1);
+  return p.replace(/\$\{HOME\}|\$HOME/g, home);
+}
+
+/**
+ * Resolve the config-home env var to set for `substrate`, given the deployment's
+ * `substrates:` config. Returns `{ name, value }` (the env var and its expanded
+ * path) or `undefined` when: the deployment declared no `configHome` for this
+ * substrate, OR the substrate has no known config-home env var. The caller sets
+ * `env[name] = value` AFTER env-scoping so isolation stays strict default-deny —
+ * this is an intentional, named export, not an inherited passthrough.
+ */
+export function resolveConfigHomeEnv(
+  substrate: SubstrateId,
+  substrates: SubstratesConfig | undefined,
+): { name: string; value: string } | undefined {
+  const configHome = substrates?.[substrate]?.configHome;
+  if (!configHome) return undefined;
+  const name = SUBSTRATE_CONFIG_HOME_ENV[substrate];
+  if (!name) return undefined;
+  return { name, value: expandHome(configHome) };
+}

--- a/src/common/substrates/config-home.ts
+++ b/src/common/substrates/config-home.ts
@@ -155,3 +155,37 @@ export function activeConfigHomeEnv(
 ): { name: string; value: string } | undefined {
   return resolveConfigHomeEnv(substrate, activeSubstrates);
 }
+
+/**
+ * Build the env for spawning `substrate`'s binary — or a subprocess that will
+ * itself exec it — by layering the configured config home on top of `baseEnv`
+ * (default: this process's env). Returns `undefined` when no config home is
+ * declared, so the caller can OMIT `env` entirely and let the child inherit
+ * (the pre-existing behaviour) rather than needlessly rebuilding it.
+ *
+ * `undefined` values in `baseEnv` are dropped, not stringified — matching what
+ * a plain inherit does.
+ *
+ * EXPORTED, and deliberately NOT inlined at the spawn sites: those wrappers are
+ * injection-seam defaults that every test replaces with a fake, so logic left
+ * inside them is never executed by the suite and can be silently reverted with
+ * CI green. Keeping the decision here makes it directly unit-testable.
+ *
+ * KNOWN GAP: this only reaches spawns cortex performs itself. A deployment-
+ * authored process spec run via `bus/process-runner.ts` gets an env pass-through
+ * ALLOWLIST (it forwards vars cortex already has; it cannot ADD one), so a
+ * `claude` invoked that way has no route to the declared home.
+ */
+export function configHomeSpawnEnv(
+  substrate: SubstrateId,
+  baseEnv: Record<string, string | undefined> = process.env,
+): Record<string, string> | undefined {
+  const configHome = activeConfigHomeEnv(substrate);
+  if (!configHome) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (value !== undefined) out[key] = value;
+  }
+  out[configHome.name] = configHome.value;
+  return out;
+}

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -7,6 +7,7 @@
  */
 
 import { z } from "zod/v4";
+import { SubstratesSchema } from "../substrates/config-home";
 import { NKEY_PUBKEY_REGEX } from "./nkey";
 import { NatsSubjectsSchema } from "./nats-subjects";
 // API-P1.3 (#2063) — the machine-layer model-provider block. Imported from the
@@ -669,6 +670,15 @@ export const AgentConfigSchema = z.object({
     normalizeToArray,
     z.array(SlackInstanceSchema).default([]),
   ),
+
+  /**
+   * Per-substrate deployment config (config-home per substrate). Carried
+   * through from CortexConfigSchema by the loader's synth path; declared here
+   * too so `AgentConfigSchema.parse` doesn't strip it by default. Read at
+   * dispatch time to export the substrate's config-home env var on spawned
+   * sessions. See common/substrates/config-home.ts.
+   */
+  substrates: SubstratesSchema.optional(),
 
   claude: z.object({
     timeoutMs: z.number().int().positive().default(120_000),

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -62,6 +62,7 @@ import {
   NetworkFileSchema,
   SecurityPostureSchema,
 } from "./config";
+import { SubstratesSchema } from "../substrates/config-home";
 import { NKEY_PUBKEY_REGEX } from "./nkey";
 import { NatsSubjectsSchema } from "./nats-subjects";
 import { LETTER_PREFIX_ID_REGEX } from "./id";
@@ -3314,6 +3315,16 @@ export const CortexConfigSchema = z.object({
 
   /** Claude runtime config — shared by all agents' dispatch sessions. */
   claude: ClaudeConfigSchema,
+
+  /**
+   * Per-substrate deployment config — keyed by substrate id. Currently carries
+   * `configHome`: the config+auth home the runner exports for every session it
+   * spawns on that substrate (claude-code → CLAUDE_CONFIG_DIR, codex →
+   * CODEX_HOME). Substrate-neutral by construction; the vendor env-var
+   * translation lives in common/substrates/config-home.ts. Optional — a
+   * deployment declares only the substrates whose home it relocates.
+   */
+  substrates: SubstratesSchema.optional(),
 
   /** Attachment handling — shared by all platform presences. */
   attachments: emptyDefault(AttachmentsConfigSchema),

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -105,7 +105,7 @@ import { GateReplyRouter } from "./bus/gate-reply-router";
 import { DaemonBrainHost } from "./brain/daemon-brain-host";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import { wireReviewConsumers } from "./runner/review-consumer-boot";
-import { setActiveSubstrates } from "./common/substrates/config-home";
+import { setActiveSubstrates, activeConfigHomeEnv } from "./common/substrates/config-home";
 import { wireBrainConsumers } from "./runner/brain-consumer-boot";
 import { wireReleaseConsumers } from "./runner/release-consumer-boot";
 import { wireSurfaceAdapters } from "./runner/surface-adapter-boot";
@@ -915,6 +915,15 @@ export async function startCortex(
   console.log(`  Agent: ${config.agent.displayName}`);
   console.log(`  Config: ${options.configPath ?? "(in-memory)"}`);
   console.log(`  PID: ${process.pid}`);
+  // Make the config home VISIBLE at boot. Sessions fall back to the vendor
+  // default silently when no `substrates.claude-code.configHome` is declared —
+  // which is a legitimate default, but indistinguishable at runtime from a
+  // misconfiguration. Logging it once turns a silent fallback into an
+  // observable fact an operator can check against intent.
+  const bootConfigHome = activeConfigHomeEnv("claude-code");
+  console.log(
+    `  Claude config home: ${bootConfigHome?.value ?? "(vendor default — no substrates.claude-code.configHome)"}`,
+  );
 
   // cortex#427 — resolve the canonical principal id ONCE at boot. Every
   // subsequent `{principal}` segment (NATS subjects, `signed_by` chains,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -105,6 +105,7 @@ import { GateReplyRouter } from "./bus/gate-reply-router";
 import { DaemonBrainHost } from "./brain/daemon-brain-host";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import { wireReviewConsumers } from "./runner/review-consumer-boot";
+import { setActiveSubstrates } from "./common/substrates/config-home";
 import { wireBrainConsumers } from "./runner/brain-consumer-boot";
 import { wireReleaseConsumers } from "./runner/release-consumer-boot";
 import { wireSurfaceAdapters } from "./runner/surface-adapter-boot";
@@ -904,6 +905,11 @@ export async function startCortex(
     : DEFAULT_CONFIG;
 
   const configDir = dirname(expandedConfigPath);
+  // Publish the deployment `substrates:` block process-wide so EVERY claude-code
+  // session this daemon spawns (dispatch, dev-loop, review, agent-team) resolves
+  // against the declared config home (cc-session reads it at spawn). Set-once at
+  // boot; refreshed on config reload below. See common/substrates/config-home.ts.
+  setActiveSubstrates(config.substrates);
   const securityPreamble = buildSecurityPreamble(config, expandedConfigPath);
   console.log("cortex: starting...");
   console.log(`  Agent: ${config.agent.displayName}`);
@@ -4037,6 +4043,9 @@ export async function startCortex(
     && existsSync(expandedConfigPath)
   ) {
     configWatcher = new ConfigWatcher(expandedConfigPath, config, (event) => {
+      // Keep the process-wide config-home current on hot reload (a `substrates:`
+      // edit takes effect for subsequently-spawned sessions without a restart).
+      setActiveSubstrates(event.config.substrates);
       dispatchHandler.updateConfig(event.config, expandedConfigPath);
       for (const adapter of adapters) adapter.updateConfig?.(event.config);
       if (cloudPublisher) {

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -919,7 +919,7 @@ export async function startCortex(
   // default silently when no `substrates.claude-code.configHome` is declared —
   // which is a legitimate default, but indistinguishable at runtime from a
   // misconfiguration. Logging it once turns a silent fallback into an
-  // observable fact an operator can check against intent.
+  // observable fact the principal can check against intent.
   const bootConfigHome = activeConfigHomeEnv("claude-code");
   console.log(
     `  Claude config home: ${bootConfigHome?.value ?? "(vendor default — no substrates.claude-code.configHome)"}`,
@@ -4056,7 +4056,7 @@ export async function startCortex(
       // edit takes effect for subsequently-spawned sessions without a restart),
       // and re-log on CHANGE. Without the re-log the boot line goes stale-but-
       // confident: deleting `substrates:` and reloading silently reverts every
-      // later session to the vendor default while the one line an operator can
+      // later session to the vendor default while the one line the principal can
       // check still reports the old home. A confidently wrong log is worse than
       // no log.
       const homeBeforeReload = activeConfigHomeEnv("claude-code")?.value;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -4053,8 +4053,20 @@ export async function startCortex(
   ) {
     configWatcher = new ConfigWatcher(expandedConfigPath, config, (event) => {
       // Keep the process-wide config-home current on hot reload (a `substrates:`
-      // edit takes effect for subsequently-spawned sessions without a restart).
+      // edit takes effect for subsequently-spawned sessions without a restart),
+      // and re-log on CHANGE. Without the re-log the boot line goes stale-but-
+      // confident: deleting `substrates:` and reloading silently reverts every
+      // later session to the vendor default while the one line an operator can
+      // check still reports the old home. A confidently wrong log is worse than
+      // no log.
+      const homeBeforeReload = activeConfigHomeEnv("claude-code")?.value;
       setActiveSubstrates(event.config.substrates);
+      const homeAfterReload = activeConfigHomeEnv("claude-code")?.value;
+      if (homeBeforeReload !== homeAfterReload) {
+        console.log(
+          `cortex: Claude config home changed on reload → ${homeAfterReload ?? "(vendor default — no substrates.claude-code.configHome)"}`,
+        );
+      }
       dispatchHandler.updateConfig(event.config, expandedConfigPath);
       for (const adapter of adapters) adapter.updateConfig?.(event.config);
       if (cloudPublisher) {

--- a/src/runner/__tests__/cc-session-env.test.ts
+++ b/src/runner/__tests__/cc-session-env.test.ts
@@ -1,5 +1,7 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, afterEach } from "bun:test";
 import { buildSessionEnv } from "../cc-session";
+import { scopeSessionEnv } from "../session-settings";
+import { setActiveSubstrates } from "../../common/substrates/config-home";
 
 describe("buildSessionEnv — G-2a/G-3a (cortex#774) sets CORTEX_* instrumentation names", () => {
   const baseEnv = { PATH: "/usr/bin" } as Record<string, string>;
@@ -57,5 +59,52 @@ describe("buildSessionEnv — G-2a/G-3a (cortex#774) sets CORTEX_* instrumentati
   test("preserves the inherited base env", () => {
     const env = buildSessionEnv(baseEnv, { channel: "ivy" });
     expect(env.PATH).toBe("/usr/bin");
+  });
+});
+
+describe("buildSessionEnv — substrate config-home (CLAUDE_CONFIG_DIR)", () => {
+  const baseEnv = { PATH: "/usr/bin" } as Record<string, string>;
+  afterEach(() => setActiveSubstrates(undefined));
+
+  test("exports the explicit opts.configHomeEnv override", () => {
+    const env = buildSessionEnv(baseEnv, {
+      configHomeEnv: { name: "CLAUDE_CONFIG_DIR", value: "/explicit/home" },
+    });
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/explicit/home");
+  });
+
+  test("falls back to the process-wide substrates published at daemon boot", () => {
+    setActiveSubstrates({ "claude-code": { configHome: "/Users/x/.claude-soma" } });
+    const env = buildSessionEnv(baseEnv, { channel: "ivy" });
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/Users/x/.claude-soma");
+  });
+
+  test("an explicit opts override beats the process-wide value", () => {
+    setActiveSubstrates({ "claude-code": { configHome: "/boot/home" } });
+    const env = buildSessionEnv(baseEnv, {
+      configHomeEnv: { name: "CLAUDE_CONFIG_DIR", value: "/explicit/home" },
+    });
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/explicit/home");
+  });
+
+  test("sets nothing when no config home is declared (vendor default)", () => {
+    setActiveSubstrates(undefined);
+    const env = buildSessionEnv(baseEnv, { channel: "ivy" });
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  // The thesis of the whole mechanism, in one test: isolation strips the
+  // principal's ambient CLAUDE_CONFIG_DIR, and the DECLARED home is re-applied
+  // on top — so an isolated session lands on the configured home, never the
+  // principal's ambient one and never the silently-expiring vendor default.
+  test("survives isolation: the scoped-away principal value is replaced by the declared home", () => {
+    setActiveSubstrates({ "claude-code": { configHome: "/Users/x/.claude-soma" } });
+    const scoped = scopeSessionEnv({
+      PATH: "/usr/bin",
+      CLAUDE_CONFIG_DIR: "/principal/.claude",
+    });
+    expect(scoped.CLAUDE_CONFIG_DIR).toBeUndefined(); // stripped by cortex#701
+    const env = buildSessionEnv(scoped, { channel: "ivy" });
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/Users/x/.claude-soma");
   });
 });

--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -237,6 +237,15 @@ describe("scopeSessionEnv — principal CLAUDE_* vars dropped", () => {
     expect(CORTEX_PRESERVED_CLAUDE_ENV.has("CLAUDE_CODE_OAUTH_TOKEN")).toBe(true);
   });
 
+  test("does NOT allowlist a substrate config-home var (set post-scope instead)", () => {
+    // Isolation stays strict default-deny for CLAUDE_CONFIG_DIR; the config
+    // home is exported explicitly AFTER scoping (config-home.ts / cc-session
+    // configHomeEnv), never inherited through this allowlist.
+    const scoped = scopeSessionEnv({ CLAUDE_CONFIG_DIR: "/Users/andreas/.claude-soma" });
+    expect(scoped.CLAUDE_CONFIG_DIR).toBeUndefined();
+    expect(CORTEX_PRESERVED_CLAUDE_ENV.has("CLAUDE_CONFIG_DIR")).toBe(false);
+  });
+
   test("preserves cortex's own pipeline + non-Claude vars", () => {
     const scoped = scopeSessionEnv({
       CORTEX_CHANNEL: "andreas",

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -110,6 +110,16 @@ export interface CCSessionOpts {
    * settings; that principal holds the implicit full grant anyway.
    */
   mcpGrants?: string[];
+  /**
+   * The substrate's config-home env var to export on the child, resolved by the
+   * dispatch layer from the deployment `substrates:` block (claude-code →
+   * `{ name: "CLAUDE_CONFIG_DIR", value: <home> }`). Set on the child env AFTER
+   * `scopeSessionEnv`, so isolation stays strict default-deny while the config
+   * home is still an intentional, named export (not an inherited passthrough).
+   * Undefined = use the substrate's default home. See
+   * common/substrates/config-home.ts.
+   */
+  configHomeEnv?: { name: string; value: string };
 }
 
 export interface CCSessionResult {
@@ -359,6 +369,14 @@ export class CCSession extends EventEmitter {
     // Suppress ANTHROPIC_API_KEY when OAuth token is present
     if (env.CLAUDE_CODE_OAUTH_TOKEN) {
       delete env.ANTHROPIC_API_KEY;
+    }
+
+    // Export the substrate's config-home var (e.g. CLAUDE_CONFIG_DIR) LAST, so
+    // it survives isolation's scopeSessionEnv strip WITHOUT widening the
+    // allowlist. Driven by the deployment `substrates:` block via the dispatch
+    // layer's resolveConfigHomeEnv — see common/substrates/config-home.ts.
+    if (this.opts.configHomeEnv) {
+      env[this.opts.configHomeEnv.name] = this.opts.configHomeEnv.value;
     }
 
     try {

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -16,6 +16,7 @@ import {
   CORTEX_MCP_GRANTS_ENV,
   type IsolatedSettings,
 } from "./session-settings";
+import { activeConfigHomeEnv } from "../common/substrates/config-home";
 
 // Re-export for convenience
 export type { UsageStats, StreamEvent };
@@ -371,12 +372,20 @@ export class CCSession extends EventEmitter {
       delete env.ANTHROPIC_API_KEY;
     }
 
-    // Export the substrate's config-home var (e.g. CLAUDE_CONFIG_DIR) LAST, so
-    // it survives isolation's scopeSessionEnv strip WITHOUT widening the
-    // allowlist. Driven by the deployment `substrates:` block via the dispatch
-    // layer's resolveConfigHomeEnv — see common/substrates/config-home.ts.
-    if (this.opts.configHomeEnv) {
-      env[this.opts.configHomeEnv.name] = this.opts.configHomeEnv.value;
+    // Export the substrate's config-home var (e.g. CLAUDE_CONFIG_DIR) LAST — the
+    // single chokepoint for EVERY claude-code session cortex spawns (chat, async,
+    // dev-loop, review, agent-team), so none can fall back to the vendor-default
+    // credential and expire. Value comes from `opts.configHomeEnv` (explicit
+    // override, e.g. tests) else the process-wide `substrates:` set at daemon
+    // boot (activeConfigHomeEnv). Set AFTER scopeSessionEnv so it survives
+    // isolation's strip WITHOUT widening the env allowlist. Caveat: relocating
+    // the config HOME also relocates its `.claude.json` MCP servers; isolation
+    // is strict at the ENV-allowlist layer, but `--setting-sources ""` does not
+    // gate config-dir MCP config (that's inherent to any config home, default or
+    // soma, and unchanged by this diff).
+    const configHomeEnv = this.opts.configHomeEnv ?? activeConfigHomeEnv("claude-code");
+    if (configHomeEnv) {
+      env[configHomeEnv.name] = configHomeEnv.value;
     }
 
     try {

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -169,7 +169,11 @@ export interface CCSessionResult {
  * `principal-env.ts`) so external setters still on `GROVE_*` keep resolving
  * during the transition.
  *
- * Pure function: does not mutate `baseEnv`. Extracted from `start()` so the
+ * Does not mutate `baseEnv` — but NOT referentially transparent: it reads the
+ * process-wide config home (`activeConfigHomeEnv`) published at daemon boot, so
+ * the same inputs yield a different `CLAUDE_CONFIG_DIR` across deployments.
+ * Tests that care must set it explicitly (`setActiveSubstrates`) or pass
+ * `opts.configHomeEnv`. Extracted from `start()` so the
  * spawned env is unit-testable without invoking the `claude` binary.
  */
 export function buildSessionEnv(

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -184,8 +184,22 @@ export function buildSessionEnv(
     | "entity"
     | "principal"
     | "parentSessionId"
+    | "configHomeEnv"
   >,
 ): Record<string, string> {
+  // The substrate's config-home var (claude-code → CLAUDE_CONFIG_DIR): explicit
+  // `opts.configHomeEnv` override, else the process-wide `substrates:` block
+  // published at daemon boot. Applied HERE — `baseEnv` is post-`scopeSessionEnv`
+  // — so it survives isolation's CLAUDE_* strip WITHOUT widening the env
+  // allowlist, while staying a pure/testable transform rather than a mutation
+  // buried in `start()`. Without it a child authenticates on the vendor-default
+  // credential, which refreshes independently of the principal's and expires.
+  //
+  // Honest boundary: relocating a config HOME also relocates its `.claude.json`
+  // MCP servers — isolation is strict at the ENV-allowlist layer, but
+  // `--setting-sources ""` does not gate config-dir MCP config. That is inherent
+  // to any config home (default or otherwise), not introduced here.
+  const configHomeEnv = opts.configHomeEnv ?? activeConfigHomeEnv("claude-code");
   return {
     ...baseEnv,
     ...(opts.channel && { CORTEX_CHANNEL: opts.channel }),
@@ -198,6 +212,7 @@ export function buildSessionEnv(
     // ST-P1 (cortex#964) — child-session linkage. The spawned child's
     // EventLogger reads CORTEX_PARENT_SESSION_ID to parent its events.
     ...(opts.parentSessionId && { CORTEX_PARENT_SESSION_ID: opts.parentSessionId }),
+    ...(configHomeEnv && { [configHomeEnv.name]: configHomeEnv.value }),
   };
 }
 
@@ -370,22 +385,6 @@ export class CCSession extends EventEmitter {
     // Suppress ANTHROPIC_API_KEY when OAuth token is present
     if (env.CLAUDE_CODE_OAUTH_TOKEN) {
       delete env.ANTHROPIC_API_KEY;
-    }
-
-    // Export the substrate's config-home var (e.g. CLAUDE_CONFIG_DIR) LAST — the
-    // single chokepoint for EVERY claude-code session cortex spawns (chat, async,
-    // dev-loop, review, agent-team), so none can fall back to the vendor-default
-    // credential and expire. Value comes from `opts.configHomeEnv` (explicit
-    // override, e.g. tests) else the process-wide `substrates:` set at daemon
-    // boot (activeConfigHomeEnv). Set AFTER scopeSessionEnv so it survives
-    // isolation's strip WITHOUT widening the env allowlist. Caveat: relocating
-    // the config HOME also relocates its `.claude.json` MCP servers; isolation
-    // is strict at the ENV-allowlist layer, but `--setting-sources ""` does not
-    // gate config-dir MCP config (that's inherent to any config home, default or
-    // soma, and unchanged by this diff).
-    const configHomeEnv = this.opts.configHomeEnv ?? activeConfigHomeEnv("claude-code");
-    if (configHomeEnv) {
-      env[configHomeEnv.name] = configHomeEnv.value;
     }
 
     try {

--- a/src/runner/sage-runner.ts
+++ b/src/runner/sage-runner.ts
@@ -81,7 +81,7 @@
  */
 
 import type { Envelope } from "../bus/myelin/envelope-validator";
-import { activeConfigHomeEnv } from "../common/substrates/config-home";
+import { configHomeSpawnEnv, type SubstrateId } from "../common/substrates/config-home";
 import {
   createReviewTaskFailedEvent,
   createReviewVerdictEvent,
@@ -127,8 +127,21 @@ export interface SageSpawnResult {
  */
 export type SageSpawnFn = (
   argv: string[],
-  opts: { stdout: "pipe"; stderr: "pipe" },
+  opts: { stdout: "pipe"; stderr: "pipe"; env?: Record<string, string> },
 ) => SageSpawnResult;
+
+/**
+ * sage's `--substrate` LLM vocabulary → the cortex substrate id used to key the
+ * deployment's `substrates:` config-home block. The two vocabularies differ
+ * (sage says `claude`; cortex says `claude-code`), so the mapping is explicit
+ * rather than assumed. `pi` is a direct pi.dev API call with no CLI config home
+ * → no entry.
+ */
+const SAGE_MODEL_TO_SUBSTRATE: Record<string, SubstrateId | undefined> = {
+  claude: "claude-code",
+  codex: "codex",
+  pi: undefined,
+};
 
 /**
  * Binary resolver — returns the absolute path to the sage CLI, or
@@ -150,8 +163,9 @@ export type SageWhichFn = (cmd: string) => string | undefined;
  *   - Use `Bun.spawn` for the subprocess.
  *   - Use the current process env (no scrubbing — sage piggybacks on the
  *     principal's `gh` auth and `GITHUB_TOKEN` via inherited env), plus the
- *     configured claude config home layered on top, so a `--substrate claude`
- *     run's own `claude` grandchild resolves against it (see `defaultSpawn`).
+ *     config home for whichever substrate sage will actually run, layered on
+ *     top, so that CLI grandchild resolves against the declared home (see the
+ *     SUBPROCESS BOUNDARY note at the spawn call site).
  */
 export interface MakeSageRunnerOpts {
   /**
@@ -283,9 +297,24 @@ export function makeSageReviewRunner(
       argv.push("--forge", forge);
     }
 
+    // SUBPROCESS BOUNDARY: sage re-execs its substrate's CLI itself, one level
+    // BELOW cortex's own spawn chokepoint (cc-session), which therefore cannot
+    // reach it. Export the config home for the substrate sage will ACTUALLY run
+    // (resolved above) — not a hardcoded one — so the grandchild resolves
+    // against the declared home rather than its vendor default. `pi` maps to no
+    // substrate → env omitted → plain inherit, which sage needs for `gh` /
+    // `GITHUB_TOKEN` anyway.
+    //
+    // ASSUMPTION, unverified in this repo (sage is not vendored here): that sage
+    // passes its env through to the CLI it execs. Default subprocess inheritance
+    // makes that near-certain, but nothing here proves it — if sage scrubs or
+    // rebuilds env for its child, this line is inert.
+    const sageSubstrate = SAGE_MODEL_TO_SUBSTRATE[substrate];
+    const spawnEnv = sageSubstrate ? configHomeSpawnEnv(sageSubstrate) : undefined;
+
     let proc: SageSpawnResult;
     try {
-      proc = spawn(argv, { stdout: "pipe", stderr: "pipe" });
+      proc = spawn(argv, { stdout: "pipe", stderr: "pipe", ...(spawnEnv && { env: spawnEnv }) });
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       return failed(
@@ -383,23 +412,15 @@ export function makeSageReviewRunner(
 /** Production spawn — `Bun.spawn`. */
 function defaultSpawn(
   argv: string[],
-  opts: { stdout: "pipe"; stderr: "pipe" },
+  opts: { stdout: "pipe"; stderr: "pipe"; env?: Record<string, string> },
 ): SageSpawnResult {
-  // SUBPROCESS BOUNDARY: with `--substrate claude`, sage re-execs `claude`
-  // itself — one level BELOW cortex's own spawn chokepoint (cc-session), which
-  // therefore cannot reach it. Export the configured config home here so that
-  // grandchild inherits it instead of authenticating on the vendor-default
-  // credential (which refreshes independently and expires). Layered on top of
-  // the inherited env, which sage relies on for `gh`/`GITHUB_TOKEN`. Harmless
-  // for non-claude substrates — the var is simply unused.
-  // See common/substrates/config-home.ts.
-  const configHome = activeConfigHomeEnv("claude-code");
+  // `env` is resolved by the CALLER (which knows the substrate sage will run) —
+  // see the SUBPROCESS BOUNDARY note at the call site. Omitted → plain inherit,
+  // which sage relies on for `gh` / `GITHUB_TOKEN`.
   const proc = Bun.spawn(argv, {
     stdout: opts.stdout,
     stderr: opts.stderr,
-    ...(configHome && {
-      env: { ...process.env, [configHome.name]: configHome.value },
-    }),
+    ...(opts.env && { env: opts.env }),
   });
   return {
     stdout: proc.stdout,

--- a/src/runner/sage-runner.ts
+++ b/src/runner/sage-runner.ts
@@ -81,6 +81,7 @@
  */
 
 import type { Envelope } from "../bus/myelin/envelope-validator";
+import { activeConfigHomeEnv } from "../common/substrates/config-home";
 import {
   createReviewTaskFailedEvent,
   createReviewVerdictEvent,
@@ -148,7 +149,9 @@ export type SageWhichFn = (cmd: string) => string | undefined;
  *   - Resolve sage binary via `SAGE_BIN` env then `Bun.which("sage")`.
  *   - Use `Bun.spawn` for the subprocess.
  *   - Use the current process env (no scrubbing — sage piggybacks on the
- *     principal's `gh` auth and `GITHUB_TOKEN` via inherited env).
+ *     principal's `gh` auth and `GITHUB_TOKEN` via inherited env), plus the
+ *     configured claude config home layered on top, so a `--substrate claude`
+ *     run's own `claude` grandchild resolves against it (see `defaultSpawn`).
  */
 export interface MakeSageRunnerOpts {
   /**
@@ -382,9 +385,21 @@ function defaultSpawn(
   argv: string[],
   opts: { stdout: "pipe"; stderr: "pipe" },
 ): SageSpawnResult {
+  // SUBPROCESS BOUNDARY: with `--substrate claude`, sage re-execs `claude`
+  // itself — one level BELOW cortex's own spawn chokepoint (cc-session), which
+  // therefore cannot reach it. Export the configured config home here so that
+  // grandchild inherits it instead of authenticating on the vendor-default
+  // credential (which refreshes independently and expires). Layered on top of
+  // the inherited env, which sage relies on for `gh`/`GITHUB_TOKEN`. Harmless
+  // for non-claude substrates — the var is simply unused.
+  // See common/substrates/config-home.ts.
+  const configHome = activeConfigHomeEnv("claude-code");
   const proc = Bun.spawn(argv, {
     stdout: opts.stdout,
     stderr: opts.stderr,
+    ...(configHome && {
+      env: { ...process.env, [configHome.name]: configHome.value },
+    }),
   });
   return {
     stdout: proc.stdout,

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -146,6 +146,12 @@ export const CORTEX_PRESERVED_CLAUDE_ENV = new Set<string>([
   "CLAUDE_CODE_USE_VERTEX",
   // Entitlement / model selection that cortex itself may set.
   "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+  // NOTE: a substrate's config-home var (claude-code → CLAUDE_CONFIG_DIR) is
+  // deliberately NOT allowlisted here. Isolation stays strict default-deny; the
+  // config-home is set EXPLICITLY on the child env AFTER scoping, driven by the
+  // deployment `substrates:` block. See common/substrates/config-home.ts and
+  // cc-session.ts (configHomeEnv). This keeps "which config home" an intentional
+  // named export, not an inherited principal-personal passthrough.
 ]);
 
 /**

--- a/src/surface/mc/session/endpoint-resolver.ts
+++ b/src/surface/mc/session/endpoint-resolver.ts
@@ -7,7 +7,7 @@
 
 import type { Database } from "bun:sqlite";
 import type { Subprocess } from "bun";
-import { activeConfigHomeEnv } from "../../../common/substrates/config-home";
+import { configHomeSpawnEnv } from "../../../common/substrates/config-home";
 import type { SessionEndpoint, ManagedProcess } from "./types";
 import type { StreamJsonContentBlock } from "./stream-json";
 import { NotControllable, SessionConflict, SessionClosed } from "./types";
@@ -50,22 +50,21 @@ export function resolveSessionEndpoint(
 export type SpawnFn = (args: string[]) => Subprocess;
 
 const defaultSpawn: SpawnFn = (args) => {
-  // This is the SECOND `claude` spawn site in cortex (the other is
-  // runner/cc-session.ts) — both must export the deployment's configured config
-  // home, or the child authenticates against the vendor-default credential and
-  // expires independently of the principal's. Without an explicit `env` the
-  // child inherits `process.env`, which does NOT carry it; layer it on top.
-  // See common/substrates/config-home.ts.
-  const configHome = activeConfigHomeEnv("claude-code");
+  // One of the two places cortex spawns `claude` (the other is
+  // runner/cc-session.ts). Both must export the deployment's configured config
+  // home, or the child authenticates against the vendor-default credential,
+  // which refreshes independently of the principal's and expires. `env` is
+  // omitted when nothing is declared → plain inherit (the pre-existing
+  // behaviour). The decision itself lives in — and is unit-tested at —
+  // common/substrates/config-home.ts, because THIS wrapper is an injection-seam
+  // default that every test replaces, so logic placed here would never run
+  // under CI.
+  const env = configHomeSpawnEnv("claude-code");
   return Bun.spawn(args, {
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
-    // Omitted entirely when no config home is declared → plain inherit (the
-    // pre-existing behaviour), rather than an env we've needlessly rebuilt.
-    ...(configHome && {
-      env: { ...process.env, [configHome.name]: configHome.value },
-    }),
+    ...(env && { env }),
   });
 };
 

--- a/src/surface/mc/session/endpoint-resolver.ts
+++ b/src/surface/mc/session/endpoint-resolver.ts
@@ -7,6 +7,7 @@
 
 import type { Database } from "bun:sqlite";
 import type { Subprocess } from "bun";
+import { activeConfigHomeEnv } from "../../../common/substrates/config-home";
 import type { SessionEndpoint, ManagedProcess } from "./types";
 import type { StreamJsonContentBlock } from "./stream-json";
 import { NotControllable, SessionConflict, SessionClosed } from "./types";
@@ -48,12 +49,25 @@ export function resolveSessionEndpoint(
  */
 export type SpawnFn = (args: string[]) => Subprocess;
 
-const defaultSpawn: SpawnFn = (args) =>
-  Bun.spawn(args, {
+const defaultSpawn: SpawnFn = (args) => {
+  // This is the SECOND `claude` spawn site in cortex (the other is
+  // runner/cc-session.ts) — both must export the deployment's configured config
+  // home, or the child authenticates against the vendor-default credential and
+  // expires independently of the principal's. Without an explicit `env` the
+  // child inherits `process.env`, which does NOT carry it; layer it on top.
+  // See common/substrates/config-home.ts.
+  const configHome = activeConfigHomeEnv("claude-code");
+  return Bun.spawn(args, {
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
+    // Omitted entirely when no config home is declared → plain inherit (the
+    // pre-existing behaviour), rather than an env we've needlessly rebuilt.
+    ...(configHome && {
+      env: { ...process.env, [configHome.name]: configHome.value },
+    }),
   });
+};
 
 /**
  * Spawn a new controlled CC session for an assignment.


### PR DESCRIPTION
## Why

Cortex-dispatched `claude` sessions authenticated against the **vendor-default `~/.claude` credential** — a different Keychain entry from the principal's own soma-backed home (Claude Code namespaces the credential *by config dir*). Nothing refreshed that separate token, so it expired, and long-running unattended sessions (the dev-loop, PR review) died on auth.

## What

A substrate-agnostic **`substrates:`** deployment block. `configHome` is neutral; each substrate owns the translation to its own env var:

```yaml
substrates:
  claude-code: { configHome: ~/.claude-soma }   # → CLAUDE_CONFIG_DIR
  openai-codex: { configHome: ~/.codex }        # → CODEX_HOME
```

Cortex core never names `CLAUDE_CONFIG_DIR`; it asks the substrate layer (`common/substrates/config-home.ts`). Adding a substrate is a one-line typed registration.

**Isolation stays strict.** The config home is set on the child *after* `scopeSessionEnv`, so cortex#701's default-deny `CLAUDE_*` strip is **not** widened — an interim commit that allowlisted `CLAUDE_CONFIG_DIR` was reverted in favour of this.

**Coverage.** In-process sessions resolve it at the single spawn site (`cc-session`, fed by a process-wide value published at `startCortex` boot + hot reload). The two spawns that can't use that path — MC's `endpoint-resolver` and sage's subprocess — call the same exported `configHomeSpawnEnv()`.

## Honest boundaries

- **sage grandchild is an assumption.** sage isn't vendored here, so nothing proves it passes env through to the CLI it execs. Default inheritance makes it near-certain; not stated as fact.
- **`process-runner` is uncovered.** Its env is a pass-through *allowlist* (forwards what cortex has, cannot add), so a deployment-authored `claude` process spec has no route to the declared home.
- **MCP config travels with the home.** Isolation is strict at the *env-allowlist* layer, but `--setting-sources ""` doesn't gate `$CLAUDE_CONFIG_DIR/.claude.json` MCP servers. Inherent to any config home, default or otherwise — not introduced here.

## Verification

- `tsc` clean · `eslint` clean · 171 tests green across the affected suites.
- **Mutation-verified**, twice — the guards actually bite: breaking `buildSessionEnv`'s config-home fails 4 tests; breaking `configHomeSpawnEnv` fails 2 (incl. the codex case). An earlier iteration could be deleted wholesale with CI green; that's fixed.
- Drift-guard test asserts `SUBSTRATE_IDS` matches `AgentRuntimeSchema.substrate`.
- Running live on a work stack: `Claude config home: /Users/andreas/.claude-soma` at boot.

## Review history

Three independent adversarial passes; each of the first two found a real blocker, both fixed here:
1. Only 2 of 5 dispatch paths wired → moved to a single chokepoint.
2. "cc-session is the only claude spawn site" was **false** (MC `endpoint-resolver` + sage) → both covered.
3. Mechanism held up (no fourth path, no ordering regression, Bun env spread verified identical to inherit), but the *guard* claim was refuted (the two new sites were untested) and a **codex regression** was found — sage hardcoded `claude-code` at a dynamic-substrate site → now resolved per-substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYejuhj9MoK7GLFEg6K8kF
