### PR TITLE
feat(quickstart): --surface <discord|web> non-Discord surface mode (#2153)

### DIFF
--- a/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
@@ -19,6 +19,7 @@ import { join } from "path";
 
 import {
   CTX_REQUIRED_KEYS,
+  CTX_WEB_REQUIRED_KEYS,
   daemonLogPath,
   evaluateHealthyBootGate,
   gatePassed,
@@ -27,9 +28,13 @@ import {
   patchStackYaml,
   patchSurfacesYaml,
   patchSystemNatsPort,
+  readSurfaceAgent,
   renderEnvTable,
   renderNatsConf,
+  renderWebSurfacesYaml,
   validateEnvContract,
+  validateWebEnvContract,
+  writeWebSurfacesYaml,
 } from "../quickstart-lib";
 
 const tmpDirs: string[] = [];
@@ -162,9 +167,10 @@ describe("secret hygiene — CTX_DISCORD_TOKEN never echoed", () => {
     const result = validateEnvContract(validEnv());
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain(SECRET);
-    // The secrets bucket must carry only the status enum, never a `value` field.
+    // The secrets bucket must carry only the status enum + the (non-secret)
+    // `gates` flag, never a `value` field.
     const tokenEntry = result.secrets.find((s) => s.key === "CTX_DISCORD_TOKEN");
-    expect(tokenEntry).toEqual({ key: "CTX_DISCORD_TOKEN", status: "set" });
+    expect(tokenEntry).toEqual({ key: "CTX_DISCORD_TOKEN", status: "set", gates: true });
   });
 
   test("renderEnvTable's rendered text never contains the token value", () => {
@@ -471,4 +477,211 @@ test("daemonLogPath matches §5's target path shape", () => {
   expect(daemonLogPath("/home/andreas", "work")).toBe(
     "/home/andreas/.local/state/metafactory/cortex/logs/cortex-work.log",
   );
+});
+
+// =============================================================================
+// cortex#2153 — web surface env contract
+// =============================================================================
+
+const WEB_SECRET = "THE-REAL-WEB-AUTH-TOKEN-VALUE";
+
+/** A fully valid WEB env — no Discord snowflakes at all. */
+function validWebEnv(): NodeJS.ProcessEnv {
+  return {
+    CTX_PRINCIPAL: "andreas",
+    CTX_SLUG: "gateway",
+    CTX_NATS_PORT: "4222",
+    CTX_NATS_MON: "8222",
+    CTX_WEB_HOST: "127.0.0.1",
+    CTX_WEB_PORT: "8090",
+    CTX_WEB_TOKEN: WEB_SECRET,
+  };
+}
+
+describe("validateWebEnvContract — the happy path", () => {
+  test("a valid web env validates ok WITHOUT any Discord snowflake", () => {
+    const result = validateWebEnvContract(validWebEnv());
+    expect(result.ok).toBe(true);
+    expect(result.values?.CTX_WEB_HOST).toBe("127.0.0.1");
+    expect(result.values?.CTX_WEB_PORT).toBe("8090");
+    // The shared identity keys survive.
+    expect(result.values?.CTX_SLUG).toBe("gateway");
+    expect(result.values?.CTX_PRINCIPAL).toBe("andreas");
+  });
+
+  test("no CTX_GUILD_ID / CTX_DISCORD_TOKEN required — a web env with NONE of them still validates", () => {
+    const env = validWebEnv();
+    // prove the discord contract's keys are entirely absent
+    expect(env.CTX_GUILD_ID).toBeUndefined();
+    expect(env.CTX_DISCORD_TOKEN).toBeUndefined();
+    expect(validateWebEnvContract(env).ok).toBe(true);
+  });
+
+  test("CLAUDE_CODE_OAUTH_TOKEN absent does NOT block ok (optional, same as discord)", () => {
+    const result = validateWebEnvContract(validWebEnv());
+    expect(result.ok).toBe(true);
+    expect(result.secrets.find((s) => s.key === "CLAUDE_CODE_OAUTH_TOKEN")?.status).toBe("missing");
+  });
+});
+
+describe("validateWebEnvContract — missing / invalid", () => {
+  for (const key of CTX_WEB_REQUIRED_KEYS) {
+    test(`missing ${key} → not ok`, () => {
+      const env = validWebEnv();
+      Reflect.deleteProperty(env, key);
+      const result = validateWebEnvContract(env);
+      expect(result.ok).toBe(false);
+      expect(result.values).toBeUndefined();
+      expect(result.checks.find((c) => c.key === key)?.ok).toBe(false);
+    });
+  }
+
+  test("CTX_WEB_TOKEN missing → not ok (it gates, like CTX_DISCORD_TOKEN)", () => {
+    const env = validWebEnv();
+    delete env.CTX_WEB_TOKEN;
+    const result = validateWebEnvContract(env);
+    expect(result.ok).toBe(false);
+    expect(result.secrets.find((s) => s.key === "CTX_WEB_TOKEN")?.gates).toBe(true);
+  });
+
+  test("CTX_WEB_HOST with a slash → invalid shape (no scheme/path allowed)", () => {
+    const env = validWebEnv();
+    env.CTX_WEB_HOST = "http://example.com/x";
+    const result = validateWebEnvContract(env);
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((c) => c.key === "CTX_WEB_HOST")?.reason).toContain("hostname or IP");
+  });
+
+  test("CTX_WEB_PORT out of range → invalid shape (reuses the port rule)", () => {
+    const env = validWebEnv();
+    env.CTX_WEB_PORT = "99999";
+    const result = validateWebEnvContract(env);
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((c) => c.key === "CTX_WEB_PORT")?.reason).toContain("port");
+  });
+});
+
+describe("validateWebEnvContract — secret hygiene", () => {
+  test("the web token value never appears in the result nor the rendered table", () => {
+    const result = validateWebEnvContract(validWebEnv());
+    expect(JSON.stringify(result)).not.toContain(WEB_SECRET);
+    const table = renderEnvTable(result);
+    expect(table).not.toContain(WEB_SECRET);
+    expect(table).toContain("CTX_WEB_TOKEN: set");
+  });
+
+  test("a MISSING gating web token renders as a hard ✗ (not the soft ○ the optional oauth token gets)", () => {
+    const env = validWebEnv();
+    delete env.CTX_WEB_TOKEN;
+    const table = renderEnvTable(validateWebEnvContract(env));
+    expect(table).toContain("✗ CTX_WEB_TOKEN: missing");
+    expect(table).toContain("○ CLAUDE_CODE_OAUTH_TOKEN: missing");
+  });
+});
+
+// =============================================================================
+// cortex#2153 — web surfaces.yaml render + write
+// =============================================================================
+
+const WEB_INPUTS = {
+  agent: "assistant",
+  stack: "andreas/gateway",
+  instanceId: "gateway",
+  host: "127.0.0.1",
+  port: "8090",
+  token: WEB_SECRET,
+};
+
+describe("renderWebSurfacesYaml", () => {
+  test("emits a web binding with the numeric port unquoted and the token quoted", () => {
+    const yaml = renderWebSurfacesYaml(WEB_INPUTS);
+    expect(yaml).toContain("web:");
+    expect(yaml).toContain("agent: assistant");
+    expect(yaml).toContain("stack: andreas/gateway");
+    expect(yaml).toContain("instanceId: gateway");
+    expect(yaml).toContain("host: 127.0.0.1");
+    expect(yaml).toContain("port: 8090"); // unquoted → YAML number
+    expect(yaml).toContain(`token: "${WEB_SECRET}"`);
+    // NO discord binding is written.
+    expect(yaml).not.toContain("discord:");
+  });
+});
+
+describe("writeWebSurfacesYaml — full-file REWRITE", () => {
+  test("REPLACES a scaffolded discord surfaces.yaml with a web-only binding", () => {
+    const dir = freshDir();
+    const path = join(dir, "surfaces.yaml");
+    // simulate the `cortex stack create` discord scaffold
+    writeFileSync(
+      path,
+      "surfaces:\n  discord:\n    - agent: assistant\n      stack: andreas/gateway\n      binding:\n        token: \"<REPLACE_ME>\"\n",
+      { mode: 0o600 },
+    );
+
+    const result = writeWebSurfacesYaml(path, WEB_INPUTS);
+    expect(result.changed).toBe(true);
+    expect(result.backupPath).toBeDefined();
+
+    const written = readFileSync(path, "utf-8");
+    expect(written).toContain("web:");
+    expect(written).not.toContain("discord:"); // the discord block is gone
+    expect(written).toContain(`token: "${WEB_SECRET}"`);
+    // the file is 0600 (secret-bearing)
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  test("idempotent: a second write with the SAME inputs is byte-identical → no change, no backup", () => {
+    const dir = freshDir();
+    const path = join(dir, "surfaces.yaml");
+    writeFileSync(path, "surfaces:\n  discord:\n    - agent: assistant\n      stack: andreas/gateway\n      binding: {}\n", {
+      mode: 0o600,
+    });
+
+    const first = writeWebSurfacesYaml(path, WEB_INPUTS);
+    expect(first.changed).toBe(true);
+    const afterFirst = readFileSync(path, "utf-8");
+
+    const second = writeWebSurfacesYaml(path, WEB_INPUTS);
+    expect(second.changed).toBe(false);
+    expect(second.backupPath).toBeUndefined();
+    expect(readFileSync(path, "utf-8")).toBe(afterFirst); // untouched
+  });
+
+  test("the backup carries the pre-existing content and is written 0600 (secret-safe)", () => {
+    const dir = freshDir();
+    const path = join(dir, "surfaces.yaml");
+    const original = "surfaces:\n  discord:\n    - agent: assistant\n      stack: andreas/gateway\n      binding:\n        token: \"OLD-SECRET\"\n";
+    writeFileSync(path, original, { mode: 0o600 });
+
+    const result = writeWebSurfacesYaml(path, WEB_INPUTS);
+    expect(result.backupPath).toBeDefined();
+    if (result.backupPath !== undefined) {
+      expect(readFileSync(result.backupPath, "utf-8")).toBe(original);
+      expect(statSync(result.backupPath).mode & 0o777).toBe(0o600);
+    }
+  });
+});
+
+describe("readSurfaceAgent", () => {
+  test("reads the agent from a scaffolded discord surfaces.yaml", () => {
+    const dir = freshDir();
+    const path = join(dir, "surfaces.yaml");
+    writeFileSync(path, "surfaces:\n  discord:\n    - agent: luna\n      stack: andreas/work\n      binding: {}\n");
+    expect(readSurfaceAgent(path)).toBe("luna");
+  });
+
+  test("reads the agent from an already-rewritten web surfaces.yaml (re-run path)", () => {
+    const dir = freshDir();
+    const path = join(dir, "surfaces.yaml");
+    writeFileSync(path, renderWebSurfacesYaml({ ...WEB_INPUTS, agent: "pylon" }));
+    expect(readSurfaceAgent(path)).toBe("pylon");
+  });
+
+  test("returns undefined when the file is missing or carries no binding entry", () => {
+    const dir = freshDir();
+    expect(readSurfaceAgent(join(dir, "nope.yaml"))).toBeUndefined();
+    const empty = join(dir, "empty.yaml");
+    writeFileSync(empty, "surfaces: {}\n");
+    expect(readSurfaceAgent(empty)).toBeUndefined();
+  });
 });

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -110,6 +110,10 @@ const CTX_KEYS = [
   "CTX_LOG_CHANNEL_ID",
   "CTX_MY_DISCORD_ID",
   "CTX_DISCORD_TOKEN",
+  // cortex#2153 — web surface contract keys (cleared/restored per test too).
+  "CTX_WEB_HOST",
+  "CTX_WEB_PORT",
+  "CTX_WEB_TOKEN",
   "CLAUDE_CODE_OAUTH_TOKEN",
 ] as const;
 
@@ -137,6 +141,23 @@ function validCtxEnv(overrides: Partial<Record<(typeof CTX_KEYS)[number], string
     CTX_LOG_CHANNEL_ID: "333333333333333333",
     CTX_MY_DISCORD_ID: "444444444444444444",
     CTX_DISCORD_TOKEN: SECRET_TOKEN,
+    ...overrides,
+  };
+}
+
+const WEB_SECRET_TOKEN = "THE-REAL-WEB-AUTH-TOKEN-VALUE-xyz789";
+
+/** A valid WEB env — the shared identity keys + host/port/token, NO Discord
+ *  snowflakes (cortex#2153). */
+function validWebCtxEnv(overrides: Partial<Record<(typeof CTX_KEYS)[number], string>> = {}): Record<string, string> {
+  return {
+    CTX_PRINCIPAL: "andreas",
+    CTX_SLUG: "gateway",
+    CTX_NATS_PORT: "4222",
+    CTX_NATS_MON: "8222",
+    CTX_WEB_HOST: "127.0.0.1",
+    CTX_WEB_PORT: "8090",
+    CTX_WEB_TOKEN: WEB_SECRET_TOKEN,
     ...overrides,
   };
 }
@@ -544,6 +565,149 @@ describe("dispatchQuickstart — --container skips the healthy-boot gate", () =>
     // is what suppresses it, not some unrelated change.
     expect(readLogCalls).toBeGreaterThan(0);
     expect(res.stdout).not.toContain("--container passed");
+  });
+});
+
+// =============================================================================
+// --surface (cortex#2153) — web/gateway surface mode
+// =============================================================================
+
+describe("dispatchQuickstart — --surface flag parsing", () => {
+  test("--surface with no value → exit 2", async () => {
+    const res = await dispatchQuickstart(["--surface"]);
+    expect(res.exitCode).toBe(2);
+  });
+
+  test("--surface bogus → exit 2 with a clear message", async () => {
+    const res = await dispatchQuickstart(["--surface", "telegram"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain('--surface must be "discord" or "web"');
+  });
+
+  test("--help documents the --surface flag and the web contract", async () => {
+    const res = await dispatchQuickstart(["--help"]);
+    expect(res.stdout).toContain("--surface");
+    expect(res.stdout).toContain("CTX_WEB_HOST");
+    expect(res.stdout).toContain("CTX_WEB_TOKEN");
+  });
+});
+
+describe("dispatchQuickstart — --surface web (macOS: step 7 auto-skips)", () => {
+  test("a full web run validates the web contract, scaffolds a web: binding, and NEVER echoes the token", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("darwin", () =>
+      withEnv(validWebCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--surface", "web"], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex quickstart: complete");
+    // secret hygiene: the web token never appears in ANY output.
+    expect(res.stdout).not.toContain(WEB_SECRET_TOKEN);
+    expect(res.stderr).not.toContain(WEB_SECRET_TOKEN);
+
+    // surfaces.yaml carries a WEB binding, no Discord snowflakes.
+    const surfaces = readFileSync(join(configDir, "gateway", "surfaces", "surfaces.yaml"), "utf-8");
+    expect(surfaces).toContain("web:");
+    expect(surfaces).not.toContain("discord:");
+    expect(surfaces).toContain("host: 127.0.0.1");
+    expect(surfaces).toContain("port: 8090");
+    expect(surfaces).toContain(`token: "${WEB_SECRET_TOKEN}"`); // the FILE carries it — only stdout must not
+    // shared parts still ran: nats conf + stack scaffold.
+    expect(existsSync(join(natsDir, "gateway.conf"))).toBe(true);
+    expect(existsSync(join(configDir, "gateway", "stacks", "gateway.yaml"))).toBe(true);
+  });
+
+  test("web run requires NO Discord snowflakes — a web env with none of them still succeeds", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const env = validWebCtxEnv();
+    // Prove the discord contract keys are entirely absent from this run.
+    expect(env.CTX_GUILD_ID).toBeUndefined();
+    expect(env.CTX_DISCORD_TOKEN).toBeUndefined();
+    const res = await withPlatform("darwin", () =>
+      withEnv(env, () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--surface", "web"], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+  });
+
+  test("a second web run mutates NOTHING (idempotent re-run)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const run = () =>
+      withPlatform("darwin", () =>
+        withEnv(validWebCtxEnv(), () =>
+          dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--surface", "web"], () => fakePorts()),
+        ),
+      );
+    const first = await run();
+    expect(first.exitCode).toBe(0);
+    const before = snapshotTree([configDir, natsDir]);
+    const second = await run();
+    expect(second.exitCode).toBe(0);
+    const after = snapshotTree([configDir, natsDir]);
+    expect(after).toEqual(before);
+    expect(second.stdout).toContain("already up to date (skip)");
+    expect(second.stdout).not.toContain(WEB_SECRET_TOKEN);
+  });
+});
+
+describe("dispatchQuickstart — --surface mismatch is rejected clearly", () => {
+  test("--surface web but only Discord env set → exit 2, names the missing web keys", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--surface", "web"], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stdout).toContain("✗ CTX_WEB_HOST: missing");
+    expect(res.stdout).toContain("CTX_WEB_TOKEN: missing");
+    // it never scaffolded anything (env gate is step 2, before scaffold).
+    expect(existsSync(join(configDir, "work"))).toBe(false);
+  });
+
+  test("--surface discord (default) but only web env set → exit 2, names the missing snowflakes", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("darwin", () =>
+      withEnv(validWebCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stdout).toContain("✗ CTX_GUILD_ID: missing");
+    expect(res.stdout).toContain("CTX_DISCORD_TOKEN: missing");
+  });
+});
+
+describe("dispatchQuickstart — --surface discord is the default (back-compat)", () => {
+  test("explicit --surface discord is byte-identical to omitting it", async () => {
+    const configDirA = freshDir();
+    const configDirB = freshDir();
+    const natsDirA = freshDir();
+    const natsDirB = freshDir();
+    const withDefault = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDirA, "--nats-dir", natsDirA], () => fakePorts()),
+      ),
+    );
+    const withExplicit = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDirB, "--nats-dir", natsDirB, "--surface", "discord"], () => fakePorts()),
+      ),
+    );
+    expect(withDefault.exitCode).toBe(0);
+    expect(withExplicit.exitCode).toBe(0);
+    // Same scaffold shape: both wrote a discord surfaces binding.
+    const surfacesA = readFileSync(join(configDirA, "work", "surfaces", "surfaces.yaml"), "utf-8");
+    const surfacesB = readFileSync(join(configDirB, "work", "surfaces", "surfaces.yaml"), "utf-8");
+    expect(surfacesA).toBe(surfacesB);
+    expect(surfacesA).toContain("discord:");
   });
 });
 

--- a/src/cli/cortex/commands/quickstart-lib.ts
+++ b/src/cli/cortex/commands/quickstart-lib.ts
@@ -36,12 +36,13 @@
 import {
   chmodSync,
   existsSync,
+  mkdirSync,
   readFileSync,
   renameSync,
   statSync,
   writeFileSync,
 } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { parseDocument } from "yaml";
 
 import { validateConfigLoads } from "../../../common/config/validate-on-write";
@@ -79,6 +80,42 @@ export type CtxRequiredKey = (typeof CTX_REQUIRED_KEYS)[number];
 export const CTX_SECRET_KEYS = ["CTX_DISCORD_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
 export type CtxSecretKey = (typeof CTX_SECRET_KEYS)[number];
 
+/**
+ * The surface a quickstart run provisions (cortex#2153, epic #2164). Explicit —
+ * chosen by `--surface <discord|web>`, NEVER auto-detected from which `CTX_*`
+ * keys happen to be present (an explicit flag is greppable + testable; the
+ * planner decision in #2164). `discord` (the default) is byte-identical to the
+ * pre-#2153 behaviour.
+ */
+export type Surface = "discord" | "web";
+
+/**
+ * The web/gateway surface's non-secret env contract (cortex#2153). Reuses the
+ * SHARED identity/transport keys (`CTX_PRINCIPAL`, `CTX_SLUG`, `CTX_NATS_PORT`,
+ * `CTX_NATS_MON` — the genuinely-useful NATS-identity + stack-scaffold parts
+ * quickstart keeps across surfaces) and swaps the four Discord snowflakes for
+ * the web binding's host/port. NO Discord snowflake is required.
+ */
+export const CTX_WEB_REQUIRED_KEYS = [
+  "CTX_PRINCIPAL",
+  "CTX_SLUG",
+  "CTX_NATS_PORT",
+  "CTX_NATS_MON",
+  "CTX_WEB_HOST",
+  "CTX_WEB_PORT",
+] as const;
+export type CtxWebRequiredKey = (typeof CTX_WEB_REQUIRED_KEYS)[number];
+
+/**
+ * The web surface's secret env vars. `CTX_WEB_TOKEN` is the web analogue of
+ * `CTX_DISCORD_TOKEN` — it GATES success (a web scaffold that "succeeded" with
+ * no token would bind an unauthenticated surface) and is validated
+ * PRESENCE-ONLY, never echoed. `CLAUDE_CODE_OAUTH_TOKEN` stays optional, same
+ * as the Discord contract.
+ */
+export const CTX_WEB_SECRET_KEYS = ["CTX_WEB_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"] as const;
+export type CtxWebSecretKey = (typeof CTX_WEB_SECRET_KEYS)[number];
+
 // Mirrors stack.ts's SLUG_RE / PRINCIPAL_ID_RE (the `cortex stack create`
 // grammar) — not exported from that module, so duplicated here rather than
 // widen stack.ts's surface for a one-line regex. Keep in sync if that
@@ -90,10 +127,15 @@ const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
  *  digit-string, never parsed to a JS number. */
 const SNOWFLAKE_RE = /^[0-9]{1,20}$/;
 const PORT_RE = /^[0-9]{1,5}$/;
+/** A web bind host — an IP or hostname (letters, digits, dots, hyphens). Kept
+ *  deliberately permissive (`127.0.0.1`, `0.0.0.0`, `localhost`, a DNS name);
+ *  rejects whitespace, slashes, and scheme prefixes. */
+const HOST_RE = /^[a-zA-Z0-9.-]+$/;
 
-/** One required key's validation verdict. */
+/** One required key's validation verdict. `key` is a plain string so the same
+ *  shape serves both the Discord and web ({@link CtxWebRequiredKey}) contracts. */
 export interface CtxKeyCheck {
-  key: CtxRequiredKey;
+  key: string;
   /** `undefined` when missing entirely (distinct from present-but-invalid). */
   value?: string;
   ok: boolean;
@@ -103,17 +145,22 @@ export interface CtxKeyCheck {
 
 /** One secret key's presence verdict — value NEVER carried here. */
 export interface CtxSecretCheck {
-  key: CtxSecretKey;
+  key: string;
   status: "set" | "missing";
+  /** `true` when this secret GATES `ok` (the surface's primary token —
+   *  `CTX_DISCORD_TOKEN` for discord, `CTX_WEB_TOKEN` for web). A missing
+   *  gating secret renders as a hard ✗; a missing non-gating one (the optional
+   *  `CLAUDE_CODE_OAUTH_TOKEN`) as a soft ○. */
+  gates: boolean;
 }
 
-export interface EnvValidationResult {
+export interface EnvValidationResult<K extends string = CtxRequiredKey> {
   ok: boolean;
   checks: CtxKeyCheck[];
   secrets: CtxSecretCheck[];
   /** Convenience: the typed values, only present when `ok`. Callers still
    *  must not log `secrets` values — this map never carries the secret keys. */
-  values?: Record<CtxRequiredKey, string>;
+  values?: Record<K, string>;
 }
 
 /**
@@ -136,6 +183,7 @@ export function validateEnvContract(env: NodeJS.ProcessEnv): EnvValidationResult
   const secrets: CtxSecretCheck[] = CTX_SECRET_KEYS.map((key) => ({
     key,
     status: env[key] !== undefined && env[key].length > 0 ? "set" : "missing",
+    gates: key === "CTX_DISCORD_TOKEN",
   }));
 
   // CTX_DISCORD_TOKEN gates `ok` (§5 needs a real token to patch into
@@ -160,9 +208,52 @@ export function validateEnvContract(env: NodeJS.ProcessEnv): EnvValidationResult
   return values !== undefined ? { ok, checks, secrets, values } : { ok, checks, secrets };
 }
 
+/**
+ * Validate the web/gateway surface's `CTX_*` env contract (cortex#2153). The
+ * web analogue of {@link validateEnvContract}: same never-throw / `ok`-gating
+ * contract, but keyed on {@link CTX_WEB_REQUIRED_KEYS} (host/port instead of
+ * the Discord snowflakes) with {@link CTX_WEB_SECRET_KEYS} (`CTX_WEB_TOKEN`
+ * gates). NO Discord snowflake is required or consulted — a web deployment
+ * never feeds placeholder snowflakes.
+ */
+export function validateWebEnvContract(
+  env: NodeJS.ProcessEnv,
+): EnvValidationResult<CtxWebRequiredKey> {
+  const checks: CtxKeyCheck[] = CTX_WEB_REQUIRED_KEYS.map((key) => {
+    const raw = env[key];
+    if (raw === undefined || raw.length === 0) {
+      return { key, ok: false, reason: "missing" };
+    }
+    const shape = shapeCheck(key, raw);
+    return shape.ok
+      ? { key, value: raw, ok: true }
+      : { key, value: raw, ok: false, reason: shape.reason };
+  });
+
+  const secrets: CtxSecretCheck[] = CTX_WEB_SECRET_KEYS.map((key) => ({
+    key,
+    status: env[key] !== undefined && env[key].length > 0 ? "set" : "missing",
+    gates: key === "CTX_WEB_TOKEN",
+  }));
+
+  // CTX_WEB_TOKEN gates `ok` (the web binding needs a real auth secret — a run
+  // that "succeeded" with a placeholder token would bind an unauthenticated
+  // surface), same PRESENCE-ONLY / never-echoed discipline CTX_DISCORD_TOKEN
+  // gets. CLAUDE_CODE_OAUTH_TOKEN stays optional.
+  const webTokenSet = secrets.some((s) => s.gates && s.status === "set");
+  const ok = checks.every((c) => c.ok) && webTokenSet;
+  const values = checks.every((c) => c.ok)
+    ? (Object.fromEntries(checks.map((c) => [c.key, c.value ?? ""])) as Record<CtxWebRequiredKey, string>)
+    : undefined;
+
+  return values !== undefined ? { ok, checks, secrets, values } : { ok, checks, secrets };
+}
+
 /** Per-key shape rule. Extracted from {@link validateEnvContract} so the
- *  matrix is independently testable per key. */
-function shapeCheck(key: CtxRequiredKey, value: string): { ok: boolean; reason?: string } {
+ *  matrix is independently testable per key. Serves both the Discord and web
+ *  contracts (hence the `string` key + `default`); every caller only ever
+ *  passes a key from its own required-key list. */
+function shapeCheck(key: string, value: string): { ok: boolean; reason?: string } {
   switch (key) {
     case "CTX_PRINCIPAL":
       return PRINCIPAL_ID_RE.test(value)
@@ -174,6 +265,7 @@ function shapeCheck(key: CtxRequiredKey, value: string): { ok: boolean; reason?:
         : { ok: false, reason: "must be lowercase alphanumeric + hyphen/underscore, letter-prefixed" };
     case "CTX_NATS_PORT":
     case "CTX_NATS_MON":
+    case "CTX_WEB_PORT":
       return PORT_RE.test(value) && Number(value) > 0 && Number(value) <= 65535
         ? { ok: true }
         : { ok: false, reason: "must be a numeric port (1-65535)" };
@@ -184,12 +276,23 @@ function shapeCheck(key: CtxRequiredKey, value: string): { ok: boolean; reason?:
       return SNOWFLAKE_RE.test(value)
         ? { ok: true }
         : { ok: false, reason: "must be a numeric Discord snowflake" };
+    case "CTX_WEB_HOST":
+      return HOST_RE.test(value)
+        ? { ok: true }
+        : { ok: false, reason: "must be a hostname or IP (letters, digits, dots, hyphens)" };
+    default:
+      // Unreachable: every caller maps its own required-key list. A present,
+      // non-empty value with no specific rule passes (shape unknown → accept).
+      return { ok: true };
   }
 }
 
 /** Render the validation result as a human-readable ✓/✗ table. Never prints
- *  a secret VALUE — only `set`/`missing` for the two secret keys. */
-export function renderEnvTable(result: EnvValidationResult): string {
+ *  a secret VALUE — only `set`/`missing` for the two secret keys. Takes the
+ *  structural subset both {@link validateEnvContract} and
+ *  {@link validateWebEnvContract} share (checks + secrets), so it renders
+ *  either surface's contract. */
+export function renderEnvTable(result: { checks: CtxKeyCheck[]; secrets: CtxSecretCheck[] }): string {
   const lines: string[] = ["env contract (CTX_*):"];
   for (const c of result.checks) {
     const mark = c.ok ? "✓" : "✗";
@@ -197,11 +300,10 @@ export function renderEnvTable(result: EnvValidationResult): string {
     lines.push(`  ${mark} ${c.key}: ${detail}`);
   }
   for (const s of result.secrets) {
-    // CTX_DISCORD_TOKEN gates `ok` (see validateEnvContract) — missing is a
-    // hard ✗, matching the required checks above. CLAUDE_CODE_OAUTH_TOKEN is
-    // always optional — missing is a soft ○, never a failure mark.
-    const gates = s.key === "CTX_DISCORD_TOKEN";
-    const mark = s.status === "set" ? "✓" : gates ? "✗" : "○";
+    // The surface's gating token (CTX_DISCORD_TOKEN / CTX_WEB_TOKEN) — missing
+    // is a hard ✗, matching the required checks above. CLAUDE_CODE_OAUTH_TOKEN
+    // is always optional — missing is a soft ○, never a failure mark.
+    const mark = s.status === "set" ? "✓" : s.gates ? "✗" : "○";
     lines.push(`  ${mark} ${s.key}: ${s.status}`);
   }
   return lines.join("\n");
@@ -449,6 +551,109 @@ export function patchSurfacesYaml(
       doc.getIn(["surfaces", "discord", 0, "binding", "agentChannelId"]) === opts.agentChannelId &&
       doc.getIn(["surfaces", "discord", 0, "binding", "logChannelId"]) === opts.logChannelId,
   );
+}
+
+// =============================================================================
+// Web surface scaffold (cortex#2153) — REPLACE, not patch
+// =============================================================================
+//
+// The Discord path PATCHES real values into the `<REPLACE_ME>` slots of the
+// discord binding `cortex stack create` scaffolds. The web path can't do that:
+// the scaffold writes a `discord:` block, and a web deployment must end up with
+// a `web:` block instead (leaving a placeholder discord binding around would
+// fail the daemon's registry pass at boot). So the web path REWRITES
+// surfaces.yaml wholesale to a single `web:` binding.
+//
+// The authoritative web binding SCHEMA is out-of-tree: it lives in the
+// `metafactory-cortex-adapter-web` bundle's own `src/schema.ts` (ADR-0024 /
+// cortex#1794 S9 — cortex core hardcodes NO per-platform binding schema). At
+// scaffold time only the STRUCTURAL pass runs (`{agent, stack?, binding:
+// record}` — `SurfaceBindingEntrySchema`); the bundle's `WebBindingSchema`
+// validates at the REGISTRY pass on daemon boot. The fields written here
+// (instanceId/host/port + the gating token) follow the epic #2164 planner's
+// `host/port/token` web contract; see the report note for the reconciliation
+// risk against the bundle's exact required-field set.
+
+/** Read the agent id off whichever surface binding the scaffold (or a prior
+ *  web rewrite) left in `surfaces.yaml`. Prefers `web` (so a re-run reads the
+ *  already-rewritten file), then the scaffold's `discord`, then slack/mattermost.
+ *  Returns `undefined` when no binding entry carries a string `agent`. */
+export function readSurfaceAgent(path: string): string | undefined {
+  if (!existsSync(path)) return undefined;
+  const doc = parseDocument(readFileSync(path, "utf-8"));
+  for (const platform of ["web", "discord", "slack", "mattermost"]) {
+    const agent = doc.getIn(["surfaces", platform, 0, "agent"]);
+    if (typeof agent === "string" && agent.length > 0) return agent;
+  }
+  return undefined;
+}
+
+export interface WebSurfaceInputs {
+  agent: string;
+  stack: string;
+  instanceId: string;
+  host: string;
+  port: string;
+  token: string;
+}
+
+/** Render a web-only `surfaces.yaml` (cortex#2153). Deterministic given its
+ *  inputs — the byte-identical fixed point a re-run compares against for the
+ *  "second run mutates nothing" guarantee. `port` is emitted UNQUOTED so YAML
+ *  parses it as a number (matching the real web binding shape). `token` is the
+ *  secret — quoted, and NEVER echoed anywhere but this file. */
+export function renderWebSurfacesYaml(opts: WebSurfaceInputs): string {
+  return `# =============================================================================
+# surfaces/surfaces.yaml — web/gateway surface binding (cortex#2153)
+# =============================================================================
+# Written by \`cortex quickstart --surface web\`. Replaces the Discord binding
+# \`cortex stack create\` scaffolds with a single \`web:\` binding. The web binding
+# SCHEMA is owned by the metafactory-cortex-adapter-web bundle (ADR-0024) and
+# validated at the daemon's registry pass on boot — not by cortex core.
+
+surfaces:
+  web:
+    - agent: ${opts.agent}
+      stack: ${opts.stack}
+      binding:
+        instanceId: ${opts.instanceId}
+        host: ${opts.host}
+        port: ${opts.port}
+        token: "${opts.token}"            # web auth secret (chmod 600 the file)
+`;
+}
+
+/** Write the web `surfaces.yaml` (cortex#2153) — a full-file REWRITE (see the
+ *  section header). Idempotent: a re-run against an already-web file is
+ *  byte-identical → no write, no backup. Backs up the pre-existing (Discord
+ *  scaffold or prior web) file at its own mode before an atomic replace, and
+ *  re-reads to verify the bytes landed. Every file here is born 0600 (stack.ts
+ *  scaffold); the backup carries the secret too, so it gets the same mode. */
+export function writeWebSurfacesYaml(path: string, opts: WebSurfaceInputs): PatchResult {
+  const desired = renderWebSurfacesYaml(opts);
+  const exists = existsSync(path);
+  const mode = exists ? statSync(path).mode & 0o777 : 0o600;
+
+  if (exists && readFileSync(path, "utf-8") === desired) {
+    return { changed: false };
+  }
+
+  mkdirSync(dirname(path), { recursive: true });
+
+  let backupPath: string | undefined;
+  if (exists) {
+    const originalText = readFileSync(path, "utf-8");
+    backupPath = `${path}.pre-quickstart-web-surfaces-${backupStamp()}.bak`;
+    writeFileSync(backupPath, originalText, { encoding: "utf-8", mode });
+    chmodSync(backupPath, mode);
+  }
+
+  atomicWriteFileSync(path, desired, mode);
+  if (readFileSync(path, "utf-8") !== desired) {
+    throw new Error(`web surfaces write failed round-trip verification for ${path}`);
+  }
+
+  return backupPath !== undefined ? { changed: true, backupPath } : { changed: true };
 }
 
 /** Patch `system/system.yaml`'s `nats.url` port. Callers skip calling this

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -65,6 +65,7 @@ import { type ExitResult } from "./_shared/exit-result";
 import { CC_AUTH_FAILURE_MESSAGE, isCcAuthFailure } from "../../../runner/cc-failure-classifier";
 import type { CCSessionResult } from "../../../runner/cc-session";
 import { resolveConfigDir } from "../../../common/config/config-path";
+import { validateConfigLoads } from "../../../common/config/validate-on-write";
 
 import { buildQuickstartPorts } from "./quickstart-adapters";
 import type { QuickstartPorts } from "./quickstart-ports";
@@ -78,6 +79,7 @@ import {
   patchSurfacesYaml,
   patchSystemNatsPort,
   pointerConfigPath,
+  readSurfaceAgent,
   renderEnvTable,
   renderGateTable,
   renderNatsConf,
@@ -86,7 +88,12 @@ import {
   surfacesConfigPath,
   systemConfigPath,
   validateEnvContract,
+  validateWebEnvContract,
+  writeWebSurfacesYaml,
+  type CtxRequiredKey,
+  type CtxWebRequiredKey,
   type EnvValidationResult,
+  type Surface,
 } from "./quickstart-lib";
 
 export { type ExitResult } from "./_shared/exit-result";
@@ -119,6 +126,7 @@ interface QuickstartFlags {
   json: boolean;
   skipServices: boolean;
   container: boolean;
+  surface: Surface;
   gateTimeoutMs: number;
   help: boolean;
 }
@@ -132,6 +140,9 @@ function parseQuickstartArgs(argv: string[]): QuickstartFlags {
     json: false,
     skipServices: false,
     container: false,
+    // Default `discord` — byte-identical to pre-#2153 behaviour for every
+    // caller that doesn't pass --surface (the entrypoint + every existing test).
+    surface: "discord",
     gateTimeoutMs: DEFAULT_GATE_TIMEOUT_MS,
     help: false,
   };
@@ -176,6 +187,19 @@ function parseQuickstartArgs(argv: string[]): QuickstartFlags {
         flags.container = true;
         flags.skipServices = true;
         break;
+      // Surface mode (cortex#2153): which surface to provision. `discord`
+      // (default) validates the Discord snowflake contract + patches a discord
+      // binding; `web` validates a host/port/token contract + scaffolds a web
+      // binding. EXPLICIT — never auto-detected from which CTX_* are present
+      // (epic #2164 planner decision).
+      case "--surface": {
+        const raw = requireValue(argv, ++i, "--surface");
+        if (raw !== "discord" && raw !== "web") {
+          throw new CliArgsError("quickstart", `--surface must be "discord" or "web", got "${raw}"`);
+        }
+        flags.surface = raw;
+        break;
+      }
       case "--help":
       case "-h":
         flags.help = true;
@@ -291,10 +315,50 @@ function runPreflight(ports: QuickstartPorts): StepReport {
 // Step 2 — env contract
 // =============================================================================
 
-function runEnvValidation(): { report: StepReport; result: EnvValidationResult } {
-  const result = validateEnvContract(process.env);
-  const lines = renderEnvTable(result).split("\n").slice(1); // drop the "env contract (CTX_*):" header — the step name is already the header
-  return { report: step("2. Validate env contract", result.ok, lines), result };
+/** The four SHARED env values every surface needs (NATS identity + stack
+ *  scaffold — the genuinely-useful parts quickstart keeps across surfaces). */
+interface SharedEnvValues {
+  principal: string;
+  slug: string;
+  natsPort: string;
+  natsMon: string;
+}
+
+/** Step-2 outcome. `ok` gates progression; `shared` is the cross-surface value
+ *  set; exactly one of `discord`/`web` is populated (the surface's typed
+ *  values) when `ok`. */
+interface EnvStepResult {
+  report: StepReport;
+  ok: boolean;
+  shared?: SharedEnvValues;
+  discord?: Record<CtxRequiredKey, string>;
+  web?: Record<CtxWebRequiredKey, string>;
+}
+
+function runEnvValidation(surface: Surface): EnvStepResult {
+  // drop the "env contract (CTX_*):" header — the step name is already the header
+  if (surface === "web") {
+    const result = validateWebEnvContract(process.env);
+    const report = step("2. Validate env contract", result.ok, renderEnvTable(result).split("\n").slice(1));
+    if (!result.ok || result.values === undefined) return { report, ok: false };
+    const v = result.values;
+    return {
+      report,
+      ok: true,
+      shared: { principal: v.CTX_PRINCIPAL, slug: v.CTX_SLUG, natsPort: v.CTX_NATS_PORT, natsMon: v.CTX_NATS_MON },
+      web: v,
+    };
+  }
+  const result: EnvValidationResult = validateEnvContract(process.env);
+  const report = step("2. Validate env contract", result.ok, renderEnvTable(result).split("\n").slice(1));
+  if (!result.ok || result.values === undefined) return { report, ok: false };
+  const v = result.values;
+  return {
+    report,
+    ok: true,
+    shared: { principal: v.CTX_PRINCIPAL, slug: v.CTX_SLUG, natsPort: v.CTX_NATS_PORT, natsMon: v.CTX_NATS_MON },
+    discord: v,
+  };
 }
 
 // =============================================================================
@@ -442,6 +506,92 @@ function runPatchConfigs(opts: {
 
   // system/system.yaml's nats.url only needs a patch when the port differs
   // from the scaffold's own default (4222) — cortex#2094's explicit gate.
+  if (opts.natsPort !== "4222") {
+    try {
+      const systemResult = patchSystemNatsPort(systemConfigPath(opts.configDir, opts.slug), opts.natsPort);
+      lines.push(
+        `  ✓ system/system.yaml ${systemResult.changed ? `patched (nats.url port → ${opts.natsPort})` : "already up to date (skip)"}`,
+      );
+    } catch (err) {
+      lines.push(`  ✗ system/system.yaml patch failed: ${errMsg(err)}`);
+      ok = false;
+    }
+  } else {
+    lines.push("  ✓ system/system.yaml nats.url — CTX_NATS_PORT is the default (4222); no patch needed");
+  }
+
+  return step("5. Patch configs from env", ok, lines);
+}
+
+// =============================================================================
+// Step 5 (web) — scaffold the web surface binding (cortex#2153)
+// =============================================================================
+
+/**
+ * The web analogue of {@link runPatchConfigs}. Instead of patching Discord
+ * values into the scaffold's `<REPLACE_ME>` slots, it REWRITES surfaces.yaml
+ * to a single `web:` binding (the scaffold's discord binding can't survive a
+ * web deployment — see quickstart-lib's web-scaffold section), then applies
+ * the SAME shared `system/system.yaml` nats-port patch the discord path does.
+ * It does NOT patch `stacks/<slug>.yaml` — a web deployment has no principal
+ * discordId to set (the scaffold's `<REPLACE_ME>` discord placeholders are
+ * inert with no discord surface bound).
+ *
+ * `token` is read from `process.env` at the call site (never stored) — same
+ * secret hygiene the discord token gets.
+ */
+function runPatchConfigsWeb(opts: {
+  slug: string;
+  principal: string;
+  configDir: string;
+  natsPort: string;
+  host: string;
+  port: string;
+  token: string;
+}): StepReport {
+  const lines: string[] = [];
+  let ok = true;
+
+  const surfacesPath = surfacesConfigPath(opts.configDir, opts.slug);
+  // The agent id the scaffold wrote (default "assistant", or whatever
+  // `--agent` a prior scaffold used). Read it off the file rather than
+  // duplicating stack.ts's default, and prefer the web entry so a re-run reads
+  // the already-rewritten file.
+  const agent = readSurfaceAgent(surfacesPath);
+  if (agent === undefined) {
+    return step("5. Patch configs from env", false, [
+      `  ✗ surfaces/surfaces.yaml: could not read the scaffolded agent id — not the shape \`cortex stack create\` writes`,
+    ]);
+  }
+
+  try {
+    const surfacesResult = writeWebSurfacesYaml(surfacesPath, {
+      agent,
+      stack: `${opts.principal}/${opts.slug}`,
+      instanceId: opts.slug,
+      host: opts.host,
+      port: opts.port,
+      token: opts.token,
+    });
+    lines.push(
+      `  ✓ surfaces/surfaces.yaml ${surfacesResult.changed ? "written (web binding — token set, never echoed)" : "already up to date (skip)"}`,
+    );
+    // FS-7 discipline: compose the WHOLE config through the daemon's boot
+    // validator so a broken web binding is caught at write time, not boot.
+    if (surfacesResult.changed) {
+      const validation = validateConfigLoads(pointerConfigPath(opts.configDir, opts.slug));
+      if (!validation.ok) {
+        lines.push(`  ✗ surfaces/surfaces.yaml written, but the composed config failed validation:`);
+        for (const e of validation.errors) lines.push(`    ${e}`);
+        ok = false;
+      }
+    }
+  } catch (err) {
+    lines.push(`  ✗ surfaces/surfaces.yaml web write failed: ${errMsg(err)}`);
+    ok = false;
+  }
+
+  // system/system.yaml's nats.url — IDENTICAL shared logic to the discord path.
   if (opts.natsPort !== "4222") {
     try {
       const systemResult = patchSystemNatsPort(systemConfigPath(opts.configDir, opts.slug), opts.natsPort);
@@ -615,19 +765,21 @@ export async function dispatchQuickstart(
   }
 
   // --- 2. Validate env contract ------------------------------------------------
-  const { report: envReport, result: env } = runEnvValidation();
-  reports.push(envReport);
-  if (!env.ok || env.values === undefined) {
+  // cortex#2153 — the contract is surface-specific: `discord` (default)
+  // validates the snowflake contract; `web` validates host/port/token.
+  const env = runEnvValidation(flags.surface);
+  reports.push(env.report);
+  if (!env.ok || env.shared === undefined) {
     return finish(reports, 2, flags.json);
   }
-  const v = env.values;
+  const s = env.shared;
 
   // --- 3. nats conf ------------------------------------------------------------
   const natsConfReport = runNatsConf({
-    slug: v.CTX_SLUG,
-    principal: v.CTX_PRINCIPAL,
-    port: v.CTX_NATS_PORT,
-    monitorPort: v.CTX_NATS_MON,
+    slug: s.slug,
+    principal: s.principal,
+    port: s.natsPort,
+    monitorPort: s.natsMon,
     natsDir,
     force: flags.force,
   });
@@ -637,38 +789,56 @@ export async function dispatchQuickstart(
   }
 
   // --- 4. Scaffold ---------------------------------------------------------
-  const scaffoldReport = await runScaffold({ slug: v.CTX_SLUG, principal: v.CTX_PRINCIPAL, configDir });
+  const scaffoldReport = await runScaffold({ slug: s.slug, principal: s.principal, configDir });
   reports.push(scaffoldReport);
   if (!scaffoldReport.ok) {
     return finish(reports, 1, flags.json);
   }
 
   // --- 5. Patch configs from env ---------------------------------------------
-  // process.env access for the two secrets happens HERE ONLY, scoped to this
-  // one call — never stored in a variable that a later step's log line could
-  // accidentally interpolate.
-  const patchReport = runPatchConfigs({
-    slug: v.CTX_SLUG,
-    principal: v.CTX_PRINCIPAL,
-    configDir,
-    natsPort: v.CTX_NATS_PORT,
-    discordToken: process.env.CTX_DISCORD_TOKEN ?? "",
-    guildId: v.CTX_GUILD_ID,
-    channelId: v.CTX_CHANNEL_ID,
-    logChannelId: v.CTX_LOG_CHANNEL_ID,
-    myDiscordId: v.CTX_MY_DISCORD_ID,
-  });
+  // process.env access for the surface's secret token happens HERE ONLY, scoped
+  // to this one call — never stored in a variable that a later step's log line
+  // could accidentally interpolate.
+  let patchReport: StepReport;
+  if (flags.surface === "web" && env.web !== undefined) {
+    const w = env.web;
+    patchReport = runPatchConfigsWeb({
+      slug: s.slug,
+      principal: s.principal,
+      configDir,
+      natsPort: s.natsPort,
+      host: w.CTX_WEB_HOST,
+      port: w.CTX_WEB_PORT,
+      token: process.env.CTX_WEB_TOKEN ?? "",
+    });
+  } else if (env.discord !== undefined) {
+    const d = env.discord;
+    patchReport = runPatchConfigs({
+      slug: s.slug,
+      principal: s.principal,
+      configDir,
+      natsPort: s.natsPort,
+      discordToken: process.env.CTX_DISCORD_TOKEN ?? "",
+      guildId: d.CTX_GUILD_ID,
+      channelId: d.CTX_CHANNEL_ID,
+      logChannelId: d.CTX_LOG_CHANNEL_ID,
+      myDiscordId: d.CTX_MY_DISCORD_ID,
+    });
+  } else {
+    // Unreachable: `env.ok` guarantees the surface's typed values are set.
+    return finish(reports, 2, flags.json);
+  }
   reports.push(patchReport);
   if (!patchReport.ok) {
     return finish(reports, 1, flags.json);
   }
 
   // --- 6. Seed provisioning ---------------------------------------------------
-  const provisionReport = runSeedProvisioning(ports, { slug: v.CTX_SLUG, configDir });
+  const provisionReport = runSeedProvisioning(ports, { slug: s.slug, configDir });
   reports.push(provisionReport);
 
   // --- 7. Services -------------------------------------------------------------
-  const servicesReport = runServices(ports, { slug: v.CTX_SLUG, skip: flags.skipServices });
+  const servicesReport = runServices(ports, { slug: s.slug, skip: flags.skipServices });
   reports.push(servicesReport);
   if (!servicesReport.ok) {
     return finish(reports, 1, flags.json);
@@ -676,8 +846,8 @@ export async function dispatchQuickstart(
 
   // --- 8. Healthy-boot gate -----------------------------------------------------
   const gateReport = await runGate(ports, {
-    slug: v.CTX_SLUG,
-    monitorPort: v.CTX_NATS_MON,
+    slug: s.slug,
+    monitorPort: s.natsMon,
     timeoutMs: flags.gateTimeoutMs,
     skip: flags.container,
   });
@@ -723,12 +893,20 @@ Runs the validated Debian runbook (README-AGENTS.md Appendix A + §5) as ONE
 idempotent command: preflight → validate env → nats conf → scaffold → patch
 configs from env → seed provisioning → services → healthy-boot gate.
 
-Requires (env, DD-L5 contract): CTX_PRINCIPAL, CTX_SLUG, CTX_NATS_PORT,
-CTX_NATS_MON, CTX_GUILD_ID, CTX_CHANNEL_ID, CTX_LOG_CHANNEL_ID,
-CTX_MY_DISCORD_ID, CTX_DISCORD_TOKEN. Optional: CLAUDE_CODE_OAUTH_TOKEN
-(native hosts with an existing \`claude\` login don't need it).
+Requires (env) — the SHARED keys, both surfaces: CTX_PRINCIPAL, CTX_SLUG,
+CTX_NATS_PORT, CTX_NATS_MON. Optional: CLAUDE_CODE_OAUTH_TOKEN (native hosts
+with an existing \`claude\` login don't need it). Then, per --surface:
+  discord (default): CTX_GUILD_ID, CTX_CHANNEL_ID, CTX_LOG_CHANNEL_ID,
+                     CTX_MY_DISCORD_ID, CTX_DISCORD_TOKEN.
+  web:               CTX_WEB_HOST, CTX_WEB_PORT, CTX_WEB_TOKEN (no Discord
+                     snowflakes — scaffolds a \`web:\` surfaces binding instead).
 
 Flags:
+  --surface <discord|web> Which surface to provision (default: discord).
+                          \`web\` validates a host/port/token contract and
+                          scaffolds a \`web:\` binding; \`discord\` validates the
+                          snowflake contract and patches a discord binding. The
+                          NATS-identity + stack scaffold is shared (cortex#2153).
   --config-dir <path>     Config dir (default: the resolved cortex config dir).
   --nats-dir <path>       NATS material dir (default: ~/.config/nats).
   --force                 Allow step 3 to overwrite a DIFFERENT existing


### PR DESCRIPTION
Closes #2153. Sub-issue of epic #2164 (L4 container standup), wave 2. Rebased onto main after #2155 (the `--container` flag it was stacked on) merged — single clean commit.

**What:** an explicit `--surface <discord|web>` flag for `cortex quickstart` (planner decision, epic #2164). `--surface web` validates a web env contract instead of Discord snowflakes and scaffolds a `web:` binding; the shared, genuinely-useful parts (NATS identity + stack scaffold) are kept.

- **Web env contract:** `CTX_WEB_HOST` / `CTX_WEB_PORT` / `CTX_WEB_TOKEN` (+ shared `CTX_PRINCIPAL`/`CTX_SLUG`/`CTX_NATS_*`). No pre-existing `CTX_WEB_*` convention existed (`.env.example` was discord-only), so this extends the established `CTX_*` prefix. Token gates success presence-only, never echoed.
- **Discord back-compat:** `--surface` defaults to `discord`; a test asserts explicit `--surface discord` yields a **byte-identical** `surfaces.yaml` to omitting the flag. All 66 pre-existing quickstart tests pass unchanged; the only discord-path edits are runtime-identical refactors.
- **Both mismatch directions rejected at step 2** (`--surface web` + discord env, and default + web env).

**Scope:** `quickstart-lib.ts` + `quickstart.ts` + their tests only. No `deploy/compose/**`, no `src/surface/**`.

**Verification:** `bunx tsc --noEmit` 0 errors; quickstart test files 96 pass / 0 fail (+30); `bun run lint` 0 errors on touched files.

## ⚠️ Known residual — web binding fields need live-bundle reconciliation (tracked #2174)

The authoritative web binding **schema is out-of-tree** in the `metafactory-cortex-adapter-web` bundle (ADR-0024). This PR scaffolds the *structural* shape `binding: {instanceId, host, port, token}`, but the in-repo fixture that drives the real bundle (`loader.web-bundle.test.ts:179`) shows the adapter reads `{instanceId, host, port, broadcastUrl, transport, authScheme}` (no `token`). So a scaffolded web stack likely needs binding-field reconciliation before it boots a live web surface. The implementer deliberately did **not guess** the out-of-tree field set. Filed as **#2174** — same "needs the live bundle/box" shape as #2156's daemon-boot check. This PR delivers the provisioning UX (the DoD's "can be provisioned without placeholder Discord values"); live web-boot is gated on #2174.

Refs: #2153, epic #2164, #2174 (binding reconciliation), #2155 (the `--container` base, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9wp7h9ThsZpMgpqSrCpWc
