### PR TITLE
chore(ci): bump confidentiality-gate engine pin → 9b63de23 (hex-SHA false-positive fix)

### DIFF
--- a/.github/workflows/confidentiality-gate.yml
+++ b/.github/workflows/confidentiality-gate.yml
@@ -70,7 +70,7 @@ jobs:
   # Tiers 1 (gitleaks) + 2 (public shape patterns) + 3 (org-secret hashed
   # denylist). mode=auto maps pull_request→diff, push→tree, schedule→history.
   gate:
-    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-gate.yml@8ed0ab26f804aa98f74dcdcaf86917e09459f874
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-gate.yml@9b63de2394c32e54d9e4ebd4a90dcb93423bbf55
     permissions:
       contents: read
     with:
@@ -78,7 +78,7 @@ jobs:
       # is the engine's immutability anchor. `github.job_workflow_sha` resolves EMPTY
       # on cross-repo caller runs, so the gate cannot derive the engine SHA itself and
       # needs this explicit pin (metafactory-actions fix: engine_sha input).
-      engine_sha: 8ed0ab26f804aa98f74dcdcaf86917e09459f874
+      engine_sha: 9b63de2394c32e54d9e4ebd4a90dcb93423bbf55
       # Burn-in posture (design doc §4 L1). cortex has no MF_CONFIDENTIALITY_DENYLIST
       # configured yet, so on the TRUSTED same-repo path we explicitly opt OUT of the
       # fail-closed-on-absent-denylist behavior and DEGRADE to tiers 1+2 (gitleaks +
@@ -106,7 +106,7 @@ jobs:
   # public issue. This is the "push-alert stub" of design doc §6 PR 4.
   alert:
     if: ${{ github.event_name == 'push' }}
-    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-push-alert.yml@8ed0ab26f804aa98f74dcdcaf86917e09459f874
+    uses: the-metafactory/metafactory-actions/.github/workflows/confidentiality-push-alert.yml@9b63de2394c32e54d9e4ebd4a90dcb93423bbf55
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Delivers the fix from **metafactory-actions#20 / PR #21** to cortex's gate.

**Why:** cortex's gate pins the scan engine by commit SHA. The old pin (`8ed0ab26`) false-BLOCKs any PR whose head commit SHA happens to contain a 17–20 digit decimal run — which is exactly what killed the confidentiality-gate on PR #2123: the head SHA `3f51af2d4c2f43207129015163693cec2cd23ad0` embeds a 17-digit decimal substring, while the PR's title, body, branch, and diff were all clean.

**What:** moves all three pins to the merge commit `9b63de23` on metafactory-actions `main`, which carries the `suppress_in_hex` fix — a digit run inside a ≥32-char hex digest token is no longer flagged (letter-adjacent ids like `guildId…` / `webhook_…` stay caught; real snowflakes still block — 140/140 tests + empirical verify).

- `gate` `uses:@` (line 73)
- `engine_sha` input (line 81)
- `alert` push-alert `uses:@` (line 109)

Pure pin bump; no policy/posture change (`require_denylist: false` burn-in untouched). The gate on this very PR runs under the new engine — and the full incident SHA quoted above (hex-embedded) is itself a live regression check: the fixed engine suppresses it, the old one would have BLOCKed this PR.

Refs: cortex#2123, metafactory-actions#20, metafactory-actions#21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9wp7h9ThsZpMgpqSrCpWc
