### PR TITLE
fix(deps): content-filter points at renamed repo — fixes silent scanner-load failure on fresh installs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@the-metafactory/cortex",
       "dependencies": {
-        "@metafactory/content-filter": "github:the-metafactory/content-filter#0e4968c6b48bf9887198fa4c5ef34736dc10a68d",
+        "@metafactory/content-filter": "github:the-metafactory/metafactory-bundle-content-filter#0e4968c6b48bf9887198fa4c5ef34736dc10a68d",
         "@nats-io/jwt": "^0.0.11",
         "@octokit/webhooks": "^14.2.0",
         "@octokit/webhooks-methods": "^6.0.0",
@@ -67,7 +67,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-0e4968c"],
+    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/metafactory-bundle-content-filter#0e4968c", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-metafactory-bundle-content-filter-0e4968c"],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@metafactory/content-filter": "github:the-metafactory/content-filter#0e4968c6b48bf9887198fa4c5ef34736dc10a68d",
+    "@metafactory/content-filter": "github:the-metafactory/metafactory-bundle-content-filter#0e4968c6b48bf9887198fa4c5ef34736dc10a68d",
     "@nats-io/jwt": "^0.0.11",
     "@octokit/webhooks": "^14.2.0",
     "@octokit/webhooks-methods": "^6.0.0",


### PR DESCRIPTION
## The bug
`@metafactory/content-filter` (the required prompt-injection scanner) still referenced its **old repo name**. The repo was renamed `content-filter` → `metafactory-bundle-content-filter` in a separate refactor; this dependency was never updated.

**Why it hid for so long:** bun's frozen install reuses the pinned tarball cache key (`the-metafactory-content-filter-0e4968c`), so CI and any already-resolved box kept working — the break was invisible on green CI. But a **fresh resolve** (reporter: Vincent, bun `1.3.14+0d9b296af`, Debian 13.6) follows GitHub's rename redirect:

```
GET api.github.com/repos/the-metafactory/content-filter/tarball/0e4968c
  → 301 → /repositories/1146673575/tarball/0e4968c
  → 302 → codeload.github.com/the-metafactory/metafactory-bundle-content-filter/legacy.tar.gz/0e4968c
  → 200 OK
```

bun 1.3.14 fetches the redirected tarball but **mis-extracts it — landing an empty package** (only the nested `zod` dep, no source). `filterContentString` is absent → the scanner silently fails to load → `prompt-filter: WARN … inbound prompts are NOT being scanned`.

## The fix
Point the dependency at the **current canonical repo name**. No redirect, correct extraction. The npm package name (`@metafactory/content-filter`, used in imports) and the pinned SHA are unchanged — only the GitHub repo path in the resolver URL.

```diff
- "@metafactory/content-filter": "github:the-metafactory/content-filter#0e4968c…",
+ "@metafactory/content-filter": "github:the-metafactory/metafactory-bundle-content-filter#0e4968c…",
```

## Verification
```
$ bun install --frozen-lockfile          # clean, no changes
$ bun -e 'const m = await import("@metafactory/content-filter"); console.log(typeof m.filterContentString)'
function        # ← real content, not the empty shell
```
Reporter confirmed the same edit resolves it on his box (bun 1.3.14). Diff is 3 lines: `package.json` + `bun.lock` only, same SHA, cache key follows the canonical name.

## Relationship to #2184
Two halves of the same finding:
- **This PR** — makes the scanner **resolve** (the common case works again).
- **#2184** — makes a *failed* resolve **hard-fail loud at boot** instead of running silently unscanned (the edge case, fail-closed).

They should land together: with #2184 alone, boxes hitting this rename bug would go from silent-WARN to hard-blocked. This PR removes the trigger for the common case; #2184 guards whatever's left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
