### PR TITLE
fix(compose): hard-fail entrypoint boot when container OAuth is empty (#2139)

### DIFF
--- a/deploy/compose/docker-entrypoint.sh
+++ b/deploy/compose/docker-entrypoint.sh
@@ -32,6 +32,20 @@ set -euo pipefail
 
 : "${CTX_SLUG:?CTX_SLUG is required — see .env.example}"
 
+# Container-only OAuth-token guard (cortex#2139). `cortex quickstart` treats
+# CLAUDE_CODE_OAUTH_TOKEN as OPTIONAL — correct for a native host, where a
+# principal can run `claude login` interactively. A container has NO interactive
+# login, so it ALWAYS needs the token; without it the daemon boots, shows
+# "running", and only fails on the first dispatch (the #2068 re-auth message).
+# Hard-fail at boot instead — cleaner container UX. This guard is entrypoint-only
+# and does NOT touch quickstart's native-host optionality.
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+  echo "cortex-entrypoint: CLAUDE_CODE_OAUTH_TOKEN is empty or unset — aborting boot." >&2
+  echo "cortex-entrypoint: a container has no interactive 'claude login', so it always needs this token." >&2
+  echo "cortex-entrypoint: set CLAUDE_CODE_OAUTH_TOKEN in your .env (see .env.example) and recreate the container." >&2
+  exit 1
+fi
+
 CONFIG_DIR="${CORTEX_CONFIG_DIR:-${HOME}/.config/metafactory/cortex}"
 POINTER="${CONFIG_DIR}/${CTX_SLUG}/${CTX_SLUG}.yaml"
 


### PR DESCRIPTION
Closes #2139. Sub-issue of epic #2164 (L4 container standup), wave 1.

**What:** container-only guard in `deploy/compose/docker-entrypoint.sh` — hard-fail at boot when the OAuth token env var is empty/unset, instead of booting "running" and failing only on first dispatch (the #2068 re-auth path). A container has no interactive `claude login`, so it always needs the token.

**Scope:** entrypoint only. quickstart's native-host token optionality is untouched (native hosts can log in interactively). The optional compose healthcheck is deliberately left out to avoid file contention with a sibling slice.

**Placement:** immediately after the existing `CTX_SLUG` required-var check, before provisioning. Uses the `set -u`-safe default-expansion form; `[ -z ]` / `echo` / `exit` are POSIX-sh.

**Verification:** `bash -n` valid; `shellcheck` clean; guard emulation — empty → 3-line message + exit 1, set → falls through. `.env.example` already documents the var as container-required, so the message's pointer is accurate.

**Residual:** only checks non-empty, not validity — an invalid non-empty token still boots and fails on first dispatch (unchanged #2068 behaviour; full validity check needs a boot-time network call, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9wp7h9ThsZpMgpqSrCpWc
