### PR TITLE
feat(session): materialise granted skills as a --plugin-dir plugin (#2149)

### DIFF
--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -421,11 +421,16 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
       expect(existsSync(join(skillsDir, "secrets"))).toBe(false);
       // And the real out-of-tree secrets dir was never copied/removed.
       expect(existsSync(join(secretsDir, "SKILL.md"))).toBe(true);
-      // Each invalid name was logged and skipped.
+      // Each invalid name was logged and skipped. The empty string is called
+      // out explicitly: basename("") === "" passes the basename check, so only
+      // the `grant.length === 0` sub-clause rejects it — without this assertion
+      // deleting that sub-clause stays green while "" resolves to the skills
+      // ROOT and cpSync merges the entire source into the plugin.
       const log = logged.join("");
       expect(log).toContain("skill grant '../secrets' invalid — skipped");
       expect(log).toContain("skill grant '..' invalid — skipped");
       expect(log).toContain("skill grant '.' invalid — skipped");
+      expect(log).toContain("skill grant '' invalid — skipped");
     } finally {
       iso!.cleanup();
       rmSync(parent, { recursive: true, force: true });

--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -363,7 +363,7 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
     process.stderr.write = ((chunk: string | Uint8Array) => {
       logged.push(String(chunk));
       return true;
-    }) as typeof process.stderr.write;
+    });
     let iso: ReturnType<typeof createIsolatedSettings>;
     try {
       iso = createIsolatedSettings("/fake/.claude", ["present", "absent"], undefined, src);
@@ -401,7 +401,7 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
     process.stderr.write = ((chunk: string | Uint8Array) => {
       logged.push(String(chunk));
       return true;
-    }) as typeof process.stderr.write;
+    });
     let iso: ReturnType<typeof createIsolatedSettings>;
     try {
       iso = createIsolatedSettings(

--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -20,6 +20,8 @@ import {
   writeFileSync,
   rmSync,
   lstatSync,
+  chmodSync,
+  symlinkSync,
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -261,7 +263,7 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
     }
   });
 
-  test("non-empty grants → validating plugin layout with EXACTLY the granted skills symlinked + --plugin-dir arg", () => {
+  test("non-empty grants → validating plugin layout with EXACTLY the granted skills COPIED (not symlinked) + --plugin-dir arg", () => {
     const src = makeSkillSource(["alpha", "beta"]);
     const iso = createIsolatedSettings("/fake/.claude", ["alpha", "beta"], undefined, src);
     try {
@@ -280,16 +282,77 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
       expect(manifest.version.length).toBeGreaterThan(0);
       expect(manifest.description).toBe("cortex per-session granted skills");
 
-      // EXACTLY the granted skills are symlinked, and each is a symlink.
+      // EXACTLY the granted skills are present, and each is a real COPY dir —
+      // NOT a symlink (review MAJOR 1: symlinks let a session write through to
+      // the shared source).
       const skillsDir = join(iso.pluginDir!, "skills");
       for (const name of ["alpha", "beta"]) {
-        expect(lstatSync(join(skillsDir, name)).isSymbolicLink()).toBe(true);
+        const st = lstatSync(join(skillsDir, name));
+        expect(st.isSymbolicLink()).toBe(false);
+        expect(st.isDirectory()).toBe(true);
         expect(existsSync(join(skillsDir, name, "SKILL.md"))).toBe(true);
       }
       expect(existsSync(join(skillsDir, "gamma"))).toBe(false);
     } finally {
       iso.cleanup();
       rmSync(src, { recursive: true, force: true });
+    }
+  });
+
+  test("MAJOR 1 — writing through a materialised skill CANNOT poison the shared source", () => {
+    const src = makeSkillSource(["poison-me"]);
+    const sourceSkill = join(src, "poison-me", "SKILL.md");
+    const original = readFileSync(sourceSkill, "utf8");
+
+    const iso = createIsolatedSettings("/fake/.claude", ["poison-me"], undefined, src);
+    try {
+      const copied = join(iso.pluginDir!, "skills", "poison-me", "SKILL.md");
+      // Defence-in-depth: the copy is read-only (0444) — the last 3 mode bits.
+      expect(lstatSync(copied).mode & 0o777).toBe(0o444);
+      // Even if a same-uid session chmods its own copy back and writes to it…
+      chmodSync(copied, 0o644);
+      writeFileSync(copied, "# PWNED");
+      // …the SHARED source is untouched, because the copy severed the link.
+      expect(readFileSync(sourceSkill, "utf8")).toBe(original);
+      expect(readFileSync(sourceSkill, "utf8")).not.toContain("PWNED");
+    } finally {
+      iso.cleanup();
+      rmSync(src, { recursive: true, force: true });
+    }
+  });
+
+  test("MAJOR 1 (regression) — SYMLINKED skill source is dereferenced, not re-linked", () => {
+    // Production reality: an installed skill dir is itself a symlink
+    // (~/.claude/skills/gws-drive → ~/.soma/skills/gws-drive). A non-
+    // dereferencing copy would recreate that symlink and the write-through
+    // hole would stay open. Reproduce that layout exactly.
+    const parent = mkdtempSync(join(tmpdir(), "cortex-symlinksrc-"));
+    const realDir = join(parent, "real-store", "linked");
+    mkdirSync(realDir, { recursive: true });
+    const realSkill = join(realDir, "SKILL.md");
+    writeFileSync(realSkill, "# real content");
+    // The skills SOURCE dir holds a SYMLINK to the real store, mirroring
+    // ~/.claude/skills/<name> → <config-home>/skills/<name>.
+    const skillsSrc = join(parent, "skills");
+    mkdirSync(skillsSrc, { recursive: true });
+    symlinkSync(realDir, join(skillsSrc, "linked"));
+
+    const original = readFileSync(realSkill, "utf8");
+    const iso = createIsolatedSettings("/fake/.claude", ["linked"], undefined, skillsSrc);
+    try {
+      const copiedDir = join(iso.pluginDir!, "skills", "linked");
+      // The materialised dir must be a REAL dir, not a recreated symlink.
+      expect(lstatSync(copiedDir).isSymbolicLink()).toBe(false);
+      expect(lstatSync(copiedDir).isDirectory()).toBe(true);
+      // Write through the copy → the real underlying source stays clean.
+      const copiedSkill = join(copiedDir, "SKILL.md");
+      chmodSync(copiedSkill, 0o644);
+      writeFileSync(copiedSkill, "# PWNED");
+      expect(readFileSync(realSkill, "utf8")).toBe(original);
+      expect(readFileSync(realSkill, "utf8")).not.toContain("PWNED");
+    } finally {
+      iso.cleanup();
+      rmSync(parent, { recursive: true, force: true });
     }
   });
 
@@ -308,7 +371,7 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
       process.stderr.write = original;
     }
     try {
-      // Session still built with a plugin; present skill symlinked, absent skipped.
+      // Session still built with a plugin; present skill copied, absent skipped.
       expect(iso.pluginDir).toBeDefined();
       expect(existsSync(join(iso.pluginDir!, "skills", "present"))).toBe(true);
       expect(existsSync(join(iso.pluginDir!, "skills", "absent"))).toBe(false);
@@ -322,7 +385,73 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
     }
   });
 
-  test("sibling-relative reference between two granted skills resolves through the symlinks", () => {
+  test("MAJOR 2 — traversal / dot grant names are rejected before any path use", () => {
+    // Self-contained layout: parent/{skills/ok, secrets}. A '../secrets' grant
+    // resolved from parent/skills would reach parent/secrets — it must NOT.
+    const parent = mkdtempSync(join(tmpdir(), "cortex-trav-"));
+    const skillsSrc = join(parent, "skills");
+    mkdirSync(join(skillsSrc, "ok"), { recursive: true });
+    writeFileSync(join(skillsSrc, "ok", "SKILL.md"), "# ok");
+    const secretsDir = join(parent, "secrets");
+    mkdirSync(secretsDir, { recursive: true });
+    writeFileSync(join(secretsDir, "SKILL.md"), "# top secret");
+
+    const logged: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      logged.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    let iso: ReturnType<typeof createIsolatedSettings>;
+    try {
+      iso = createIsolatedSettings(
+        "/fake/.claude",
+        ["../secrets", "..", ".", "", "ok"],
+        undefined,
+        skillsSrc,
+      );
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    try {
+      // Session constructs; only the single valid grant materialised.
+      const skillsDir = join(iso.pluginDir!, "skills");
+      expect(existsSync(join(skillsDir, "ok"))).toBe(true);
+      // No entry escaped skills/ — the traversal grant never reached 'secrets'.
+      expect(existsSync(join(skillsDir, "secrets"))).toBe(false);
+      // And the real out-of-tree secrets dir was never copied/removed.
+      expect(existsSync(join(secretsDir, "SKILL.md"))).toBe(true);
+      // Each invalid name was logged and skipped.
+      const log = logged.join("");
+      expect(log).toContain("skill grant '../secrets' invalid — skipped");
+      expect(log).toContain("skill grant '..' invalid — skipped");
+      expect(log).toContain("skill grant '.' invalid — skipped");
+    } finally {
+      iso!.cleanup();
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  test("MINOR — every grant invalid/missing → NO plugin dir, no --plugin-dir arg", () => {
+    const src = makeSkillSource([]); // empty source: valid names, but nothing present
+    const iso = createIsolatedSettings(
+      "/fake/.claude",
+      ["nope", "also-nope", ".."],
+      undefined,
+      src,
+    );
+    try {
+      expect(iso.pluginDir).toBeUndefined();
+      expect(iso.args).not.toContain("--plugin-dir");
+      // The empty plugin dir was removed, not left on disk.
+      expect(existsSync(join(iso.settingsPath, "..", "plugin"))).toBe(false);
+    } finally {
+      iso.cleanup();
+      rmSync(src, { recursive: true, force: true });
+    }
+  });
+
+  test("sibling-relative reference between two granted skills resolves through the copies", () => {
     // gws-drive references ../gws-shared/SKILL.md — the canonical case (#990 §3).
     const src = makeSkillSource(["gws-drive", "gws-shared"], {
       "gws-drive": "See ../gws-shared/SKILL.md",
@@ -335,7 +464,7 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
     );
     try {
       const skillsDir = join(iso.pluginDir!, "skills");
-      // Path resolution across the two sibling symlinks must reach the target.
+      // Both copies land in the same skills/ dir, so the sibling path resolves.
       const sibling = join(skillsDir, "gws-drive", "..", "gws-shared", "SKILL.md");
       expect(existsSync(sibling)).toBe(true);
     } finally {
@@ -344,19 +473,20 @@ describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () 
     }
   });
 
-  test("cleanup removes the plugin tree (symlinks) but NOT the symlink targets", () => {
+  test("cleanup removes the read-only plugin tree but NOT the copied-from sources", () => {
     const src = makeSkillSource(["keeper"]);
     const iso = createIsolatedSettings("/fake/.claude", ["keeper"], undefined, src);
     const pluginDir = iso.pluginDir!;
     expect(existsSync(pluginDir)).toBe(true);
     expect(existsSync(join(pluginDir, "skills", "keeper"))).toBe(true);
 
-    iso.cleanup();
+    // cleanup must succeed even though the copies are read-only (0444/0555).
+    expect(() => iso.cleanup()).not.toThrow();
 
-    // The whole temp tree (settings + plugin + symlinks) is gone…
+    // The whole temp tree (settings + plugin + copies) is gone…
     expect(existsSync(pluginDir)).toBe(false);
     expect(existsSync(iso.settingsPath)).toBe(false);
-    // …but the symlink TARGET (the real source skill) is untouched.
+    // …but the SOURCE skill (what we copied FROM) is untouched.
     expect(existsSync(join(src, "keeper", "SKILL.md"))).toBe(true);
     rmSync(src, { recursive: true, force: true });
   });

--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -12,14 +12,43 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { readFileSync, existsSync } from "fs";
+import {
+  readFileSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  lstatSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   CORTEX_SETTING_SOURCES,
   CORTEX_PRESERVED_CLAUDE_ENV,
+  CORTEX_GRANTED_PLUGIN_NAME,
   buildCuratedSettings,
   createIsolatedSettings,
   scopeSessionEnv,
 } from "../session-settings";
+
+/**
+ * Build a throwaway skills-source dir with one sub-dir per named skill, each
+ * carrying a `SKILL.md`. Returns the dir; caller cleans it up. `refs` maps a
+ * skill name → text appended to its SKILL.md (used to plant a sibling-relative
+ * reference like `../other/SKILL.md`).
+ */
+function makeSkillSource(
+  skills: string[],
+  refs: Record<string, string> = {},
+): string {
+  const src = mkdtempSync(join(tmpdir(), "cortex-skillsrc-"));
+  for (const name of skills) {
+    mkdirSync(join(src, name), { recursive: true });
+    writeFileSync(join(src, name, "SKILL.md"), `# ${name}\n${refs[name] ?? ""}`);
+  }
+  return src;
+}
 
 describe("CORTEX_SETTING_SOURCES — no ambient source loaded", () => {
   test("never loads the principal's `user` source", () => {
@@ -208,6 +237,128 @@ describe("createIsolatedSettings — materialised file + args", () => {
     expect(existsSync(iso.settingsPath)).toBe(false);
     // Second call must not throw.
     expect(() => iso.cleanup()).not.toThrow();
+  });
+});
+
+describe("createIsolatedSettings — granted-skills plugin (cortex#990 A1)", () => {
+  test("empty/undefined grants → NO plugin dir, args unchanged from current main", () => {
+    for (const grants of [undefined, []] as const) {
+      const iso = createIsolatedSettings("/fake/.claude", grants);
+      try {
+        expect(iso.pluginDir).toBeUndefined();
+        expect(iso.args).not.toContain("--plugin-dir");
+        // Byte-identical arg shape to the pre-#990 isolation args.
+        expect(iso.args).toEqual([
+          "--setting-sources",
+          "",
+          "--settings",
+          iso.settingsPath,
+        ]);
+        expect(existsSync(join(iso.settingsPath, "..", "plugin"))).toBe(false);
+      } finally {
+        iso.cleanup();
+      }
+    }
+  });
+
+  test("non-empty grants → validating plugin layout with EXACTLY the granted skills symlinked + --plugin-dir arg", () => {
+    const src = makeSkillSource(["alpha", "beta"]);
+    const iso = createIsolatedSettings("/fake/.claude", ["alpha", "beta"], undefined, src);
+    try {
+      // --plugin-dir points at the materialised plugin, inside the temp dir.
+      const pdIdx = iso.args.indexOf("--plugin-dir");
+      expect(pdIdx).toBeGreaterThan(-1);
+      expect(iso.args[pdIdx + 1]).toBe(iso.pluginDir);
+      expect(iso.pluginDir).toBeDefined();
+
+      // plugin.json is present and shaped as the spike requires.
+      const manifest = JSON.parse(
+        readFileSync(join(iso.pluginDir!, ".claude-plugin", "plugin.json"), "utf8"),
+      );
+      expect(manifest.name).toBe(CORTEX_GRANTED_PLUGIN_NAME);
+      expect(typeof manifest.version).toBe("string");
+      expect(manifest.version.length).toBeGreaterThan(0);
+      expect(manifest.description).toBe("cortex per-session granted skills");
+
+      // EXACTLY the granted skills are symlinked, and each is a symlink.
+      const skillsDir = join(iso.pluginDir!, "skills");
+      for (const name of ["alpha", "beta"]) {
+        expect(lstatSync(join(skillsDir, name)).isSymbolicLink()).toBe(true);
+        expect(existsSync(join(skillsDir, name, "SKILL.md"))).toBe(true);
+      }
+      expect(existsSync(join(skillsDir, "gamma"))).toBe(false);
+    } finally {
+      iso.cleanup();
+      rmSync(src, { recursive: true, force: true });
+    }
+  });
+
+  test("missing-skill grant → loud log line + skipped, session still constructs", () => {
+    const src = makeSkillSource(["present"]); // 'absent' has no source dir
+    const logged: string[] = [];
+    const original = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      logged.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write;
+    let iso: ReturnType<typeof createIsolatedSettings>;
+    try {
+      iso = createIsolatedSettings("/fake/.claude", ["present", "absent"], undefined, src);
+    } finally {
+      process.stderr.write = original;
+    }
+    try {
+      // Session still built with a plugin; present skill symlinked, absent skipped.
+      expect(iso.pluginDir).toBeDefined();
+      expect(existsSync(join(iso.pluginDir!, "skills", "present"))).toBe(true);
+      expect(existsSync(join(iso.pluginDir!, "skills", "absent"))).toBe(false);
+      // Loud log line naming the missing grant + the searched dir.
+      const line = logged.join("");
+      expect(line).toContain("skill grant 'absent' not found");
+      expect(line).toContain(src);
+    } finally {
+      iso!.cleanup();
+      rmSync(src, { recursive: true, force: true });
+    }
+  });
+
+  test("sibling-relative reference between two granted skills resolves through the symlinks", () => {
+    // gws-drive references ../gws-shared/SKILL.md — the canonical case (#990 §3).
+    const src = makeSkillSource(["gws-drive", "gws-shared"], {
+      "gws-drive": "See ../gws-shared/SKILL.md",
+    });
+    const iso = createIsolatedSettings(
+      "/fake/.claude",
+      ["gws-drive", "gws-shared"],
+      undefined,
+      src,
+    );
+    try {
+      const skillsDir = join(iso.pluginDir!, "skills");
+      // Path resolution across the two sibling symlinks must reach the target.
+      const sibling = join(skillsDir, "gws-drive", "..", "gws-shared", "SKILL.md");
+      expect(existsSync(sibling)).toBe(true);
+    } finally {
+      iso.cleanup();
+      rmSync(src, { recursive: true, force: true });
+    }
+  });
+
+  test("cleanup removes the plugin tree (symlinks) but NOT the symlink targets", () => {
+    const src = makeSkillSource(["keeper"]);
+    const iso = createIsolatedSettings("/fake/.claude", ["keeper"], undefined, src);
+    const pluginDir = iso.pluginDir!;
+    expect(existsSync(pluginDir)).toBe(true);
+    expect(existsSync(join(pluginDir, "skills", "keeper"))).toBe(true);
+
+    iso.cleanup();
+
+    // The whole temp tree (settings + plugin + symlinks) is gone…
+    expect(existsSync(pluginDir)).toBe(false);
+    expect(existsSync(iso.settingsPath)).toBe(false);
+    // …but the symlink TARGET (the real source skill) is untouched.
+    expect(existsSync(join(src, "keeper", "SKILL.md"))).toBe(true);
+    rmSync(src, { recursive: true, force: true });
   });
 });
 

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -7,6 +7,7 @@
 
 import { EventEmitter } from "events";
 import { homedir } from "os";
+import { join } from "path";
 import { parseStreamLine, StreamLineBuffer, type UsageStats, type StreamEvent } from "./stream-parser";
 import { buildClaudeArgs, type ClaudeInvocationOpts } from "./claude-invoker";
 import {
@@ -298,10 +299,20 @@ export class CCSession extends EventEmitter {
         : [];
     const isolationArgs: string[] = [];
     if (isolate) {
+      // cortex#990 A1 — granted skills are symlinked from the claude-code
+      // config home's `skills/` dir (the same home the child authenticates
+      // against, #2132), falling back to `~/.claude/skills` when no config
+      // home was declared. Resolved here, at the single spawn site, so every
+      // dispatch path uses the same source without threading it through.
+      const skillSourceDir = join(
+        activeConfigHomeEnv("claude-code")?.value ?? `${homedir()}/.claude`,
+        "skills",
+      );
       this.isolatedSettings = createIsolatedSettings(
         this.opts.claudeDir ?? `${homedir()}/.claude`,
         skillGrants,
         mcpGrants,
+        skillSourceDir,
       );
       isolationArgs.push(...this.isolatedSettings.args);
     }

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -95,9 +95,18 @@
  * See {@link scopeSessionEnv}.
  */
 
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
-import { tmpdir } from "os";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  symlinkSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+} from "fs";
+import { tmpdir, homedir } from "os";
 import { join } from "path";
+import { parse as parseYaml } from "yaml";
 
 /**
  * The setting sources cortex bot sessions load: NONE. Deliberately empty.
@@ -179,6 +188,103 @@ export const CORTEX_SKILL_GRANTS_ENV = "CORTEX_SKILL_GRANTS";
  * — exactly the {@link CORTEX_SKILL_GRANTS_ENV} pattern.
  */
 export const CORTEX_MCP_GRANTS_ENV = "CORTEX_MCP_GRANTS";
+
+/**
+ * Name of the Claude Code plugin cortex materialises to carry a session's
+ * granted skills (cortex#990 A1). Fixed string — the plugin is per-session
+ * and single-purpose, so its name never varies. The `/`-prefixed skill
+ * invocation the model sees is namespaced under it (`/cortex-granted:<skill>`).
+ */
+export const CORTEX_GRANTED_PLUGIN_NAME = "cortex-granted";
+
+/**
+ * Default source dir for granted skills: `~/.claude/skills`. Used when the
+ * deployment declared no `configHome` for the claude-code substrate (#2132).
+ * The caller (cc-session.ts) overrides this with `<configHome>/skills` when a
+ * config home IS declared, so grants resolve against the SAME home the child
+ * session authenticates and loads config from.
+ */
+export const DEFAULT_SKILL_SOURCE_DIR = join(homedir(), ".claude", "skills");
+
+/**
+ * Cortex's version string for the materialised plugin's `plugin.json`, read
+ * from the repo-root `arc-manifest.yaml` (the same source `getVersion` in
+ * cortex.ts uses) with a `"0.0.0"` fallback. Cosmetic for `claude plugin
+ * validate` — any non-empty string validates — but we carry the real version
+ * so a materialised plugin is self-describing. Computed lazily and cached so
+ * module load stays free of filesystem work.
+ */
+let cachedCortexVersion: string | undefined;
+function cortexPluginVersion(): string {
+  if (cachedCortexVersion !== undefined) return cachedCortexVersion;
+  try {
+    const manifestPath = join(import.meta.dir, "..", "..", "arc-manifest.yaml");
+    const manifest = parseYaml(readFileSync(manifestPath, "utf-8")) as { version?: string };
+    cachedCortexVersion = manifest.version ?? "0.0.0";
+  } catch {
+    cachedCortexVersion = "0.0.0";
+  }
+  return cachedCortexVersion;
+}
+
+/**
+ * Materialise the granted skills as a Claude Code **plugin** inside `dir`
+ * (cortex#990 A1). Layout, matching the validated spike:
+ *
+ *   plugin/
+ *   ├── .claude-plugin/plugin.json   ← {name, version, description}
+ *   └── skills/<grant>/              ← one symlink per granted skill
+ *
+ * Each grant is symlinked from `<skillSourceDir>/<grant>`. A grant whose
+ * source dir does not exist is logged loudly and skipped — never thrown, so a
+ * stale grant can't abort session construction. All grants land in ONE
+ * `skills/` dir, so a skill's sibling-relative reference
+ * (e.g. `../gws-shared/SKILL.md`) resolves through the symlinks.
+ *
+ * Returns the plugin dir when it was created (grants non-empty), else
+ * `undefined`. The caller appends `--plugin-dir <pluginDir>` to the session
+ * args; `cleanup()` removes the whole temp tree (the symlinks, never their
+ * targets).
+ */
+function materialiseGrantedPlugin(
+  dir: string,
+  skillGrants: readonly string[],
+  skillSourceDir: string,
+): string | undefined {
+  if (skillGrants.length === 0) return undefined;
+
+  const pluginDir = join(dir, "plugin");
+  const skillsDir = join(pluginDir, "skills");
+  mkdirSync(join(pluginDir, ".claude-plugin"), { recursive: true });
+  mkdirSync(skillsDir, { recursive: true });
+  writeFileSync(
+    join(pluginDir, ".claude-plugin", "plugin.json"),
+    JSON.stringify(
+      {
+        name: CORTEX_GRANTED_PLUGIN_NAME,
+        version: cortexPluginVersion(),
+        description: "cortex per-session granted skills",
+      },
+      null,
+      2,
+    ),
+  );
+
+  for (const grant of skillGrants) {
+    const target = join(skillSourceDir, grant);
+    if (!existsSync(target)) {
+      process.stderr.write(
+        `cortex: skill grant '${grant}' not found under ${skillSourceDir} — skipped\n`,
+      );
+      continue;
+    }
+    // Symlink the source skill DIR (not its contents) — one link per grant, all
+    // siblings under `skills/`, so intra-skill `../other` refs keep resolving.
+    symlinkSync(target, join(skillsDir, grant));
+  }
+
+  return pluginDir;
+}
 
 /**
  * Build the curated settings object cortex spawns bot sessions under.
@@ -281,11 +387,20 @@ export interface IsolatedSettings {
   settingsPath: string;
   /**
    * CLI args to append: `--setting-sources "" --settings <path>` (empty
-   * source list ⇒ load no ambient source; only the curated file). Order
-   * matters only in that both must precede `-p <prompt>` (handled by
-   * buildClaudeArgs putting the prompt last).
+   * source list ⇒ load no ambient source; only the curated file). When the
+   * session is granted skills, ALSO carries `--plugin-dir <pluginDir>` (the
+   * materialised granted-skills plugin, cortex#990 A1). Order matters only in
+   * that all must precede `-p <prompt>` (handled by buildClaudeArgs putting
+   * the prompt last).
    */
   args: string[];
+  /**
+   * Absolute path to the materialised granted-skills plugin dir, or
+   * `undefined` when the session was granted no skills. Exposed so callers/
+   * tests can locate it (e.g. to run `claude plugin validate`); it lives
+   * INSIDE the temp dir, so `cleanup()` removes it.
+   */
+  pluginDir?: string;
   /** Remove the temp dir. Safe to call multiple times. */
   cleanup: () => void;
 }
@@ -306,11 +421,17 @@ export interface IsolatedSettings {
  *   `[]`) → the curated file registers the MCP Guard PreToolUse hook and the
  *   caller must set the {@link CORTEX_MCP_GRANTS_ENV} env var. Undefined →
  *   no MCP hook (non-policy path, behaviour unchanged).
+ * @param skillSourceDir Dir the granted skills are symlinked FROM (cortex#990
+ *   A1). Defaults to {@link DEFAULT_SKILL_SOURCE_DIR} (`~/.claude/skills`); the
+ *   caller passes `<configHome>/skills` when the deployment relocated the
+ *   claude-code config home (#2132). Only consulted when `skillGrants` is
+ *   non-empty.
  */
 export function createIsolatedSettings(
   claudeDir: string,
   skillGrants?: readonly string[],
   mcpGrants?: readonly string[],
+  skillSourceDir: string = DEFAULT_SKILL_SOURCE_DIR,
 ): IsolatedSettings {
   const dir = mkdtempSync(join(tmpdir(), "cortex-session-"));
   const settingsPath = join(dir, "settings.json");
@@ -322,14 +443,29 @@ export function createIsolatedSettings(
     },
   );
 
+  const args = [
+    "--setting-sources",
+    CORTEX_SETTING_SOURCES.join(","),
+    "--settings",
+    settingsPath,
+  ];
+
+  // cortex#990 A1 — when the session is granted skills, materialise them as a
+  // --plugin-dir plugin ALONGSIDE the curated settings (the isolation posture,
+  // empty --setting-sources included, is untouched). Empty/undefined grants →
+  // no plugin, no extra arg → byte-identical to the pre-#990 behaviour.
+  const pluginDir =
+    skillGrants !== undefined && skillGrants.length > 0
+      ? materialiseGrantedPlugin(dir, skillGrants, skillSourceDir)
+      : undefined;
+  if (pluginDir !== undefined) {
+    args.push("--plugin-dir", pluginDir);
+  }
+
   return {
     settingsPath,
-    args: [
-      "--setting-sources",
-      CORTEX_SETTING_SOURCES.join(","),
-      "--settings",
-      settingsPath,
-    ],
+    args,
+    pluginDir,
     cleanup: () => {
       try {
         rmSync(dir, { recursive: true, force: true });

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -99,13 +99,16 @@ import {
   mkdtempSync,
   mkdirSync,
   writeFileSync,
-  symlinkSync,
+  cpSync,
+  chmodSync,
+  lstatSync,
+  readdirSync,
   existsSync,
   readFileSync,
   rmSync,
 } from "fs";
 import { tmpdir, homedir } from "os";
-import { join } from "path";
+import { join, basename } from "path";
 import { parse as parseYaml } from "yaml";
 
 /**
@@ -233,18 +236,28 @@ function cortexPluginVersion(): string {
  *
  *   plugin/
  *   ├── .claude-plugin/plugin.json   ← {name, version, description}
- *   └── skills/<grant>/              ← one symlink per granted skill
+ *   └── skills/<grant>/              ← a read-only COPY per granted skill
  *
- * Each grant is symlinked from `<skillSourceDir>/<grant>`. A grant whose
- * source dir does not exist is logged loudly and skipped — never thrown, so a
- * stale grant can't abort session construction. All grants land in ONE
- * `skills/` dir, so a skill's sibling-relative reference
- * (e.g. `../gws-shared/SKILL.md`) resolves through the symlinks.
+ * Each grant is COPIED (not symlinked) from `<skillSourceDir>/<grant>`. The
+ * copy is the fix for the review's MAJOR 1: a symlinked source dir let a
+ * Bash-holding session write THROUGH the link and poison the shared skill
+ * source; copying severs that link. All grants land in ONE `skills/` dir, so a
+ * skill's sibling-relative reference (e.g. `../gws-shared/SKILL.md`) still
+ * resolves. Files are set 0444 / dirs 0555 as defence-in-depth (a same-uid
+ * session can chmod its own throwaway copy back — accepted residual; the
+ * shared source is already out of reach because the link is gone).
  *
- * Returns the plugin dir when it was created (grants non-empty), else
- * `undefined`. The caller appends `--plugin-dir <pluginDir>` to the session
- * args; `cleanup()` removes the whole temp tree (the symlinks, never their
- * targets).
+ * Grant names are validated BEFORE any path use (review MAJOR 2): anything
+ * that isn't a bare basename (`../secrets`, `..`, `.`, empty) is logged and
+ * skipped — a crafted grant can neither escape `skills/` nor abort session
+ * construction. Each copy is wrapped in try/catch for the same reason: any
+ * failure (e.g. a pre-existing name) is logged and skipped, never thrown.
+ *
+ * Returns the plugin dir only when ≥1 skill actually materialised; when every
+ * grant was invalid/missing/failed it removes the empty plugin dir and returns
+ * `undefined` (review MINOR — no `--plugin-dir` for a zero-skill plugin). The
+ * caller appends `--plugin-dir <pluginDir>` to the session args; `cleanup()`
+ * removes the whole temp tree (the copies, never the sources).
  */
 function materialiseGrantedPlugin(
   dir: string,
@@ -270,7 +283,22 @@ function materialiseGrantedPlugin(
     ),
   );
 
+  let materialised = 0;
   for (const grant of skillGrants) {
+    // Reject unsafe grant names BEFORE building any path (review MAJOR 2). A
+    // bare character class like /^[\w.-]+$/ is NOT enough — `..` matches it —
+    // so require the name to equal its own basename AND exclude the dot names
+    // and the empty string explicitly.
+    if (
+      grant.length === 0 ||
+      grant === "." ||
+      grant === ".." ||
+      basename(grant) !== grant
+    ) {
+      process.stderr.write(`cortex: skill grant '${grant}' invalid — skipped\n`);
+      continue;
+    }
+
     const target = join(skillSourceDir, grant);
     if (!existsSync(target)) {
       process.stderr.write(
@@ -278,12 +306,78 @@ function materialiseGrantedPlugin(
       );
       continue;
     }
-    // Symlink the source skill DIR (not its contents) — one link per grant, all
-    // siblings under `skills/`, so intra-skill `../other` refs keep resolving.
-    symlinkSync(target, join(skillsDir, grant));
+
+    try {
+      const dest = join(skillsDir, grant);
+      // Recursive COPY (not symlink) severs the write path back to the shared
+      // source. `dereference: true` is LOAD-BEARING, not cosmetic: an installed
+      // skill dir is itself typically a symlink (e.g. ~/.claude/skills/gws-drive
+      // → ~/.soma/skills/gws-drive), and a non-dereferencing copy would just
+      // recreate that symlink — leaving the write-through-to-source hole open.
+      // Dereferencing materialises real files, fully severing the link. Then
+      // lock it down read-only as defence-in-depth.
+      cpSync(target, dest, { recursive: true, dereference: true });
+      chmodTreeReadOnly(dest);
+      materialised++;
+    } catch (err) {
+      // Never let a crafted/racy grant abort session construction.
+      process.stderr.write(
+        `cortex: skill grant '${grant}' — materialise failed, skipped: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    }
   }
 
+  if (materialised === 0) {
+    // Every grant was invalid/missing/failed — don't advertise an empty plugin.
+    rmSync(pluginDir, { recursive: true, force: true });
+    return undefined;
+  }
   return pluginDir;
+}
+
+/**
+ * Recursively set a materialised skill tree read-only: files 0444, dirs 0555.
+ * Defence-in-depth over the copy (cortex#990 A1, review MAJOR 1). Symlinks
+ * inside a skill are left untouched (chmod would follow to a target outside the
+ * copy); they are removed with the tree at cleanup regardless. 0555 keeps dirs
+ * traversable/readable, so this and a later read both still work.
+ */
+function chmodTreeReadOnly(path: string): void {
+  const st = lstatSync(path);
+  if (st.isSymbolicLink()) return;
+  if (st.isDirectory()) {
+    for (const entry of readdirSync(path)) chmodTreeReadOnly(join(path, entry));
+    chmodSync(path, 0o555);
+  } else {
+    chmodSync(path, 0o444);
+  }
+}
+
+/**
+ * Restore writable permissions across a tree so `rmSync` can remove it. The
+ * read-only skill copies (0444 files under 0555 dirs) block removal — a
+ * read-only DIRECTORY can't have its entries unlinked. Chmod each dir writable
+ * BEFORE descending (0700 keeps it traversable), same-uid so always permitted.
+ * Best-effort per node; the caller still force-removes afterwards.
+ */
+function restoreWritableTree(path: string): void {
+  let st;
+  try {
+    st = lstatSync(path);
+  } catch {
+    return;
+  }
+  if (st.isSymbolicLink()) return;
+  if (st.isDirectory()) {
+    try {
+      chmodSync(path, 0o700);
+    } catch {
+      /* best-effort */
+    }
+    for (const entry of readdirSync(path)) restoreWritableTree(join(path, entry));
+  }
 }
 
 /**
@@ -396,9 +490,10 @@ export interface IsolatedSettings {
   args: string[];
   /**
    * Absolute path to the materialised granted-skills plugin dir, or
-   * `undefined` when the session was granted no skills. Exposed so callers/
-   * tests can locate it (e.g. to run `claude plugin validate`); it lives
-   * INSIDE the temp dir, so `cleanup()` removes it.
+   * `undefined` when the session was granted no skills (or every grant was
+   * invalid/missing/failed). Exposed so callers/tests can locate it (e.g. to
+   * run `claude plugin validate`); it lives INSIDE the temp dir, so `cleanup()`
+   * removes it.
    */
   pluginDir?: string;
   /** Remove the temp dir. Safe to call multiple times. */
@@ -469,16 +564,25 @@ export function createIsolatedSettings(
     cleanup: () => {
       try {
         rmSync(dir, { recursive: true, force: true });
-      } catch (err) {
-        // Best-effort cleanup of an OS temp dir. A leftover dir is inert
-        // (mode 0600, no secrets — only hook paths) and the OS reclaims
-        // tmp eventually; log rather than throw so session teardown can't
-        // fail on a transient fs error.
-        process.stderr.write(
-          `session-settings: temp cleanup failed for ${dir}: ${
-            err instanceof Error ? err.message : String(err)
-          }\n`,
-        );
+      } catch {
+        // The granted-skills copies are materialised read-only (0444 files
+        // under 0555 dirs), and a read-only DIRECTORY blocks removal of its
+        // entries. Restore writable perms (same-uid, always permitted) and
+        // retry once before giving up.
+        try {
+          restoreWritableTree(dir);
+          rmSync(dir, { recursive: true, force: true });
+        } catch (err) {
+          // Best-effort cleanup of an OS temp dir. A leftover dir is inert
+          // (no secrets — only hook paths + read-only skill copies) and the OS
+          // reclaims tmp eventually; log rather than throw so session teardown
+          // can't fail on a transient fs error.
+          process.stderr.write(
+            `session-settings: temp cleanup failed for ${dir}: ${
+              err instanceof Error ? err.message : String(err)
+            }\n`,
+          );
+        }
       }
     },
   };

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -316,6 +316,13 @@ function materialiseGrantedPlugin(
       // recreate that symlink — leaving the write-through-to-source hole open.
       // Dereferencing materialises real files, fully severing the link. Then
       // lock it down read-only as defence-in-depth.
+      //
+      // Trust note: dereference also copies a skill's OWN inner symlink targets
+      // into the plugin — transitive trust of the granted skill's content. Safe
+      // at same-uid (the session could already read those targets directly);
+      // REVISIT if cortex ever runs sessions at lower fs privilege than the
+      // daemon, where a skill's symlink could pull in bytes the session may not
+      // otherwise read.
       cpSync(target, dest, { recursive: true, dereference: true });
       chmodTreeReadOnly(dest);
       materialised++;


### PR DESCRIPTION
Closes #2149. Part of #990 wave 1.

## What

Materialises policy-granted skills for a cortex-dispatched claude session as a per-session **plugin** passed via `--plugin-dir`, so granted skills are discoverable/invocable **without** re-enabling any ambient setting source. `--setting-sources ""` (cortex#701 isolation) is untouched — this is the mechanism #990 needed.

`createIsolatedSettings` gains a `skillSourceDir` param; `cc-session.ts` resolves it from the #2132 config home (`~/.claude` fallback). Non-empty grants → a validating plugin with the granted skills; empty/undefined grants → byte-identical to main.

## Security (this slice is the #701 isolation boundary)

Adversarially reviewed twice; the first pass found two MAJORs, both now empirically closed:

- **Write-through (isolation regression).** Granted skills are materialised as recursive **read-only copies** (`cpSync … { recursive: true, dereference: true }`, files 0444 / dirs 0555), NOT dir symlinks. `dereference: true` is load-bearing: the production skill source is itself a symlink (`~/.claude/skills/gws-drive → ~/.soma/skills/…`), and a non-dereferencing copy would recreate that link and leave write-through open. Reviewer reproduced the real symlinked-source layout, wrote through the materialised copy, and confirmed the underlying source is byte-for-byte unchanged. Regression test pins it. (0444/0555 is same-uid-bypassable and documented as defence-in-depth; the copy severing the link is the real protection.)
- **Grant-name traversal.** Grant names (operator YAML) are validated before any path use — `length===0 || "." || ".." || basename(grant)!==grant` → loud log + skip; every copy wrapped in try/catch so no crafted name aborts construction. `../secrets`, `..`, `.`, ``, `a/b`, `/etc` all rejected, nothing escapes `skills/`.

Cleanup handles the read-only tree (restore-writable-then-rm), short-circuits on symlinks so the chmod walk can't leave the temp dir.

## Test

- `bun test src/runner/__tests__/session-settings.test.ts` → 32 pass. `cc-session-isolation` → 14 pass. `tsc --noEmit` clean. Scoped only.
- Mutation: neutralising the materialise block fails 6 tests; the empty-string grant guard is independently pinned.

## Note

A real skill source file was briefly corrupted DURING review (a write-through repro hit the live `~/.soma/skills/gws-drive` before the fix landed); restored and verified byte-identical. Future write-through repros must target a fixture, not the configured source — worth a reviewer-hygiene note when the wave closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
