### PR TITLE
fix(prompt-filter): hard-fail boot + stack create when the injection scanner can't load (cortex#2184)

### DIFF
--- a/src/__tests__/cortex.prompt-filter-boot.test.ts
+++ b/src/__tests__/cortex.prompt-filter-boot.test.ts
@@ -1,0 +1,113 @@
+/**
+ * cortex#2184 — `cortex start` hard-fails when @metafactory/content-filter
+ * failed to load, unless the deliberate opt-out env var is set.
+ *
+ * `assertPromptFilterReady("cortex start")` is the FIRST statement in
+ * `startCortex` (src/cortex.ts) — a load failure rejects the boot promise
+ * before any runtime/NATS/dispatch wiring runs, so these tests don't need
+ * the heavier recording-runtime harness other boot tests use (e.g.
+ * `cortex.security-posture-boot.test.ts`).
+ *
+ * The load failure is simulated via prompt-filter's `__set…ForTests` test
+ * seam — never by uninstalling @metafactory/content-filter (verified working
+ * on this machine; cortex#2184 issue body).
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { startCortex, bootOrDie } from "../cortex";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import {
+  __setPromptFilterLoadErrorForTests,
+} from "../runner/prompt-filter";
+
+function minimalConfig(): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-promptfilter-boot-test-published" },
+  });
+}
+
+describe("startCortex — prompt-filter boot gate (cortex#2184)", () => {
+  const ENV_VAR = "CORTEX_ALLOW_UNSCANNED_PROMPTS";
+  const originalEnv = process.env[ENV_VAR];
+
+  afterEach(() => {
+    __setPromptFilterLoadErrorForTests(null);
+    if (originalEnv === undefined) delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+    else process.env[ENV_VAR] = originalEnv;
+  });
+
+  test("content-filter NOT loadable + opt-out unset → startCortex rejects with an actionable error", async () => {
+    __setPromptFilterLoadErrorForTests("simulated: Cannot find package '@metafactory/content-filter'");
+    delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+
+    await expect(startCortex(minimalConfig())).rejects.toThrow(
+      /@metafactory\/content-filter/,
+    );
+  });
+
+  test("content-filter NOT loadable → bootOrDie maps the rejection to process.exit(1) (mirrors every other fatal boot check)", async () => {
+    __setPromptFilterLoadErrorForTests("simulated load failure");
+    delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+
+    const origExit = process.exit;
+    const origError = console.error;
+    let exitCode: number | undefined;
+    const errors: string[] = [];
+    process.exit = (code?: number): never => {
+      exitCode = code;
+      // bootOrDie doesn't use the return value; throw to unwind like a real
+      // process.exit would (no code after it runs in production).
+      throw new Error("__test_process_exit__");
+    };
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+
+    try {
+      await expect(
+        bootOrDie(() => startCortex(minimalConfig()), "/tmp/grove-cortex-promptfilter-boot-test.pid"),
+      ).rejects.toThrow("__test_process_exit__");
+    } finally {
+      process.exit = origExit;
+      console.error = origError;
+    }
+
+    expect(exitCode).toBe(1);
+    expect(errors.some((l) => l.includes("FATAL") && l.includes("@metafactory/content-filter"))).toBe(true);
+  });
+
+  test("content-filter NOT loadable + opt-out set → startCortex proceeds past the gate (fails later for unrelated harness reasons, not the gate)", async () => {
+    __setPromptFilterLoadErrorForTests("simulated load failure");
+    process.env[ENV_VAR] = "1";
+
+    const logged: string[] = [];
+    const orig = console.error;
+    console.error = (...args: unknown[]) => {
+      logged.push(args.map(String).join(" "));
+    };
+
+    try {
+      // No `nats:` block in minimalConfig() → no real NATS connect attempted,
+      // so startCortex can fully resolve here. We only assert it did NOT fail
+      // with the prompt-filter gate's message (i.e. it proceeded past the
+      // gate), and that the one loud SECURITY warning fired. Stop the handle
+      // either way so no boot-started timers/watchers leak into other test
+      // files in the same process.
+      const handle = await startCortex(minimalConfig()).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).not.toContain("REFUSING TO PROCEED");
+        return null;
+      });
+      if (handle) await handle.stop();
+    } finally {
+      console.error = orig;
+    }
+
+    const warnings = logged.filter((l) => l.includes("SECURITY") && l.includes(ENV_VAR));
+    expect(warnings.length).toBe(1);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -18,6 +18,7 @@ import { join } from "path";
 
 import { dispatchStack } from "../stack";
 import { loadConfigWithAgents } from "../../../../common/config/loader";
+import { __setPromptFilterLoadErrorForTests } from "../../../../runner/prompt-filter";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -155,6 +156,70 @@ describe("create validation", () => {
     const res = await dispatchStack(["create", "research", "--config-dir", cfg]);
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toContain("--principal");
+  });
+});
+
+// =============================================================================
+// create — prompt-filter boot gate (cortex#2184)
+// =============================================================================
+
+describe("create prompt-filter boot gate", () => {
+  const ENV_VAR = "CORTEX_ALLOW_UNSCANNED_PROMPTS";
+  const originalEnv = process.env[ENV_VAR];
+
+  // Simulated via the test seam, never by uninstalling content-filter — see
+  // prompt-filter.ts's __setPromptFilterLoadErrorForTests doc comment.
+  afterEach(() => {
+    __setPromptFilterLoadErrorForTests(null);
+    if (originalEnv === undefined) delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+    else process.env[ENV_VAR] = originalEnv;
+  });
+
+  test("content-filter NOT loadable → exit 1 with actionable message, writes nothing (dry-run default)", async () => {
+    __setPromptFilterLoadErrorForTests("simulated: Cannot find package '@metafactory/content-filter'");
+    delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg]);
+
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("@metafactory/content-filter");
+    expect(res.stderr).toContain("bun install");
+    expect(existsSync(join(cfg, "research"))).toBe(false);
+  });
+
+  test("content-filter NOT loadable + --apply → still exit 1, no scaffold written", async () => {
+    __setPromptFilterLoadErrorForTests("simulated load failure");
+    delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply",
+    ]);
+
+    expect(res.exitCode).toBe(1);
+    expect(existsSync(join(cfg, "research"))).toBe(false);
+  });
+
+  test("content-filter NOT loadable + opt-out set → proceeds normally (exit 0)", async () => {
+    __setPromptFilterLoadErrorForTests("simulated load failure");
+    process.env[ENV_VAR] = "1";
+
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg]);
+
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("andreas/research");
+  });
+
+  test("content-filter loadable (no simulated failure) → unaffected, exit 0", async () => {
+    __setPromptFilterLoadErrorForTests(null);
+    delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg]);
+
+    expect(res.exitCode).toBe(0);
   });
 });
 

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -218,7 +218,7 @@ function runCreate(
   // --- prompt-filter boot gate (cortex#2184) --------------------------------
   // Surface a content-filter load failure at CREATE time — the point Vincent
   // hit it — not just as a WARN buried in `cortex start` output. Fires even in
-  // the dry-run default so an operator sees it before ever running `--apply`.
+  // the dry-run default so the principal sees it before ever running `--apply`.
   try {
     assertPromptFilterReady("cortex stack create");
   } catch (err) {

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -46,6 +46,7 @@ import { CliArgsError } from "./_shared/arg-error";
 import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
 import { type ExitResult } from "./_shared/exit-result";
 import { parseSubcommandArgs, type FlagMap, type SubcommandSpec } from "./_shared/parser";
+import { assertPromptFilterReady } from "../../../runner/prompt-filter";
 import {
   assertAligned,
   discoverStacks,
@@ -214,6 +215,16 @@ function runCreate(
   flags: FlagMap,
   json: boolean,
 ): ExitResult {
+  // --- prompt-filter boot gate (cortex#2184) --------------------------------
+  // Surface a content-filter load failure at CREATE time — the point Vincent
+  // hit it — not just as a WARN buried in `cortex start` output. Fires even in
+  // the dry-run default so an operator sees it before ever running `--apply`.
+  try {
+    assertPromptFilterReady("cortex stack create");
+  } catch (err) {
+    return opError("create", err instanceof Error ? err.message : String(err), json);
+  }
+
   // --- validate slug -------------------------------------------------------
   if (!SLUG_RE.test(slug)) {
     return usageError(

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -62,6 +62,7 @@ import {
 // `loadAccountSigningKey` independently.
 
 import { buildSecurityPreamble } from "./runner/security-preamble";
+import { assertPromptFilterReady } from "./runner/prompt-filter";
 import { DispatchHandler } from "./bus/dispatch-handler";
 import {
   makeSubjectPlaceholderSubstituter,
@@ -906,6 +907,14 @@ export async function startCortex(
   config: AgentConfig,
   options: StartCortexOptions = {},
 ): Promise<CortexHandle> {
+  // cortex#2184 — hard-fail before any other boot work if the prompt-injection
+  // scanner failed to load (unless the deliberate opt-out is set). The daemon
+  // must never linger half-booted dispatching unscanned prompts — see
+  // assertPromptFilterReady's doc comment. `bootOrDie` (the CLI's `start`
+  // wrapper) maps a throw here to `console.error` + `process.exit(1)`, same as
+  // every other fatal boot check.
+  assertPromptFilterReady("cortex start");
+
   const expandedConfigPath = options.configPath
     ? options.configPath.replace(/^~/, process.env.HOME ?? "~")
     : DEFAULT_CONFIG;

--- a/src/runner/__tests__/prompt-filter.test.ts
+++ b/src/runner/__tests__/prompt-filter.test.ts
@@ -15,6 +15,7 @@ import {
   scanPrompt,
   deriveReasonCategory,
   assertPromptFilterReady,
+  validateLoadedFilter,
   __setPromptFilterLoadErrorForTests,
 } from "../prompt-filter";
 
@@ -271,5 +272,41 @@ describe("assertPromptFilterReady (cortex#2184 boot gate)", () => {
     const warnings = logged.filter((l) => l.includes("SECURITY") && l.includes(ENV_VAR));
     expect(warnings.length).toBe(1);
     expect(warnings[0]).toContain("DISABLED");
+  });
+});
+
+describe("validateLoadedFilter (cortex#2184 round 2 — resolved-but-degraded import)", () => {
+  // A RESOLVED import promise is not proof of a working filter: a partial
+  // fetch, an ESM/CJS interop quirk landing the export on `.default`, or a
+  // renamed/missing export all resolve without throwing — so the module-init
+  // `catch` never fires, yet `scanPrompt`'s fail-open check
+  // (`if (!filterContentString)`) would still trip. These tests pin that
+  // `validateLoadedFilter` uses the SAME predicate scanPrompt does, on a few
+  // plausible degraded-module shapes, without needing a real broken import.
+
+  test("mod exports a real callable filterContentString → null (ready)", () => {
+    const mod = { filterContentString: () => ({}) as unknown };
+    expect(validateLoadedFilter(mod)).toBeNull();
+  });
+
+  test("mod.filterContentString is undefined (missing export) → error string", () => {
+    const mod = { filterContentString: undefined };
+    const result = validateLoadedFilter(mod);
+    expect(result).not.toBeNull();
+    expect(result).toContain("@metafactory/content-filter");
+    expect(result).toContain("did not export a callable");
+  });
+
+  test("mod.filterContentString present but not a function (e.g. landed on .default, wrong shape) → error string", () => {
+    const mod = { filterContentString: { default: () => {} } };
+    const result = validateLoadedFilter(mod);
+    expect(result).not.toBeNull();
+    expect(result).toContain("did not export a callable");
+  });
+
+  test("mod with no filterContentString key at all → error string", () => {
+    const mod = {};
+    const result = validateLoadedFilter(mod);
+    expect(result).not.toBeNull();
   });
 });

--- a/src/runner/__tests__/prompt-filter.test.ts
+++ b/src/runner/__tests__/prompt-filter.test.ts
@@ -10,8 +10,13 @@
  * prompt injection scanner is silently fail-open — exactly the bug grove#173
  * was filed to fix.
  */
-import { describe, test, expect } from "bun:test";
-import { scanPrompt, deriveReasonCategory } from "../prompt-filter";
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  scanPrompt,
+  deriveReasonCategory,
+  assertPromptFilterReady,
+  __setPromptFilterLoadErrorForTests,
+} from "../prompt-filter";
 
 describe("scanPrompt (grove#173 acceptance)", () => {
   test("allows clean conversational text", () => {
@@ -197,5 +202,74 @@ describe("scanPrompt trust gate (cortex#741)", () => {
   test("trusted score is still surfaced for the audit record", () => {
     const result = scanPrompt(EX004_FP, "discord", { trusted: true });
     expect(typeof result.score).toBe("number");
+  });
+});
+
+describe("assertPromptFilterReady (cortex#2184 boot gate)", () => {
+  const ENV_VAR = "CORTEX_ALLOW_UNSCANNED_PROMPTS";
+  const originalEnv = process.env[ENV_VAR];
+
+  // Real content-filter loads cleanly in this environment (the whole point of
+  // grove#173 Phase B — see the file-level doc comment above), so
+  // `promptFilterLoadError` is `null` at module init. We simulate a load
+  // failure via the test seam rather than uninstalling the dependency — reset
+  // it after every test so we never leak the simulated failure into the
+  // scanPrompt tests above/below.
+  afterEach(() => {
+    __setPromptFilterLoadErrorForTests(null);
+    if (originalEnv === undefined) {
+      delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+    } else {
+      process.env[ENV_VAR] = originalEnv;
+    }
+  });
+
+  test("loaded (no simulated failure) → no-op, never throws", () => {
+    __setPromptFilterLoadErrorForTests(null);
+    delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+    expect(() => assertPromptFilterReady("cortex start")).not.toThrow();
+  });
+
+  test("not loaded + opt-out unset → throws an actionable error", () => {
+    __setPromptFilterLoadErrorForTests("Cannot find package '@metafactory/content-filter'");
+    delete process.env.CORTEX_ALLOW_UNSCANNED_PROMPTS;
+
+    let thrown: unknown;
+    try {
+      assertPromptFilterReady("cortex start");
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    // Names the module, states scanning would be OFF, gives the fix, echoes
+    // the underlying error, and mentions the opt-out — per cortex#2184.
+    expect(message).toContain("@metafactory/content-filter");
+    expect(message).toContain("scanning would be OFF");
+    expect(message).toContain("bun install");
+    expect(message).toContain("Cannot find package '@metafactory/content-filter'");
+    expect(message).toContain(ENV_VAR);
+    expect(message).toContain("cortex start");
+  });
+
+  test("not loaded + opt-out set → proceeds with exactly one loud SECURITY warning", () => {
+    __setPromptFilterLoadErrorForTests("simulated load failure");
+    process.env[ENV_VAR] = "1";
+
+    const logged: string[] = [];
+    const orig = console.error;
+    console.error = (...args: unknown[]) => {
+      logged.push(args.map(String).join(" "));
+    };
+    try {
+      expect(() => assertPromptFilterReady("cortex stack create")).not.toThrow();
+    } finally {
+      console.error = orig;
+    }
+
+    const warnings = logged.filter((l) => l.includes("SECURITY") && l.includes(ENV_VAR));
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("DISABLED");
   });
 });

--- a/src/runner/prompt-filter.ts
+++ b/src/runner/prompt-filter.ts
@@ -22,9 +22,20 @@ type FilterContentString = (
 
 let filterContentString: FilterContentString | null = null;
 
+/**
+ * cortex#2184 — set (from the module-init catch below) when
+ * @metafactory/content-filter failed to load. `null` means the filter loaded
+ * cleanly. Read by {@link assertPromptFilterReady} so `cortex start` /
+ * `cortex stack create` can hard-fail on a load failure instead of the
+ * runtime `scanPrompt` fail-open path being the only signal (grove#173 kept
+ * that path loud but open; this closes the boot-time gap).
+ */
+export let promptFilterLoadError: string | null = null;
+
 // Load @metafactory/content-filter at module init. This is a required security
 // control — if the package fails to load we log loudly so principals notice.
-// Previously this was silently fail-open (grove#173).
+// Previously this was silently fail-open (grove#173). Since cortex#2184 the
+// failure is also hard-gated at boot — see assertPromptFilterReady below.
 try {
   const mod = await import("@metafactory/content-filter");
   filterContentString = mod.filterContentString;
@@ -32,10 +43,71 @@ try {
     "prompt-filter: @metafactory/content-filter loaded — inbound prompts will be scanned",
   );
 } catch (err) {
+  promptFilterLoadError = err instanceof Error ? err.message : String(err);
   console.error(
     "prompt-filter: WARN @metafactory/content-filter failed to load — " +
       "inbound prompts are NOT being scanned for prompt injection:",
     err instanceof Error ? err.message : err,
+  );
+}
+
+/**
+ * Test seam (cortex#2184) — override the module-init load state to simulate
+ * @metafactory/content-filter failing to load, WITHOUT actually uninstalling
+ * or breaking the dependency. Pass `null` to restore the loaded state.
+ * Mirrors the `__set…ForTests` convention used elsewhere in this repo (e.g.
+ * `network-adapters.ts` `__setAdmissionResolverForTests`).
+ */
+export function __setPromptFilterLoadErrorForTests(err: string | null): void {
+  promptFilterLoadError = err;
+}
+
+/** The deliberate opt-out — see {@link assertPromptFilterReady}. */
+const ALLOW_UNSCANNED_PROMPTS_ENV = "CORTEX_ALLOW_UNSCANNED_PROMPTS";
+
+/**
+ * cortex#2184 — boot-time gate: refuse to proceed past `context` (e.g.
+ * `"cortex start"`, `"cortex stack create"`) when @metafactory/content-filter
+ * failed to load, unless the deliberate opt-out env var is set.
+ *
+ * The prompt-injection scanner is a required security control (gate doctrine,
+ * cortex#1381 PRINCIPLES #9/#10, arc#332). Previously a load failure only
+ * logged a WARN and let boot continue with `scanPrompt` silently fail-open —
+ * so any host where content-filter didn't load ran with injection scanning
+ * OFF and no one noticed. This closes that gap: the two security-relevant
+ * lifecycle points (daemon boot, stack scaffolding) now hard-fail on a load
+ * failure, with an explicit, loud escape hatch for anyone who genuinely needs
+ * to proceed unscanned.
+ *
+ * - filter loaded (`promptFilterLoadError === null`) → no-op.
+ * - not loaded + opt-out unset → throws with an actionable message (module
+ *   name, "scanning would be OFF", the fix, the underlying error, and the
+ *   opt-out). Callers map the throw to a non-zero exit — see `bootOrDie` in
+ *   `src/cortex.ts` (daemon boot) and the `try`/`opError` wrap around
+ *   `assertAligned` in `src/cli/cortex/commands/stack.ts` (stack create).
+ * - not loaded + opt-out set (`CORTEX_ALLOW_UNSCANNED_PROMPTS=1`) → proceeds,
+ *   but prints ONE loud single-line SECURITY warning first. Not a silent
+ *   bypass — the opt-out must be an explicit, deliberate env var.
+ *
+ * This gate does NOT change `scanPrompt`'s own runtime fail-open behavior
+ * (out of scope, cortex#2184) — it exists so that path is never reached
+ * unscanned in the first place, absent the opt-out.
+ */
+export function assertPromptFilterReady(context: string): void {
+  if (promptFilterLoadError === null) return;
+
+  if (process.env[ALLOW_UNSCANNED_PROMPTS_ENV] === "1") {
+    console.error(
+      `⚠ SECURITY: prompt-injection scanning is DISABLED by the opt-out env var ${ALLOW_UNSCANNED_PROMPTS_ENV}=1 (${context}) — proceeding unscanned.`,
+    );
+    return;
+  }
+
+  throw new Error(
+    `prompt-filter: REFUSING TO PROCEED (${context}) — @metafactory/content-filter failed to load, ` +
+      `so inbound prompt-injection scanning would be OFF. Fix: ensure a current bun and re-run ` +
+      `\`bun install\` in the cortex repo. Underlying error: ${promptFilterLoadError}. ` +
+      `To proceed anyway (NOT recommended — scanning stays OFF), set ${ALLOW_UNSCANNED_PROMPTS_ENV}=1.`,
   );
 }
 

--- a/src/runner/prompt-filter.ts
+++ b/src/runner/prompt-filter.ts
@@ -32,16 +32,52 @@ let filterContentString: FilterContentString | null = null;
  */
 export let promptFilterLoadError: string | null = null;
 
+/**
+ * cortex#2184 round 2 — validate a successfully-RESOLVED content-filter import
+ * actually exports a callable `filterContentString`. A resolved import promise
+ * is not proof of a working filter: a partial fetch, an ESM/CJS interop quirk
+ * landing the export on `.default`, or a renamed/missing export all resolve
+ * without throwing — the module-init `catch` below never fires for any of
+ * those. `scanPrompt`'s own fail-open check is on the FUNCTION VALUE
+ * (`if (!filterContentString)`), not on whether the import threw, so this gate
+ * must check the SAME thing or a degraded-but-non-throwing load slips through
+ * with `promptFilterLoadError` staying `null` — a boot-time false negative.
+ *
+ * Pure + exported so the degraded-load shapes are unit-testable without a
+ * real broken import (see prompt-filter.test.ts): a mod whose
+ * `filterContentString` is `undefined`, or present but not a function.
+ */
+export function validateLoadedFilter(mod: {
+  filterContentString?: unknown;
+}): string | null {
+  if (typeof mod.filterContentString !== "function") {
+    return (
+      "@metafactory/content-filter loaded but did not export a callable " +
+      "filterContentString — inbound prompts would NOT be scanned"
+    );
+  }
+  return null;
+}
+
 // Load @metafactory/content-filter at module init. This is a required security
 // control — if the package fails to load we log loudly so principals notice.
 // Previously this was silently fail-open (grove#173). Since cortex#2184 the
 // failure is also hard-gated at boot — see assertPromptFilterReady below.
 try {
   const mod = await import("@metafactory/content-filter");
-  filterContentString = mod.filterContentString;
-  console.log(
-    "prompt-filter: @metafactory/content-filter loaded — inbound prompts will be scanned",
-  );
+  const validationError = validateLoadedFilter(mod);
+  if (validationError !== null) {
+    // Resolved import, but the export shape is unusable — treat identically
+    // to a throw: promptFilterLoadError set, filterContentString stays null,
+    // scanPrompt fails open, assertPromptFilterReady hard-gates.
+    promptFilterLoadError = validationError;
+    console.error(`prompt-filter: WARN ${validationError}`);
+  } else {
+    filterContentString = mod.filterContentString;
+    console.log(
+      "prompt-filter: @metafactory/content-filter loaded — inbound prompts will be scanned",
+    );
+  }
 } catch (err) {
   promptFilterLoadError = err instanceof Error ? err.message : String(err);
   console.error(


### PR DESCRIPTION
Closes #2184. Security-posture fix from Vincent's fresh v6.10.0 install.

**The gap:** the prompt-injection scanner (`@metafactory/content-filter`) is a *required* security control, but its absence **failed open** — cortex ran, dispatched, and scanned nothing behind a WARN. Any host where content-filter didn't load silently ran with injection scanning OFF. (The dep itself is *not* broken — it resolves cleanly on bun 1.3.2 fresh + frozen; the load failure is environment-specific. This PR fixes the *posture*, not the dep — both explicitly out of scope per the issue.)

**The fix — hard-fail loud, not silently open:**
- `prompt-filter.ts` exports the load state (`promptFilterLoadError`) + `assertPromptFilterReady(context)`: no-op when loaded; else throw an actionable error (names the module, "scanning would be OFF", the fix, the underlying error, the opt-out) — *unless* the deliberate opt-out env var is set to `"1"` (strict compare, no accidental-truthy bypass), in which case one loud single-line SECURITY warning + proceed.
- Wired as an early statement in the two security-relevant lifecycle points: `cortex start` (daemon boot, before any dispatch — mapped to non-zero exit via `bootOrDie`, mirroring the `verifier-self-check` refuse-to-boot pattern) and `cortex stack create` (via `opError` → exit 1, mirroring `assertAligned`).
- Runtime `scanPrompt` fail-open path unchanged (out of scope) — the boot gate ensures it's never reached unscanned without the explicit opt-out.

**Doctrine tie-in:** a security scan you bypass by breaking it isn't a gate (PRINCIPLES #9/#10, arc#332). This makes the scanner fail closed-and-loud at the boundary.

**Verification:** 60 pass / 0 fail across the 3 scoped test files (3 branches each: loaded→noop, not-loaded→hard-fail, opt-out→warn-proceed, incl. asserting `process.exit(1)` fires at boot); tsc clean; lint 0 errors. Not-loaded is simulated via a `__set…ForTests` seam that sets the *same* `promptFilterLoadError` the real module-init catch assigns (same code path, trigger swapped) — content-filter never uninstalled.

Trust-path lane: CI + adversarial security review gate the merge. (Note: `cortex.capability-boot.test.ts`'s 6 failures are pre-existing on clean main, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
