### PR TITLE
feat(compose): L4a — docker-compose deployment path (cortex#2095)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ dist/
 tmp-screenshots/
 .playwright-cli/
 .specflow/
+
+# L4 compose path (cortex#2095): the filled .env carries the Discord bot token
+# and Claude OAuth token — never commit it. The .env.example placeholder file IS
+# tracked.
+deploy/compose/.env

--- a/deploy/compose/.dockerignore
+++ b/deploy/compose/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context minimal AND secret-free. The image clones cortex at a
+# pinned release tag (CORTEX_REF) inside the build — it does NOT COPY local
+# source — so the only file the build needs from this directory is
+# docker-entrypoint.sh.
+#
+# .env is excluded FIRST and unconditionally: a filled .env must never enter the
+# build context, so it can never end up in an image layer.
+.env
+
+# Everything else, then re-include only what the build actually COPYs.
+*
+!docker-entrypoint.sh

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -1,0 +1,52 @@
+# .env.example — the DD-L5 env contract for the L4 compose path (cortex#2095).
+#
+#   cp .env.example .env      # then replace every <REPLACE_ME>
+#
+# `.env` holds SECRETS. It is git-ignored (see ../../.gitignore) and is NEVER
+# copied into an image layer — docker-compose injects it at RUNTIME via
+# `env_file:`. Do not commit a filled `.env`. Do not paste real tokens or real
+# Discord ids into THIS example file — every value here is a placeholder.
+#
+# Every <REPLACE_ME> is an intentional tripwire: `cortex quickstart` shape-checks
+# the contract on boot and refuses to start until each is a real value, so an
+# unfilled file fails loudly and safely rather than booting a broken stack.
+
+# ── Identity ────────────────────────────────────────────────────────────────
+# CTX_PRINCIPAL — your principal id. Lowercase letters/digits/hyphens,
+#                 letter-first (e.g. the shape "ada-lovelace").
+CTX_PRINCIPAL=<REPLACE_ME>
+# CTX_SLUG — this stack's slug. Lowercase letters/digits/hyphens/underscores,
+#            letter-first. Also the COMPOSE_PROJECT_NAME you'll want to set.
+CTX_SLUG=<REPLACE_ME>
+
+# ── Bus ports ───────────────────────────────────────────────────────────────
+# Pinned to the scaffold defaults for v1. cortex reaches the bus over the shared
+# loopback (see the README "Networking model"). If you change these you MUST
+# also edit nats.conf's `listen:` / `http:` lines to match.
+CTX_NATS_PORT=4222
+CTX_NATS_MON=8222
+
+# ── Discord ids ─────────────────────────────────────────────────────────────
+# All four are numeric Discord snowflakes. In Discord: enable Developer Mode,
+# then right-click → Copy ID. (Guide: README-AGENTS.md Appendix A / §3.)
+# CTX_GUILD_ID — the server (guild) the bot is a member of.
+CTX_GUILD_ID=<REPLACE_ME>
+# CTX_CHANNEL_ID — the channel the assistant listens/replies in.
+CTX_CHANNEL_ID=<REPLACE_ME>
+# CTX_LOG_CHANNEL_ID — the channel the assistant posts operational logs to.
+CTX_LOG_CHANNEL_ID=<REPLACE_ME>
+# CTX_MY_DISCORD_ID — YOUR user id (the principal). The principal-only gate uses
+#                     this: only you can drive the assistant.
+CTX_MY_DISCORD_ID=<REPLACE_ME>
+
+# ── Secrets (required) ──────────────────────────────────────────────────────
+# CTX_DISCORD_TOKEN — REQUIRED. The bot token from the Discord Developer Portal
+#   (Bot → Reset Token). Must have the Message Content intent enabled. Leave
+#   BLANK here; fill only in your private, git-ignored `.env`.
+CTX_DISCORD_TOKEN=
+# CLAUDE_CODE_OAUTH_TOKEN — REQUIRED in a container (headless — there is no
+#   interactive `claude login` inside the image). Generate on a machine where
+#   you are logged into Claude Code with:  claude setup-token
+#   Honored by src/runner/cc-session.ts (suppresses ANTHROPIC_API_KEY when set).
+#   Leave BLANK here; fill only in your private, git-ignored `.env`.
+CLAUDE_CODE_OAUTH_TOKEN=

--- a/deploy/compose/Dockerfile.cortex
+++ b/deploy/compose/Dockerfile.cortex
@@ -1,0 +1,105 @@
+# syntax=docker/dockerfile:1
+#
+# Dockerfile.cortex — the container image for the L4 compose path (cortex#2095).
+#
+# Design decisions this image encodes (arc design/linux-host-support.md, arc#309):
+#   - DD-L4: containers are a DISTINCT supervision host — compose `restart:`
+#     policies supervise, systemd is absent (its detect() correctly no-ops here).
+#   - Claude Code auth is HEADLESS via CLAUDE_CODE_OAUTH_TOKEN at RUNTIME
+#     (honored by src/runner/cc-session.ts, which suppresses ANTHROPIC_API_KEY
+#     when the token is set). No token is ever baked into a layer — it arrives
+#     via `env_file: .env` at run time only. `docker history` shows zero secrets.
+#   - claude CLI + bun + nats-server are BAKED (reproducible), pinned by ARG.
+#
+# Every pinned version is an ARG so the image is reproducible and a rebuild can
+# bump a single component. CORTEX_REF defaults to a RELEASE TAG, never `main`.
+
+ARG CORTEX_REF=v6.8.5
+ARG BUN_VERSION=1.3.14
+ARG CLAUDE_VERSION=2.1.211
+ARG NATS_SERVER_VERSION=2.14.3
+
+FROM debian:bookworm-slim
+
+# Re-declare the ARGs consumed in this stage (ARGs before FROM are build-global
+# but must be re-stated to be visible in the build stage).
+ARG CORTEX_REF
+ARG BUN_VERSION
+ARG CLAUDE_VERSION
+ARG NATS_SERVER_VERSION
+# Provided automatically by BuildKit; used to fetch the right nats-server binary.
+ARG TARGETARCH
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    BUN_INSTALL=/usr/local \
+    HOME=/home/cortex \
+    CORTEX_CONFIG_DIR=/home/cortex/.config/metafactory/cortex
+
+# 1. Minimum toolchain. git/gh/ripgrep are needed by dispatched Claude Code
+#    sessions inside the container (the assistant's own tool surface); curl,
+#    unzip, ca-certificates, bash for install + the entrypoint.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gh \
+        ripgrep \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. Bun (pinned) — the only supported cortex runtime. Installs to
+#    $BUN_INSTALL/bin = /usr/local/bin (system-wide, on every user's PATH).
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
+    && bun --version
+
+# 3. Claude Code CLI (pinned). Global bun install lands in /usr/local/bin.
+#    Authentication is NOT performed here — it happens at runtime via the
+#    CLAUDE_CODE_OAUTH_TOKEN env var (DD-L4 headless auth).
+RUN bun install -g "@anthropic-ai/claude-code@${CLAUDE_VERSION}" \
+    && claude --version
+
+# 4. nats-server binary (pinned) — present ONLY to satisfy `cortex quickstart`'s
+#    preflight (step 1), which checks `nats-server` on PATH (a native-host
+#    assumption). The RUNNING bus is the SEPARATE official `nats` service in
+#    docker-compose.yaml — this binary is never launched as the daemon. See the
+#    README section "Why nats-server is baked into the cortex image". A future
+#    L3 follow-up (a quickstart `--container` mode) would let this be dropped.
+RUN arch="${TARGETARCH:-amd64}" \
+    && curl -fsSL -o /tmp/nats.tar.gz \
+        "https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER_VERSION}/nats-server-v${NATS_SERVER_VERSION}-linux-${arch}.tar.gz" \
+    && tar -xzf /tmp/nats.tar.gz -C /tmp \
+    && mv "/tmp/nats-server-v${NATS_SERVER_VERSION}-linux-${arch}/nats-server" /usr/local/bin/nats-server \
+    && rm -rf /tmp/nats.tar.gz /tmp/nats-server-v${NATS_SERVER_VERSION}-linux-${arch} \
+    && nats-server --version
+
+# 5. Non-root runtime user (uid 1000). All runtime state lives under its home,
+#    on named volumes mounted at run time.
+RUN useradd --create-home --uid 1000 --shell /bin/bash cortex
+
+# 6. cortex source at the pinned RELEASE tag (not main). Clone shallow, install
+#    frozen deps, drop a PATH shim, and hand ownership to the runtime user.
+RUN git clone --depth 1 --branch "${CORTEX_REF}" \
+        https://github.com/the-metafactory/cortex /opt/cortex \
+    && cd /opt/cortex \
+    && bun install --frozen-lockfile \
+    && printf '#!/usr/bin/env bash\nexec bun /opt/cortex/src/cortex.ts "$@"\n' \
+        > /usr/local/bin/cortex \
+    && chmod 0755 /usr/local/bin/cortex \
+    && chown -R cortex:cortex /opt/cortex
+
+# 7. Scaffold runtime dirs + default relay policy as the runtime user. The
+#    systemd render inside postinstall.sh detects the absent host bus and skips
+#    silently (DD-L4 / scripts/lib/systemd-render.sh:systemd_host_detected), so
+#    this is a clean no-op for the container's service story. Guarded with a
+#    tolerant fallback so a scaffolding hiccup never hard-fails the build.
+USER cortex
+WORKDIR /home/cortex
+RUN cd /opt/cortex && ./scripts/postinstall.sh || \
+    echo "cortex: postinstall.sh returned non-zero (systemd-less container) — continuing"
+
+# 8. Entrypoint: idempotent provision (quickstart) then hand off to the daemon.
+COPY --chown=cortex:cortex --chmod=0755 docker-entrypoint.sh /usr/local/bin/cortex-entrypoint
+
+ENTRYPOINT ["cortex-entrypoint"]

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -1,0 +1,105 @@
+# cortex on Docker Compose (L4)
+
+`docker compose up -d` = a running assistant. This is the container path from
+arc's `design/linux-host-support.md` (§L4 / DD-L4): compose supervises via
+`restart:` policies — systemd is absent by design.
+
+## Quickstart
+
+1. **Create the Discord bot** (one-time, manual — the Developer Portal has no
+   API for it). Create an application + bot, enable the **Message Content
+   intent**, invite it to your server, and copy the bot token. Full walkthrough:
+   [`README-AGENTS.md`](../../README-AGENTS.md) Appendix A / §3.
+2. **Generate a Claude OAuth token** on a machine already logged into Claude
+   Code: `claude setup-token`.
+3. `cp .env.example .env` and fill in every `<REPLACE_ME>` plus the two secrets
+   (`CTX_DISCORD_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`). `.env` is git-ignored.
+4. `docker compose up -d`
+5. **Verify:** `docker compose logs cortex | grep -E "Stack:|connected"` then
+   `@mention` the assistant in your channel as the principal — it replies.
+
+## What each file is
+
+| File | Role |
+|------|------|
+| `docker-compose.yaml` | Two services: `nats` (bus) + `cortex` (assistant). |
+| `Dockerfile.cortex` | The cortex image — bun + claude CLI + cortex, all pinned. |
+| `docker-entrypoint.sh` | Provisions (idempotent `cortex quickstart`) then `exec`s the daemon. |
+| `nats.conf` | The isolated per-stack JetStream bus config (mounted read-only). |
+| `.env.example` | The DD-L5 `CTX_*` env contract — placeholders only. |
+
+## Networking model (why `network_mode: "service:nats"`)
+
+cortex's scaffolded `system.yaml` sets `nats.url` to `nats://127.0.0.1:4222`, and
+cortex requires a **loopback** bus (`src/surface/mc/.../sibling-discovery.ts`).
+`cortex quickstart` patches only the bus *port*, never the *host*. So rather than
+rewrite the host to a service name, the `cortex` service **shares the `nats`
+container's network namespace** — cortex reaches the bus on `127.0.0.1:4222`
+exactly as on a native host, and `nats.conf` binds loopback so the bus is
+unreachable from outside the compose project (the project is the isolation
+boundary). `depends_on: condition: service_healthy` still gates cortex on the
+bus being up.
+
+_Alternative considered:_ a standard bridge network with cortex dialing
+`nats:4222`. That needs the entrypoint to rewrite `nats.url`'s host (which
+quickstart can't do) and breaks the loopback assumption. The shared-namespace
+approach needs zero config patching and mirrors the native single-host model. A
+future quickstart `--container` mode could make either explicit.
+
+## Why nats-server is baked into the cortex image
+
+`cortex quickstart`'s preflight (step 1) checks for `nats-server` on `PATH` — a
+native-host assumption. The cortex image therefore carries the pinned
+`nats-server` **binary solely to satisfy that check**. It is never launched as a
+daemon: the running bus is the separate official `nats` service. A quickstart
+`--container` / `--skip-preflight-nats` mode (recommended L3 follow-up) would let
+this binary be dropped.
+
+## The healthy-boot gate is deferred, not skipped
+
+quickstart's step 8 greps the cortex daemon's own log for healthy-boot lines, but
+in a container the daemon only starts *after* quickstart returns (`exec cortex
+start`). The entrypoint tolerates a **lone** step-8 failure and aborts on any
+earlier one. The real health signal in a container is the running daemon under
+`restart: unless-stopped` plus the nats healthcheck — verify with the `logs`
+grep in step 5 and by `@mention`.
+
+## Lifecycle
+
+- **Restart** (`docker compose restart`) preserves stack identity, seeds, and
+  sessions — all mutable state lives on the named volumes
+  (`cortex-config`, `cortex-state`, `cortex-nats`, `nats-jetstream`). quickstart
+  re-runs idempotently (every step a verified no-op).
+- **Stop/start** (`docker compose down && docker compose up -d`) with volumes
+  intact behaves identically. `docker compose down -v` **destroys** the stack
+  identity — don't, unless you mean to re-provision from scratch.
+- **Upgrade** — bump `CORTEX_REF` in `.env` (or the compose default) and
+  `docker compose build --pull && docker compose up -d`. (An automated
+  build+publish pipeline is the sibling L4b issue, cortex#2096.)
+
+## Pinned versions
+
+All are build ARGs, overridable from `.env`: `CORTEX_REF` (a release tag, **not**
+`main`), `BUN_VERSION`, `CLAUDE_VERSION`, `NATS_SERVER_VERSION`, and the
+`NATS_IMAGE` tag. Bump one, rebuild, redeploy.
+
+## Known limitation: Claude OAuth token lifetime
+
+Whether `CLAUDE_CODE_OAUTH_TOKEN` survives a long-lived headless container
+(≥ 48 h) without mid-flight expiry is an open observation (arc §L4 known
+challenge). If the token expires, the cortex#2068 auth-failure classifier is the
+safety net (it surfaces a clear re-auth message rather than failing silently).
+Refresh procedure: regenerate with `claude setup-token`, update `.env`, and
+`docker compose up -d` to recreate the cortex container with the new token.
+
+## Troubleshooting
+
+- **quickstart aborts before the gate** — an earlier step failed. Read
+  `docker compose logs cortex`; the ✓/✗ step table names the failure (a missing
+  `CTX_*`, an unauthenticated `claude`, etc.).
+- **No reply to @mention** — confirm the bot has the Message Content intent, is
+  in the guild, and that `CTX_MY_DISCORD_ID` is *your* id (the principal-only
+  gate stays silent for non-principals by design).
+- **Verify no secrets in the image** — `docker history cortex:local` and
+  `docker compose config` should show zero tokens (they arrive via `env_file`
+  at runtime only).

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -1,0 +1,74 @@
+# docker-compose.yaml — the L4 container path (cortex#2095).
+#
+#   cp .env.example .env      # then fill it in (see the README)
+#   docker compose up -d      # = a running assistant
+#
+# Two services:
+#   - nats:   the isolated per-stack JetStream bus (official image + mounted conf).
+#   - cortex: the assistant daemon, built from Dockerfile.cortex, provisioned +
+#             started by its entrypoint from the CTX_* env contract in .env.
+#
+# SUPERVISION (DD-L4): compose `restart: unless-stopped` is the supervisor —
+# systemd is absent by design in a container.
+#
+# NETWORKING: cortex shares the nats container's network namespace
+# (`network_mode: "service:nats"`) so it reaches the loopback bus at
+# 127.0.0.1:4222 — matching cortex's scaffolded `nats.url` and its
+# loopback-bus requirement, with NO host patching needed. See the README
+# ("Networking model") for the full rationale and the alternative.
+#
+# ISOLATION: one stack per compose project. `COMPOSE_PROJECT_NAME` (or the
+# `name:` below) namespaces the containers, network, and volumes, so a second
+# stack is a second copy of this directory with its own project name.
+
+name: cortex
+
+services:
+  nats:
+    image: ${NATS_IMAGE:-nats:2.14-alpine}
+    command: ["-c", "/etc/nats/stack.conf"]
+    volumes:
+      - ./nats.conf:/etc/nats/stack.conf:ro
+      - nats-jetstream:/data/jetstream
+    # The monitor endpoint (/healthz) gates cortex's start via depends_on. The
+    # alpine image variant carries busybox wget for an in-container probe.
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8222/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  cortex:
+    build:
+      context: .
+      dockerfile: Dockerfile.cortex
+      args:
+        CORTEX_REF: ${CORTEX_REF:-v6.8.5}
+        BUN_VERSION: ${BUN_VERSION:-1.3.14}
+        CLAUDE_VERSION: ${CLAUDE_VERSION:-2.1.211}
+        NATS_SERVER_VERSION: ${NATS_SERVER_VERSION:-2.14.3}
+    image: ${CORTEX_IMAGE:-cortex:local}
+    # Secrets + the CTX_* contract arrive at RUNTIME only — never baked (env_file,
+    # not build args / ENV). `docker history` therefore shows zero secrets.
+    env_file: .env
+    # Share the nats container's network namespace: cortex talks to the bus over
+    # 127.0.0.1 (see the header + README). depends_on still gates on nats health.
+    network_mode: "service:nats"
+    depends_on:
+      nats:
+        condition: service_healthy
+    volumes:
+      # All mutable, identity-bearing state — so restart / down+up preserve the
+      # stack identity, seeds, and sessions.
+      - cortex-config:/home/cortex/.config/metafactory/cortex
+      - cortex-state:/home/cortex/.local/state/metafactory/cortex
+      - cortex-nats:/home/cortex/.config/nats
+    restart: unless-stopped
+
+volumes:
+  nats-jetstream:
+  cortex-config:
+  cortex-state:
+  cortex-nats:

--- a/deploy/compose/docker-entrypoint.sh
+++ b/deploy/compose/docker-entrypoint.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# cortex-entrypoint — the cortex container's PID 1 (cortex#2095, L4a).
+#
+# Two phases, both driven by the DD-L5 `CTX_*` env contract that `env_file: .env`
+# injects:
+#
+#   1. Provision — `cortex quickstart` (L3, cortex#2094). Idempotent: on a fresh
+#      config volume it scaffolds + patches the stack; on a restart (config
+#      volume persisted) every step is a verified no-op. `--skip-services`
+#      because containers supervise via compose `restart:`, NOT systemd (DD-L4).
+#
+#   2. Run — `exec cortex start` becomes the container's long-running main
+#      process, so compose's `restart: unless-stopped` supervises the daemon and
+#      SIGTERM on `docker compose stop` reaches it directly.
+#
+# The healthy-boot gate (quickstart step 8) is EXPECTED to fail here: it greps
+# the cortex daemon's own log for healthy-boot lines, but the daemon only starts
+# in phase 2 (AFTER quickstart returns). In the split-container model the gate is
+# structurally a post-start check, so a LONE step-8 failure is tolerated; a
+# failure at any EARLIER step (preflight, env validation, scaffold, patch) is a
+# real provisioning error and aborts the boot. The compose healthcheck + restart
+# policy is the container's actual supervision contract.
+#
+# Secret hygiene: this script never echoes CTX_DISCORD_TOKEN or
+# CLAUDE_CODE_OAUTH_TOKEN. quickstart itself only ever prints "set"/"missing" for
+# those two keys (src/cli/cortex/commands/quickstart-lib.ts). Its provisioning
+# output is surfaced verbatim below precisely because it is secret-safe by
+# construction.
+
+set -euo pipefail
+
+: "${CTX_SLUG:?CTX_SLUG is required — see .env.example}"
+
+CONFIG_DIR="${CORTEX_CONFIG_DIR:-${HOME}/.config/metafactory/cortex}"
+POINTER="${CONFIG_DIR}/${CTX_SLUG}/${CTX_SLUG}.yaml"
+
+echo "cortex-entrypoint: provisioning stack '${CTX_SLUG}' (idempotent)…"
+
+# Run provisioning. `--json` so we can reason about WHICH step failed without
+# scraping human text. Capture instead of letting `set -e` abort on the expected
+# gate failure.
+set +e
+qs_out="$(cortex quickstart --skip-services --json 2>&1)"
+qs_rc=$?
+set -e
+
+printf '%s\n' "${qs_out}"
+
+if [ "${qs_rc}" -ne 0 ]; then
+  # quickstart stops at the FIRST failing step, so if the failing step is the
+  # healthy-boot gate then steps 1–7 all passed. Any other failing step means
+  # provisioning genuinely failed → abort (compose will restart us).
+  if printf '%s' "${qs_out}" | grep -q '8. Healthy-boot gate'; then
+    echo "cortex-entrypoint: provisioning complete; healthy-boot gate deferred to the daemon + compose healthcheck (expected in a container)." >&2
+  else
+    echo "cortex-entrypoint: quickstart failed before the healthy-boot gate — aborting boot." >&2
+    exit "${qs_rc}"
+  fi
+fi
+
+if [ ! -f "${POINTER}" ]; then
+  echo "cortex-entrypoint: expected stack pointer not found at ${POINTER} after provisioning — aborting." >&2
+  exit 1
+fi
+
+echo "cortex-entrypoint: starting daemon (cortex start --config ${POINTER})…"
+exec cortex start --config "${POINTER}"

--- a/deploy/compose/nats.conf
+++ b/deploy/compose/nats.conf
@@ -1,0 +1,28 @@
+# nats.conf — the isolated per-stack JetStream bus for the L4 compose path
+# (cortex#2095). Mounted read-only into the official `nats` image at
+# /etc/nats/stack.conf.
+#
+# ISOLATION WALL (README-AGENTS.md §4): the isolation is the ABSENCE of any
+# leafnodes{} / cluster{} / gateway{} block. One stack, one bus, no federation.
+#
+# LOOPBACK (deliberate): the cortex service shares this container's network
+# namespace (`network_mode: "service:nats"` in docker-compose.yaml), so cortex
+# reaches the bus at 127.0.0.1:4222 — matching cortex's scaffolded
+# system.yaml `nats.url` (nats://127.0.0.1:4222) AND cortex's loopback-bus
+# requirement (src/surface/mc/local-aggregation/sibling-discovery.ts). Binding
+# to loopback keeps the bus unreachable from outside the compose project — the
+# compose project IS the isolation boundary. Nothing is published to the host.
+#
+# The client (4222) and monitor (8222) ports MUST match CTX_NATS_PORT /
+# CTX_NATS_MON in .env. v1 pins them to the scaffold defaults; changing them
+# means editing BOTH this file and .env.
+
+server_name: cortex-nats
+listen: 127.0.0.1:4222
+http: 127.0.0.1:8222
+
+jetstream {
+  store_dir: /data/jetstream
+  max_mem: 64mb
+  max_file: 1gb
+}


### PR DESCRIPTION
Closes #2095. Epic arc#312 Wave 3 (L4a) — Vincent's stated destination: `docker compose up -d` → running assistant.

`deploy/compose/`: `Dockerfile.cortex` (debian-slim, non-root uid 1000, bun/claude-CLI/nats-server/cortex all ARG-pinned, `CORTEX_REF` defaults to the v6.8.5 release tag not main, no source COPY), `docker-compose.yaml` (`nats:2.14-alpine` + healthcheck; cortex `env_file: .env`, `depends_on: service_healthy`, `restart: unless-stopped`, named config/state/nats volumes), `docker-entrypoint.sh` (runs the merged `cortex quickstart` — idempotent), `nats.conf`, `.env.example`, `README.md`, `.dockerignore`, `.gitignore` for `.env`.

## Verified
- **Confidentiality:** `.env.example` is `<REPLACE_ME>` placeholders only; both secrets blank with "required" notes; `.env` git-ignored + dockerignored. Local confidentiality scan (diff mode): **0 findings**.
- `docker compose config -q` parses clean, secrets stay in `env_file` (no inline). shellcheck clean on the entrypoint.

## NOT verified in-session (honest gaps)
- **`docker build` + `docker history` secret check** — the sandbox OrbStack VM hit `no space left on device` mid-build (environment limit, not an instruction error; the executor correctly refused to force-prune a shared host). So image-builds-clean and no-secrets-in-layers are **unverified**. This gets its first real build at L4b's release-publish (fresh CI disk); recommend Vincent also validates on his real Debian box.
- End-to-end `up -d` → @mention (needs real tokens); 48h OAuth-token lifetime (documented as a README limitation, not faked).

## For the adversarial pass to scrutinize
1. `network_mode: "service:nats"` — cortex shares nats's netns for the required 127.0.0.1 loopback bus (quickstart patches port, not host; cortex needs a loopback bus per sibling-discovery.ts:22). Bridge-net alternative documented in the README.
2. `nats-server` baked into the cortex image *only* to satisfy quickstart's `which nats-server` preflight (the running bus is the separate nats service). Recommended L3 follow-up: a quickstart `--container` mode to drop both accommodations.
3. `CLAUDE_CODE_OAUTH_TOKEN` is "REQUIRED in a container" here (no interactive login) but quickstart (#2094) treats it as optional — the container relies on the README/comment, not a hard gate. Worth confirming that's acceptable.

Merges **before** L4b (#2096, the publish pipeline that builds this Dockerfile). Trust-path lane: CI + adversarial (confidentiality + secret-in-image + the accommodations) gate the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
