### PR TITLE
feat(quickstart): --container flag to skip the healthy-boot gate (#2155)

### DIFF
--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -446,6 +446,108 @@ describe("dispatchQuickstart — step 8 gate", () => {
 });
 
 // =============================================================================
+// --container — skip step 8 (cortex#2155, L4 container standup)
+// =============================================================================
+
+describe("dispatchQuickstart — --container skips the healthy-boot gate", () => {
+  test("--container skips step 8 with NO log-grep / healthz probe, and does not stall or fail", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    let readLogCalls = 0;
+    let healthzCalls = 0;
+    const res = await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(
+        // A gate that would NEVER pass if it ran (empty log + failing healthz)
+        // — plus a tiny timeout that WOULD have surfaced a timeout message.
+        ["--config-dir", configDir, "--nats-dir", natsDir, "--container", "--gate-timeout-ms", "5000"],
+        () =>
+          fakePorts({
+            readLog: () => {
+              readLogCalls++;
+              return undefined;
+            },
+            fetchHealthz: () => {
+              healthzCalls++;
+              return Promise.resolve(false);
+            },
+          }),
+      ),
+    );
+    // Exit 0 even though the gate ports are rigged to fail — because step 8
+    // never ran.
+    expect(res.exitCode).toBe(0);
+    // Explicit skip marker (mirrors step 7's --skip-services convention).
+    expect(res.stdout).toContain("--container passed");
+    // No log-grep, no /healthz probe — the two things that cost the ~60s stall.
+    expect(readLogCalls).toBe(0);
+    expect(healthzCalls).toBe(0);
+    // The gate's bounded-wait timeout path was never entered.
+    expect(res.stdout).not.toContain("timed out after");
+  });
+
+  test("--container implies --skip-services (step 7 is skipped too, even on a faked Linux host)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--container"],
+          () => fakePorts({ unitFileExists: () => false }), // would fail step 7 if NOT skipped
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("--skip-services passed");
+    expect(res.stdout).toContain("--container passed");
+  });
+
+  test("--json under --container: envelope is ok and step 8 is reported (skipped), not omitted", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--container", "--json"],
+          () => fakePorts({ readLog: () => undefined, fetchHealthz: () => Promise.resolve(false) }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as { status: string; items?: { step: string; ok: string }[] };
+    expect(parsed.status).toBe("ok");
+    // The trace still carries step 8 as an ok (skipped) entry — an observer
+    // sees it explicitly skipped, not silently absent.
+    expect(parsed.items?.some((i) => i.step === "8. Healthy-boot gate" && i.ok === "true")).toBe(true);
+    expect(res.stdout).not.toContain(SECRET_TOKEN);
+  });
+
+  test("WITHOUT --container the gate still runs (default behaviour unchanged): the log IS grepped", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    let readLogCalls = 0;
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              readLog: () => {
+                readLogCalls++;
+                return FULL_HEALTHY_LOG;
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    // The gate ran — the log was grepped at least once — proving --container
+    // is what suppresses it, not some unrelated change.
+    expect(readLogCalls).toBeGreaterThan(0);
+    expect(res.stdout).not.toContain("--container passed");
+  });
+});
+
+// =============================================================================
 // End to end — happy path, secret non-echo, and idempotent re-run
 // =============================================================================
 

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -118,6 +118,7 @@ interface QuickstartFlags {
   force: boolean;
   json: boolean;
   skipServices: boolean;
+  container: boolean;
   gateTimeoutMs: number;
   help: boolean;
 }
@@ -130,6 +131,7 @@ function parseQuickstartArgs(argv: string[]): QuickstartFlags {
     force: false,
     json: false,
     skipServices: false,
+    container: false,
     gateTimeoutMs: DEFAULT_GATE_TIMEOUT_MS,
     help: false,
   };
@@ -161,6 +163,17 @@ function parseQuickstartArgs(argv: string[]): QuickstartFlags {
       // `process.platform`); this flag exists for CI/tests that want to
       // exercise steps 1-6+8 without a systemd host at all.
       case "--skip-services":
+        flags.skipServices = true;
+        break;
+      // Container mode (cortex#2155): skip step 8's healthy-boot gate. Under
+      // the L4 split-container model the daemon starts only AFTER quickstart
+      // returns (`exec cortex start`), so the gate's log-grep can never pass —
+      // it just stalls the whole poll window (~60s) then fails on every boot.
+      // The container's real health signal is compose `restart:` + the nats
+      // healthcheck (deploy/compose/README.md). Implies --skip-services (the
+      // daemon is launched by the entrypoint, not by step 7 here).
+      case "--container":
+        flags.container = true;
         flags.skipServices = true;
         break;
       case "--help":
@@ -529,8 +542,19 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
 
 async function runGate(
   ports: QuickstartPorts,
-  opts: { slug: string; monitorPort: string; timeoutMs: number },
+  opts: { slug: string; monitorPort: string; timeoutMs: number; skip: boolean },
 ): Promise<StepReport> {
+  // Container mode (cortex#2155): the daemon isn't up yet (the entrypoint
+  // `exec cortex start`s it only AFTER quickstart returns), so the gate could
+  // never pass — it would only burn the whole poll window before failing.
+  // Short-circuit BEFORE any ports.gate call: no log-grep, no /healthz probe,
+  // no wall-clock wait. Reported as an explicit skip (ok), mirroring step 7's
+  // --skip-services convention.
+  if (opts.skip) {
+    return step("8. Healthy-boot gate", true, [
+      "  ○ --container passed — skipping healthy-boot gate (container health is compose restart: + nats healthcheck)",
+    ]);
+  }
   const logPath = daemonLogPath(process.env.HOME ?? "", opts.slug);
   const healthzUrl = `http://127.0.0.1:${opts.monitorPort}/healthz`;
   const deadline = ports.gate.now() + opts.timeoutMs;
@@ -655,6 +679,7 @@ export async function dispatchQuickstart(
     slug: v.CTX_SLUG,
     monitorPort: v.CTX_NATS_MON,
     timeoutMs: flags.gateTimeoutMs,
+    skip: flags.container,
   });
   reports.push(gateReport);
   if (!gateReport.ok) {
@@ -710,6 +735,15 @@ Flags:
                           .conf file (default: refuse).
   --skip-services         Skip step 7 (systemd) entirely — for CI/tests
                           without a systemd host.
+  --container             L4 container mode (cortex#2155): skip step 8's
+                          healthy-boot gate and return after step 7. Implies
+                          --skip-services. In the split-container model the
+                          daemon starts only AFTER quickstart returns
+                          (\`exec cortex start\`), so the gate could never pass —
+                          it would only add ~60s of stall then fail. The
+                          container's real health signal is compose \`restart:\`
+                          + the nats healthcheck. Step 8 is reported as an
+                          explicit skip (ok) rather than run.
   --gate-timeout-ms <n>   Step 8's bounded wait (default: ${String(DEFAULT_GATE_TIMEOUT_MS)}).
   --json                  Emit a { status, items, data, error } envelope.
 


### PR DESCRIPTION
Closes #2155. Sub-issue of epic #2164 (L4 container standup), wave 2.

**What:** a `--container` flag for `cortex quickstart` that skips step 8 (the "Healthy-boot gate"). Under `--skip-services` (the container path) the daemon starts only *after* quickstart returns (`exec cortex start`), so step 8 can never pass — it stalled ~60s then failed on every boot. `--container` short-circuits step 8 before any log-grep / healthz probe / poll loop and reports it as an explicit skip.

**Design notes:**
- `--container` implies `--skip-services` (in a container systemd isn't the launcher, so step 7 also skips). Deliberate coupling — "skip gate but keep systemd" is nonsensical in the container model.
- Step 8 is reported as a skipped-but-present step (`ok:true` + a `○ --container passed` line), matching the existing `--skip-services` convention for step 7, so the `--json` trace shape stays consistent. Asserted by test.
- Skip lives in the orchestrator (`runGate` gained a `skip` param mirroring `runServices`), not `quickstart-lib.ts` — which keeps the sibling #2153 rebase conflict-free.

**Scope:** `src/cli/cortex/commands/quickstart.ts` + its test only. `deploy/compose/**` untouched.

**Follow-up (deferred to the compose slice):** once this lands, `docker-entrypoint.sh` should switch `quickstart --skip-services` → `quickstart --container` and drop its special-case tolerance of the expected step-8 failure (step 8 no longer runs/fails).

**Verification:** `bunx tsc --noEmit` clean; quickstart test files 66 pass / 0 fail (+4 new: `--container` skips step 8 with no grep; default path still runs step 8 unchanged — regression-guarded); `bun run lint` 0 errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9wp7h9ThsZpMgpqSrCpWc
