### PR TITLE
feat(registry): admission identity-binding M9/M17/M12 + M13 window (Closes #2188)

### DIFF
--- a/src/services/network-registry/__tests__/admission-identity-binding.test.ts
+++ b/src/services/network-registry/__tests__/admission-identity-binding.test.ts
@@ -299,4 +299,93 @@ describe("M17 — sealed-secret claim identity binding", () => {
     expect(narrowAdmissionClaimCount()).toBe(1);
     expect(warnings.some((w) => w.includes("sealed-secret") && w.includes("narrow"))).toBe(true);
   });
+
+  test("a WRONG-peer seal claim does NOT count (mismatch is not an admission)", async () => {
+    const req = await admittedRow("alice");
+    const other = await makePrincipalKey();
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, hubAdmin, { peerPubkey: other.publicKeyB64 }),
+    );
+    expect(res.status).toBe(409);
+    // A wide (bound) claim never counts anyway, but assert the counter is clean.
+    expect(narrowAdmissionClaimCount()).toBe(0);
+  });
+});
+
+// =============================================================================
+// M13 — the counter is POISON-RESISTANT: only a CONFIRMED admit counts
+// (PR #2194 adversarial BLOCKER). A narrow claim that bounces pre-transition
+// (403 unauthorised / 404 missing row / 409 nonce-replay) must NOT increment
+// the §7.3 zero-narrow flip gate.
+// =============================================================================
+
+describe("M13 — counter poison-resistance", () => {
+  test("a narrow claim that 403s (stranger signer) does NOT count", async () => {
+    const pna = await makePrincipalKey();
+    const stranger = await makePrincipalKey(); // neither global nor per-network admin
+    await createNetwork("research-collab", pna.publicKeyB64);
+    const req = await registerInto("joel", "research-collab");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", stranger); // narrow
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+    expect(res.status).toBe(403);
+    expect(narrowAdmissionClaimCount()).toBe(0);
+  });
+
+  test("a narrow claim against a nonexistent row (404) does NOT count", async () => {
+    // Valid-format but nonexistent request_id; global admin passes auth, so it
+    // reaches the transition → 404 not_found, AFTER which counting is gated.
+    const missingId = "0".repeat(32);
+    const decision = await makeSignedAdminDecision(missingId, "admit", globalAdmin); // narrow
+    const res = await post(`/admission-requests/${missingId}/admit`, decision);
+    expect(res.status).toBe(404);
+    expect(narrowAdmissionClaimCount()).toBe(0);
+  });
+
+  test("a replayed narrow claim (nonce reuse) counts only the first, confirmed admit", async () => {
+    const pna = await makePrincipalKey();
+    await createNetwork("research-collab", pna.publicKeyB64);
+    const req = await registerInto("joel", "research-collab");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", pna); // narrow
+    expect((await post(`/admission-requests/${req.request_id}/admit`, decision)).status).toBe(200);
+    expect(narrowAdmissionClaimCount()).toBe(1);
+
+    // Replay the identical signed claim (same nonce) → 409, no second count.
+    const replay = await post(`/admission-requests/${req.request_id}/admit`, decision);
+    expect(replay.status).toBe(409);
+    expect(narrowAdmissionClaimCount()).toBe(1);
+  });
+});
+
+// =============================================================================
+// Strip-downgrade — an attacker cannot strip the binding off a signed WIDE
+// claim to masquerade as narrow: the signature is over the wide bytes, so the
+// stripped (narrow) wire canonical-JSON no longer verifies → 401.
+// =============================================================================
+
+describe("strip-downgrade resistance", () => {
+  test("deleting peer_pubkey + network_id from a signed wide claim → 401", async () => {
+    const pna = await makePrincipalKey();
+    await createNetwork("research-collab", pna.publicKeyB64);
+    const req = await registerInto("joel", "research-collab");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", pna, {
+      peerPubkey: req.peer_pubkey,
+      networkId: "research-collab",
+    });
+    // Tamper the wire: strip the binding AFTER signing (signature is over the
+    // wide claim). The route verifies over canonicalJSON(signed.claim) — now the
+    // narrow bytes — so it can no longer match the wide-claim signature.
+    const wire = decision.claim as unknown as Record<string, unknown>;
+    delete wire.peer_pubkey;
+    delete wire.network_id;
+
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+    expect(res.status).toBe(401);
+    expect(((await res.json()) as { error: string }).error).toBe("signature_invalid");
+    // A rejected forgery is not a narrow admission — counter untouched.
+    expect(narrowAdmissionClaimCount()).toBe(0);
+  });
 });

--- a/src/services/network-registry/__tests__/admission-identity-binding.test.ts
+++ b/src/services/network-registry/__tests__/admission-identity-binding.test.ts
@@ -1,0 +1,302 @@
+/**
+ * cortex#2188 — admission identity-binding (RFC-0006 §7.3 / §8.3, myelin#235 W5).
+ *
+ * TRUST-PATH claim verification. Covers:
+ *   - M9  — a WIDE decision claim binds peer_pubkey/network_id; each MUST match
+ *           the row → else 409 identity_mismatch (BEFORE the authority check).
+ *   - M12 — the per-network authority check consumes the BOUND network_id when
+ *           present (falls back to the stored row network_id for narrow claims).
+ *   - M13 — a NARROW claim is still admitted, but counted + a warning logged
+ *           (dual-accept window OPEN; require-present flip NOT performed).
+ *   - M17 — the seal write binds peer_pubkey the same way → 409 on mismatch.
+ *
+ * The headline case is the §7.3 CROSS-NETWORK CONFUSED-DEPUTY: a claim bound to
+ * network A, replayed onto a network-B row, is refused 409 EVEN WHEN the signing
+ * admin is legitimately authorised on B (fail-before: it admitted; pass-after:
+ * 409).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedNetworkCreate,
+  makeSignedRegistration,
+  makeSignedAdminRead,
+  makeSignedAdminDecision,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import { narrowAdmissionClaimCount } from "../src/admission-window";
+import type { AdmissionRequest } from "../src/types";
+
+let env: Env;
+let globalAdmin: PrincipalKey;
+let hubAdmin: PrincipalKey;
+
+const SEALED = btoa("sealed-leaf-psk-opaque-ciphertext-v1");
+
+async function post(path: string, body: unknown, e: Env = env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), env);
+}
+
+async function createNetwork(networkId: string, adminPubkeys?: string): Promise<void> {
+  const body = await makeSignedNetworkCreate(networkId, globalAdmin, { adminPubkeys });
+  expect((await post(`/networks/${networkId}`, body)).status).toBe(201);
+}
+
+/** Register a principal into a network; return the PENDING row (carries peer_pubkey + network_id). */
+async function registerInto(principalId: string, networkId: string): Promise<AdmissionRequest> {
+  const pk = await makePrincipalKey();
+  const reg = await makeSignedRegistration(principalId, pk, {
+    networkId,
+    stacks: [{ stack_id: `${principalId}/main`, stack_pubkey: pk.publicKeyB64 }],
+  });
+  expect((await post(`/principals/${principalId}/register`, reg)).status).toBe(201);
+
+  const signedRead = await makeSignedAdminRead(globalAdmin);
+  const listRes = await get("/admission-requests?status=PENDING", {
+    "x-admin-signed": JSON.stringify(signedRead),
+  });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const found = list.find((r) => r.principal_id === principalId && r.network_id === networkId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+async function makeSealedWrite(
+  requestId: string,
+  signer: PrincipalKey,
+  opts: { peerPubkey?: string } = {},
+): Promise<{ claim: unknown; signature: string }> {
+  const claim = {
+    request_id: requestId,
+    sealed_secret: SEALED,
+    ...(opts.peerPubkey !== undefined && { peer_pubkey: opts.peerPubkey }),
+    hub_admin_pubkey: signer.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(signer.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+// A console.warn spy so the M13 deprecation-warning assertion doesn't depend on
+// log inspection tooling.
+let warnings: string[] = [];
+const realWarn = console.warn;
+
+beforeEach(async () => {
+  resetStores();
+  warnings = [];
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  const reg = await makeRegistryKey();
+  globalAdmin = await makePrincipalKey();
+  hubAdmin = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: globalAdmin.publicKeyB64,
+    REGISTRY_HUB_ADMIN_PUBKEYS: hubAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+});
+
+afterEach(() => {
+  console.warn = realWarn;
+});
+
+// =============================================================================
+// M9 — wide decision claim binding (peer_pubkey + network_id)
+// =============================================================================
+
+describe("M9 — decision claim identity binding", () => {
+  test("a WIDE claim whose peer_pubkey + network_id match the row → admitted", async () => {
+    const pna = await makePrincipalKey();
+    await createNetwork("research-collab", pna.publicKeyB64);
+    const req = await registerInto("joel", "research-collab");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", pna, {
+      peerPubkey: req.peer_pubkey,
+      networkId: "research-collab",
+    });
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as AdmissionRequest).status).toBe("ADMITTED");
+    // A wide claim is NOT a narrow claim — the window counter stays at zero.
+    expect(narrowAdmissionClaimCount()).toBe(0);
+  });
+
+  test("a mismatched peer_pubkey → 409 identity_mismatch", async () => {
+    const pna = await makePrincipalKey();
+    const other = await makePrincipalKey();
+    await createNetwork("research-collab", pna.publicKeyB64);
+    const req = await registerInto("joel", "research-collab");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", pna, {
+      peerPubkey: other.publicKeyB64, // NOT the row's peer
+      networkId: "research-collab",
+    });
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; details?: { field: string } };
+    expect(body.error).toBe("identity_mismatch");
+    expect(body.details?.field).toBe("peer_pubkey");
+    // Refused → not admitted.
+    expect(req.status).toBe("PENDING");
+  });
+
+  test("a mismatched network_id → 409 identity_mismatch", async () => {
+    const pna = await makePrincipalKey();
+    await createNetwork("research-collab", pna.publicKeyB64);
+    await createNetwork("other-net", pna.publicKeyB64);
+    const req = await registerInto("joel", "research-collab");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", pna, {
+      peerPubkey: req.peer_pubkey,
+      networkId: "other-net", // row is research-collab
+    });
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("identity_mismatch");
+  });
+});
+
+// =============================================================================
+// §7.3 CROSS-NETWORK CONFUSED-DEPUTY — the headline case
+// =============================================================================
+
+describe("§7.3 cross-network confused-deputy", () => {
+  test("claim bound to network A, row is network B, admin authorised on B → 409 (even though authorised on B)", async () => {
+    const adminA = await makePrincipalKey();
+    const adminB = await makePrincipalKey();
+    await createNetwork("net-a", adminA.publicKeyB64);
+    await createNetwork("net-b", adminB.publicKeyB64);
+
+    // The victim row lives on net-b; adminB is a legitimate net-b admin.
+    const reqB = await registerInto("joel", "net-b");
+
+    // adminB signs a decision BOUND to net-a (the claim they believe/intend is
+    // for A) but it is submitted against the net-b row. Pre-M9 this ADMITTED
+    // (authority keyed off the stored net-b, on which adminB IS authorised) —
+    // the confused deputy. M9 refuses it: the bound network_id contradicts the
+    // row BEFORE authority is even consulted.
+    const decision = await makeSignedAdminDecision(reqB.request_id, "admit", adminB, {
+      peerPubkey: reqB.peer_pubkey,
+      networkId: "net-a",
+    });
+    const res = await post(`/admission-requests/${reqB.request_id}/admit`, decision);
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; details?: { field: string } };
+    expect(body.error).toBe("identity_mismatch");
+    expect(body.details?.field).toBe("network_id");
+  });
+});
+
+// =============================================================================
+// M12 — the authority check consumes the bound network_id
+// =============================================================================
+
+describe("M12 — per-network authority keyed off the bound network_id", () => {
+  test("a per-network admin of B, wide-claim-bound to B, on a B row → admitted", async () => {
+    const adminB = await makePrincipalKey();
+    await createNetwork("net-b", adminB.publicKeyB64);
+    const reqB = await registerInto("joel", "net-b");
+
+    const decision = await makeSignedAdminDecision(reqB.request_id, "admit", adminB, {
+      peerPubkey: reqB.peer_pubkey,
+      networkId: "net-b",
+    });
+    expect((await post(`/admission-requests/${reqB.request_id}/admit`, decision)).status).toBe(200);
+  });
+});
+
+// =============================================================================
+// M13 — dual-accept window: narrow claims still admitted, counted + warned
+// =============================================================================
+
+describe("M13 — narrow claim dual-accept window", () => {
+  test("a NARROW claim (no binding) is still admitted, counted, and warns", async () => {
+    const pna = await makePrincipalKey();
+    await createNetwork("research-collab", pna.publicKeyB64);
+    const req = await registerInto("joel", "research-collab");
+
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", pna); // no binding
+    const res = await post(`/admission-requests/${req.request_id}/admit`, decision);
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as AdmissionRequest).status).toBe("ADMITTED");
+
+    // Counter incremented + a deprecation warning logged (the require-present
+    // flip's zero-narrow gate reads this).
+    expect(narrowAdmissionClaimCount()).toBe(1);
+    expect(warnings.some((w) => w.includes("admission-window") && w.includes("narrow"))).toBe(true);
+  });
+});
+
+// =============================================================================
+// M17 — seal write identity binding
+// =============================================================================
+
+describe("M17 — sealed-secret claim identity binding", () => {
+  async function admittedRow(principalId: string): Promise<AdmissionRequest> {
+    await createNetwork("metafactory");
+    const req = await registerInto(principalId, "metafactory");
+    // Admit with a WIDE claim so the admit step doesn't bump the narrow counter —
+    // keeps the seal-surface narrow-count assertions below isolated.
+    const decision = await makeSignedAdminDecision(req.request_id, "admit", globalAdmin, {
+      peerPubkey: req.peer_pubkey,
+      networkId: "metafactory",
+    });
+    expect((await post(`/admission-requests/${req.request_id}/admit`, decision)).status).toBe(200);
+    return req;
+  }
+
+  test("a seal claim binding the row's peer_pubkey → written (200)", async () => {
+    const req = await admittedRow("alice");
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, hubAdmin, { peerPubkey: req.peer_pubkey }),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as AdmissionRequest).sealed_secret).toBe(SEALED);
+  });
+
+  test("a seal claim binding the WRONG peer_pubkey → 409 identity_mismatch", async () => {
+    const req = await admittedRow("alice");
+    const other = await makePrincipalKey();
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, hubAdmin, { peerPubkey: other.publicKeyB64 }),
+    );
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("identity_mismatch");
+  });
+
+  test("a NARROW seal claim (no binding) still writes, counted + warns", async () => {
+    const req = await admittedRow("alice");
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, hubAdmin),
+    );
+    expect(res.status).toBe(200);
+    expect(narrowAdmissionClaimCount()).toBe(1);
+    expect(warnings.some((w) => w.includes("sealed-secret") && w.includes("narrow"))).toBe(true);
+  });
+});

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -12,6 +12,7 @@ import type { AdmissionDecisionClaim, AdmissionReadClaim, Capability, Registrati
 import { _setNonceCacheForTest, _setStoreForTest, _setIssuanceStoreForTest } from "../src/store";
 import { _resetDerivedPublicKeyForTest } from "../src/index";
 import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+import { _resetAdmissionWindowForTest } from "../src/admission-window";
 
 export interface PrincipalKey {
   privateKeyB64: string;
@@ -50,6 +51,7 @@ export function resetStores(): void {
   _setIssuanceStoreForTest(undefined);
   _resetDerivedPublicKeyForTest();
   _resetRateLimitBucketsForTest();
+  _resetAdmissionWindowForTest();
 }
 
 /**
@@ -126,12 +128,20 @@ export async function makeSignedAdminDecision(
     /** Sign with a DIFFERENT key than the claim declares — forged signature tests. */
     signWith?: PrincipalKey;
     adminPubkeyOverride?: string;
+    /** cortex#2188 (M9) — bind peer_pubkey into the signed claim (wide claim). */
+    peerPubkey?: string;
+    /** cortex#2188 (M9/M12) — bind network_id into the signed claim (wide claim). */
+    networkId?: string;
   } = {},
 ): Promise<{ claim: AdmissionDecisionClaim; signature: string }> {
   const claim: AdmissionDecisionClaim = {
     request_id: requestId,
     decision,
     admin_pubkey: opts.adminPubkeyOverride ?? adminKey.publicKeyB64,
+    // Bind identity fields ONLY when supplied — narrow claim otherwise, so the
+    // canonical bytes stay stable for the legacy two-field decision claim.
+    ...(opts.peerPubkey !== undefined && { peer_pubkey: opts.peerPubkey }),
+    ...(opts.networkId !== undefined && { network_id: opts.networkId }),
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
   };

--- a/src/services/network-registry/src/admission-window.ts
+++ b/src/services/network-registry/src/admission-window.ts
@@ -1,0 +1,52 @@
+/**
+ * cortex#2188 / RFC-0006 §7.3 §12 (M13) — the dual-accept window bookkeeping for
+ * admission identity-binding.
+ *
+ * During the M13 window BOTH claim shapes are accepted: a WIDE claim (carrying
+ * the `peer_pubkey` / `network_id` identity binding) and a legacy NARROW claim
+ * (carrying neither). A narrow claim is still honoured — but it is COUNTED and a
+ * deprecation warning is logged, so the eventual require-present flip (make the
+ * binding mandatory) can be gated on a ZERO-narrow signal.
+ *
+ * IMPORTANT: the require-present flip is FUTURE and is NOT performed here. This
+ * module only observes. The counter is best-effort in-process observability (it
+ * resets with the worker isolate); the authoritative signal for the flip
+ * decision is the aggregated deprecation-warning log line, which carries the
+ * surface + request id.
+ */
+
+/** The identity-binding surfaces that run the dual-accept window. */
+export type AdmissionWindowSurface = "decision" | "sealed-secret";
+
+let narrowClaimCount = 0;
+
+/**
+ * Record that a NARROW (unbound) claim was accepted on the given surface:
+ * increment the window counter and log the deprecation warning. Call ONLY on
+ * the authentic + authorised path, after the claim is otherwise honoured.
+ */
+export function recordNarrowAdmissionClaim(
+  surface: AdmissionWindowSurface,
+  requestId: string,
+): void {
+  narrowClaimCount += 1;
+  // console.warn is the Cloudflare Workers-native log sink (no process.stderr in
+  // workerd). One line per narrow claim so the aggregate is countable for the
+  // require-present flip gate.
+  console.warn(
+    `admission-window: DEPRECATED narrow (unbound) ${surface} claim accepted for ` +
+      `request ${requestId} — RFC-0006 §7.3 identity binding (peer_pubkey/network_id) ` +
+      `absent. The require-present flip is gated on zero narrow claims (M13). ` +
+      `narrow_claim_count=${narrowClaimCount}`,
+  );
+}
+
+/** Current in-process count of accepted narrow claims (both surfaces). */
+export function narrowAdmissionClaimCount(): number {
+  return narrowClaimCount;
+}
+
+/** Test-only: reset the window counter between cases. */
+export function _resetAdmissionWindowForTest(): void {
+  narrowClaimCount = 0;
+}

--- a/src/services/network-registry/src/admission-window.ts
+++ b/src/services/network-registry/src/admission-window.ts
@@ -21,9 +21,16 @@ export type AdmissionWindowSurface = "decision" | "sealed-secret";
 let narrowClaimCount = 0;
 
 /**
- * Record that a NARROW (unbound) claim was accepted on the given surface:
- * increment the window counter and log the deprecation warning. Call ONLY on
- * the authentic + authorised path, after the claim is otherwise honoured.
+ * Record that a NARROW (unbound) claim was HONOURED on the given surface:
+ * increment the window counter and log the deprecation warning.
+ *
+ * CONTRACT — call ONLY after the write it counts is CONFIRMED to have taken
+ * effect: past the allowlist gate AND the nonce record AND a successful state
+ * transition / secret write (decision: `updated` truthy; sealed-secret:
+ * `setSealedSecret` truthy). Counting any earlier lets an unauthorised,
+ * replayed, or nonexistent-row claim increment then bounce (403/409/404),
+ * permanently poisoning the §7.3 zero-narrow require-present flip gate (the
+ * PR #2194 adversarial blocker). Every call site must be on the 200 path.
  */
 export function recordNarrowAdmissionClaim(
   surface: AdmissionWindowSurface,

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -74,6 +74,7 @@ import {
   retryAfterSeconds,
   TOO_MANY_REQUESTS_BODY,
 } from "../rate-limit";
+import { recordNarrowAdmissionClaim } from "../admission-window";
 import type { AdmissionMineRow, AdmissionStatus } from "../types";
 
 /** Maximum clock skew for admin decision claims — mirrors the network-create route. */
@@ -195,19 +196,64 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "signature_invalid" }, 401);
     }
 
-    // 4b. Authorisation (#1321 per-network admin). The proven key must be
+    const issuanceStore = getIssuanceStore(c.env);
+    const reqForAuth = await issuanceStore.getIssuanceRequest(requestId);
+
+    // 4a. M9 (cortex#2188, RFC-0006 §7.3) — IDENTITY BINDING. When the admin
+    // binds `peer_pubkey` / `network_id` into the signed claim, each MUST equal
+    // the stored row → else `409 identity_mismatch`. This is the §7.3
+    // cross-network confused-deputy fix: an admin legitimately authorised on
+    // network B, whose signed decision is redirected onto a network-A row, is
+    // refused HERE — BEFORE the authority check — because the binding is the row
+    // the admin *intended*, and it must match regardless of where they hold
+    // authority. Only enforced when the row exists (a missing row 404s at the
+    // transition). Narrow claims (no binding) skip this during the M13 window.
+    if (reqForAuth) {
+      if (
+        claim.peer_pubkey !== undefined &&
+        claim.peer_pubkey !== reqForAuth.peer_pubkey
+      ) {
+        return c.json(
+          { error: "identity_mismatch", details: { field: "peer_pubkey" } },
+          409,
+        );
+      }
+      if (
+        claim.network_id !== undefined &&
+        claim.network_id !== (reqForAuth.network_id ?? undefined)
+      ) {
+        return c.json(
+          { error: "identity_mismatch", details: { field: "network_id" } },
+          409,
+        );
+      }
+    }
+
+    // 4b. M13 (cortex#2188) — dual-accept window bookkeeping. A NARROW claim (no
+    // bound network_id) is still authorised + admitted below, but it is counted
+    // and a deprecation warning logged. Do NOT flip to require-present here — the
+    // flip is FUTURE, gated on a zero-narrow signal.
+    if (claim.network_id === undefined) {
+      recordNarrowAdmissionClaim("decision", requestId);
+    }
+
+    // 4c. Authorisation (#1321 per-network admin). The proven key must be
     // authorised to admit onto THIS request's network — either a GLOBAL admin
     // (REGISTRY_ADMIN_PUBKEYS, the metafactory bootstrap) OR a PER-NETWORK admin
     // listed in the target network's `admin_pubkeys` (the **Network posture**
     // authority — each network sovereign over its own roster, CONTEXT.md). A
-    // network-less request (network_id null) is global-admin-only. Authorization
-    // is keyed off the request's stored network_id, NEVER off anything on the
-    // wire — control-plane only.
-    const issuanceStore = getIssuanceStore(c.env);
-    const reqForAuth = await issuanceStore.getIssuanceRequest(requestId);
+    // network-less request (network_id null) is global-admin-only.
+    //
+    // M12 (cortex#2188, RFC-0006 §7) — key the per-network check off the BOUND
+    // claim `network_id` when present (M9 just proved it equals the row), falling
+    // back to the STORED row network_id only for a narrow claim during the
+    // window. Still control-plane only: nothing here rides the wire GRAMMAR (no
+    // subject/source/originator), and a wide claim's network_id was already
+    // matched to the row above, so this cannot widen authority.
+    const authNetworkId = claim.network_id ?? reqForAuth?.network_id ?? null;
     let authorized = adminPubkeys.has(claim.admin_pubkey);
-    if (!authorized && reqForAuth?.network_id) {
-      const net = await getStore(c.env).getNetwork(reqForAuth.network_id);
+    if (!authorized && authNetworkId) {
+      const net = await getStore(c.env).getNetwork(authNetworkId);
       authorized = parseNetworkAdminPubkeys(net?.admin_pubkeys).has(claim.admin_pubkey);
     }
     if (!authorized) {
@@ -493,6 +539,28 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     if (!gate.ok) return gate.response;
 
     const store = getIssuanceStore(c.env);
+
+    // M17 (cortex#2188, RFC-0006 §8.3) — IDENTITY BINDING on the seal write.
+    // When the hub-admin binds `peer_pubkey` into the signed claim it MUST equal
+    // the row's stored peer_pubkey → else `409 identity_mismatch`, so a sealed
+    // blob can never be delivered onto the wrong member's row. Enforced only when
+    // the row exists (a missing row 404s below). Narrow claims (no binding) are
+    // still written during the M13 window, but counted + warned.
+    const sealRow = await store.getIssuanceRequest(requestId);
+    if (
+      sealRow &&
+      gate.claim.peer_pubkey !== undefined &&
+      gate.claim.peer_pubkey !== sealRow.peer_pubkey
+    ) {
+      return c.json(
+        { error: "identity_mismatch", details: { field: "peer_pubkey" } },
+        409,
+      );
+    }
+    if (gate.claim.peer_pubkey === undefined) {
+      recordNarrowAdmissionClaim("sealed-secret", requestId);
+    }
+
     const updated = await store.setSealedSecret(requestId, gate.claim.sealed_secret);
     if (!updated) {
       // Row missing OR not ADMITTED — distinguish for the caller.

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -229,15 +229,7 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
       }
     }
 
-    // 4b. M13 (cortex#2188) — dual-accept window bookkeeping. A NARROW claim (no
-    // bound network_id) is still authorised + admitted below, but it is counted
-    // and a deprecation warning logged. Do NOT flip to require-present here — the
-    // flip is FUTURE, gated on a zero-narrow signal.
-    if (claim.network_id === undefined) {
-      recordNarrowAdmissionClaim("decision", requestId);
-    }
-
-    // 4c. Authorisation (#1321 per-network admin). The proven key must be
+    // 4b. Authorisation (#1321 per-network admin). The proven key must be
     // authorised to admit onto THIS request's network — either a GLOBAL admin
     // (REGISTRY_ADMIN_PUBKEYS, the metafactory bootstrap) OR a PER-NETWORK admin
     // listed in the target network's `admin_pubkeys` (the **Network posture**
@@ -292,6 +284,17 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
 
     if (!updated) {
       return c.json({ error: "not_found" }, 404);
+    }
+
+    // M13 (cortex#2188) — dual-accept window bookkeeping, recorded ONLY here:
+    // AFTER auth + nonce + a CONFIRMED transition. Counting any earlier (as the
+    // first cut did) let an unauthorised / replayed / nonexistent-row narrow
+    // claim increment the counter then bounce (403/409/404) — permanently
+    // poisoning the §7.3 zero-narrow require-present flip gate (PR #2194
+    // adversarial BLOCKER). A NARROW claim (no bound network_id) is honoured
+    // during the window but counted + deprecation-warned; the flip stays FUTURE.
+    if (claim.network_id === undefined) {
+      recordNarrowAdmissionClaim("decision", requestId);
     }
 
     return c.json(updated, 200);
@@ -419,6 +422,12 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     requestId: string,
     validateEnvelope: (body: unknown) => { ok: true; signed: { claim: unknown; signature: string } } | { ok: false; errors: unknown },
     validateClaim: (claim: unknown, expectedRequestId: string) => { ok: true; claim: C } | { ok: false; errors: unknown },
+    // Optional identity-binding check (cortex#2188, RFC-0006 §8.3 M17). Runs
+    // AFTER the signature+allowlist gate but BEFORE the nonce is recorded —
+    // identity-before-nonce, mirroring handleDecision's order (§12 hygiene): a
+    // mismatched claim must be rejected without consuming a nonce. Returns a
+    // Response to short-circuit (e.g. 409 identity_mismatch), or null to proceed.
+    identityCheck?: (claim: C) => Promise<Response | null>,
   ): Promise<{ ok: true; claim: C } | { ok: false; response: Response }> {
     // M2 — validate request_id path param BEFORE body parse or crypto.
     if (!isValidRequestId(requestId)) {
@@ -507,6 +516,14 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
       return { ok: false, response: c.json({ error: gateResult.error }, gateResult.status as 401 | 403) };
     }
 
+    // 4b. Identity binding (cortex#2188 M17) — BEFORE the nonce record, so a
+    // mismatched claim is refused without burning a nonce (identity-before-nonce,
+    // mirrors handleDecision's 4a → 5 order).
+    if (identityCheck) {
+      const mismatch = await identityCheck(claim);
+      if (mismatch) return { ok: false, response: mismatch };
+    }
+
     // 5. Replay check — only on the authentic + authorised path.
     const nonceCache = getNonceCache(c.env);
     const fresh = await nonceCache.recordIfFresh(claim.nonce, now);
@@ -530,36 +547,30 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
 
   app.post("/admission-requests/:request_id/sealed-secret", async (c) => {
     const requestId = c.req.param("request_id") ?? "";
+    const store = getIssuanceStore(c.env);
     const gate = await verifyHubAdminWrite(
       c,
       requestId,
       validateSignedSealedSecretWrite,
       validateSealedSecretClaim,
+      // M17 (cortex#2188, RFC-0006 §8.3) — IDENTITY BINDING, run BEFORE the nonce
+      // record. When the hub-admin binds `peer_pubkey` it MUST equal the row's
+      // stored peer_pubkey → else 409 identity_mismatch, so a sealed blob can
+      // never land on the wrong member's row. Enforced only when the row exists
+      // (a missing row 404s at the write below).
+      async (claim) => {
+        if (claim.peer_pubkey === undefined) return null;
+        const row = await store.getIssuanceRequest(requestId);
+        if (row && claim.peer_pubkey !== row.peer_pubkey) {
+          return c.json(
+            { error: "identity_mismatch", details: { field: "peer_pubkey" } },
+            409,
+          );
+        }
+        return null;
+      },
     );
     if (!gate.ok) return gate.response;
-
-    const store = getIssuanceStore(c.env);
-
-    // M17 (cortex#2188, RFC-0006 §8.3) — IDENTITY BINDING on the seal write.
-    // When the hub-admin binds `peer_pubkey` into the signed claim it MUST equal
-    // the row's stored peer_pubkey → else `409 identity_mismatch`, so a sealed
-    // blob can never be delivered onto the wrong member's row. Enforced only when
-    // the row exists (a missing row 404s below). Narrow claims (no binding) are
-    // still written during the M13 window, but counted + warned.
-    const sealRow = await store.getIssuanceRequest(requestId);
-    if (
-      sealRow &&
-      gate.claim.peer_pubkey !== undefined &&
-      gate.claim.peer_pubkey !== sealRow.peer_pubkey
-    ) {
-      return c.json(
-        { error: "identity_mismatch", details: { field: "peer_pubkey" } },
-        409,
-      );
-    }
-    if (gate.claim.peer_pubkey === undefined) {
-      recordNarrowAdmissionClaim("sealed-secret", requestId);
-    }
 
     const updated = await store.setSealedSecret(requestId, gate.claim.sealed_secret);
     if (!updated) {
@@ -570,6 +581,15 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
         { error: "not_admitted", details: `request ${requestId} is ${existing.status}, not ADMITTED — cannot deliver a sealed secret` },
         409,
       );
+    }
+
+    // M13 (cortex#2188) — count the narrow (unbound) seal claim ONLY after the
+    // write is CONFIRMED (updated truthy), for the same anti-poisoning reason as
+    // the decision route: an unauthorised / replayed / not-admitted narrow claim
+    // must never increment the zero-narrow flip gate (PR #2194 adversarial
+    // BLOCKER). Still honoured during the window; deprecation-warned.
+    if (gate.claim.peer_pubkey === undefined) {
+      recordNarrowAdmissionClaim("sealed-secret", requestId);
     }
     return c.json(updated, 200);
   });

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -448,6 +448,24 @@ export interface AdmissionDecisionClaim {
   decision: "admit" | "reject";
   /** Base64 Ed25519 pubkey of the admin signing this claim. */
   admin_pubkey: string;
+  /**
+   * cortex#2188 / RFC-0006 §7.3 (M9) — OPTIONAL identity binding. The admin
+   * binds the peer they intend to decide on into the SIGNED claim; the route
+   * compares it to the row's stored `peer_pubkey` and refuses `409
+   * identity_mismatch` on disagreement. Absent on a NARROW claim (still admitted
+   * during the M13 dual-accept window). Preserved verbatim into the reconstructed
+   * claim (signed-bytes discipline).
+   */
+  peer_pubkey?: string;
+  /**
+   * cortex#2188 / RFC-0006 §7.3 (M9/M12) — OPTIONAL identity binding. The
+   * network the admin intends to decide onto, bound into the SIGNED claim.
+   * Compared to the row's `network_id` (→ `409 identity_mismatch` on mismatch,
+   * closing the §7.3 cross-network confused-deputy: an admin authorised on
+   * network B cannot be steered into deciding a network-A row) AND consumed as
+   * the per-network authority key when present (M12). Absent on a narrow claim.
+   */
+  network_id?: string;
   /** ISO-8601 UTC timestamp at which the admin signed this claim. */
   issued_at: string;
   /** Random nonce to prevent replay (same replay cache as network-create). */
@@ -605,6 +623,15 @@ export interface SealedSecretWriteClaim {
    * the member whose pubkey it was sealed to.
    */
   sealed_secret: string;
+  /**
+   * cortex#2188 / RFC-0006 §8.3 (M17) — OPTIONAL identity binding. The
+   * hub-admin binds the peer the blob is sealed TO into the signed claim; the
+   * route compares it to the row's `peer_pubkey` and refuses `409
+   * identity_mismatch` on disagreement — so a sealed secret can never be
+   * delivered onto the wrong member's row. Absent on a narrow claim (still
+   * written during the M13 dual-accept window). Preserved verbatim.
+   */
+  peer_pubkey?: string;
   /** Base64 Ed25519 pubkey of the hub-admin signing this claim. */
   hub_admin_pubkey: string;
   /** ISO-8601 UTC timestamp at which the hub-admin signed this claim. */

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -691,6 +691,25 @@ export function validateAdmissionDecisionClaim(
     errors.push({ field: "admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
   }
 
+  // cortex#2188 / RFC-0006 §7.3 (M9/M13) — OPTIONAL identity-binding fields.
+  // Absent = NARROW claim (still valid — dual-accept window OPEN). Present =
+  // WIDE claim, shape-checked here and compared to the row by the route (409
+  // identity_mismatch). SIGNED-bytes discipline (like expected_updated_at): a
+  // present field MUST be preserved verbatim into the reconstructed claim or a
+  // wide claim's canonical bytes change and every one 401s.
+  if (
+    c.peer_pubkey !== undefined &&
+    (typeof c.peer_pubkey !== "string" || !isValidPubkey(c.peer_pubkey))
+  ) {
+    errors.push({ field: "peer_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars) when present" });
+  }
+  if (
+    c.network_id !== undefined &&
+    (typeof c.network_id !== "string" || !isValidNetworkId(c.network_id))
+  ) {
+    errors.push({ field: "network_id", message: "must be a valid network id when present" });
+  }
+
   if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
     errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
   }
@@ -707,6 +726,8 @@ export function validateAdmissionDecisionClaim(
       request_id: c.request_id as string,
       decision: c.decision as "admit" | "reject",
       admin_pubkey: c.admin_pubkey as string,
+      ...(typeof c.peer_pubkey === "string" && { peer_pubkey: c.peer_pubkey }),
+      ...(typeof c.network_id === "string" && { network_id: c.network_id }),
       issued_at: c.issued_at as string,
       nonce: c.nonce as string,
     },
@@ -951,6 +972,16 @@ export function validateSealedSecretClaim(
     errors.push({ field: "hub_admin_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
   }
 
+  // cortex#2188 / RFC-0006 §8.3 (M17) — OPTIONAL peer_pubkey binding. Same
+  // narrow/wide + signed-bytes discipline as the decision claim: present =
+  // compared to the row (409 identity_mismatch), preserved verbatim.
+  if (
+    c.peer_pubkey !== undefined &&
+    (typeof c.peer_pubkey !== "string" || !isValidPubkey(c.peer_pubkey))
+  ) {
+    errors.push({ field: "peer_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars) when present" });
+  }
+
   if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
     errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
   }
@@ -966,6 +997,7 @@ export function validateSealedSecretClaim(
     claim: {
       request_id: c.request_id as string,
       sealed_secret: c.sealed_secret as string,
+      ...(typeof c.peer_pubkey === "string" && { peer_pubkey: c.peer_pubkey }),
       hub_admin_pubkey: c.hub_admin_pubkey as string,
       issued_at: c.issued_at as string,
       nonce: c.nonce as string,


### PR DESCRIPTION
RFC-0006 §7.3/§8.3 · TRUST-PATH. Closes cross-network confused-deputy. M9 peer_pubkey+network_id bind→409 identity_mismatch; M12 authority off bound network_id; M17 seal bind; M13 narrow dual-accept (counted+warned, no flip). Confused-deputy test fail-before/pass-after. Registry suites+tsc+lint green. Needs adversarial review lane.