### PR TITLE
chore: bump to v6.10.0 + point L4 compose default at it (closes #2154)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.9.0"
+version: "6.10.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin layer model"

--- a/deploy/compose/Dockerfile.cortex
+++ b/deploy/compose/Dockerfile.cortex
@@ -21,7 +21,7 @@
 # Every pinned version is an ARG so the image is reproducible and a rebuild can
 # bump a single component. CORTEX_REF defaults to a RELEASE TAG, never `main`.
 
-ARG CORTEX_REF=v6.8.5
+ARG CORTEX_REF=v6.10.0
 ARG BUN_VERSION=1.3.14
 ARG CLAUDE_VERSION=2.1.211
 ARG NATS_SERVER_VERSION=2.14.3

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -120,7 +120,9 @@ default Discord quickstart needs `discord`; a `web:`-only stack should build
 ## Pinned versions
 
 All are build ARGs, overridable from `.env`: `CORTEX_REF` (a release tag, **not**
-`main`), `BUN_VERSION`, `CLAUDE_VERSION`, `NATS_SERVER_VERSION`, `ARC_REF` (the
+`main` — default `v6.10.0`, the first release that carries `cortex quickstart`
+and the L4 container fixes; earlier tags lack `quickstart` and abort at boot,
+cortex#2154), `BUN_VERSION`, `CLAUDE_VERSION`, `NATS_SERVER_VERSION`, `ARC_REF` (the
 arc release tag used to install the surface-adapter package manager),
 `CORTEX_SURFACES` (which adapter bundle(s) to bake — see above), and the
 `NATS_IMAGE` tag. Bump one, rebuild, redeploy.

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       context: .
       dockerfile: Dockerfile.cortex
       args:
-        CORTEX_REF: ${CORTEX_REF:-v6.8.5}
+        CORTEX_REF: ${CORTEX_REF:-v6.10.0}
         BUN_VERSION: ${BUN_VERSION:-1.3.14}
         CLAUDE_VERSION: ${CLAUDE_VERSION:-2.1.211}
         NATS_SERVER_VERSION: ${NATS_SERVER_VERSION:-2.14.3}


### PR DESCRIPTION
Closes #2154. Sub-issue of epic #2164 (L4 container standup) — the second boot blocker.

**Problem:** the L4 compose default `CORTEX_REF=v6.8.5` builds an image whose cortex has no `quickstart` command (it's only on `main`, in no release tag), so `docker compose up -d` aborts at boot with `unknown command 'quickstart'`.

**Fix (your decision — cut a release from main):**
- Bumps `arc-manifest.yaml` → **v6.10.0** — the first release that carries `cortex quickstart` **and** the merged L4 container fixes (#2139 entrypoint OAuth guard, #2155 quickstart `--container`, #2156 arc-installed surface adapter bundles, #2153 `--surface web`).
- Points the compose default at `v6.10.0` in both `docker-compose.yaml` and `Dockerfile.cortex` — honoring the Dockerfile's "release tag, not `main`" rule (now satisfiable).
- README documents the version floor.

The `v6.10.0` tag is cut immediately on merge, so the default resolves.

Epic #2164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9wp7h9ThsZpMgpqSrCpWc
