### PR TITLE
feat(policy): normalise granted-skill names in the Skill Guard (#2150)

### DIFF
--- a/src/runner/__tests__/cc-session-isolation.test.ts
+++ b/src/runner/__tests__/cc-session-isolation.test.ts
@@ -13,8 +13,11 @@
  */
 
 import { describe, test, expect, spyOn, afterEach } from "bun:test";
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync, mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { CCSession } from "../cc-session";
+import { setActiveSubstrates } from "../../common/substrates/config-home";
 
 interface Captured {
   cmd: string[];
@@ -434,3 +437,77 @@ describe("CCSession — per-principal MCP grants (cortex#2111)", () => {
       restore();
     }
   });
+
+// cortex#2150 (AC4) — the Skill Guard env and the materialiser plugin must
+// carry the SAME grant list, drawn from the SAME decision (CCSession's
+// `opts.allowedSkills`). cc-session feeds that one value to BOTH consumers:
+// `createIsolatedSettings(skillGrants)` (which materialises the plugin) and
+// `CORTEX_SKILL_GRANTS = JSON.stringify(skillGrants)` (the guard env). This
+// proves they never diverge.
+describe("CCSession — grant list is single-sourced to guard env + materialiser (cortex#2150)", () => {
+  /**
+   * Spawn spy that ALSO snapshots the materialised plugin's skills dir at
+   * spawn time — before the throw triggers CCSession's catch/cleanup, which
+   * deletes the temp plugin tree.
+   */
+  function captureSpawnWithPlugin(): {
+    calls: (Captured & { pluginSkills: string[] | undefined })[];
+    restore: () => void;
+  } {
+    const calls: (Captured & { pluginSkills: string[] | undefined })[] = [];
+    const spy = spyOn(Bun, "spawn").mockImplementation(((
+      cmd: string[],
+      opts: { env: Record<string, string> },
+    ) => {
+      const idx = cmd.indexOf("--plugin-dir");
+      const pluginSkills =
+        idx > -1 ? readdirSync(join(cmd[idx + 1]!, "skills")).sort() : undefined;
+      calls.push({ cmd, env: opts.env, pluginSkills });
+      throw new Error("spawn intercepted by test");
+    }) as unknown as typeof Bun.spawn);
+    return { calls, restore: () => spy.mockRestore() };
+  }
+
+  /** Build a config home whose `skills/` dir holds each named skill. */
+  function makeSkillSource(names: string[]): string {
+    const home = mkdtempSync(join(tmpdir(), "cortex-skillsrc-"));
+    for (const n of names) {
+      mkdirSync(join(home, "skills", n), { recursive: true });
+      writeFileSync(join(home, "skills", n, "SKILL.md"), `# ${n}\n`);
+    }
+    return home;
+  }
+
+  afterEach(() => setActiveSubstrates(undefined));
+
+  test("plugin skills and CORTEX_SKILL_GRANTS come from the one allowedSkills list", () => {
+    const grants = ["gws-drive", "gws-shared"];
+    const home = makeSkillSource(grants);
+    // Point cc-session's skillSourceDir at the temp home (its `skills/` dir).
+    setActiveSubstrates({ "claude-code": { configHome: home } });
+    const { calls, restore } = captureSpawnWithPlugin();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        claudeDir: "/fake/.claude",
+        allowedSkills: grants,
+      });
+      session.on("error", () => {/* expected — spawn intercepted */});
+      session.start();
+
+      expect(calls.length).toBe(1);
+      const { env, pluginSkills } = calls[0]!;
+      // Consumer A — the Skill Guard env.
+      expect(env.CORTEX_SKILL_GRANTS).toBe(JSON.stringify(grants));
+      // Consumer B — the materialiser plugin.
+      expect(pluginSkills).toEqual([...grants].sort());
+      // The two are the SAME list. Mutation guard: if cc-session pointed one
+      // consumer at a different source (a hard-coded list, a different opts
+      // field), env and pluginSkills would diverge and one of the above fails.
+      expect(JSON.parse(env.CORTEX_SKILL_GRANTS!).sort()).toEqual(pluginSkills);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/runner/hooks/__tests__/skill-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/skill-guard.hook.test.ts
@@ -20,7 +20,9 @@ import {
   parseGrantList,
   extractSkillName,
   decideSkill,
+  normaliseSkillName,
 } from "../skill-guard.hook";
+import { CORTEX_GRANTED_PLUGIN_NAME } from "../../session-settings";
 
 const HOOK_PATH = join(import.meta.dir, "..", "skill-guard.hook.ts");
 
@@ -139,6 +141,59 @@ describe("decideSkill — allow/deny decision", () => {
   test("null skill name (not a Skill invocation) → allow pass-through", () => {
     expect(decideSkill(null, ["code-review"]).allow).toBe(true);
   });
+
+  // cortex#2150 — name normalisation. Policy grants are BARE; CC surfaces the
+  // granted skill as `cortex-granted:<name>`. The guard must accept BOTH
+  // spellings of a granted skill and deny BOTH spellings of a non-granted one.
+  test("namespaced spelling of a granted skill → allow", () => {
+    expect(decideSkill("cortex-granted:gws-drive", ["gws-drive"]).allow).toBe(true);
+  });
+
+  test("bare spelling of a granted skill → allow", () => {
+    expect(decideSkill("gws-drive", ["gws-drive"]).allow).toBe(true);
+  });
+
+  test("bare non-granted skill → deny", () => {
+    expect(decideSkill("anything-else", ["gws-drive"]).allow).toBe(false);
+  });
+
+  test("namespaced non-granted skill → deny (prefix is not a bypass)", () => {
+    const d = decideSkill("cortex-granted:anything-else", ["gws-drive"]);
+    expect(d.allow).toBe(false);
+    // The reason names the spelling the model actually invoked.
+    expect(d.reason).toContain("cortex-granted:anything-else");
+  });
+
+  test("prefix does NOT widen: a bare grant matches only its own skill", () => {
+    // Regression: normalisation must not let `cortex-granted:` match a grant
+    // that merely CONTAINS the bare name, nor allow an empty tail.
+    expect(decideSkill("cortex-granted:", ["gws-drive"]).allow).toBe(false);
+  });
+});
+
+describe("normaliseSkillName — namespace prefix stripping (cortex#2150)", () => {
+  test("strips a leading cortex-granted: prefix", () => {
+    expect(normaliseSkillName("cortex-granted:gws-drive")).toBe("gws-drive");
+  });
+
+  test("leaves a bare name unchanged", () => {
+    expect(normaliseSkillName("gws-drive")).toBe("gws-drive");
+  });
+
+  test("strips only ONE leading prefix (not recursive)", () => {
+    expect(normaliseSkillName("cortex-granted:cortex-granted:x")).toBe(
+      "cortex-granted:x",
+    );
+  });
+
+  // Drift guard: the hook's hard-coded prefix must track the materialiser's
+  // plugin name. If session-settings renames the plugin, this fails loudly
+  // rather than silently denying every real (namespaced) invocation.
+  test("prefix tracks the materialiser plugin name", () => {
+    expect(normaliseSkillName(`${CORTEX_GRANTED_PLUGIN_NAME}:gws-drive`)).toBe(
+      "gws-drive",
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -202,6 +257,29 @@ describe("skill-guard.hook — process behaviour", () => {
 
   test("malformed payload → deny (fail-closed)", () => {
     const r = runHook("not json at all", '["code-review"]');
+    expect(r.status).toBe(2);
+    expect(JSON.parse(r.stdout.trim()).hookSpecificOutput.permissionDecision).toBe(
+      "deny",
+    );
+  });
+
+  // cortex#2150 — the running hook honours normalisation end-to-end: the
+  // namespaced spelling CC actually emits for a granted skill is allowed, and
+  // the namespaced spelling of a non-granted skill is still denied.
+  test("namespaced granted skill → exit 0 (allow)", () => {
+    const r = runHook(
+      { tool_name: "Skill", tool_input: { skill: "cortex-granted:gws-drive" } },
+      '["gws-drive"]',
+    );
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("namespaced non-granted skill → exit 2 (deny; prefix is no bypass)", () => {
+    const r = runHook(
+      { tool_name: "Skill", tool_input: { skill: "cortex-granted:art" } },
+      '["gws-drive"]',
+    );
     expect(r.status).toBe(2);
     expect(JSON.parse(r.stdout.trim()).hookSpecificOutput.permissionDecision).toBe(
       "deny",

--- a/src/runner/hooks/skill-guard.hook.ts
+++ b/src/runner/hooks/skill-guard.hook.ts
@@ -66,6 +66,37 @@ interface HookInput {
 const SKILL_TOOL_NAMES = new Set(["Skill", "skill"]);
 
 /**
+ * The plugin namespace Claude Code prefixes onto a granted skill's name.
+ *
+ * cortex#990 materialises a session's granted skills as a `--plugin-dir`
+ * plugin named `cortex-granted` (session-settings.ts
+ * `CORTEX_GRANTED_PLUGIN_NAME` — kept in sync by a drift test). Claude Code
+ * surfaces every plugin skill — in the session-init `skills` listing AND at
+ * invocation — as `cortex-granted:<name>`, NEVER the bare `<name>` (verified
+ * CC 2.1.211, cortex#2151). Policy grants, by contrast, are written BARE
+ * (`gws-drive`) and reach this hook that way via `CORTEX_SKILL_GRANTS`. So an
+ * invoked name must be stripped of this prefix before matching the bare grant
+ * list — otherwise every real invocation (which is namespaced) would miss.
+ * Duplicated here as a literal rather than imported so the security gate stays
+ * dependency-free (it is spawned per Skill call).
+ */
+const CORTEX_GRANTED_PLUGIN_PREFIX = "cortex-granted:";
+
+/**
+ * Normalise an invoked skill name to its BARE spelling for grant matching:
+ * strip a single leading `cortex-granted:` namespace prefix when present. Both
+ * `cortex-granted:gws-drive` (how CC surfaces the granted skill) and
+ * `gws-drive` (how the grant is written in policy) normalise to `gws-drive`,
+ * so both match the same BARE grant. A name without the prefix is returned
+ * unchanged. Exported for unit tests.
+ */
+export function normaliseSkillName(skillName: string): string {
+  return skillName.startsWith(CORTEX_GRANTED_PLUGIN_PREFIX)
+    ? skillName.slice(CORTEX_GRANTED_PLUGIN_PREFIX.length)
+    : skillName;
+}
+
+/**
  * Parse the per-session grant list from `CORTEX_SKILL_GRANTS` (JSON array of
  * skill-name strings). Returns `[]` (deny-all) on absence or malformed input
  * — fail-closed. Exported for unit tests.
@@ -116,7 +147,12 @@ export function decideSkill(
   grants: string[],
 ): { allow: boolean; reason?: string } {
   if (skillName === null) return { allow: true };
-  if (grants.includes(skillName)) return { allow: true };
+  // Match against the BARE grant list on the normalised (prefix-stripped)
+  // name, so the namespaced `cortex-granted:<name>` spelling CC actually emits
+  // and the bare `<name>` spelling both resolve to the same grant. The grant
+  // list stays canonically BARE (policy authority); only the invoked name is
+  // normalised.
+  if (grants.includes(normaliseSkillName(skillName))) return { allow: true };
   return {
     allow: false,
     reason:


### PR DESCRIPTION
Closes #2150. Part of #990 wave 2.

## What

Makes the Skill Guard (#710, the per-invocation default-deny gate) accept the namespaced spelling Claude Code actually emits for a materialised granted skill.

A1 (#2149) materialises granted skills as a plugin named `cortex-granted`; CC surfaces them — in the session-init listing AND at invocation — as `cortex-granted:<name>`, never bare (verified CC 2.1.211, #2151). Policy grants are written BARE and reach the guard bare via `CORTEX_SKILL_GRANTS`, so the pre-existing exact-match guard denied every real (namespaced) invocation. `normaliseSkillName()` strips a single leading `cortex-granted:` prefix before matching; the grant list stays canonically bare.

Threading of `AccessDecision.allowedSkills` into both consumers (materialiser + guard env) was already wired end-to-end by A1 + #710 + #2111 — verified, nothing added there (the revised issue notes this).

## Security (default-deny boundary code)

Adversarially reviewed, refutation posture — the fail-open question was the gate. Confirmed safe:

- **No bypass.** The strip is single, anchored (`startsWith`), case-sensitive, non-recursive. The preimage of a bare grant G is exactly {G, `cortex-granted:`+G} — both the same granted skill. Double-prefix, mid-string, casing/homoglyph, whitespace, colon-in-name all normalise to a non-grant → DENY. It can only shorten toward an exact match, never fabricate a different grant.
- **Deny-side intact.** Empty/malformed/absent `CORTEX_SKILL_GRANTS` → `[]` → deny-all. Normalisation touches only the invoked name, never the grant list — cannot widen the allow set.
- **Drift fails CLOSED.** Guard's `cortex-granted:` literal is pinned to session-settings' `CORTEX_GRANTED_PLUGIN_NAME` by a drift test; a plugin rename makes every real invocation DENY (nothing un-granted ever runs), not allow.
- **Atomicity real.** cc-session.ts reads `allowedSkills` into one local feeding both the materialiser and the guard env; a mutation-verified test builds the real plugin + real env and asserts both equal the one list.

## Test

- `bun test src/runner/hooks/__tests__/skill-guard.hook.test.ts src/runner/__tests__/cc-session-isolation.test.ts src/runner/__tests__/session-settings.test.ts` → 85+ pass.
- Mutations RED: exact-match revert → namespaced-allow tests fail; plugin rename → drift test fails; divergent guard env → atomicity test fails.
- `tsc --noEmit` clean; eslint clean on changed files. Scoped only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
