### PR TITLE
fix(transport): Nats-Msg-Id dedup header on JetStream publish (part of #2016)

### DIFF
--- a/src/bus/myelin/__tests__/runtime-linkpool.test.ts
+++ b/src/bus/myelin/__tests__/runtime-linkpool.test.ts
@@ -40,6 +40,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type {
   ConnectionOptions,
+  MsgHdrs,
   NatsConnection,
   Status,
   Subscription,
@@ -62,7 +63,13 @@ function makeConfig(natsBlock: AgentConfig["nats"]): AgentConfig {
 function makeFakeConn() {
   const statusListeners = new Set<(s: Status | null) => void>();
   const subscribePatterns: string[] = [];
-  const publishes: { subject: string; payload: string | Uint8Array }[] = [];
+  const publishes: {
+    subject: string;
+    payload: string | Uint8Array;
+    // RFC-0007 §6.3 (cortex#2016): the `Nats-Msg-Id` header the runtime
+    // stamps for JetStream dedup, or undefined when no header rode the publish.
+    msgId: string | undefined;
+  }[] = [];
 
   const status = () =>
     (async function* () {
@@ -118,9 +125,18 @@ function makeFakeConn() {
     for (const l of statusListeners) l(null);
   });
 
-  const publish = mock((subject: string, payload: string | Uint8Array) => {
-    publishes.push({ subject, payload });
-  });
+  const publish = mock(
+    (
+      subject: string,
+      payload: string | Uint8Array,
+      options?: { headers?: MsgHdrs },
+    ) => {
+      // `MsgHdrs.get` returns "" for an absent key; normalize to undefined so
+      // the "no header" case is distinguishable from an empty-string id.
+      const msgId = options?.headers?.get("Nats-Msg-Id") || undefined;
+      publishes.push({ subject, payload, msgId });
+    },
+  );
 
   const nc = { status, subscribe, drain, publish } as unknown as NatsConnection;
   return { nc, subscribe, subscribePatterns, publishes, publish, drain };
@@ -287,6 +303,33 @@ describe("MyelinRuntime LinkPool (F-3b, cortex#659; ADR 0001)", () => {
     ]);
     // No routing error was logged in the back-compat case.
     expect(logs.some((l) => l.msg.includes("unknown_network_in_publish_subject"))).toBe(false);
+
+    await runtime.stop();
+  });
+
+  // (g) RFC-0007 §6.3 / grill D12 (cortex#2016) — every runtime publish stamps
+  //     the envelope id as the `Nats-Msg-Id` header so JetStream deduplicates a
+  //     duplicated/retried publish within the stream's `duplicate_window`. The
+  //     header rides the SAME single publish funnel every emit uses, so proving
+  //     it on the primary link proves it for every stream-backed subject.
+  test("(g) runtime.publish stamps Nats-Msg-Id = envelope.id on the wire (JetStream dedup, cortex#2016)", async () => {
+    const reg = makeFakeRegistry();
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: ["local.{principal}.>"] }),
+      { connectImpl: reg.connectImpl, stack: "default" },
+    );
+    const primary = reg.forUrl(PRIMARY_URL)!;
+
+    const id = "abcabcab-1111-4111-8111-abcabcabcabc";
+    await runtime.publish(makeEnvelope({ id, type: "system.adapter.degraded" }));
+
+    expect(primary.publishes).toHaveLength(1);
+    // The dedup key is the envelope id verbatim.
+    expect(primary.publishes[0]?.msgId).toBe(id);
+    // Sanity: the id header rode the publish that carried the envelope subject.
+    expect(primary.publishes[0]?.subject).toBe(
+      "local.metafactory.default.system.adapter.degraded",
+    );
 
     await runtime.stop();
   });

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -1767,7 +1767,12 @@ export async function startMyelinRuntime(
     //
     // F-3c (cortex#662): publish on the captured non-null `targetLink`
     // (narrowed above) — a down leaf never reaches here.
-    targetLink.publish(subject, JSON.stringify(envelopeToPublish));
+    // RFC-0007 §6.3 (grill D12): carry the envelope id as `Nats-Msg-Id` so
+    // JetStream deduplicates a duplicated/retried publish of the same
+    // envelope within the stream's `duplicate_window`. `envelope.id` is the
+    // canonical, signature-stable id (sealing/signing above never rewrite
+    // it), so it is the dedup key the spec names.
+    targetLink.publish(subject, JSON.stringify(envelopeToPublish), envelope.id);
   };
 
   const publishEnabled = async (envelope: Envelope): Promise<void> => {

--- a/src/bus/nats/__tests__/connection.test.ts
+++ b/src/bus/nats/__tests__/connection.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
-import type { ConnectionOptions, NatsConnection } from "nats";
+import type { ConnectionOptions, MsgHdrs, NatsConnection } from "nats";
 import { Events } from "nats";
 import { NatsLink } from "../connection";
 
@@ -35,7 +35,13 @@ SUFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAK
 
 function makeFakeConnection() {
   const statusEvents: { type: string; data: unknown }[] = [];
-  const publishes: { subject: string; payload: string | Uint8Array }[] = [];
+  const publishes: {
+    subject: string;
+    payload: string | Uint8Array;
+    // cortex#2016: the `Nats-Msg-Id` header the caller attached (JetStream
+    // dedup key), or undefined when the publish carried no header.
+    msgId: string | undefined;
+  }[] = [];
   // Promise the test awaits to know an event has been observed by the status
   // loop. Avoids real-time setTimeout sleeps in tests.
   let observed: Promise<void> = Promise.resolve();
@@ -57,9 +63,17 @@ function makeFakeConnection() {
     if (closeStatus) closeStatus();
   });
 
-  const publish = mock((subject: string, payload: string | Uint8Array) => {
-    publishes.push({ subject, payload });
-  });
+  const publish = mock(
+    (
+      subject: string,
+      payload: string | Uint8Array,
+      options?: { headers?: MsgHdrs },
+    ) => {
+      // `MsgHdrs.get` returns "" for an absent key; normalize to undefined.
+      const msgId = options?.headers?.get("Nats-Msg-Id") || undefined;
+      publishes.push({ subject, payload, msgId });
+    },
+  );
 
   const fakeNc = {
     status: () => statusIterator,
@@ -252,6 +266,7 @@ describe("NatsLink", () => {
     expect(fake.publishes[0]).toEqual({
       subject: "local.metafactory.system.adapter.degraded",
       payload: '{"id":"abc"}',
+      msgId: undefined,
     });
     await link.close();
   });
@@ -266,6 +281,34 @@ describe("NatsLink", () => {
     link.publish("local.metafactory.test", bytes);
     expect(fake.publishes[0]?.subject).toBe("local.metafactory.test");
     expect(fake.publishes[0]?.payload).toBe(bytes);
+    await link.close();
+  });
+
+  test("publish() with a msgId attaches it as the Nats-Msg-Id header (RFC-0007 §6.3, cortex#2016)", async () => {
+    const fake = makeFakeConnection();
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      connectImpl: async () => fake.nc,
+    });
+    const id = "11111111-1111-4111-8111-111111111111";
+    link.publish("local.metafactory.default.tasks.code-review.typescript", "{}", id);
+    // JetStream deduplicates stored messages by this header within the
+    // stream's duplicate_window — the id is the dedup key.
+    expect(fake.publishes[0]?.msgId).toBe(id);
+    await link.close();
+  });
+
+  test("publish() without a msgId sends NO header (byte-identical to pre-#2016)", async () => {
+    const fake = makeFakeConnection();
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      connectImpl: async () => fake.nc,
+    });
+    link.publish("local.metafactory.system.adapter.degraded", "{}");
+    // An empty string is treated as "no id" too — no header rides the publish.
+    link.publish("local.metafactory.system.adapter.degraded", "{}", "");
+    expect(fake.publishes[0]?.msgId).toBeUndefined();
+    expect(fake.publishes[1]?.msgId).toBeUndefined();
     await link.close();
   });
 

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -18,6 +18,7 @@ import {
   connect as natsConnect,
   credsAuthenticator,
   Events,
+  headers as natsHeaders,
   type ConnectionOptions,
   type NatsConnection,
   type TlsOptions,
@@ -169,14 +170,32 @@ export class NatsLink {
    * opportunistically — there is no per-publish ack on Core NATS. JetStream
    * publishes are a separate API (`jsm.publish`) and are not used here.
    *
+   * `msgId` (RFC-0007 §6.3, grill D12) — when set, attaches a `Nats-Msg-Id`
+   * header carrying the envelope id. cortex publishes on Core NATS to
+   * subjects that JetStream streams capture; a stream deduplicates stored
+   * messages by `Nats-Msg-Id` within its `duplicate_window` regardless of
+   * which publish API produced them, so setting the header here is what
+   * turns JetStream dedup on for every stream-backed subject. The id is the
+   * envelope id — globally unique per envelope — so the header only ever
+   * collapses a genuine duplicate publish of the SAME envelope (e.g. a
+   * publish retry) and never conflates two distinct envelopes. Omitted (or
+   * empty) ⇒ no header ⇒ byte-identical to the pre-#2016 publish, so
+   * non-envelope / non-stream publishes are unaffected.
+   *
    * Errors at publish time are exceedingly rare on Core NATS — typically
    * either "connection closed" (we're shutting down) or "subject too long".
    * The caller decides what to do with them; we don't catch here so the
    * `MyelinRuntime.publish` wrapper can apply its swallow-and-log policy
    * uniformly.
    */
-  publish(subject: string, payload: string | Uint8Array): void {
-    this.raw.publish(subject, payload);
+  publish(subject: string, payload: string | Uint8Array, msgId?: string): void {
+    if (msgId === undefined || msgId === "") {
+      this.raw.publish(subject, payload);
+      return;
+    }
+    const hdrs = natsHeaders();
+    hdrs.set("Nats-Msg-Id", msgId);
+    this.raw.publish(subject, payload, { headers: hdrs });
   }
 
   /**


### PR DESCRIPTION
Part of #2016 (item 3, RFC-0007 §6.3/D12). NatsLink.publish attaches Nats-Msg-Id=envelope.id via the runtime's single publish funnel; omitted⇒no header⇒byte-identical. Tests: connection + runtime level. Item 4 (TASKS_DEAD) is myelin-side, not cortex — see PR thread.