### PR TITLE
feat(policy): declarative per-agent variable passthrough, isolation boundary preserved (#2133)

### DIFF
--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -133,6 +133,17 @@ interface DispatchTargetAgent {
    * complete zero-tool airgap alongside `agentDisallowedTools`.
    */
   strictMcpConfig?: boolean;
+  /**
+   * cortex#2133 (epic #2164) — the agent's declared `env:` passthrough map
+   * (`NAME → literal-or-`env:NAME`-reference`; see `AgentSchema.env`). Carried
+   * per-target-agent (narrowest scope) and threaded onto the CC session's
+   * `agentEnv`, where `resolveAgentEnv` resolves references from the daemon env
+   * and layers the vars AFTER `scopeSessionEnv` — never touching the default-deny
+   * `CLAUDE_*` namespace. Absent → no passthrough. Applies to the DIRECT dispatch
+   * paths (async, team, sync-fallback); the canonical bus-mediated sync path is
+   * injected receiving-stack-authoritatively in the dispatch-listener.
+   */
+  env?: Record<string, string>;
 }
 
 export interface DispatchHandlerOpts {
@@ -1077,13 +1088,13 @@ export class DispatchHandler extends EventEmitter {
       // 12. Route by mode
       switch (parsed.mode) {
         case "async":
-          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants);
+          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
           break;
         case "team":
-          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants);
+          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
           break;
         default:
-          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants);
+          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
           break;
       }
     } catch (error) {
@@ -1127,6 +1138,8 @@ export class DispatchHandler extends EventEmitter {
     additionalArgs?: string[],
     /** cortex#2111 — per-principal MCP grants (defined ⇒ deny-by-default over mcp__*). */
     mcpGrants?: string[],
+    /** cortex#2133 — the target agent's declared env passthrough (NAME → literal-or-`env:NAME`). */
+    agentEnv?: Record<string, string>,
   ): Promise<void> {
     const target = this.targetFromMsg(adapter, msg);
 
@@ -1171,6 +1184,9 @@ export class DispatchHandler extends EventEmitter {
       // cortex#2111 — arm the MCP Guard when the policy decision carried a
       // grant list (defined ⇒ deny-by-default over mcp__*).
       ...(mcpGrants !== undefined && { mcpGrants }),
+      // cortex#2133 — the agent's declared env passthrough (resolved + CLAUDE_*
+      // re-denied in cc-session's resolveAgentEnv before it hits the child env).
+      ...(agentEnv !== undefined && { agentEnv }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       cwd,
       bashAllowlist,
@@ -1494,6 +1510,8 @@ export class DispatchHandler extends EventEmitter {
     additionalArgs?: string[],
     /** cortex#2111 — per-principal MCP grants (defined ⇒ deny-by-default over mcp__*). */
     mcpGrants?: string[],
+    /** cortex#2133 — the target agent's declared env passthrough (NAME → literal-or-`env:NAME`). */
+    agentEnv?: Record<string, string>,
   ): Promise<void> {
     const taskId = `task-${randomUUID()}`;
 
@@ -1519,6 +1537,9 @@ export class DispatchHandler extends EventEmitter {
       // cortex#2111 — arm the MCP Guard when the policy decision carried a
       // grant list (defined ⇒ deny-by-default over mcp__*).
       ...(mcpGrants !== undefined && { mcpGrants }),
+      // cortex#2133 — the agent's declared env passthrough (resolved + CLAUDE_*
+      // re-denied in cc-session's resolveAgentEnv before it hits the child env).
+      ...(agentEnv !== undefined && { agentEnv }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       cwd,
       project: groveProject,
@@ -1637,6 +1658,8 @@ export class DispatchHandler extends EventEmitter {
     additionalArgs?: string[],
     /** cortex#2111 — per-principal MCP grants (defined ⇒ deny-by-default over mcp__*). */
     mcpGrants?: string[],
+    /** cortex#2133 — the target agent's declared env passthrough (NAME → literal-or-`env:NAME`). */
+    agentEnv?: Record<string, string>,
   ): Promise<void> {
     const taskId = `team-${randomUUID()}`;
 
@@ -1663,6 +1686,9 @@ export class DispatchHandler extends EventEmitter {
       // cortex#2111 — every team-member session inherits the invoking
       // principal's MCP grant list (defined ⇒ deny-by-default over mcp__*).
       ...(mcpGrants !== undefined && { mcpGrants }),
+      // cortex#2133 — every team-member session inherits the agent's declared
+      // env passthrough (resolved + CLAUDE_* re-denied in cc-session).
+      ...(agentEnv !== undefined && { agentEnv }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       timeoutMs: this.config.claude.asyncTimeoutMs,
       bashGuardDisabled,

--- a/src/common/config/__tests__/agent-env.test.ts
+++ b/src/common/config/__tests__/agent-env.test.ts
@@ -1,32 +1,56 @@
 /**
  * cortex#2133 (epic #2164, TRUST-PATH) — per-agent env passthrough SCHEMA tests.
  *
- * The security-critical assertion: {@link AgentEnvSchema} REJECTS any `CLAUDE_*`
- * key at config-load time, so the passthrough can never be a route to widen the
- * cortex#701 default-deny isolation boundary (the #2132 revert is the
- * precedent). The runtime defence-in-depth (resolveAgentEnv drops CLAUDE_* too)
- * is asserted in `src/runner/__tests__/agent-env-passthrough.test.ts`.
+ * The security-critical assertion: {@link AgentEnvSchema} is DENY-BY-DEFAULT (an
+ * ALLOWLIST). Only the exact, case-sensitive names in
+ * {@link ALLOWED_AGENT_ENV_KEYS} load; EVERY other name is rejected at
+ * config-load time. This replaced a reserved-prefix DENYLIST that an adversarial
+ * review of PR #2171 proved un-completable — the session-hijack set is
+ * open-ended (BASH_ENV, PATH, NODE_OPTIONS, LD_PRELOAD, DYLD_INSERT_LIBRARIES,
+ * GIT_SSH_COMMAND, *_PROXY, NODE_EXTRA_CA_CERTS, CLAUDE_/ANTHROPIC_/CORTEX_/…).
+ * The runtime defence-in-depth (resolveAgentEnv re-asserts the allowlist) is
+ * asserted in `src/runner/__tests__/agent-env-passthrough.test.ts`.
  */
 
 import { describe, test, expect } from "bun:test";
 import {
   AgentEnvSchema,
-  isDeniedAgentEnvKey,
+  isAllowedAgentEnvKey,
+  isReservedRefSource,
+  ALLOWED_AGENT_ENV_KEYS,
   AGENT_ENV_KEY_PATTERN,
-  RESERVED_ENV_PREFIXES,
 } from "../agent-env";
 
-describe("AgentEnvSchema — accepts valid passthrough maps", () => {
-  test("a non-secret literal (a credential PATH) is accepted", () => {
+/**
+ * The adversarial hit-list — the open-ended set of session-hijacking env vars a
+ * denylist could never fully enumerate. Every one MUST be rejected by the
+ * allowlist at schema load AND dropped at runtime (the runtime half lives in the
+ * passthrough test). Parametrised so this is a standing regression fence.
+ */
+const REJECT_LIST = [
+  "BASH_ENV",
+  "PATH",
+  "NODE_OPTIONS",
+  "LD_PRELOAD",
+  "DYLD_INSERT_LIBRARIES",
+  "GIT_SSH_COMMAND",
+  "HTTPS_PROXY",
+  "NODE_EXTRA_CA_CERTS",
+  "ANTHROPIC_BASE_URL",
+  "CORTEX_BASH_GUARD",
+];
+
+describe("AgentEnvSchema — accepts ONLY allowlisted keys", () => {
+  test("the sole allowlisted var GOOGLE_APPLICATION_CREDENTIALS (a credential PATH) is accepted", () => {
     const result = AgentEnvSchema.safeParse({
       GOOGLE_APPLICATION_CREDENTIALS: "/Users/andreas/.config/gws/sa.json",
     });
     expect(result.success).toBe(true);
   });
 
-  test("an `env:NAME` secret reference value is accepted (resolved at call time)", () => {
+  test("an `env:NAME` secret reference on an allowlisted key is accepted (resolved at call time)", () => {
     const result = AgentEnvSchema.safeParse({
-      SOME_TOKEN: "env:SOME_TOKEN",
+      GOOGLE_APPLICATION_CREDENTIALS: "env:GWS_SA_PATH",
     });
     expect(result.success).toBe(true);
   });
@@ -35,137 +59,96 @@ describe("AgentEnvSchema — accepts valid passthrough maps", () => {
     expect(AgentEnvSchema.safeParse({}).success).toBe(true);
   });
 
-  test("a mix of several non-CLAUDE keys is accepted", () => {
-    const result = AgentEnvSchema.safeParse({
-      GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
-      GWS_PROFILE: "manda",
-      HTTPS_PROXY: "http://proxy.internal:8080",
-    });
-    expect(result.success).toBe(true);
+  test("ALLOWED_AGENT_ENV_KEYS is seeded with exactly GOOGLE_APPLICATION_CREDENTIALS", () => {
+    expect([...ALLOWED_AGENT_ENV_KEYS]).toEqual(["GOOGLE_APPLICATION_CREDENTIALS"]);
   });
 });
 
-describe("AgentEnvSchema — REJECTS CLAUDE_* keys (cortex#701 security assertion)", () => {
-  test("a bare CLAUDE_CONFIG_DIR key is rejected", () => {
-    const result = AgentEnvSchema.safeParse({
-      CLAUDE_CONFIG_DIR: "/tmp/evil-home",
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      // The error names the offending key and cites the isolation boundary.
-      const msg = JSON.stringify(result.error.issues);
-      expect(msg).toContain("CLAUDE_CONFIG_DIR");
-      expect(msg).toContain("default-deny");
-    }
-  });
-
-  test("any CLAUDE_* var is rejected, even an unknown/future one", () => {
-    expect(
-      AgentEnvSchema.safeParse({ CLAUDE_CODE_EXTRA_SETTINGS_SOURCES: "/x" }).success,
-    ).toBe(false);
-    expect(
-      AgentEnvSchema.safeParse({ CLAUDE_SOMETHING_NEW: "x" }).success,
-    ).toBe(false);
-  });
-
-  test("the deny is case-insensitive — lower/mixed-case claude_ spellings are rejected", () => {
-    expect(AgentEnvSchema.safeParse({ claude_config_dir: "/x" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ Claude_Config_Dir: "/x" }).success).toBe(false);
-  });
-
-  test("a CLAUDE_* key is rejected even alongside otherwise-valid keys", () => {
-    const result = AgentEnvSchema.safeParse({
-      GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
-      CLAUDE_CODE_OAUTH_TOKEN: "sk-evil",
-    });
-    expect(result.success).toBe(false);
-  });
-});
-
-describe("AgentEnvSchema — REJECTS the broadened reserved prefixes (cortex#2133)", () => {
-  test("an ANTHROPIC_* key is rejected (auth / endpoint redirect vector)", () => {
-    // Claude Code honours ANTHROPIC_BASE_URL / _API_KEY / _AUTH_TOKEN / _MODEL —
-    // a declared value would redirect auth or the inference endpoint.
-    expect(AgentEnvSchema.safeParse({ ANTHROPIC_BASE_URL: "https://evil" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ ANTHROPIC_API_KEY: "sk-evil" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ ANTHROPIC_AUTH_TOKEN: "t" }).success).toBe(false);
-  });
-
-  test("a CORTEX_* control var is rejected (would disable a cortex guard)", () => {
-    // The MAJOR-1 vector: a declared CORTEX_BASH_GUARD could disable/widen the guard.
-    const result = AgentEnvSchema.safeParse({
-      CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}',
-    });
+describe("AgentEnvSchema — REJECTS the adversarial hit-list (deny-by-default regression fence)", () => {
+  test.each(REJECT_LIST)("%s is rejected at schema load", (key) => {
+    const result = AgentEnvSchema.safeParse({ [key]: "x" });
     expect(result.success).toBe(false);
     if (!result.success) {
       const msg = JSON.stringify(result.error.issues);
-      expect(msg).toContain("CORTEX_BASH_GUARD");
-      expect(msg).toContain("default-deny");
+      expect(msg).toContain(key);
+      expect(msg.toLowerCase()).toContain("deny-by-default");
     }
-    expect(AgentEnvSchema.safeParse({ CORTEX_SKILL_GRANTS: "[]" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ CORTEX_MCP_GRANTS: "[]" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ CORTEX_CHANNEL: "spoofed" }).success).toBe(false);
   });
 
-  test("a GROVE_* legacy-alias control var is rejected", () => {
-    expect(AgentEnvSchema.safeParse({ GROVE_CHANNEL: "spoofed" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ GROVE_OPERATOR: "x" }).success).toBe(false);
-  });
-
-  test("the broadened deny is case-insensitive across all reserved prefixes", () => {
-    expect(AgentEnvSchema.safeParse({ anthropic_base_url: "x" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ cortex_bash_guard: "x" }).success).toBe(false);
-    expect(AgentEnvSchema.safeParse({ Grove_Channel: "x" }).success).toBe(false);
+  test("a hit-list key is rejected even alongside the allowlisted key", () => {
+    const result = AgentEnvSchema.safeParse({
+      GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
+      LD_PRELOAD: "/tmp/evil.so",
+    });
+    expect(result.success).toBe(false);
   });
 });
 
-describe("AgentEnvSchema — key/value shape validation", () => {
+describe("AgentEnvSchema — REJECTS non-allowlisted + case-variant keys", () => {
+  test("an arbitrary non-allowlisted key FOO_BAR is rejected", () => {
+    const result = AgentEnvSchema.safeParse({ FOO_BAR: "x" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = JSON.stringify(result.error.issues);
+      expect(msg).toContain("FOO_BAR");
+      expect(msg.toLowerCase()).toContain("deny-by-default");
+    }
+  });
+
+  test("case variants of the allowed key are rejected (env var names are case-sensitive)", () => {
+    expect(
+      AgentEnvSchema.safeParse({ google_application_credentials: "/x" }).success,
+    ).toBe(false);
+    expect(
+      AgentEnvSchema.safeParse({ Google_Application_Credentials: "/x" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("AgentEnvSchema — key/value shape validation (secondary POSIX-grammar gate)", () => {
   test("a non-identifier key is rejected", () => {
     expect(AgentEnvSchema.safeParse({ "bad-key": "x" }).success).toBe(false);
     expect(AgentEnvSchema.safeParse({ "9LEADING_DIGIT": "x" }).success).toBe(false);
     expect(AgentEnvSchema.safeParse({ "has space": "x" }).success).toBe(false);
   });
 
-  test("an empty-string value is rejected", () => {
-    expect(AgentEnvSchema.safeParse({ GOOD_KEY: "" }).success).toBe(false);
+  test("an empty-string value on the allowlisted key is rejected", () => {
+    expect(
+      AgentEnvSchema.safeParse({ GOOGLE_APPLICATION_CREDENTIALS: "" }).success,
+    ).toBe(false);
   });
 });
 
-describe("isDeniedAgentEnvKey — the single-source deny predicate", () => {
-  test("denies every reserved prefix case-insensitively; allows everything else", () => {
-    // CLAUDE_
-    expect(isDeniedAgentEnvKey("CLAUDE_CONFIG_DIR")).toBe(true);
-    expect(isDeniedAgentEnvKey("claude_config_dir")).toBe(true);
-    expect(isDeniedAgentEnvKey("Claude_X")).toBe(true);
-    // ANTHROPIC_
-    expect(isDeniedAgentEnvKey("ANTHROPIC_BASE_URL")).toBe(true);
-    expect(isDeniedAgentEnvKey("anthropic_api_key")).toBe(true);
-    // CORTEX_ (now denied — this is the #2133 broadening)
-    expect(isDeniedAgentEnvKey("CORTEX_BASH_GUARD")).toBe(true);
-    expect(isDeniedAgentEnvKey("CORTEX_CHANNEL")).toBe(true);
-    expect(isDeniedAgentEnvKey("cortex_skill_grants")).toBe(true);
-    // GROVE_
-    expect(isDeniedAgentEnvKey("GROVE_CHANNEL")).toBe(true);
-    expect(isDeniedAgentEnvKey("grove_operator")).toBe(true);
-    // Allowed — outside every reserved prefix.
-    expect(isDeniedAgentEnvKey("GOOGLE_APPLICATION_CREDENTIALS")).toBe(false);
-    expect(isDeniedAgentEnvKey("GWS_PROFILE")).toBe(false);
-    // A var that merely CONTAINS a reserved token (not a prefix) is fine.
-    expect(isDeniedAgentEnvKey("MY_CLAUDE_HELPER")).toBe(false);
-    expect(isDeniedAgentEnvKey("MY_CORTEX_HELPER")).toBe(false);
-  });
-
-  test("RESERVED_ENV_PREFIXES lists the four guarded namespaces", () => {
-    expect([...RESERVED_ENV_PREFIXES]).toEqual([
-      "CLAUDE_",
-      "ANTHROPIC_",
-      "CORTEX_",
-      "GROVE_",
-    ]);
+describe("isAllowedAgentEnvKey — the single-source allowlist predicate", () => {
+  test("permits the blessed spelling; denies everything else, case-sensitively", () => {
+    // Permitted — the exact blessed name.
+    expect(isAllowedAgentEnvKey("GOOGLE_APPLICATION_CREDENTIALS")).toBe(true);
+    // Case variants are NOT the blessed spelling (POSIX names are case-sensitive).
+    expect(isAllowedAgentEnvKey("google_application_credentials")).toBe(false);
+    expect(isAllowedAgentEnvKey("Google_Application_Credentials")).toBe(false);
+    // The whole adversarial hit-list is denied.
+    for (const key of REJECT_LIST) {
+      expect(isAllowedAgentEnvKey(key)).toBe(false);
+    }
+    // An arbitrary key is denied.
+    expect(isAllowedAgentEnvKey("FOO_BAR")).toBe(false);
   });
 });
 
-describe("AGENT_ENV_KEY_PATTERN — POSIX identifier grammar", () => {
+describe("isReservedRefSource — the env:NAME ref-source prefix deny (different shape)", () => {
+  test("denies cortex/substrate control namespaces case-insensitively; allows others", () => {
+    // A ref SOURCE is a READ from the daemon env — guarded by a prefix deny.
+    expect(isReservedRefSource("CLAUDE_CODE_OAUTH_TOKEN")).toBe(true);
+    expect(isReservedRefSource("anthropic_api_key")).toBe(true);
+    expect(isReservedRefSource("CORTEX_BASH_GUARD")).toBe(true);
+    expect(isReservedRefSource("grove_operator")).toBe(true);
+    // A non-reserved daemon var is a legitimate credential source.
+    expect(isReservedRefSource("GWS_SA_PATH")).toBe(false);
+    expect(isReservedRefSource("MANDA_GWS_TOKEN")).toBe(false);
+  });
+});
+
+describe("AGENT_ENV_KEY_PATTERN — POSIX identifier grammar (secondary gate)", () => {
   test("matches valid identifiers and rejects invalid ones", () => {
     expect(AGENT_ENV_KEY_PATTERN.test("GOOGLE_APPLICATION_CREDENTIALS")).toBe(true);
     expect(AGENT_ENV_KEY_PATTERN.test("_UNDERSCORE_START")).toBe(true);

--- a/src/common/config/__tests__/agent-env.test.ts
+++ b/src/common/config/__tests__/agent-env.test.ts
@@ -13,6 +13,7 @@ import {
   AgentEnvSchema,
   isDeniedAgentEnvKey,
   AGENT_ENV_KEY_PATTERN,
+  RESERVED_ENV_PREFIXES,
 } from "../agent-env";
 
 describe("AgentEnvSchema — accepts valid passthrough maps", () => {
@@ -81,6 +82,43 @@ describe("AgentEnvSchema — REJECTS CLAUDE_* keys (cortex#701 security assertio
   });
 });
 
+describe("AgentEnvSchema — REJECTS the broadened reserved prefixes (cortex#2133)", () => {
+  test("an ANTHROPIC_* key is rejected (auth / endpoint redirect vector)", () => {
+    // Claude Code honours ANTHROPIC_BASE_URL / _API_KEY / _AUTH_TOKEN / _MODEL —
+    // a declared value would redirect auth or the inference endpoint.
+    expect(AgentEnvSchema.safeParse({ ANTHROPIC_BASE_URL: "https://evil" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ ANTHROPIC_API_KEY: "sk-evil" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ ANTHROPIC_AUTH_TOKEN: "t" }).success).toBe(false);
+  });
+
+  test("a CORTEX_* control var is rejected (would disable a cortex guard)", () => {
+    // The MAJOR-1 vector: a declared CORTEX_BASH_GUARD could disable/widen the guard.
+    const result = AgentEnvSchema.safeParse({
+      CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = JSON.stringify(result.error.issues);
+      expect(msg).toContain("CORTEX_BASH_GUARD");
+      expect(msg).toContain("default-deny");
+    }
+    expect(AgentEnvSchema.safeParse({ CORTEX_SKILL_GRANTS: "[]" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ CORTEX_MCP_GRANTS: "[]" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ CORTEX_CHANNEL: "spoofed" }).success).toBe(false);
+  });
+
+  test("a GROVE_* legacy-alias control var is rejected", () => {
+    expect(AgentEnvSchema.safeParse({ GROVE_CHANNEL: "spoofed" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ GROVE_OPERATOR: "x" }).success).toBe(false);
+  });
+
+  test("the broadened deny is case-insensitive across all reserved prefixes", () => {
+    expect(AgentEnvSchema.safeParse({ anthropic_base_url: "x" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ cortex_bash_guard: "x" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ Grove_Channel: "x" }).success).toBe(false);
+  });
+});
+
 describe("AgentEnvSchema — key/value shape validation", () => {
   test("a non-identifier key is rejected", () => {
     expect(AgentEnvSchema.safeParse({ "bad-key": "x" }).success).toBe(false);
@@ -94,14 +132,36 @@ describe("AgentEnvSchema — key/value shape validation", () => {
 });
 
 describe("isDeniedAgentEnvKey — the single-source deny predicate", () => {
-  test("denies CLAUDE_* case-insensitively; allows everything else", () => {
+  test("denies every reserved prefix case-insensitively; allows everything else", () => {
+    // CLAUDE_
     expect(isDeniedAgentEnvKey("CLAUDE_CONFIG_DIR")).toBe(true);
     expect(isDeniedAgentEnvKey("claude_config_dir")).toBe(true);
     expect(isDeniedAgentEnvKey("Claude_X")).toBe(true);
+    // ANTHROPIC_
+    expect(isDeniedAgentEnvKey("ANTHROPIC_BASE_URL")).toBe(true);
+    expect(isDeniedAgentEnvKey("anthropic_api_key")).toBe(true);
+    // CORTEX_ (now denied — this is the #2133 broadening)
+    expect(isDeniedAgentEnvKey("CORTEX_BASH_GUARD")).toBe(true);
+    expect(isDeniedAgentEnvKey("CORTEX_CHANNEL")).toBe(true);
+    expect(isDeniedAgentEnvKey("cortex_skill_grants")).toBe(true);
+    // GROVE_
+    expect(isDeniedAgentEnvKey("GROVE_CHANNEL")).toBe(true);
+    expect(isDeniedAgentEnvKey("grove_operator")).toBe(true);
+    // Allowed — outside every reserved prefix.
     expect(isDeniedAgentEnvKey("GOOGLE_APPLICATION_CREDENTIALS")).toBe(false);
-    expect(isDeniedAgentEnvKey("CORTEX_CHANNEL")).toBe(false);
-    // Not a CLAUDE_ prefix — a var that merely contains "claude" is fine.
+    expect(isDeniedAgentEnvKey("GWS_PROFILE")).toBe(false);
+    // A var that merely CONTAINS a reserved token (not a prefix) is fine.
     expect(isDeniedAgentEnvKey("MY_CLAUDE_HELPER")).toBe(false);
+    expect(isDeniedAgentEnvKey("MY_CORTEX_HELPER")).toBe(false);
+  });
+
+  test("RESERVED_ENV_PREFIXES lists the four guarded namespaces", () => {
+    expect([...RESERVED_ENV_PREFIXES]).toEqual([
+      "CLAUDE_",
+      "ANTHROPIC_",
+      "CORTEX_",
+      "GROVE_",
+    ]);
   });
 });
 

--- a/src/common/config/__tests__/agent-env.test.ts
+++ b/src/common/config/__tests__/agent-env.test.ts
@@ -141,7 +141,7 @@ describe("isReservedRefSource — the env:NAME ref-source prefix deny (different
     expect(isReservedRefSource("CLAUDE_CODE_OAUTH_TOKEN")).toBe(true);
     expect(isReservedRefSource("anthropic_api_key")).toBe(true);
     expect(isReservedRefSource("CORTEX_BASH_GUARD")).toBe(true);
-    expect(isReservedRefSource("grove_operator")).toBe(true);
+    expect(isReservedRefSource("grove_channel")).toBe(true);
     // A non-reserved daemon var is a legitimate credential source.
     expect(isReservedRefSource("GWS_SA_PATH")).toBe(false);
     expect(isReservedRefSource("MANDA_GWS_TOKEN")).toBe(false);

--- a/src/common/config/__tests__/agent-env.test.ts
+++ b/src/common/config/__tests__/agent-env.test.ts
@@ -1,0 +1,115 @@
+/**
+ * cortex#2133 (epic #2164, TRUST-PATH) — per-agent env passthrough SCHEMA tests.
+ *
+ * The security-critical assertion: {@link AgentEnvSchema} REJECTS any `CLAUDE_*`
+ * key at config-load time, so the passthrough can never be a route to widen the
+ * cortex#701 default-deny isolation boundary (the #2132 revert is the
+ * precedent). The runtime defence-in-depth (resolveAgentEnv drops CLAUDE_* too)
+ * is asserted in `src/runner/__tests__/agent-env-passthrough.test.ts`.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  AgentEnvSchema,
+  isDeniedAgentEnvKey,
+  AGENT_ENV_KEY_PATTERN,
+} from "../agent-env";
+
+describe("AgentEnvSchema — accepts valid passthrough maps", () => {
+  test("a non-secret literal (a credential PATH) is accepted", () => {
+    const result = AgentEnvSchema.safeParse({
+      GOOGLE_APPLICATION_CREDENTIALS: "/Users/andreas/.config/gws/sa.json",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("an `env:NAME` secret reference value is accepted (resolved at call time)", () => {
+    const result = AgentEnvSchema.safeParse({
+      SOME_TOKEN: "env:SOME_TOKEN",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("an empty map is accepted (no passthrough)", () => {
+    expect(AgentEnvSchema.safeParse({}).success).toBe(true);
+  });
+
+  test("a mix of several non-CLAUDE keys is accepted", () => {
+    const result = AgentEnvSchema.safeParse({
+      GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
+      GWS_PROFILE: "manda",
+      HTTPS_PROXY: "http://proxy.internal:8080",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("AgentEnvSchema — REJECTS CLAUDE_* keys (cortex#701 security assertion)", () => {
+  test("a bare CLAUDE_CONFIG_DIR key is rejected", () => {
+    const result = AgentEnvSchema.safeParse({
+      CLAUDE_CONFIG_DIR: "/tmp/evil-home",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // The error names the offending key and cites the isolation boundary.
+      const msg = JSON.stringify(result.error.issues);
+      expect(msg).toContain("CLAUDE_CONFIG_DIR");
+      expect(msg).toContain("default-deny");
+    }
+  });
+
+  test("any CLAUDE_* var is rejected, even an unknown/future one", () => {
+    expect(
+      AgentEnvSchema.safeParse({ CLAUDE_CODE_EXTRA_SETTINGS_SOURCES: "/x" }).success,
+    ).toBe(false);
+    expect(
+      AgentEnvSchema.safeParse({ CLAUDE_SOMETHING_NEW: "x" }).success,
+    ).toBe(false);
+  });
+
+  test("the deny is case-insensitive — lower/mixed-case claude_ spellings are rejected", () => {
+    expect(AgentEnvSchema.safeParse({ claude_config_dir: "/x" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ Claude_Config_Dir: "/x" }).success).toBe(false);
+  });
+
+  test("a CLAUDE_* key is rejected even alongside otherwise-valid keys", () => {
+    const result = AgentEnvSchema.safeParse({
+      GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
+      CLAUDE_CODE_OAUTH_TOKEN: "sk-evil",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AgentEnvSchema — key/value shape validation", () => {
+  test("a non-identifier key is rejected", () => {
+    expect(AgentEnvSchema.safeParse({ "bad-key": "x" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ "9LEADING_DIGIT": "x" }).success).toBe(false);
+    expect(AgentEnvSchema.safeParse({ "has space": "x" }).success).toBe(false);
+  });
+
+  test("an empty-string value is rejected", () => {
+    expect(AgentEnvSchema.safeParse({ GOOD_KEY: "" }).success).toBe(false);
+  });
+});
+
+describe("isDeniedAgentEnvKey — the single-source deny predicate", () => {
+  test("denies CLAUDE_* case-insensitively; allows everything else", () => {
+    expect(isDeniedAgentEnvKey("CLAUDE_CONFIG_DIR")).toBe(true);
+    expect(isDeniedAgentEnvKey("claude_config_dir")).toBe(true);
+    expect(isDeniedAgentEnvKey("Claude_X")).toBe(true);
+    expect(isDeniedAgentEnvKey("GOOGLE_APPLICATION_CREDENTIALS")).toBe(false);
+    expect(isDeniedAgentEnvKey("CORTEX_CHANNEL")).toBe(false);
+    // Not a CLAUDE_ prefix — a var that merely contains "claude" is fine.
+    expect(isDeniedAgentEnvKey("MY_CLAUDE_HELPER")).toBe(false);
+  });
+});
+
+describe("AGENT_ENV_KEY_PATTERN — POSIX identifier grammar", () => {
+  test("matches valid identifiers and rejects invalid ones", () => {
+    expect(AGENT_ENV_KEY_PATTERN.test("GOOGLE_APPLICATION_CREDENTIALS")).toBe(true);
+    expect(AGENT_ENV_KEY_PATTERN.test("_UNDERSCORE_START")).toBe(true);
+    expect(AGENT_ENV_KEY_PATTERN.test("1BAD")).toBe(false);
+    expect(AGENT_ENV_KEY_PATTERN.test("has-dash")).toBe(false);
+  });
+});

--- a/src/common/config/agent-env.ts
+++ b/src/common/config/agent-env.ts
@@ -11,23 +11,47 @@
 // needs the credential gets it) that is applied at the SESSION layer, so it is
 // a cortex-only change with no arc/plist dependency.
 //
-// ## HARD CONSTRAINT — CLAUDE_* stays default-deny (cortex#701)
+// ## HARD CONSTRAINT — a RESERVED-PREFIX denylist stays default-deny (cortex#701, #2133)
 //
-// This passthrough must NEVER become a route to set a `CLAUDE_*` variable. A
-// `CLAUDE_*` var can re-introduce hooks/plugins/settings/alternate config
-// homes and thereby undo the cortex#701 session-isolation boundary
-// (`scopeSessionEnv` in `src/runner/session-settings.ts`). The cortex#2132
-// revert — which allowlisted `CLAUDE_CONFIG_DIR` through the scope and then
-// reverted in favour of a typed `substrates:` table — is the binding
-// precedent. So {@link isDeniedAgentEnvKey} is the SINGLE SOURCE OF TRUTH for
-// the deny, used in BOTH places that must agree:
+// This passthrough must NEVER become a route to disable a cortex guard or
+// redirect auth. A declared variable that lands in one of four reserved
+// prefixes can do exactly that, so {@link isDeniedAgentEnvKey} refuses ANY key
+// whose upper-cased name starts with one of:
+//
+//   - `CLAUDE_`    — a `CLAUDE_*` var can re-introduce hooks/plugins/settings/
+//     alternate config homes and thereby undo the cortex#701 session-isolation
+//     boundary (`scopeSessionEnv` in `src/runner/session-settings.ts`). The
+//     cortex#2132 revert — which allowlisted `CLAUDE_CONFIG_DIR` through the
+//     scope and then reverted in favour of a typed `substrates:` table — is the
+//     binding precedent.
+//   - `ANTHROPIC_` — Claude Code ALSO honours `ANTHROPIC_BASE_URL`,
+//     `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_MODEL`. (The
+//     old comment here claiming "Claude Code only reads the upper-case CLAUDE_*
+//     names" was FALSE.) A declared `ANTHROPIC_BASE_URL` would REDIRECT the
+//     session's inference endpoint (exfil / MITM), and `ANTHROPIC_API_KEY` /
+//     `_AUTH_TOKEN` would swap the credential the session authenticates with —
+//     both are auth-redirect vectors this map must never open.
+//   - `CORTEX_` — cortex's OWN control-plane vars live here: `CORTEX_BASH_GUARD`
+//     (the bash-guard config — a declared value could DISABLE the guard or widen
+//     it to `.*`), `CORTEX_SKILL_GRANTS` / `CORTEX_MCP_GRANTS` (the per-session
+//     capability grant lists the guards read), plus the `CORTEX_CHANNEL` /
+//     `CORTEX_AGENT_*` / `CORTEX_PRINCIPAL` instrumentation identity. None may be
+//     settable by a declared var — that would let an agent rewrite its own
+//     guard config or identity.
+//   - `GROVE_` — the legacy alias namespace for the same `CORTEX_*` control vars
+//     (still read as a transition fallback, cortex#767/#774). Denied for the
+//     identical reason; leaving it open would be a trivial bypass of the
+//     `CORTEX_` deny via the legacy name.
+//
+// {@link isDeniedAgentEnvKey} is the SINGLE SOURCE OF TRUTH for the deny, used
+// in BOTH places that must agree:
 //
 //   1. Config LOAD  — {@link AgentEnvSchema} rejects any denied key at parse
-//      time, so a stack whose config declares a `CLAUDE_*` passthrough fails
-//      to load (the daemon refuses it).
+//      time, so a stack whose config declares a reserved-prefix passthrough
+//      fails to load (the daemon refuses it).
 //   2. Session BUILD — `resolveAgentEnv` (session-settings.ts) re-asserts the
 //      deny at runtime as defence-in-depth, so no code path (a test, a future
-//      direct caller, a schema regression) can ever layer a `CLAUDE_*` var
+//      direct caller, a schema regression) can ever layer a reserved-prefix var
 //      onto a child session's env.
 //
 // Keeping ONE predicate means the two layers cannot drift.
@@ -52,23 +76,41 @@ import { z } from "zod/v4";
 export const AGENT_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
- * The default-deny prefix. Any variable whose name (case-folded) begins with
- * `CLAUDE_` is refused by the per-agent env passthrough — see the module doc.
+ * The default-deny prefixes. Any variable whose name (case-folded) begins with
+ * one of these is refused by the per-agent env passthrough — see the module doc
+ * for the per-prefix rationale. Each prefix names a namespace where a declared
+ * var could disable a cortex guard (`CORTEX_`/`GROVE_`), redirect auth or the
+ * inference endpoint (`ANTHROPIC_`), or re-open the session-isolation boundary
+ * (`CLAUDE_`).
+ */
+export const RESERVED_ENV_PREFIXES = [
+  "CLAUDE_",
+  "ANTHROPIC_",
+  "CORTEX_",
+  "GROVE_",
+] as const;
+
+/**
+ * The default-deny `CLAUDE_` prefix. Retained as a named export (it is the
+ * historically-referenced one) even though the deny now spans
+ * {@link RESERVED_ENV_PREFIXES}.
  */
 export const CLAUDE_ENV_PREFIX = "CLAUDE_";
 
 /**
  * The ONE predicate deciding whether a key is refused by the per-agent env
- * passthrough. `true` ⇒ deny. Case-INSENSITIVE on the `CLAUDE_` prefix: env
- * var names are case-sensitive on POSIX and Claude Code only reads the
- * upper-case `CLAUDE_*` names, so a case-insensitive check is strictly SAFER
- * (it also refuses `claude_*`/`Claude_*` spelling tricks) at the cost of
- * blocking a vanishingly rare legitimate lower-case `claude_…` var — an
- * acceptable, airtight trade. Used by BOTH {@link AgentEnvSchema} (load-time
- * reject) and `resolveAgentEnv` (runtime drop) so they cannot diverge.
+ * passthrough. `true` ⇒ deny. Case-INSENSITIVE on the reserved prefixes: env
+ * var names are case-sensitive on POSIX but the substrates that read these
+ * names (Claude Code, cortex's own hooks) read the upper-case spellings, so a
+ * case-insensitive check is strictly SAFER — it also refuses `claude_*` /
+ * `Cortex_*` spelling tricks — at the cost of blocking a vanishingly rare
+ * legitimate lower-case `claude_…`/`cortex_…`/etc. var, an acceptable, airtight
+ * trade. Used by BOTH {@link AgentEnvSchema} (load-time reject) and
+ * `resolveAgentEnv` (runtime drop) so they cannot diverge.
  */
 export function isDeniedAgentEnvKey(key: string): boolean {
-  return key.toUpperCase().startsWith(CLAUDE_ENV_PREFIX);
+  const upper = key.toUpperCase();
+  return RESERVED_ENV_PREFIXES.some((prefix) => upper.startsWith(prefix));
 }
 
 /**
@@ -88,10 +130,11 @@ export const AgentEnvValueSchema = z
 /**
  * cortex#2133 — the per-agent `env:` map schema. Keys are env-var names
  * ({@link AGENT_ENV_KEY_PATTERN}); values are {@link AgentEnvValueSchema}. A
- * `CLAUDE_*` key (case-insensitive) is REJECTED at parse time via
- * {@link isDeniedAgentEnvKey}, so the isolation boundary cannot be widened
- * through this surface. Optional on the agent; absent ⇒ no passthrough (the
- * pre-#2133 behaviour, byte-for-byte).
+ * reserved-prefix key ({@link RESERVED_ENV_PREFIXES}, case-insensitive) is
+ * REJECTED at parse time via {@link isDeniedAgentEnvKey}, so a declared var can
+ * neither widen the isolation boundary nor disable a cortex guard / redirect
+ * auth. Optional on the agent; absent ⇒ no passthrough (the pre-#2133
+ * behaviour, byte-for-byte).
  */
 export const AgentEnvSchema = z
   .record(
@@ -111,11 +154,14 @@ export const AgentEnvSchema = z
           code: "custom",
           path: [key],
           message:
-            `agent env key '${key}' is not allowed: CLAUDE_* variables are default-deny ` +
-            `(cortex#701 session isolation). A per-agent env passthrough must never set a ` +
-            `CLAUDE_* var — that would re-introduce hooks/plugins/settings and undo the ` +
-            `isolation boundary. Use the substrates: configHome seam (cortex#2132) to relocate ` +
-            `a substrate config home; this map is for everything that is NOT a substrate config var.`,
+            `agent env key '${key}' is not allowed: variables in the reserved prefixes ` +
+            `[${RESERVED_ENV_PREFIXES.join(", ")}] are default-deny (cortex#701 / #2133). A ` +
+            `per-agent env passthrough must never set one — CLAUDE_*/ANTHROPIC_* would ` +
+            `re-introduce hooks/plugins/settings or redirect auth and the inference endpoint, ` +
+            `and CORTEX_*/GROVE_* would disable a cortex guard (e.g. CORTEX_BASH_GUARD) or ` +
+            `rewrite the session's grants/identity. Use the substrates: configHome seam ` +
+            `(cortex#2132) to relocate a substrate config home; this map is for everything ` +
+            `that is NOT a substrate config or cortex control var.`,
         });
       }
     }

--- a/src/common/config/agent-env.ts
+++ b/src/common/config/agent-env.ts
@@ -11,50 +11,82 @@
 // needs the credential gets it) that is applied at the SESSION layer, so it is
 // a cortex-only change with no arc/plist dependency.
 //
-// ## HARD CONSTRAINT — a RESERVED-PREFIX denylist stays default-deny (cortex#701, #2133)
+// ## HARD CONSTRAINT — this is an ALLOWLIST: deny-by-default (cortex#2133, epic #2164)
 //
-// This passthrough must NEVER become a route to disable a cortex guard or
-// redirect auth. A declared variable that lands in one of four reserved
-// prefixes can do exactly that, so {@link isDeniedAgentEnvKey} refuses ANY key
-// whose upper-cased name starts with one of:
+// The passthrough permits ONLY the exact env-var names in
+// {@link ALLOWED_AGENT_ENV_KEYS}. Every other name is refused — at config load
+// and again at runtime. This is a DELIBERATE inversion from the original
+// reserved-prefix DENYLIST, which an adversarial review of PR #2171 proved
+// UNSOUND: the set of names that can hijack a child session is open-ended and
+// cannot be fully enumerated, so a denylist can never be complete. The classes
+// a denylist has to chase (non-exhaustive — that is the whole point) include:
 //
-//   - `CLAUDE_`    — a `CLAUDE_*` var can re-introduce hooks/plugins/settings/
-//     alternate config homes and thereby undo the cortex#701 session-isolation
-//     boundary (`scopeSessionEnv` in `src/runner/session-settings.ts`). The
-//     cortex#2132 revert — which allowlisted `CLAUDE_CONFIG_DIR` through the
-//     scope and then reverted in favour of a typed `substrates:` table — is the
-//     binding precedent.
-//   - `ANTHROPIC_` — Claude Code ALSO honours `ANTHROPIC_BASE_URL`,
-//     `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, and `ANTHROPIC_MODEL`. (The
-//     old comment here claiming "Claude Code only reads the upper-case CLAUDE_*
-//     names" was FALSE.) A declared `ANTHROPIC_BASE_URL` would REDIRECT the
-//     session's inference endpoint (exfil / MITM), and `ANTHROPIC_API_KEY` /
-//     `_AUTH_TOKEN` would swap the credential the session authenticates with —
-//     both are auth-redirect vectors this map must never open.
-//   - `CORTEX_` — cortex's OWN control-plane vars live here: `CORTEX_BASH_GUARD`
-//     (the bash-guard config — a declared value could DISABLE the guard or widen
-//     it to `.*`), `CORTEX_SKILL_GRANTS` / `CORTEX_MCP_GRANTS` (the per-session
-//     capability grant lists the guards read), plus the `CORTEX_CHANNEL` /
-//     `CORTEX_AGENT_*` / `CORTEX_PRINCIPAL` instrumentation identity. None may be
-//     settable by a declared var — that would let an agent rewrite its own
-//     guard config or identity.
-//   - `GROVE_` — the legacy alias namespace for the same `CORTEX_*` control vars
-//     (still read as a transition fallback, cortex#767/#774). Denied for the
-//     identical reason; leaving it open would be a trivial bypass of the
-//     `CORTEX_` deny via the legacy name.
+//   - bash startup files:      `BASH_ENV`, `ENV` — sourced before every
+//     non-interactive shell, i.e. arbitrary code execution on any `bash -c`.
+//   - node / bun runtime:      `NODE_OPTIONS` (e.g. `--require /evil.js`),
+//     `NODE_EXTRA_CA_CERTS` (trust a MITM CA), `BUN_INSPECT`, …
+//   - dynamic-loader injection: `LD_PRELOAD`, `LD_LIBRARY_PATH` (Linux),
+//     `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH` (macOS) — load attacker code
+//     into every spawned process.
+//   - lookup path takeover:    `PATH` — shadow `git`, `gh`, `node`, anything.
+//   - git subprocess hooks:    `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF`,
+//     `GIT_PAGER`, `GIT_*` — arbitrary commands run by routine git calls.
+//   - network redirection:     `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`,
+//     `*_PROXY` — route the session's traffic through an attacker.
+//   - cortex / substrate control: `CLAUDE_*`, `ANTHROPIC_*`, `CORTEX_*`,
+//     `GROVE_*` — re-open the cortex#701 isolation boundary, redirect auth /
+//     the inference endpoint, or disable a cortex guard (`CORTEX_BASH_GUARD`).
 //
-// {@link isDeniedAgentEnvKey} is the SINGLE SOURCE OF TRUTH for the deny, used
-// in BOTH places that must agree:
+// There is no reason to believe that list is closed; the next runtime, tool, or
+// cortex control var adds another entry no denylist author thought of. So we
+// invert: nothing passes unless it is a name we have explicitly BLESSED as a
+// benign credential input. Adding a permitted variable is a DELIBERATE, REVIEWED
+// change to {@link ALLOWED_AGENT_ENV_KEYS} in THIS file — a cortex PR that a
+// reviewer weighs against exactly the hijack classes above — never a config-time
+// or runtime decision. Deny-by-default means an omission fails CLOSED (the var
+// is simply not passed), which is the only safe direction for a trust-path
+// control.
 //
-//   1. Config LOAD  — {@link AgentEnvSchema} rejects any denied key at parse
-//      time, so a stack whose config declares a reserved-prefix passthrough
+// The allowlist is seeded with exactly one name — `GOOGLE_APPLICATION_CREDENTIALS`,
+// the credential PATH the `gws` Google Drive skill needs and the sole motivating
+// case today. {@link isAllowedAgentEnvKey} is the SINGLE SOURCE OF TRUTH for the
+// permit, used in BOTH places that must agree:
+//
+//   1. Config LOAD  — {@link AgentEnvSchema} rejects any non-allowlisted key at
+//      parse time, so a stack whose config declares an unblessed passthrough
 //      fails to load (the daemon refuses it).
 //   2. Session BUILD — `resolveAgentEnv` (session-settings.ts) re-asserts the
-//      deny at runtime as defence-in-depth, so no code path (a test, a future
-//      direct caller, a schema regression) can ever layer a reserved-prefix var
-//      onto a child session's env.
+//      allowlist at runtime as defence-in-depth, so no code path (a test, a
+//      future direct caller, a schema regression) can ever layer an
+//      unblessed var onto a child session's env.
 //
 // Keeping ONE predicate means the two layers cannot drift.
+//
+// ## Case sensitivity — EXACT match, never case-folded
+//
+// POSIX env var names are case-SENSITIVE: `PATH` and `Path` are DIFFERENT
+// variables. {@link isAllowedAgentEnvKey} therefore does an EXACT membership
+// test and does NOT upper-case-fold — only the blessed spelling passes. A
+// case-fold would be actively wrong here: folding could let `path` match a
+// blessed `PATH`-shaped entry, or (in the mirror image of the old denylist)
+// admit a spelling the reader never intended. Exact match is the only correct
+// shape for an allowlist of case-sensitive names.
+//
+// ## Ref-source guard uses a DIFFERENT shape (a prefix DENY) — and why
+//
+// A value may be an `env:NAME` SECRET REFERENCE ({@link SECRET_REF_PATTERN}),
+// resolved from the DAEMON env at call time. The destination KEY is allowlisted
+// as above (it is a name we SET on the child session). But the ref SOURCE name
+// is a READ FROM the daemon env, not a set — so its risk is different: a blessed
+// destination key could otherwise surface a SENSITIVE daemon var's value under a
+// clean name (`GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN"` exfiltrates the OAuth
+// token). For a read, a PREFIX DENY on the cortex/substrate control namespaces
+// ({@link RESERVED_REF_SOURCE_PREFIXES}) is the right shape: we are protecting a
+// bounded, known set of guarded daemon vars from being re-surfaced, not deciding
+// which arbitrary daemon var is a legitimate credential source. `resolveAgentEnv`
+// applies {@link isReservedRefSource} to the ref source (session-settings.ts).
+// Two sides, two shapes: allowlist what we SET, prefix-deny the guarded
+// namespaces we must never READ-AND-RE-SURFACE.
 //
 // ## Secrets posture (design §"Secrets and egress", D6)
 //
@@ -71,19 +103,57 @@ import { z } from "zod/v4";
  * Environment-variable name grammar: a letter or underscore, then any run of
  * alphanumerics/underscores. The conventional POSIX-ish identifier shape — the
  * same one `SECRET_REF_PATTERN` (`../inference/secret-ref`) accepts after the
- * `env:` prefix.
+ * `env:` prefix. This is the SECONDARY gate: a permitted key must ALSO be a
+ * valid POSIX name (every {@link ALLOWED_AGENT_ENV_KEYS} entry already is; the
+ * grammar check defends a non-schema runtime caller).
  */
 export const AGENT_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
- * The default-deny prefixes. Any variable whose name (case-folded) begins with
- * one of these is refused by the per-agent env passthrough — see the module doc
- * for the per-prefix rationale. Each prefix names a namespace where a declared
- * var could disable a cortex guard (`CORTEX_`/`GROVE_`), redirect auth or the
- * inference endpoint (`ANTHROPIC_`), or re-open the session-isolation boundary
- * (`CLAUDE_`).
+ * The ALLOWLIST — the exact, case-sensitive set of env-var names the per-agent
+ * passthrough permits. Deny-by-default: a name not in this set is refused at
+ * BOTH config load ({@link AgentEnvSchema}) and session build (`resolveAgentEnv`).
+ *
+ * Seeded with EXACTLY the one var a supported skill needs today:
+ *   - `GOOGLE_APPLICATION_CREDENTIALS` — the service-account credential PATH the
+ *     `gws` Google Drive skill reads.
+ *
+ * To permit a NEW variable, add its exact name here in a cortex PR and have a
+ * reviewer weigh it against the session-hijack classes in the module doc. This
+ * is the ONLY place the permitted set is defined — never widen it at config or
+ * runtime. See the module doc for why this is an allowlist and not a denylist
+ * (epic #2164 + the PR #2171 adversarial finding: the denylist was proven
+ * un-completable).
  */
-export const RESERVED_ENV_PREFIXES = [
+export const ALLOWED_AGENT_ENV_KEYS = ["GOOGLE_APPLICATION_CREDENTIALS"] as const;
+
+/** O(1) membership backing for {@link isAllowedAgentEnvKey}. */
+const ALLOWED_AGENT_ENV_KEY_SET: ReadonlySet<string> = new Set(ALLOWED_AGENT_ENV_KEYS);
+
+/**
+ * The ONE predicate deciding whether a key is PERMITTED by the per-agent env
+ * passthrough. `true` ⇒ allow; anything else ⇒ deny (deny-by-default).
+ *
+ * The test is EXACT and case-SENSITIVE — POSIX env var names are case-sensitive
+ * (`PATH` ≠ `Path`), so only the blessed spelling passes; there is NO
+ * case-folding. Used by BOTH {@link AgentEnvSchema} (load-time reject) and
+ * `resolveAgentEnv` (runtime drop) so they cannot diverge.
+ */
+export function isAllowedAgentEnvKey(key: string): boolean {
+  return ALLOWED_AGENT_ENV_KEY_SET.has(key);
+}
+
+/**
+ * Prefix deny for the `env:NAME` SECRET-REF SOURCE side ONLY. A ref source is a
+ * READ from the daemon env, so its guard is a prefix deny over the cortex /
+ * substrate control namespaces (see the module doc "Ref-source guard uses a
+ * DIFFERENT shape"). NOT used for the destination key — that side is the
+ * allowlist {@link isAllowedAgentEnvKey}.
+ *
+ *   - `CLAUDE_` / `ANTHROPIC_` — substrate auth / config / endpoint vars.
+ *   - `CORTEX_` / `GROVE_`     — cortex's own control-plane + legacy alias.
+ */
+export const RESERVED_REF_SOURCE_PREFIXES = [
   "CLAUDE_",
   "ANTHROPIC_",
   "CORTEX_",
@@ -91,26 +161,16 @@ export const RESERVED_ENV_PREFIXES = [
 ] as const;
 
 /**
- * The default-deny `CLAUDE_` prefix. Retained as a named export (it is the
- * historically-referenced one) even though the deny now spans
- * {@link RESERVED_ENV_PREFIXES}.
+ * `true` ⇒ the given `env:NAME` SOURCE name is in a guarded namespace and must
+ * NOT be re-surfaced under a clean destination key. Case-INSENSITIVE on the
+ * prefixes: the substrates that read these names use the upper-case spellings,
+ * so a case-insensitive check is strictly SAFER (it also refuses `claude_*` /
+ * `cortex_*` spelling tricks). Applies to the ref SOURCE only — see the module
+ * doc for why the two sides use different shapes.
  */
-export const CLAUDE_ENV_PREFIX = "CLAUDE_";
-
-/**
- * The ONE predicate deciding whether a key is refused by the per-agent env
- * passthrough. `true` ⇒ deny. Case-INSENSITIVE on the reserved prefixes: env
- * var names are case-sensitive on POSIX but the substrates that read these
- * names (Claude Code, cortex's own hooks) read the upper-case spellings, so a
- * case-insensitive check is strictly SAFER — it also refuses `claude_*` /
- * `Cortex_*` spelling tricks — at the cost of blocking a vanishingly rare
- * legitimate lower-case `claude_…`/`cortex_…`/etc. var, an acceptable, airtight
- * trade. Used by BOTH {@link AgentEnvSchema} (load-time reject) and
- * `resolveAgentEnv` (runtime drop) so they cannot diverge.
- */
-export function isDeniedAgentEnvKey(key: string): boolean {
-  const upper = key.toUpperCase();
-  return RESERVED_ENV_PREFIXES.some((prefix) => upper.startsWith(prefix));
+export function isReservedRefSource(name: string): boolean {
+  const upper = name.toUpperCase();
+  return RESERVED_REF_SOURCE_PREFIXES.some((prefix) => upper.startsWith(prefix));
 }
 
 /**
@@ -129,12 +189,13 @@ export const AgentEnvValueSchema = z
 
 /**
  * cortex#2133 — the per-agent `env:` map schema. Keys are env-var names
- * ({@link AGENT_ENV_KEY_PATTERN}); values are {@link AgentEnvValueSchema}. A
- * reserved-prefix key ({@link RESERVED_ENV_PREFIXES}, case-insensitive) is
- * REJECTED at parse time via {@link isDeniedAgentEnvKey}, so a declared var can
- * neither widen the isolation boundary nor disable a cortex guard / redirect
- * auth. Optional on the agent; absent ⇒ no passthrough (the pre-#2133
- * behaviour, byte-for-byte).
+ * ({@link AGENT_ENV_KEY_PATTERN}); values are {@link AgentEnvValueSchema}. A key
+ * that is NOT in the {@link ALLOWED_AGENT_ENV_KEYS} allowlist is REJECTED at
+ * parse time via {@link isAllowedAgentEnvKey} (deny-by-default), so a declared
+ * var can neither widen the isolation boundary, redirect auth, disable a cortex
+ * guard, nor hijack the session via any of the open-ended runtime/loader/PATH
+ * classes a denylist could never fully enumerate. Optional on the agent; absent
+ * ⇒ no passthrough (the pre-#2133 behaviour, byte-for-byte).
  */
 export const AgentEnvSchema = z
   .record(
@@ -149,19 +210,21 @@ export const AgentEnvSchema = z
   )
   .superRefine((map, ctx) => {
     for (const key of Object.keys(map)) {
-      if (isDeniedAgentEnvKey(key)) {
+      if (!isAllowedAgentEnvKey(key)) {
         ctx.addIssue({
           code: "custom",
           path: [key],
           message:
-            `agent env key '${key}' is not allowed: variables in the reserved prefixes ` +
-            `[${RESERVED_ENV_PREFIXES.join(", ")}] are default-deny (cortex#701 / #2133). A ` +
-            `per-agent env passthrough must never set one — CLAUDE_*/ANTHROPIC_* would ` +
-            `re-introduce hooks/plugins/settings or redirect auth and the inference endpoint, ` +
-            `and CORTEX_*/GROVE_* would disable a cortex guard (e.g. CORTEX_BASH_GUARD) or ` +
-            `rewrite the session's grants/identity. Use the substrates: configHome seam ` +
-            `(cortex#2132) to relocate a substrate config home; this map is for everything ` +
-            `that is NOT a substrate config or cortex control var.`,
+            `agent env key '${key}' is not allowed: the per-agent env passthrough is ` +
+            `DENY-BY-DEFAULT (an allowlist, cortex#2133 / epic #2164). Only these exact, ` +
+            `case-sensitive names may be set: [${ALLOWED_AGENT_ENV_KEYS.join(", ")}]. This ` +
+            `replaced a reserved-prefix DENYLIST that an adversarial review proved ` +
+            `un-completable — the set of session-hijacking vars (BASH_ENV, PATH, ` +
+            `NODE_OPTIONS, LD_PRELOAD, DYLD_INSERT_LIBRARIES, GIT_SSH_COMMAND, *_PROXY, ` +
+            `NODE_EXTRA_CA_CERTS, CLAUDE_*/ANTHROPIC_*/CORTEX_*/GROVE_*, …) is open-ended. ` +
+            `To permit a new variable, add its exact name to ALLOWED_AGENT_ENV_KEYS in ` +
+            `src/common/config/agent-env.ts via a cortex PR (a reviewed change). Names are ` +
+            `case-sensitive: '${key}' is not the blessed spelling of any allowed key.`,
         });
       }
     }

--- a/src/common/config/agent-env.ts
+++ b/src/common/config/agent-env.ts
@@ -1,0 +1,125 @@
+// cortex#2133 (epic #2164) — declarative per-agent environment passthrough.
+//
+// ## The gap this closes
+//
+// A deployment credential a CLI-based skill needs (e.g.
+// `GOOGLE_APPLICATION_CREDENTIALS` for the `gws` Google Drive skill) has no
+// declarative home in cortex config. The only route was hand-editing the
+// launchd plist that `arc` renders — which `arc upgrade cortex` re-renders,
+// silently dropping the edit and quietly killing the capability. This adds a
+// per-agent `env:` map on `agents[]` (narrowest scope — only the agent that
+// needs the credential gets it) that is applied at the SESSION layer, so it is
+// a cortex-only change with no arc/plist dependency.
+//
+// ## HARD CONSTRAINT — CLAUDE_* stays default-deny (cortex#701)
+//
+// This passthrough must NEVER become a route to set a `CLAUDE_*` variable. A
+// `CLAUDE_*` var can re-introduce hooks/plugins/settings/alternate config
+// homes and thereby undo the cortex#701 session-isolation boundary
+// (`scopeSessionEnv` in `src/runner/session-settings.ts`). The cortex#2132
+// revert — which allowlisted `CLAUDE_CONFIG_DIR` through the scope and then
+// reverted in favour of a typed `substrates:` table — is the binding
+// precedent. So {@link isDeniedAgentEnvKey} is the SINGLE SOURCE OF TRUTH for
+// the deny, used in BOTH places that must agree:
+//
+//   1. Config LOAD  — {@link AgentEnvSchema} rejects any denied key at parse
+//      time, so a stack whose config declares a `CLAUDE_*` passthrough fails
+//      to load (the daemon refuses it).
+//   2. Session BUILD — `resolveAgentEnv` (session-settings.ts) re-asserts the
+//      deny at runtime as defence-in-depth, so no code path (a test, a future
+//      direct caller, a schema regression) can ever layer a `CLAUDE_*` var
+//      onto a child session's env.
+//
+// Keeping ONE predicate means the two layers cannot drift.
+//
+// ## Secrets posture (design §"Secrets and egress", D6)
+//
+// A value is EITHER a non-secret literal (a path like
+// `/Users/andreas/.config/gws/sa.json` — a path, not a secret) OR a SECRET
+// REFERENCE of the form `env:NAME` ({@link SECRET_REF_PATTERN}). A reference is
+// resolved from the daemon env AT CALL TIME (`resolveAgentEnv`), never at parse
+// time, so a config dump shows `env:NAME` and never the secret value. This
+// mirrors the `providers.*.apiKey` convention.
+
+import { z } from "zod/v4";
+
+/**
+ * Environment-variable name grammar: a letter or underscore, then any run of
+ * alphanumerics/underscores. The conventional POSIX-ish identifier shape — the
+ * same one `SECRET_REF_PATTERN` (`../inference/secret-ref`) accepts after the
+ * `env:` prefix.
+ */
+export const AGENT_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * The default-deny prefix. Any variable whose name (case-folded) begins with
+ * `CLAUDE_` is refused by the per-agent env passthrough — see the module doc.
+ */
+export const CLAUDE_ENV_PREFIX = "CLAUDE_";
+
+/**
+ * The ONE predicate deciding whether a key is refused by the per-agent env
+ * passthrough. `true` ⇒ deny. Case-INSENSITIVE on the `CLAUDE_` prefix: env
+ * var names are case-sensitive on POSIX and Claude Code only reads the
+ * upper-case `CLAUDE_*` names, so a case-insensitive check is strictly SAFER
+ * (it also refuses `claude_*`/`Claude_*` spelling tricks) at the cost of
+ * blocking a vanishingly rare legitimate lower-case `claude_…` var — an
+ * acceptable, airtight trade. Used by BOTH {@link AgentEnvSchema} (load-time
+ * reject) and `resolveAgentEnv` (runtime drop) so they cannot diverge.
+ */
+export function isDeniedAgentEnvKey(key: string): boolean {
+  return key.toUpperCase().startsWith(CLAUDE_ENV_PREFIX);
+}
+
+/**
+ * A single passthrough value: a non-empty string that is either a literal or
+ * an `env:NAME` secret reference. The `env:NAME` vs literal distinction is made
+ * at RESOLUTION time (`resolveAgentEnv`), not here — this schema only requires
+ * the value be present and non-empty, so a literal path is accepted as-is.
+ */
+export const AgentEnvValueSchema = z
+  .string()
+  .min(
+    1,
+    "agent env value must be a non-empty string — a literal (e.g. a credential path) " +
+      "or an `env:NAME` secret reference",
+  );
+
+/**
+ * cortex#2133 — the per-agent `env:` map schema. Keys are env-var names
+ * ({@link AGENT_ENV_KEY_PATTERN}); values are {@link AgentEnvValueSchema}. A
+ * `CLAUDE_*` key (case-insensitive) is REJECTED at parse time via
+ * {@link isDeniedAgentEnvKey}, so the isolation boundary cannot be widened
+ * through this surface. Optional on the agent; absent ⇒ no passthrough (the
+ * pre-#2133 behaviour, byte-for-byte).
+ */
+export const AgentEnvSchema = z
+  .record(
+    z
+      .string()
+      .regex(
+        AGENT_ENV_KEY_PATTERN,
+        "agent env var name must be a POSIX identifier — a letter or underscore " +
+          "followed by letters, digits, or underscores (e.g. 'GOOGLE_APPLICATION_CREDENTIALS')",
+      ),
+    AgentEnvValueSchema,
+  )
+  .superRefine((map, ctx) => {
+    for (const key of Object.keys(map)) {
+      if (isDeniedAgentEnvKey(key)) {
+        ctx.addIssue({
+          code: "custom",
+          path: [key],
+          message:
+            `agent env key '${key}' is not allowed: CLAUDE_* variables are default-deny ` +
+            `(cortex#701 session isolation). A per-agent env passthrough must never set a ` +
+            `CLAUDE_* var — that would re-introduce hooks/plugins/settings and undo the ` +
+            `isolation boundary. Use the substrates: configHome seam (cortex#2132) to relocate ` +
+            `a substrate config home; this map is for everything that is NOT a substrate config var.`,
+        });
+      }
+    }
+  });
+
+/** A validated per-agent env passthrough map (name → literal-or-`env:NAME`). */
+export type AgentEnv = z.infer<typeof AgentEnvSchema>;

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -301,6 +301,21 @@ export interface DispatchRuntime {
    * absent for an agent-rooted dispatch.
    */
   parentSessionId?: string;
+  /**
+   * cortex#2133 (epic #2164) — the receiving agent's declared `env:` passthrough
+   * map (`NAME → literal-or-`env:NAME`-reference`; see `AgentSchema.env`). The
+   * claude-code harness threads this onto `CCSessionOpts.agentEnv`, where
+   * `resolveAgentEnv` (session-settings.ts) resolves references from the daemon
+   * env and layers the vars onto the child AFTER `scopeSessionEnv` — never
+   * touching the default-deny `CLAUDE_*` namespace. Non-CC harnesses ignore it.
+   *
+   * **Receiving-stack-authoritative.** The runner populates this from the
+   * EXECUTING stack's own config (looked up by receiving agent id), NOT from
+   * the inbound wire — so a federated peer cannot inject env vars into a host
+   * session (same trust model as the receiving-stack-authoritative `mcpGrants`).
+   * Optional everywhere; absent ⇒ no passthrough.
+   */
+  agentEnv?: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1033,11 +1033,19 @@ export const AgentSchema = z.object({
    * secret) OR an `env:NAME` SECRET REFERENCE resolved from the daemon env at
    * call time and never stored in config (design §"Secrets and egress", D6).
    *
-   * **HARD CONSTRAINT — `CLAUDE_*` is default-deny.** A `CLAUDE_*` key is
-   * REJECTED at parse time ({@link AgentEnvSchema}); this passthrough must never
-   * re-introduce the hooks/plugins/settings a `CLAUDE_*` var would, undoing the
-   * cortex#701 isolation boundary. Relocating a substrate config home is the
-   * `substrates:` `configHome` seam's job (cortex#2132), not this map's.
+   * **HARD CONSTRAINT — a RESERVED-PREFIX denylist is default-deny.** A key in
+   * any of `CLAUDE_` / `ANTHROPIC_` / `CORTEX_` / `GROVE_` (case-insensitive) is
+   * REJECTED at parse time ({@link AgentEnvSchema}) and re-dropped at runtime
+   * (`resolveAgentEnv`). This passthrough must never re-introduce the
+   * hooks/plugins/settings a `CLAUDE_*` var would (cortex#701 isolation),
+   * redirect auth or the inference endpoint (`ANTHROPIC_BASE_URL`/`_API_KEY`/
+   * `_AUTH_TOKEN`/`_MODEL`), or disable a cortex guard / rewrite grants+identity
+   * (`CORTEX_BASH_GUARD`, `CORTEX_SKILL_GRANTS`, `CORTEX_MCP_GRANTS`,
+   * `CORTEX_CHANNEL`, …, and their legacy `GROVE_*` aliases). The `env:NAME`
+   * REF SOURCE name is denied by the same predicate, so a benign key cannot
+   * re-surface a guarded daemon var's value (cortex#2133). Relocating a
+   * substrate config home is the `substrates:` `configHome` seam's job
+   * (cortex#2132), not this map's.
    *
    * Additive: existing agents omit this key and are unaffected (byte-identical
    * to the pre-#2133 session env).

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1033,19 +1033,20 @@ export const AgentSchema = z.object({
    * secret) OR an `env:NAME` SECRET REFERENCE resolved from the daemon env at
    * call time and never stored in config (design §"Secrets and egress", D6).
    *
-   * **HARD CONSTRAINT — a RESERVED-PREFIX denylist is default-deny.** A key in
-   * any of `CLAUDE_` / `ANTHROPIC_` / `CORTEX_` / `GROVE_` (case-insensitive) is
+   * **HARD CONSTRAINT — an ALLOWLIST: deny-by-default (cortex#2133/#2164).**
+   * Only the exact, case-sensitive names in `ALLOWED_AGENT_ENV_KEYS` (seeded
+   * with just `GOOGLE_APPLICATION_CREDENTIALS`) may be set; every other key is
    * REJECTED at parse time ({@link AgentEnvSchema}) and re-dropped at runtime
-   * (`resolveAgentEnv`). This passthrough must never re-introduce the
-   * hooks/plugins/settings a `CLAUDE_*` var would (cortex#701 isolation),
-   * redirect auth or the inference endpoint (`ANTHROPIC_BASE_URL`/`_API_KEY`/
-   * `_AUTH_TOKEN`/`_MODEL`), or disable a cortex guard / rewrite grants+identity
-   * (`CORTEX_BASH_GUARD`, `CORTEX_SKILL_GRANTS`, `CORTEX_MCP_GRANTS`,
-   * `CORTEX_CHANNEL`, …, and their legacy `GROVE_*` aliases). The `env:NAME`
-   * REF SOURCE name is denied by the same predicate, so a benign key cannot
-   * re-surface a guarded daemon var's value (cortex#2133). Relocating a
-   * substrate config home is the `substrates:` `configHome` seam's job
-   * (cortex#2132), not this map's.
+   * (`resolveAgentEnv`). This inverts a former reserved-prefix DENYLIST that an
+   * adversarial review proved un-completable — the session-hijack set (BASH_ENV,
+   * PATH, NODE_OPTIONS, LD_PRELOAD, DYLD_INSERT_LIBRARIES, GIT_SSH_COMMAND,
+   * *_PROXY, NODE_EXTRA_CA_CERTS, CLAUDE_/ANTHROPIC_/CORTEX_/GROVE_ prefixes, …) is
+   * open-ended. Adding a permitted var is a reviewed cortex PR editing
+   * `ALLOWED_AGENT_ENV_KEYS`. The `env:NAME` REF SOURCE name uses a DIFFERENT
+   * shape — a prefix deny on CLAUDE_/ANTHROPIC_/CORTEX_/GROVE_ — because a source
+   * is a READ, so a benign key cannot re-surface a guarded daemon var's value
+   * (cortex#2133). Relocating a substrate config home is the `substrates:`
+   * `configHome` seam's job (cortex#2132), not this map's.
    *
    * Additive: existing agents omit this key and are unaffected (byte-identical
    * to the pre-#2133 session env).

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -51,6 +51,7 @@ import type {
   InferenceProfile,
   InferenceConfig,
 } from "../inference/inference-config-schema";
+import { AgentEnvSchema } from "../config/agent-env";
 import { CapabilitySchema } from "./capability";
 import { REVIEW_FLAVORS, reviewFlavorOfCapability } from "./review-flavors";
 import {
@@ -1014,6 +1015,34 @@ export const AgentSchema = z.object({
       version: z.string().min(1),
     })
     .optional(),
+  /**
+   * cortex#2133 (epic #2164) — OPT-IN declarative per-agent environment
+   * passthrough. A map of `NAME → literal-or-`env:NAME`-reference` that is
+   * layered onto THIS agent's CC sessions at the SESSION layer (after
+   * `scopeSessionEnv`, alongside cortex's own `CORTEX_*` pipeline vars — see
+   * `resolveAgentEnv` in `src/runner/session-settings.ts`).
+   *
+   * Purpose: give a deployment credential a CLI-based skill needs (e.g.
+   * `GOOGLE_APPLICATION_CREDENTIALS` for the `gws` skill) a declarative home in
+   * cortex config, instead of a hand-edited launchd plist that `arc upgrade`
+   * overwrites. Narrowest scope by design (same asymmetric-agent argument as
+   * cortex#2111): only the agent that declares it gets the var, not every agent
+   * on the stack.
+   *
+   * Values: a non-secret LITERAL (a path like `/…/sa.json` is a path, not a
+   * secret) OR an `env:NAME` SECRET REFERENCE resolved from the daemon env at
+   * call time and never stored in config (design §"Secrets and egress", D6).
+   *
+   * **HARD CONSTRAINT — `CLAUDE_*` is default-deny.** A `CLAUDE_*` key is
+   * REJECTED at parse time ({@link AgentEnvSchema}); this passthrough must never
+   * re-introduce the hooks/plugins/settings a `CLAUDE_*` var would, undoing the
+   * cortex#701 isolation boundary. Relocating a substrate config home is the
+   * `substrates:` `configHome` seam's job (cortex#2132), not this map's.
+   *
+   * Additive: existing agents omit this key and are unaffected (byte-identical
+   * to the pre-#2133 session env).
+   */
+  env: AgentEnvSchema.optional(),
 });
 // cortex#245 — the previous `at least one presence block` refine was
 // dropped to admit headless agents (bus-only participants with no

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -843,7 +843,7 @@ function resolvePrincipalId(
 }
 
 function targetAgentForDispatch(
-  agent: Pick<Agent, "id" | "displayName" | "persona" | "openOnboarding" | "openOnboardingAllowedTools" | "runtime" | "agentDisallowedTools" | "strictMcpConfig">,
+  agent: Pick<Agent, "id" | "displayName" | "persona" | "openOnboarding" | "openOnboardingAllowedTools" | "runtime" | "agentDisallowedTools" | "strictMcpConfig" | "env">,
   configDir: string,
 ): {
   id: string;
@@ -854,6 +854,7 @@ function targetAgentForDispatch(
   capabilities?: readonly string[];
   agentDisallowedTools?: string[];
   strictMcpConfig?: boolean;
+  env?: Record<string, string>;
 } {
   const expandedPersona = expandTilde(agent.persona);
   return {
@@ -884,6 +885,11 @@ function targetAgentForDispatch(
       agentDisallowedTools: agent.agentDisallowedTools,
     }),
     ...(agent.strictMcpConfig === true && { strictMcpConfig: true }),
+    // cortex#2133 — carry the agent's declared env passthrough so the DIRECT
+    // dispatch paths (async/team/sync-fallback) layer it onto the CC session
+    // (resolved + CLAUDE_* re-denied in cc-session). The canonical bus-mediated
+    // sync path is injected receiving-stack-authoritatively in the listener.
+    ...(agent.env !== undefined && { env: agent.env }),
   };
 }
 
@@ -3714,6 +3720,16 @@ export async function startCortex(
   for (const a of mergedAgents) {
     if (a.runtime !== undefined) agentRuntimesById.set(a.id, a.runtime);
   }
+  // cortex#2133 (epic #2164) — BOOT snapshot of each agent's declared `env:`
+  // passthrough, keyed by agent id. The dispatch-listener injects the RECEIVING
+  // agent's map onto `req.runtime.agentEnv` receiving-stack-authoritatively (the
+  // executing stack's config is the single source of truth — the value NEVER
+  // comes from the inbound wire, mirroring the `bashAllowlist`/`mcpGrants`
+  // receiving-side authority). Empty map ⇒ no agent declared `env:` ⇒ no-op.
+  const agentEnvById = new Map<string, Record<string, string>>();
+  for (const a of mergedAgents) {
+    if (a.env !== undefined) agentEnvById.set(a.id, a.env);
+  }
   const inferenceRegistry = createInferenceRegistry(
     config.inference ?? { providers: {}, profiles: {} },
   );
@@ -3738,6 +3754,7 @@ export async function startCortex(
     source: systemEventSource,
     stack: derivedStack.stack,
     agentRuntimesById,
+    agentEnvById,
     inferenceRegistry,
     ...(policyEngine !== undefined && { policyEngine }),
     trustResolver,

--- a/src/runner/__tests__/agent-env-passthrough.test.ts
+++ b/src/runner/__tests__/agent-env-passthrough.test.ts
@@ -1,0 +1,128 @@
+/**
+ * cortex#2133 (epic #2164, TRUST-PATH) — per-agent env passthrough RUNTIME tests.
+ *
+ * Covers the four ACs the slice must prove:
+ *   (a) a declared NON-SECRET env var reaches the session env,
+ *   (b) a `env:NAME` SecretRef value resolves from the daemon env,
+ *   (c) a CLAUDE_* key is DROPPED at the runtime layer (defence-in-depth over
+ *       the schema's load-time reject — the airtight security assertion),
+ *   (d) an agent with NO env is byte-unchanged (no regression).
+ *
+ * `resolveAgentEnv` is the pure, env-injectable unit; the composition tests then
+ * feed its output through the exported `buildSessionEnv` exactly as `start()`
+ * does, proving the vars actually reach the child session env AND that cortex's
+ * own instrumentation + config-home vars always WIN over a declared passthrough.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { resolveAgentEnv } from "../session-settings";
+import { buildSessionEnv } from "../cc-session";
+import { setActiveSubstrates } from "../../common/substrates/config-home";
+
+describe("resolveAgentEnv — resolution + CLAUDE_* runtime deny", () => {
+  test("(a) a declared non-secret literal passes through verbatim", () => {
+    const out = resolveAgentEnv(
+      { GOOGLE_APPLICATION_CREDENTIALS: "/Users/andreas/.config/gws/sa.json" },
+      {},
+    );
+    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe(
+      "/Users/andreas/.config/gws/sa.json",
+    );
+  });
+
+  test("(b) an `env:NAME` reference resolves from the (injected) daemon env", () => {
+    const out = resolveAgentEnv(
+      { GWS_TOKEN: "env:MANDA_GWS_TOKEN" },
+      { MANDA_GWS_TOKEN: "resolved-secret-value" },
+    );
+    expect(out.GWS_TOKEN).toBe("resolved-secret-value");
+  });
+
+  test("(b′) an unresolved reference (unset/empty daemon var) is SKIPPED, not thrown", () => {
+    // Unset
+    expect(resolveAgentEnv({ X: "env:NOPE" }, {})).toEqual({});
+    // Whitespace-only is treated as empty
+    expect(resolveAgentEnv({ X: "env:BLANK" }, { BLANK: "   " })).toEqual({});
+  });
+
+  test("(c) a CLAUDE_* key is DROPPED at runtime even if it reaches this fn", () => {
+    // Simulates a schema bypass / regression: the runtime layer must still
+    // refuse to set a CLAUDE_* var. This is the airtight security property.
+    const out = resolveAgentEnv(
+      {
+        CLAUDE_CONFIG_DIR: "/tmp/evil-home",
+        CLAUDE_CODE_OAUTH_TOKEN: "sk-evil",
+        GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
+      },
+      {},
+    );
+    expect(out.CLAUDE_CONFIG_DIR).toBeUndefined();
+    expect(out.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    // The legitimate non-CLAUDE var still comes through.
+    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe("/x/sa.json");
+  });
+
+  test("(c′) the CLAUDE_* runtime deny is case-insensitive", () => {
+    const out = resolveAgentEnv(
+      { claude_config_dir: "/tmp/x", Claude_Code_Oauth_Token: "y" },
+      {},
+    );
+    expect(Object.keys(out)).toHaveLength(0);
+  });
+
+  test("(d) undefined agentEnv resolves to an empty map (no passthrough)", () => {
+    expect(resolveAgentEnv(undefined)).toEqual({});
+    expect(resolveAgentEnv({})).toEqual({});
+  });
+});
+
+describe("agent env reaches the session env via buildSessionEnv (start() composition)", () => {
+  afterEach(() => setActiveSubstrates(undefined));
+
+  // Mirror start(): env = buildSessionEnv({ ...baseEnv, ...resolveAgentEnv(...) }, opts)
+  const compose = (
+    baseEnv: Record<string, string>,
+    agentEnv: Record<string, string> | undefined,
+    opts: Parameters<typeof buildSessionEnv>[1],
+    daemonEnv: Record<string, string | undefined> = {},
+  ) => buildSessionEnv({ ...baseEnv, ...resolveAgentEnv(agentEnv, daemonEnv) }, opts);
+
+  test("(a) a declared literal lands on the composed session env", () => {
+    const env = compose(
+      { PATH: "/usr/bin" },
+      { GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json" },
+      { channel: "manda" },
+    );
+    expect(env.GOOGLE_APPLICATION_CREDENTIALS).toBe("/x/sa.json");
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.CORTEX_CHANNEL).toBe("manda");
+  });
+
+  test("(d) no agentEnv ⇒ session env byte-identical to the no-passthrough build", () => {
+    const opts = { channel: "manda", agentId: "luna" } as const;
+    const withNone = compose({ PATH: "/usr/bin" }, undefined, opts);
+    const baseline = buildSessionEnv({ PATH: "/usr/bin" }, opts);
+    expect(withNone).toEqual(baseline);
+  });
+
+  test("cortex's own CORTEX_* pipeline var WINS over a same-named passthrough", () => {
+    // A declared var may not shadow cortex's instrumentation identity.
+    const env = compose(
+      { PATH: "/usr/bin" },
+      { CORTEX_CHANNEL: "spoofed" },
+      { channel: "authoritative" },
+    );
+    expect(env.CORTEX_CHANNEL).toBe("authoritative");
+  });
+
+  test("cortex's config-home (CLAUDE_CONFIG_DIR) is untouched by the passthrough", () => {
+    // The passthrough can't set CLAUDE_* at all (dropped), and the config-home
+    // export layered by buildSessionEnv is the only thing that sets it.
+    const env = compose(
+      { PATH: "/usr/bin" },
+      { CLAUDE_CONFIG_DIR: "/tmp/evil-home" },
+      { configHomeEnv: { name: "CLAUDE_CONFIG_DIR", value: "/real/home" } },
+    );
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/real/home");
+  });
+});

--- a/src/runner/__tests__/agent-env-passthrough.test.ts
+++ b/src/runner/__tests__/agent-env-passthrough.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, test, expect, afterEach } from "bun:test";
 import { resolveAgentEnv } from "../session-settings";
-import { buildSessionEnv } from "../cc-session";
+import { buildSessionEnv, resolveBashGuardEnv } from "../cc-session";
 import { setActiveSubstrates } from "../../common/substrates/config-home";
 
 describe("resolveAgentEnv — resolution + CLAUDE_* runtime deny", () => {
@@ -73,6 +73,168 @@ describe("resolveAgentEnv — resolution + CLAUDE_* runtime deny", () => {
   test("(d) undefined agentEnv resolves to an empty map (no passthrough)", () => {
     expect(resolveAgentEnv(undefined)).toEqual({});
     expect(resolveAgentEnv({})).toEqual({});
+  });
+});
+
+describe("resolveAgentEnv — broadened reserved-prefix deny (cortex#2133)", () => {
+  test("a CORTEX_BASH_GUARD key is DROPPED at runtime (MAJOR-1 key-layer close)", () => {
+    const out = resolveAgentEnv(
+      {
+        CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}',
+        GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
+      },
+      {},
+    );
+    expect(out.CORTEX_BASH_GUARD).toBeUndefined();
+    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe("/x/sa.json");
+  });
+
+  test("ANTHROPIC_* keys are DROPPED at runtime (auth / endpoint redirect)", () => {
+    const out = resolveAgentEnv(
+      {
+        ANTHROPIC_BASE_URL: "https://evil.example",
+        ANTHROPIC_API_KEY: "sk-evil",
+        ANTHROPIC_AUTH_TOKEN: "t",
+      },
+      {},
+    );
+    expect(Object.keys(out)).toHaveLength(0);
+  });
+
+  test("GROVE_* legacy-alias control keys are DROPPED at runtime", () => {
+    const out = resolveAgentEnv(
+      { GROVE_CHANNEL: "spoofed", GROVE_OPERATOR: "x" },
+      {},
+    );
+    expect(Object.keys(out)).toHaveLength(0);
+  });
+
+  test("other CORTEX_* control keys (grants/identity) are DROPPED at runtime", () => {
+    const out = resolveAgentEnv(
+      {
+        CORTEX_SKILL_GRANTS: "[]",
+        CORTEX_MCP_GRANTS: "[]",
+        CORTEX_CHANNEL: "spoofed",
+      },
+      {},
+    );
+    expect(Object.keys(out)).toHaveLength(0);
+  });
+});
+
+describe("resolveAgentEnv — env: REF SOURCE deny (MINOR-3)", () => {
+  test("a benign key referencing env:CLAUDE_CODE_OAUTH_TOKEN is DROPPED (no exfil)", () => {
+    // The exfil vector: a clean destination name that re-surfaces a guarded
+    // daemon var's VALUE. Even with the secret present in the daemon env, the
+    // ref must be refused because its SOURCE name is reserved-prefix.
+    const out = resolveAgentEnv(
+      { GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN" },
+      { CLAUDE_CODE_OAUTH_TOKEN: "sk-oauth-secret" },
+    );
+    expect(out.GDRIVE_TOKEN).toBeUndefined();
+    expect(Object.values(out)).not.toContain("sk-oauth-secret");
+  });
+
+  test("refs to ANTHROPIC_* / CORTEX_* sources are DROPPED even when resolvable", () => {
+    const out = resolveAgentEnv(
+      {
+        A: "env:ANTHROPIC_API_KEY",
+        B: "env:CORTEX_BASH_GUARD",
+      },
+      { ANTHROPIC_API_KEY: "sk-x", CORTEX_BASH_GUARD: '{"disabled":true}' },
+    );
+    expect(Object.keys(out)).toHaveLength(0);
+  });
+
+  test("a ref to a NON-reserved source still resolves (no over-blocking)", () => {
+    const out = resolveAgentEnv(
+      { GWS_TOKEN: "env:MANDA_GWS_TOKEN" },
+      { MANDA_GWS_TOKEN: "ok" },
+    );
+    expect(out.GWS_TOKEN).toBe("ok");
+  });
+});
+
+describe("resolveAgentEnv — runtime key-grammar re-check (MINOR-4)", () => {
+  test("a leading-space ' CLAUDE_X' key is DROPPED by the pattern re-check", () => {
+    // The leading space would dodge the prefix check; the ASCII grammar catches
+    // it first. Proves a non-schema caller can't slip a mangled key past runtime.
+    const out = resolveAgentEnv(
+      { " CLAUDE_X": "/tmp/x", "GOOD_KEY": "ok" },
+      {},
+    );
+    expect(out[" CLAUDE_X"]).toBeUndefined();
+    expect(out.GOOD_KEY).toBe("ok");
+  });
+
+  test("keys with '=', dashes, or interior whitespace are DROPPED at runtime", () => {
+    const out = resolveAgentEnv(
+      { "A=B": "x", "has-dash": "y", "has space": "z", "1LEADING": "w" },
+      {},
+    );
+    expect(Object.keys(out)).toHaveLength(0);
+  });
+});
+
+describe("resolveBashGuardEnv — CORTEX_BASH_GUARD safe default (cortex#2133)", () => {
+  test("neither flag ⇒ the safe default '{}' (guard active, built-in default-deny)", () => {
+    expect(resolveBashGuardEnv({})).toBe("{}");
+    expect(JSON.parse(resolveBashGuardEnv({}))).toEqual({});
+  });
+
+  test("bashGuardDisabled ⇒ {\"disabled\":true}", () => {
+    expect(resolveBashGuardEnv({ bashGuardDisabled: true })).toBe(
+      JSON.stringify({ disabled: true }),
+    );
+  });
+
+  test("bashAllowlist ⇒ the serialised allowlist", () => {
+    const allow = { rules: [{ pattern: "^gh\\s" }], repos: [] };
+    expect(resolveBashGuardEnv({ bashAllowlist: allow })).toBe(JSON.stringify(allow));
+  });
+
+  test("the safe default NEVER carries disabled:true (does not weaken the guard)", () => {
+    expect(JSON.parse(resolveBashGuardEnv({})).disabled).toBeUndefined();
+  });
+});
+
+describe("MAJOR-1 exploit is closed end-to-end (cortex#2133)", () => {
+  // The exploit: an agent declares `env: { CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}' }`
+  // and the stack sets NO bashAllowlist. We prove the malicious value can NEVER
+  // land on the composed session env, closed at BOTH layers:
+  //   (1) the key layer — resolveAgentEnv drops the reserved-prefix key, and
+  //   (2) the writer layer — cortex writes the authoritative guard value last.
+  test("a declared CORTEX_BASH_GUARD with no bashAllowlist does NOT reach the session env", () => {
+    const agentEnv = { CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}' };
+
+    // (1) Key layer: the passthrough drops it — it never even enters baseEnv.
+    const resolved = resolveAgentEnv(agentEnv, {});
+    expect(resolved.CORTEX_BASH_GUARD).toBeUndefined();
+
+    // Compose exactly as start() does: base ← {scoped ∪ resolved}, then cortex
+    // writes the authoritative guard value LAST (unconditional overwrite).
+    const composed: Record<string, string> = {
+      ...buildSessionEnv({ PATH: "/usr/bin", ...resolved }, { channel: "manda" }),
+    };
+    composed.CORTEX_BASH_GUARD = resolveBashGuardEnv({
+      /* no bashGuardDisabled, no bashAllowlist */
+    });
+
+    // (2) Writer layer: even if a value HAD leaked into baseEnv by some other
+    // route, the authoritative write pins it to the safe default.
+    expect(composed.CORTEX_BASH_GUARD).toBe("{}");
+    expect(composed.CORTEX_BASH_GUARD).not.toContain(".*");
+  });
+
+  test("even a base-env-injected CORTEX_BASH_GUARD is overwritten by the authoritative write", () => {
+    // Simulate a stale/injected value arriving via the base env by ANY route.
+    const base = buildSessionEnv(
+      { PATH: "/usr/bin", CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}' },
+      { channel: "manda" },
+    );
+    const composed: Record<string, string> = { ...base };
+    composed.CORTEX_BASH_GUARD = resolveBashGuardEnv({});
+    expect(composed.CORTEX_BASH_GUARD).toBe("{}");
   });
 });
 

--- a/src/runner/__tests__/agent-env-passthrough.test.ts
+++ b/src/runner/__tests__/agent-env-passthrough.test.ts
@@ -1,11 +1,15 @@
 /**
  * cortex#2133 (epic #2164, TRUST-PATH) — per-agent env passthrough RUNTIME tests.
  *
- * Covers the four ACs the slice must prove:
- *   (a) a declared NON-SECRET env var reaches the session env,
- *   (b) a `env:NAME` SecretRef value resolves from the daemon env,
- *   (c) a CLAUDE_* key is DROPPED at the runtime layer (defence-in-depth over
- *       the schema's load-time reject — the airtight security assertion),
+ * Covers the ACs the slice must prove under the ALLOWLIST (deny-by-default)
+ * design:
+ *   (a) the allowlisted var (`GOOGLE_APPLICATION_CREDENTIALS`) reaches the
+ *       session env as a literal,
+ *   (b) an `env:NAME` SecretRef on the allowlisted key resolves from the daemon
+ *       env,
+ *   (c) every var on the adversarial hit-list is DROPPED at the runtime layer
+ *       (defence-in-depth over the schema's load-time reject — the airtight
+ *       security assertion),
  *   (d) an agent with NO env is byte-unchanged (no regression).
  *
  * `resolveAgentEnv` is the pure, env-injectable unit; the composition tests then
@@ -19,8 +23,27 @@ import { resolveAgentEnv } from "../session-settings";
 import { buildSessionEnv, resolveBashGuardEnv } from "../cc-session";
 import { setActiveSubstrates } from "../../common/substrates/config-home";
 
-describe("resolveAgentEnv — resolution + CLAUDE_* runtime deny", () => {
-  test("(a) a declared non-secret literal passes through verbatim", () => {
+/**
+ * The adversarial hit-list — the open-ended set of session-hijacking env vars a
+ * denylist could never fully enumerate. Every one MUST be DROPPED at runtime by
+ * the allowlist (the schema-load half is asserted in the config test's identical
+ * list). Parametrised so this is a standing regression fence.
+ */
+const REJECT_LIST = [
+  "BASH_ENV",
+  "PATH",
+  "NODE_OPTIONS",
+  "LD_PRELOAD",
+  "DYLD_INSERT_LIBRARIES",
+  "GIT_SSH_COMMAND",
+  "HTTPS_PROXY",
+  "NODE_EXTRA_CA_CERTS",
+  "ANTHROPIC_BASE_URL",
+  "CORTEX_BASH_GUARD",
+];
+
+describe("resolveAgentEnv — allowlisted resolution", () => {
+  test("(a) the allowlisted GOOGLE_APPLICATION_CREDENTIALS literal passes through verbatim", () => {
     const out = resolveAgentEnv(
       { GOOGLE_APPLICATION_CREDENTIALS: "/Users/andreas/.config/gws/sa.json" },
       {},
@@ -30,44 +53,26 @@ describe("resolveAgentEnv — resolution + CLAUDE_* runtime deny", () => {
     );
   });
 
-  test("(b) an `env:NAME` reference resolves from the (injected) daemon env", () => {
+  test("(b) an `env:NAME` reference on the allowlisted key resolves from the daemon env", () => {
     const out = resolveAgentEnv(
-      { GWS_TOKEN: "env:MANDA_GWS_TOKEN" },
-      { MANDA_GWS_TOKEN: "resolved-secret-value" },
+      { GOOGLE_APPLICATION_CREDENTIALS: "env:GWS_SA_PATH" },
+      { GWS_SA_PATH: "/resolved/sa.json" },
     );
-    expect(out.GWS_TOKEN).toBe("resolved-secret-value");
+    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe("/resolved/sa.json");
   });
 
   test("(b′) an unresolved reference (unset/empty daemon var) is SKIPPED, not thrown", () => {
     // Unset
-    expect(resolveAgentEnv({ X: "env:NOPE" }, {})).toEqual({});
+    expect(
+      resolveAgentEnv({ GOOGLE_APPLICATION_CREDENTIALS: "env:NOPE" }, {}),
+    ).toEqual({});
     // Whitespace-only is treated as empty
-    expect(resolveAgentEnv({ X: "env:BLANK" }, { BLANK: "   " })).toEqual({});
-  });
-
-  test("(c) a CLAUDE_* key is DROPPED at runtime even if it reaches this fn", () => {
-    // Simulates a schema bypass / regression: the runtime layer must still
-    // refuse to set a CLAUDE_* var. This is the airtight security property.
-    const out = resolveAgentEnv(
-      {
-        CLAUDE_CONFIG_DIR: "/tmp/evil-home",
-        CLAUDE_CODE_OAUTH_TOKEN: "sk-evil",
-        GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
-      },
-      {},
-    );
-    expect(out.CLAUDE_CONFIG_DIR).toBeUndefined();
-    expect(out.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
-    // The legitimate non-CLAUDE var still comes through.
-    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe("/x/sa.json");
-  });
-
-  test("(c′) the CLAUDE_* runtime deny is case-insensitive", () => {
-    const out = resolveAgentEnv(
-      { claude_config_dir: "/tmp/x", Claude_Code_Oauth_Token: "y" },
-      {},
-    );
-    expect(Object.keys(out)).toHaveLength(0);
+    expect(
+      resolveAgentEnv(
+        { GOOGLE_APPLICATION_CREDENTIALS: "env:BLANK" },
+        { BLANK: "   " },
+      ),
+    ).toEqual({});
   });
 
   test("(d) undefined agentEnv resolves to an empty map (no passthrough)", () => {
@@ -76,45 +81,33 @@ describe("resolveAgentEnv — resolution + CLAUDE_* runtime deny", () => {
   });
 });
 
-describe("resolveAgentEnv — broadened reserved-prefix deny (cortex#2133)", () => {
-  test("a CORTEX_BASH_GUARD key is DROPPED at runtime (MAJOR-1 key-layer close)", () => {
-    const out = resolveAgentEnv(
-      {
-        CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}',
-        GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json",
-      },
-      {},
-    );
-    expect(out.CORTEX_BASH_GUARD).toBeUndefined();
-    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe("/x/sa.json");
-  });
+describe("resolveAgentEnv — deny-by-default allowlist (cortex#2133/#2164)", () => {
+  test.each(REJECT_LIST)(
+    "%s is DROPPED at runtime even if it reaches this fn",
+    (key) => {
+      // Simulates a schema bypass / regression: the runtime layer must still
+      // refuse to set a non-allowlisted var. This is the airtight property.
+      const out = resolveAgentEnv(
+        { [key]: "hijack-value", GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json" },
+        {},
+      );
+      expect(out[key]).toBeUndefined();
+      // The legitimate allowlisted var still comes through.
+      expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe("/x/sa.json");
+    },
+  );
 
-  test("ANTHROPIC_* keys are DROPPED at runtime (auth / endpoint redirect)", () => {
-    const out = resolveAgentEnv(
-      {
-        ANTHROPIC_BASE_URL: "https://evil.example",
-        ANTHROPIC_API_KEY: "sk-evil",
-        ANTHROPIC_AUTH_TOKEN: "t",
-      },
-      {},
-    );
+  test("an arbitrary non-allowlisted key FOO_BAR is DROPPED at runtime", () => {
+    const out = resolveAgentEnv({ FOO_BAR: "x" }, {});
+    expect(out.FOO_BAR).toBeUndefined();
     expect(Object.keys(out)).toHaveLength(0);
   });
 
-  test("GROVE_* legacy-alias control keys are DROPPED at runtime", () => {
-    const out = resolveAgentEnv(
-      { GROVE_CHANNEL: "spoofed", GROVE_OPERATOR: "x" },
-      {},
-    );
-    expect(Object.keys(out)).toHaveLength(0);
-  });
-
-  test("other CORTEX_* control keys (grants/identity) are DROPPED at runtime", () => {
+  test("case variants of the allowed key are DROPPED (env var names are case-sensitive)", () => {
     const out = resolveAgentEnv(
       {
-        CORTEX_SKILL_GRANTS: "[]",
-        CORTEX_MCP_GRANTS: "[]",
-        CORTEX_CHANNEL: "spoofed",
+        google_application_credentials: "/tmp/x",
+        Google_Application_Credentials: "/tmp/y",
       },
       {},
     );
@@ -122,49 +115,51 @@ describe("resolveAgentEnv — broadened reserved-prefix deny (cortex#2133)", () 
   });
 });
 
-describe("resolveAgentEnv — env: REF SOURCE deny (MINOR-3)", () => {
-  test("a benign key referencing env:CLAUDE_CODE_OAUTH_TOKEN is DROPPED (no exfil)", () => {
-    // The exfil vector: a clean destination name that re-surfaces a guarded
-    // daemon var's VALUE. Even with the secret present in the daemon env, the
-    // ref must be refused because its SOURCE name is reserved-prefix.
+describe("resolveAgentEnv — env: REF SOURCE deny (MINOR-3, prefix-deny shape)", () => {
+  test("an allowlisted key referencing env:CLAUDE_CODE_OAUTH_TOKEN is DROPPED (no exfil)", () => {
+    // The exfil vector: a clean, allowlisted destination name that re-surfaces a
+    // guarded daemon var's VALUE. Even with the secret present in the daemon
+    // env, the ref must be refused because its SOURCE name is reserved-prefix.
     const out = resolveAgentEnv(
-      { GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN" },
+      { GOOGLE_APPLICATION_CREDENTIALS: "env:CLAUDE_CODE_OAUTH_TOKEN" },
       { CLAUDE_CODE_OAUTH_TOKEN: "sk-oauth-secret" },
     );
-    expect(out.GDRIVE_TOKEN).toBeUndefined();
+    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined();
     expect(Object.values(out)).not.toContain("sk-oauth-secret");
   });
 
-  test("refs to ANTHROPIC_* / CORTEX_* sources are DROPPED even when resolvable", () => {
-    const out = resolveAgentEnv(
-      {
-        A: "env:ANTHROPIC_API_KEY",
-        B: "env:CORTEX_BASH_GUARD",
-      },
-      { ANTHROPIC_API_KEY: "sk-x", CORTEX_BASH_GUARD: '{"disabled":true}' },
-    );
-    expect(Object.keys(out)).toHaveLength(0);
+  test("refs to ANTHROPIC_* / CORTEX_* / GROVE_* sources are DROPPED even when resolvable", () => {
+    for (const src of [
+      "ANTHROPIC_API_KEY",
+      "CORTEX_BASH_GUARD",
+      "GROVE_OPERATOR",
+    ]) {
+      const out = resolveAgentEnv(
+        { GOOGLE_APPLICATION_CREDENTIALS: `env:${src}` },
+        { [src]: "sensitive" },
+      );
+      expect(Object.keys(out)).toHaveLength(0);
+    }
   });
 
   test("a ref to a NON-reserved source still resolves (no over-blocking)", () => {
     const out = resolveAgentEnv(
-      { GWS_TOKEN: "env:MANDA_GWS_TOKEN" },
-      { MANDA_GWS_TOKEN: "ok" },
+      { GOOGLE_APPLICATION_CREDENTIALS: "env:GWS_SA_PATH" },
+      { GWS_SA_PATH: "/ok/sa.json" },
     );
-    expect(out.GWS_TOKEN).toBe("ok");
+    expect(out.GOOGLE_APPLICATION_CREDENTIALS).toBe("/ok/sa.json");
   });
 });
 
 describe("resolveAgentEnv — runtime key-grammar re-check (MINOR-4)", () => {
-  test("a leading-space ' CLAUDE_X' key is DROPPED by the pattern re-check", () => {
-    // The leading space would dodge the prefix check; the ASCII grammar catches
-    // it first. Proves a non-schema caller can't slip a mangled key past runtime.
+  test("a leading-space ' GOOGLE_APPLICATION_CREDENTIALS' key is DROPPED by the pattern re-check", () => {
+    // A leading space would otherwise slip past a naive membership test; the
+    // ASCII grammar catches it first (and the allowlist would reject it anyway).
     const out = resolveAgentEnv(
-      { " CLAUDE_X": "/tmp/x", "GOOD_KEY": "ok" },
+      { " GOOGLE_APPLICATION_CREDENTIALS": "/tmp/x" },
       {},
     );
-    expect(out[" CLAUDE_X"]).toBeUndefined();
-    expect(out.GOOD_KEY).toBe("ok");
+    expect(Object.keys(out)).toHaveLength(0);
   });
 
   test("keys with '=', dashes, or interior whitespace are DROPPED at runtime", () => {
@@ -202,7 +197,7 @@ describe("MAJOR-1 exploit is closed end-to-end (cortex#2133)", () => {
   // The exploit: an agent declares `env: { CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}' }`
   // and the stack sets NO bashAllowlist. We prove the malicious value can NEVER
   // land on the composed session env, closed at BOTH layers:
-  //   (1) the key layer — resolveAgentEnv drops the reserved-prefix key, and
+  //   (1) the key layer — resolveAgentEnv drops the non-allowlisted key, and
   //   (2) the writer layer — cortex writes the authoritative guard value last.
   test("a declared CORTEX_BASH_GUARD with no bashAllowlist does NOT reach the session env", () => {
     const agentEnv = { CORTEX_BASH_GUARD: '{"rules":[{"pattern":".*"}]}' };
@@ -249,7 +244,7 @@ describe("agent env reaches the session env via buildSessionEnv (start() composi
     daemonEnv: Record<string, string | undefined> = {},
   ) => buildSessionEnv({ ...baseEnv, ...resolveAgentEnv(agentEnv, daemonEnv) }, opts);
 
-  test("(a) a declared literal lands on the composed session env", () => {
+  test("(a) the allowlisted literal lands on the composed session env", () => {
     const env = compose(
       { PATH: "/usr/bin" },
       { GOOGLE_APPLICATION_CREDENTIALS: "/x/sa.json" },
@@ -268,7 +263,8 @@ describe("agent env reaches the session env via buildSessionEnv (start() composi
   });
 
   test("cortex's own CORTEX_* pipeline var WINS over a same-named passthrough", () => {
-    // A declared var may not shadow cortex's instrumentation identity.
+    // A declared CORTEX_CHANNEL is not allowlisted (dropped) AND cortex writes
+    // its authoritative instrumentation identity — belt and braces.
     const env = compose(
       { PATH: "/usr/bin" },
       { CORTEX_CHANNEL: "spoofed" },
@@ -278,8 +274,9 @@ describe("agent env reaches the session env via buildSessionEnv (start() composi
   });
 
   test("cortex's config-home (CLAUDE_CONFIG_DIR) is untouched by the passthrough", () => {
-    // The passthrough can't set CLAUDE_* at all (dropped), and the config-home
-    // export layered by buildSessionEnv is the only thing that sets it.
+    // The passthrough can't set CLAUDE_* at all (not allowlisted → dropped), and
+    // the config-home export layered by buildSessionEnv is the only thing that
+    // sets it.
     const env = compose(
       { PATH: "/usr/bin" },
       { CLAUDE_CONFIG_DIR: "/tmp/evil-home" },

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -130,6 +130,13 @@ export interface AgentTeamOpts {
    * Undefined → no MCP hook (non-policy path, behaviour unchanged).
    */
   mcpGrants?: string[];
+  /**
+   * cortex#2133 — the agent's declared env passthrough, propagated to ALL team
+   * sessions (moderator + participants + synthesis). Resolved + CLAUDE_*
+   * re-denied per-session in cc-session's `resolveAgentEnv`. Undefined → no
+   * passthrough.
+   */
+  agentEnv?: Record<string, string>;
   allowedDirs?: string[];
   timeoutMs?: number;
   /** Bash guard config — propagated to all team sessions (moderator + participants) */
@@ -597,6 +604,7 @@ export class AgentTeam extends EventEmitter {
       disallowedTools: this.opts.disallowedTools,
       ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
       ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
+      ...(this.opts.agentEnv !== undefined && { agentEnv: this.opts.agentEnv }),
       allowedDirs: this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
@@ -719,6 +727,7 @@ export class AgentTeam extends EventEmitter {
       disallowedTools: config.disallowedTools ?? this.opts.disallowedTools,
       ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
       ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
+      ...(this.opts.agentEnv !== undefined && { agentEnv: this.opts.agentEnv }),
       allowedDirs: config.dirs ?? this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
@@ -900,6 +909,7 @@ export class AgentTeam extends EventEmitter {
       disallowedTools: this.opts.disallowedTools,
       ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
       ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
+      ...(this.opts.agentEnv !== undefined && { agentEnv: this.opts.agentEnv }),
       allowedDirs: this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -233,6 +233,35 @@ export function buildSessionEnv(
   };
 }
 
+/**
+ * Resolve the AUTHORITATIVE `CORTEX_BASH_GUARD` value cortex writes onto every
+ * spawned session env (cortex#2133, defense-in-depth for MAJOR-1). Total —
+ * ALWAYS returns a string — so `start()` can write it unconditionally and no
+ * stale/injected base-env value can survive:
+ *
+ *   - `bashGuardDisabled`  → `{"disabled":true}` — the principal-DM / CLI-trust
+ *     posture (the guard hook's `loadConfig()` returns null ⇒ pass-through).
+ *   - `bashAllowlist`      → the serialised allowlist (guard active, that list).
+ *   - neither              → `{}` — the SAFE DEFAULT. The guard hook's
+ *     `loadConfig()` treats `{}` IDENTICALLY to an unset var: guard ACTIVE with
+ *     the built-in read-only default-deny allowlist (its `DEFAULT_CONFIG`). It
+ *     carries no `disabled:true`, so it never weakens the guard's default-deny.
+ *     Writing it also removes a bot session from the hook's Gate-2 CLI-principal
+ *     bypass (keyed on `CORTEX_BASH_GUARD` being ABSENT), so a bot session with
+ *     no allowlist config falls through to default-deny, never full-trust
+ *     pass-through.
+ *
+ * Extracted so the MAJOR-1 property (a declared `CORTEX_BASH_GUARD` cannot
+ * survive) is unit-testable without spawning the `claude` binary.
+ */
+export function resolveBashGuardEnv(
+  opts: Pick<CCSessionOpts, "bashGuardDisabled" | "bashAllowlist">,
+): string {
+  if (opts.bashGuardDisabled) return JSON.stringify({ disabled: true });
+  if (opts.bashAllowlist) return JSON.stringify(opts.bashAllowlist);
+  return JSON.stringify({});
+}
+
 export class CCSession extends EventEmitter {
   private proc: ReturnType<typeof Bun.spawn> | null = null;
   private timeoutId: Timer | null = null;
@@ -410,12 +439,15 @@ export class CCSession extends EventEmitter {
       }),
     };
 
-    // Pass bash allowlist config to bash-guard.hook.ts
-    if (this.opts.bashGuardDisabled) {
-      env.CORTEX_BASH_GUARD = JSON.stringify({ disabled: true });
-    } else if (this.opts.bashAllowlist) {
-      env.CORTEX_BASH_GUARD = JSON.stringify(this.opts.bashAllowlist);
-    }
+    // Pass bash allowlist config to bash-guard.hook.ts. CORTEX_BASH_GUARD is
+    // written UNCONDITIONALLY (cortex#2133, defense-in-depth for MAJOR-1): cortex
+    // is always the authoritative writer of this var — this assignment OVERWRITES
+    // whatever the layered base/agent env carried, so a stale/injected value can
+    // never win. The reserved-prefix deny (resolveAgentEnv / AgentEnvSchema)
+    // already blocks a declared CORTEX_* key at the key layer; writing the guard
+    // var here makes it authoritative even if a value reaches the base env by any
+    // other route. See {@link resolveBashGuardEnv} for the value semantics.
+    env.CORTEX_BASH_GUARD = resolveBashGuardEnv(this.opts);
 
     // Suppress ANTHROPIC_API_KEY when OAuth token is present
     if (env.CLAUDE_CODE_OAUTH_TOKEN) {

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -13,6 +13,7 @@ import { buildClaudeArgs, type ClaudeInvocationOpts } from "./claude-invoker";
 import {
   createIsolatedSettings,
   scopeSessionEnv,
+  resolveAgentEnv,
   CORTEX_SKILL_GRANTS_ENV,
   CORTEX_MCP_GRANTS_ENV,
   type IsolatedSettings,
@@ -122,6 +123,17 @@ export interface CCSessionOpts {
    * common/substrates/config-home.ts.
    */
   configHomeEnv?: { name: string; value: string };
+  /**
+   * cortex#2133 (epic #2164) — the target agent's declared `env:` passthrough
+   * map (`NAME → literal-or-`env:NAME`-reference`; see `AgentSchema.env`).
+   * Layered onto the child env by `start()` AFTER `scopeSessionEnv` and BEFORE
+   * cortex's own `CORTEX_*`/config-home/grant vars, so a declared var can
+   * neither shadow cortex's pipeline vars nor touch the `CLAUDE_*` namespace
+   * (resolution + the re-asserted `CLAUDE_*` deny live in `resolveAgentEnv`,
+   * session-settings.ts). Undefined/absent ⇒ no passthrough (byte-identical to
+   * the pre-#2133 env).
+   */
+  agentEnv?: Record<string, string>;
 }
 
 export interface CCSessionResult {
@@ -370,8 +382,16 @@ export class CCSession extends EventEmitter {
       ? scopeSessionEnv(process.env)
       : { ...(process.env as Record<string, string>) };
 
+    // cortex#2133 — the agent's declarative `env:` passthrough. Resolved (refs
+    // read from the daemon env; CLAUDE_* re-denied as defence-in-depth) and
+    // layered on the scoped base BEFORE buildSessionEnv applies cortex's own
+    // CORTEX_*/config-home/grant vars — so cortex's pipeline vars always win and
+    // a declared var can never reach the CLAUDE_* namespace scopeSessionEnv
+    // guards. Undefined/empty ⇒ {} ⇒ byte-identical to the pre-#2133 env.
+    const agentEnv = resolveAgentEnv(this.opts.agentEnv, process.env);
+
     const env: Record<string, string> = {
-      ...buildSessionEnv(baseEnv, this.opts),
+      ...buildSessionEnv({ ...baseEnv, ...agentEnv }, this.opts),
       // cortex#710 — pass the per-skill grant list to the Skill Guard hook.
       // Only set when the curated settings actually registered the hook
       // (hasSkillGrants), so the env var and the hook move atomically. Layered

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -129,9 +129,9 @@ export interface CCSessionOpts {
    * Layered onto the child env by `start()` AFTER `scopeSessionEnv` and BEFORE
    * cortex's own `CORTEX_*`/config-home/grant vars, so a declared var can
    * neither shadow cortex's pipeline vars nor touch the `CLAUDE_*` namespace
-   * (resolution + the re-asserted `CLAUDE_*` deny live in `resolveAgentEnv`,
-   * session-settings.ts). Undefined/absent ⇒ no passthrough (byte-identical to
-   * the pre-#2133 env).
+   * (resolution + the re-asserted deny-by-default allowlist live in
+   * `resolveAgentEnv`, session-settings.ts). Undefined/absent ⇒ no passthrough
+   * (byte-identical to the pre-#2133 env).
    */
   agentEnv?: Record<string, string>;
 }
@@ -412,11 +412,11 @@ export class CCSession extends EventEmitter {
       : { ...(process.env as Record<string, string>) };
 
     // cortex#2133 — the agent's declarative `env:` passthrough. Resolved (refs
-    // read from the daemon env; CLAUDE_* re-denied as defence-in-depth) and
-    // layered on the scoped base BEFORE buildSessionEnv applies cortex's own
-    // CORTEX_*/config-home/grant vars — so cortex's pipeline vars always win and
-    // a declared var can never reach the CLAUDE_* namespace scopeSessionEnv
-    // guards. Undefined/empty ⇒ {} ⇒ byte-identical to the pre-#2133 env.
+    // read from the daemon env; deny-by-default allowlist re-asserted as
+    // defence-in-depth) and layered on the scoped base BEFORE buildSessionEnv
+    // applies cortex's own CORTEX_*/config-home/grant vars — so cortex's pipeline
+    // vars always win and a declared var can never reach the CLAUDE_* namespace
+    // scopeSessionEnv guards. Undefined/empty ⇒ {} ⇒ byte-identical to pre-#2133.
     const agentEnv = resolveAgentEnv(this.opts.agentEnv, process.env);
 
     const env: Record<string, string> = {
@@ -443,10 +443,11 @@ export class CCSession extends EventEmitter {
     // written UNCONDITIONALLY (cortex#2133, defense-in-depth for MAJOR-1): cortex
     // is always the authoritative writer of this var — this assignment OVERWRITES
     // whatever the layered base/agent env carried, so a stale/injected value can
-    // never win. The reserved-prefix deny (resolveAgentEnv / AgentEnvSchema)
-    // already blocks a declared CORTEX_* key at the key layer; writing the guard
-    // var here makes it authoritative even if a value reaches the base env by any
-    // other route. See {@link resolveBashGuardEnv} for the value semantics.
+    // never win. The deny-by-default allowlist (resolveAgentEnv / AgentEnvSchema)
+    // already blocks a declared CORTEX_* key at the key layer (it isn't in
+    // ALLOWED_AGENT_ENV_KEYS); writing the guard var here makes it authoritative
+    // even if a value reaches the base env by any other route. See
+    // {@link resolveBashGuardEnv} for the value semantics.
     env.CORTEX_BASH_GUARD = resolveBashGuardEnv(this.opts);
 
     // Suppress ANTHROPIC_API_KEY when OAuth token is present

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -427,6 +427,16 @@ export interface DispatchListenerOptions {
    */
   agentRuntimesById?: Map<string, AgentRuntime>;
   /**
+   * cortex#2133 (epic #2164) — the RECEIVING agents' declared `env:` passthrough
+   * maps indexed by agent id. When present, the handler injects the
+   * `receivingAgentId`'s map onto `req.runtime.agentEnv`
+   * receiving-stack-AUTHORITATIVELY (the executing stack's config is the single
+   * source of truth — NEVER the inbound wire, so a federated peer cannot inject
+   * env vars into a host session). Mirrors the `bashAllowlist`/`mcpGrants`
+   * receiving-side authority. Absent / no entry ⇒ no passthrough.
+   */
+  agentEnvById?: Map<string, Record<string, string>>;
+  /**
    * API-P1.3 (#2063) — the inference registry the `api-agent` substrate resolves
    * its profile through. Threaded to `HarnessResolver`. Absent on stacks with no
    * `inference` config → an `api-agent` dispatch fails closed at the harness.
@@ -830,6 +840,7 @@ export function createDispatchListener(
     trustResolver,
     receivingAgentId,
     agentRuntimesById,
+    agentEnvById,
     inferenceRegistry,
     principalId,
     stackIdentity,
@@ -913,6 +924,7 @@ export function createDispatchListener(
         principalId,
         receivingAgentId,
         agentRuntimesById,
+        agentEnvById,
         inferenceRegistry,
         stackIdentity,
         stackNKeyPub,
@@ -1348,6 +1360,8 @@ interface DispatchHandlerContext {
   receivingAgentId: string | undefined;
   /** API-P1.3 (#2063) — receiving agents' runtime configs by id, for substrate selection. */
   agentRuntimesById: Map<string, AgentRuntime> | undefined;
+  /** cortex#2133 — receiving agents' declared `env:` passthrough maps by id (receiving-stack-authoritative). */
+  agentEnvById: Map<string, Record<string, string>> | undefined;
   /** API-P1.3 (#2063) — inference registry the `api-agent` substrate resolves through. */
   inferenceRegistry: InferenceRegistry | undefined;
   /** cortex#480 — receiving stack's signing DID for own-stack trust. */
@@ -1424,6 +1438,7 @@ async function handleDispatchEnvelope(
     principalId,
     receivingAgentId,
     agentRuntimesById,
+    agentEnvById,
     inferenceRegistry,
     stackIdentity,
     stackNKeyPub,
@@ -2120,6 +2135,24 @@ async function handleDispatchEnvelope(
     if (bashGuardDisabled !== undefined) {
       runtime.bashGuardDisabled = bashGuardDisabled;
     }
+    req.runtime = runtime;
+  }
+
+  // cortex#2133 (epic #2164) — RECEIVING-STACK-AUTHORITATIVE agent env
+  // passthrough, the #127 model applied to the per-agent `env:` map. The wire
+  // NEVER carries it (`buildDispatchRequest` does not populate `runtime.agentEnv`
+  // from the payload) — the EXECUTING stack's own config is the single source of
+  // truth, looked up by the receiving agent id. So a federated peer (or a
+  // crafted publisher) can neither inject env vars into a host session nor
+  // widen this agent's declared set. The claude-code harness threads this onto
+  // `CCSessionOpts.agentEnv`, where `resolveAgentEnv` resolves references and
+  // re-denies `CLAUDE_*` before it reaches the child env. Absent / no entry ⇒
+  // nothing injected (default: no passthrough).
+  const receivingAgentEnv =
+    receivingAgentId !== undefined ? agentEnvById?.get(receivingAgentId) : undefined;
+  if (receivingAgentEnv !== undefined) {
+    const runtime = req.runtime ?? {};
+    runtime.agentEnv = receivingAgentEnv;
     req.runtime = runtime;
   }
 

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -110,6 +110,8 @@ import {
 import { tmpdir, homedir } from "os";
 import { join, basename } from "path";
 import { parse as parseYaml } from "yaml";
+import { isDeniedAgentEnvKey } from "../common/config/agent-env";
+import { SECRET_REF_PATTERN } from "../common/inference/secret-ref";
 
 /**
  * The setting sources cortex bot sessions load: NONE. Deliberately empty.
@@ -620,4 +622,75 @@ export function scopeSessionEnv(
     scoped[key] = value;
   }
   return scoped;
+}
+
+/**
+ * cortex#2133 (epic #2164, TRUST-PATH) — resolve an agent's declarative `env:`
+ * passthrough map ({@link AgentEnvSchema}) into the concrete `NAME → value`
+ * pairs to layer onto a CC session's child env.
+ *
+ * The caller (`cc-session.ts`) merges the result onto the scoped base env
+ * BEFORE `buildSessionEnv` layers cortex's own `CORTEX_*`/config-home/grant
+ * vars — so a declared var can never shadow cortex's pipeline vars, and (with
+ * the deny below) can never touch the `CLAUDE_*` namespace `scopeSessionEnv`
+ * guards.
+ *
+ * Two responsibilities, both security-relevant:
+ *
+ *   1. **Re-assert the `CLAUDE_*` deny (defence-in-depth).** The config schema
+ *      already rejects a `CLAUDE_*` key at load ({@link isDeniedAgentEnvKey} in
+ *      `common/config/agent-env.ts`, the SHARED predicate), but we DROP it here
+ *      too so NO path — a test, a future direct caller, a schema regression —
+ *      can layer a `CLAUDE_*` var onto a child session. Dropping (not throwing)
+ *      is the fail-closed choice: the var simply never gets set, isolation
+ *      holds regardless of how the map arrived, and a crafted map cannot DoS
+ *      the session. Each drop is logged.
+ *
+ *   2. **Resolve secret references at call time.** A value of the form
+ *      `env:NAME` ({@link SECRET_REF_PATTERN}) is a SECRET REFERENCE, read from
+ *      `parentEnv` here (the daemon env) and never stored in config; anything
+ *      else is a literal (e.g. a credential PATH) and passes through verbatim.
+ *      An unresolved reference (unset/empty daemon var) is SKIPPED with a loud
+ *      stderr line rather than throwing — the session still runs and the
+ *      dependent skill surfaces its own "credential missing" error, instead of
+ *      one bad ref taking down the whole dispatch.
+ *
+ * @param agentEnv The agent's declared passthrough map, or `undefined`/absent
+ *   (⇒ `{}`, byte-identical to the pre-#2133 session env).
+ * @param parentEnv The daemon env to resolve `env:NAME` references against.
+ *   Injectable for testing; defaults to `process.env`.
+ */
+export function resolveAgentEnv(
+  agentEnv: Record<string, string> | undefined,
+  parentEnv: Record<string, string | undefined> = process.env,
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  if (agentEnv === undefined) return resolved;
+  for (const [key, rawValue] of Object.entries(agentEnv)) {
+    if (isDeniedAgentEnvKey(key)) {
+      // See responsibility (1). Never set a CLAUDE_* var from this map.
+      process.stderr.write(
+        `session-settings: agent env key '${key}' dropped — CLAUDE_* is default-deny (cortex#701 isolation)\n`,
+      );
+      continue;
+    }
+    const refMatch = SECRET_REF_PATTERN.exec(rawValue);
+    if (refMatch?.[1] !== undefined) {
+      const refEnvVar = refMatch[1];
+      const secretVal = parentEnv[refEnvVar];
+      if (secretVal === undefined || secretVal.trim() === "") {
+        // See responsibility (2): skip an unresolved ref, don't throw.
+        process.stderr.write(
+          `session-settings: agent env '${key}' → secret reference env:${refEnvVar} ` +
+            `could not be resolved (unset/empty) — variable not set for this session\n`,
+        );
+        continue;
+      }
+      resolved[key] = secretVal;
+    } else {
+      // A literal (e.g. a credential path). Passes through verbatim.
+      resolved[key] = rawValue;
+    }
+  }
+  return resolved;
 }

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -110,7 +110,12 @@ import {
 import { tmpdir, homedir } from "os";
 import { join, basename } from "path";
 import { parse as parseYaml } from "yaml";
-import { isDeniedAgentEnvKey, AGENT_ENV_KEY_PATTERN } from "../common/config/agent-env";
+import {
+  isAllowedAgentEnvKey,
+  isReservedRefSource,
+  ALLOWED_AGENT_ENV_KEYS,
+  AGENT_ENV_KEY_PATTERN,
+} from "../common/config/agent-env";
 import { SECRET_REF_PATTERN } from "../common/inference/secret-ref";
 
 /**
@@ -637,24 +642,30 @@ export function scopeSessionEnv(
  *
  * Four responsibilities, all security-relevant:
  *
- *   1. **Re-assert the reserved-prefix deny on the DESTINATION KEY
- *      (defence-in-depth).** The config schema already rejects a reserved-prefix
- *      key at load ({@link isDeniedAgentEnvKey} in `common/config/agent-env.ts`,
- *      the SHARED predicate — now `CLAUDE_`/`ANTHROPIC_`/`CORTEX_`/`GROVE_`), but
- *      we DROP it here too so NO path — a test, a future direct caller, a schema
- *      regression — can layer a reserved-prefix var onto a child session.
- *      Dropping (not throwing) is the fail-closed choice: the var simply never
- *      gets set, isolation holds regardless of how the map arrived, and a
- *      crafted map cannot DoS the session. Each drop is logged.
+ *   1. **Re-assert the ALLOWLIST on the DESTINATION KEY (defence-in-depth).**
+ *      The config schema already rejects any non-allowlisted key at load
+ *      ({@link isAllowedAgentEnvKey} in `common/config/agent-env.ts`, the SHARED
+ *      predicate — deny-by-default; only {@link ALLOWED_AGENT_ENV_KEYS} pass),
+ *      but we DROP anything not allowed here too so NO path — a test, a future
+ *      direct caller, a schema regression — can layer an unblessed var onto a
+ *      child session. Dropping (not throwing) is the fail-closed choice: the var
+ *      simply never gets set, isolation holds regardless of how the map arrived,
+ *      and a crafted map cannot DoS the session. Each drop is logged. This is
+ *      the destination side of the two-shape design (see agent-env.ts module
+ *      doc): allowlist what we SET.
  *
- *   2. **Re-assert the reserved-prefix deny on the `env:` REF SOURCE NAME too
- *      (MINOR-3).** A benign destination key whose value is `env:DENIED_NAME`
- *      would otherwise re-surface a denied daemon var's VALUE under a clean name
- *      — e.g. `GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN"` exfiltrates the OAuth
- *      token. So when a value is an `env:NAME` reference we also drop it if
- *      `isDeniedAgentEnvKey(NAME)` holds. The stderr line names the key and the
- *      ref NAME only — NEVER the resolved value — preserving the module's
- *      no-value-logging property.
+ *   2. **Prefix-deny the `env:` REF SOURCE NAME (MINOR-3).** A benign,
+ *      allowlisted destination key whose value is `env:GUARDED_NAME` would
+ *      otherwise re-surface a guarded daemon var's VALUE under a clean name —
+ *      e.g. `GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN"` exfiltrates the OAuth
+ *      token. The ref source is a READ FROM the daemon env (not a set), so its
+ *      guard is a PREFIX DENY on the cortex/substrate control namespaces
+ *      ({@link isReservedRefSource} — CLAUDE_/ANTHROPIC_/CORTEX_/GROVE_), NOT the
+ *      destination allowlist: we are protecting a bounded set of guarded daemon
+ *      vars from re-surfacing, not deciding which arbitrary daemon var is a
+ *      legitimate credential source. Two sides, two shapes — deliberate. The
+ *      stderr line names the key and the ref NAME only — NEVER the resolved value
+ *      — preserving the module's no-value-logging property.
  *
  *   3. **Re-assert the KEY GRAMMAR at runtime (MINOR-4).** We re-check the
  *      destination key against {@link AGENT_ENV_KEY_PATTERN} (the ASCII-anchored
@@ -694,11 +705,13 @@ export function resolveAgentEnv(
       );
       continue;
     }
-    if (isDeniedAgentEnvKey(key)) {
-      // Responsibility (1). Never set a reserved-prefix
-      // (CLAUDE_/ANTHROPIC_/CORTEX_/GROVE_) var from this map.
+    if (!isAllowedAgentEnvKey(key)) {
+      // Responsibility (1). Deny-by-default: only exact, case-sensitive
+      // ALLOWED_AGENT_ENV_KEYS names may be set from this map. Anything else —
+      // the open-ended session-hijack classes a denylist could never fully
+      // enumerate — is dropped (cortex#2133 / epic #2164 allowlist inversion).
       process.stderr.write(
-        `session-settings: agent env key '${key}' dropped — reserved-prefix vars are default-deny (cortex#701/#2133 isolation)\n`,
+        `session-settings: agent env key '${key}' dropped — per-agent env is deny-by-default (allowlist); only [${ALLOWED_AGENT_ENV_KEYS.join(", ")}] are permitted (cortex#2133/#2164)\n`,
       );
       continue;
     }
@@ -709,7 +722,7 @@ export function resolveAgentEnv(
       // re-surface a denied daemon var's VALUE under a clean name
       // (e.g. `GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN"`). Log the key + ref
       // NAME only — never the value (preserve the no-value-logging property).
-      if (isDeniedAgentEnvKey(refEnvVar)) {
+      if (isReservedRefSource(refEnvVar)) {
         process.stderr.write(
           `session-settings: agent env '${key}' → secret reference env:${refEnvVar} dropped — ` +
             `the referenced var is in a reserved prefix (CLAUDE_/ANTHROPIC_/CORTEX_/GROVE_); ` +

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -110,7 +110,7 @@ import {
 import { tmpdir, homedir } from "os";
 import { join, basename } from "path";
 import { parse as parseYaml } from "yaml";
-import { isDeniedAgentEnvKey } from "../common/config/agent-env";
+import { isDeniedAgentEnvKey, AGENT_ENV_KEY_PATTERN } from "../common/config/agent-env";
 import { SECRET_REF_PATTERN } from "../common/inference/secret-ref";
 
 /**
@@ -635,18 +635,36 @@ export function scopeSessionEnv(
  * the deny below) can never touch the `CLAUDE_*` namespace `scopeSessionEnv`
  * guards.
  *
- * Two responsibilities, both security-relevant:
+ * Four responsibilities, all security-relevant:
  *
- *   1. **Re-assert the `CLAUDE_*` deny (defence-in-depth).** The config schema
- *      already rejects a `CLAUDE_*` key at load ({@link isDeniedAgentEnvKey} in
- *      `common/config/agent-env.ts`, the SHARED predicate), but we DROP it here
- *      too so NO path — a test, a future direct caller, a schema regression —
- *      can layer a `CLAUDE_*` var onto a child session. Dropping (not throwing)
- *      is the fail-closed choice: the var simply never gets set, isolation
- *      holds regardless of how the map arrived, and a crafted map cannot DoS
- *      the session. Each drop is logged.
+ *   1. **Re-assert the reserved-prefix deny on the DESTINATION KEY
+ *      (defence-in-depth).** The config schema already rejects a reserved-prefix
+ *      key at load ({@link isDeniedAgentEnvKey} in `common/config/agent-env.ts`,
+ *      the SHARED predicate — now `CLAUDE_`/`ANTHROPIC_`/`CORTEX_`/`GROVE_`), but
+ *      we DROP it here too so NO path — a test, a future direct caller, a schema
+ *      regression — can layer a reserved-prefix var onto a child session.
+ *      Dropping (not throwing) is the fail-closed choice: the var simply never
+ *      gets set, isolation holds regardless of how the map arrived, and a
+ *      crafted map cannot DoS the session. Each drop is logged.
  *
- *   2. **Resolve secret references at call time.** A value of the form
+ *   2. **Re-assert the reserved-prefix deny on the `env:` REF SOURCE NAME too
+ *      (MINOR-3).** A benign destination key whose value is `env:DENIED_NAME`
+ *      would otherwise re-surface a denied daemon var's VALUE under a clean name
+ *      — e.g. `GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN"` exfiltrates the OAuth
+ *      token. So when a value is an `env:NAME` reference we also drop it if
+ *      `isDeniedAgentEnvKey(NAME)` holds. The stderr line names the key and the
+ *      ref NAME only — NEVER the resolved value — preserving the module's
+ *      no-value-logging property.
+ *
+ *   3. **Re-assert the KEY GRAMMAR at runtime (MINOR-4).** We re-check the
+ *      destination key against {@link AGENT_ENV_KEY_PATTERN} (the ASCII-anchored
+ *      POSIX-identifier grammar the schema enforces at load) so a non-schema
+ *      caller (a future direct caller, a test) cannot slip a whitespace/`=`/dash-
+ *      mangled key like `" CLAUDE_X"` — whose leading space would dodge the
+ *      prefix check — past the runtime layer. A key that fails the pattern is
+ *      dropped and logged.
+ *
+ *   4. **Resolve secret references at call time.** A value of the form
  *      `env:NAME` ({@link SECRET_REF_PATTERN}) is a SECRET REFERENCE, read from
  *      `parentEnv` here (the daemon env) and never stored in config; anything
  *      else is a literal (e.g. a credential PATH) and passes through verbatim.
@@ -667,16 +685,38 @@ export function resolveAgentEnv(
   const resolved: Record<string, string> = {};
   if (agentEnv === undefined) return resolved;
   for (const [key, rawValue] of Object.entries(agentEnv)) {
-    if (isDeniedAgentEnvKey(key)) {
-      // See responsibility (1). Never set a CLAUDE_* var from this map.
+    // Responsibility (3): re-assert the ASCII key grammar at runtime, so a
+    // non-schema caller can't slip a mangled key (e.g. `" CLAUDE_X"` whose
+    // leading space would dodge the prefix check below) past this layer.
+    if (!AGENT_ENV_KEY_PATTERN.test(key)) {
       process.stderr.write(
-        `session-settings: agent env key '${key}' dropped — CLAUDE_* is default-deny (cortex#701 isolation)\n`,
+        `session-settings: agent env key '${key}' dropped — not a POSIX identifier (cortex#2133 runtime key-grammar re-check)\n`,
+      );
+      continue;
+    }
+    if (isDeniedAgentEnvKey(key)) {
+      // Responsibility (1). Never set a reserved-prefix
+      // (CLAUDE_/ANTHROPIC_/CORTEX_/GROVE_) var from this map.
+      process.stderr.write(
+        `session-settings: agent env key '${key}' dropped — reserved-prefix vars are default-deny (cortex#701/#2133 isolation)\n`,
       );
       continue;
     }
     const refMatch = SECRET_REF_PATTERN.exec(rawValue);
     if (refMatch?.[1] !== undefined) {
       const refEnvVar = refMatch[1];
+      // Responsibility (2): deny the REF SOURCE name too. A benign key must not
+      // re-surface a denied daemon var's VALUE under a clean name
+      // (e.g. `GDRIVE_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN"`). Log the key + ref
+      // NAME only — never the value (preserve the no-value-logging property).
+      if (isDeniedAgentEnvKey(refEnvVar)) {
+        process.stderr.write(
+          `session-settings: agent env '${key}' → secret reference env:${refEnvVar} dropped — ` +
+            `the referenced var is in a reserved prefix (CLAUDE_/ANTHROPIC_/CORTEX_/GROVE_); ` +
+            `a passthrough may not re-surface a guarded daemon var's value (cortex#2133)\n`,
+        );
+        continue;
+      }
       const secretVal = parentEnv[refEnvVar];
       if (secretVal === undefined || secretVal.trim() === "") {
         // See responsibility (2): skip an unresolved ref, don't throw.

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -412,6 +412,10 @@ export class ClaudeCodeHarness implements SessionHarness {
       // ST-P1 (cortex#964) — thread the session-tree parent so the spawned
       // child stamps CORTEX_PARENT_SESSION_ID (cc-session.ts buildSessionEnv).
       if (runtime.parentSessionId !== undefined) opts.parentSessionId = runtime.parentSessionId;
+      // cortex#2133 — the agent's declared env passthrough (receiving-stack-
+      // authoritative; see DispatchRuntime.agentEnv). cc-session resolves refs +
+      // re-denies CLAUDE_* before layering onto the child env.
+      if (runtime.agentEnv !== undefined) opts.agentEnv = runtime.agentEnv;
     }
 
     // Surface env context kinds the substrate understands. Unknown kinds


### PR DESCRIPTION
Closes #2133. Sub-issue of epic #2164 (L4 container standup). **TRUST-PATH** (touches the cortex#701 isolation boundary) — undergoing independent adversarial review before merge.

**What:** a declarative opt-in per-agent `env:` map on `agents[]`, applied at the **session layer** (post-`scopeSessionEnv`), so a deployment credential (e.g. `GOOGLE_APPLICATION_CREDENTIALS` for the `gws` skill) can be declared in cortex config instead of a hand-edited plist that `arc upgrade` overwrites. No arc/plist dependency — cortex-only.

**Planner-decided shape (epic #2164):** per-agent (narrowest, same asymmetric-agent argument as #2111); session-layered; values are literal-or-`SecretRef` (`env:NAME`); **`CLAUDE_*` stays default-deny.**

**The `CLAUDE_*` deny — two layers, one predicate** (`isDeniedAgentEnvKey = key.toUpperCase().startsWith("CLAUDE_")`, case-insensitive):
1. **Config load** — `AgentEnvSchema.superRefine` fails the stack parse on any denied key (daemon refuses the config).
2. **Runtime defence-in-depth** — `resolveAgentEnv` drops any denied key even if it reached the fn, so a schema bypass/regression/direct-caller can never layer `CLAUDE_*` onto a child session. Layering order also prevents a declared var shadowing `CORTEX_*` / config-home / grants, and the preserved OAuth token stays untouchable.

**Receiving-stack-authoritative on the bus** (mirrors #127 / the #2111 MCP fix): a boot snapshot `agentEnvById` is looked up locally by receiving agent id — refs/paths never travel the envelope, so a federated peer can neither inject nor widen an agent's env.

**Scope of wiring:** chat/dispatch (bus-mediated sync + async + team + sync-fallback). Review-pipeline / dev-consumer spawn paths intentionally not wired (outside the scenario).

**Out of scope:** the `ai.meta-factory.nats.<stack>.plist` gap noted in #2133 — separate issue (same silent-clobber class, arc-side).

**Verification:** `bunx tsc --noEmit` clean; 22 new tests (schema rejects `CLAUDE_*` incl. case variants; literal + SecretRef reach the session; runtime drop; no-env byte-unchanged); touched suites 1083 pass / 0 fail; eslint 0/0.

**Residual (for the adversarial reviewer):** an `env:NAME`-shaped literal is read as a ref (documented convention, mirrors `providers.*.apiKey`); path coverage is chat/dispatch only.

Refs: #2133, epic #2164, precedent #2132 (the `CLAUDE_CONFIG_DIR` revert), #701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9wp7h9ThsZpMgpqSrCpWc
