### PR TITLE
fix(lint): nullish coalescing in #2197 test helpers (unbreaks main)

### DIFF
--- a/src/bus/myelin/__tests__/runtime-linkpool.test.ts
+++ b/src/bus/myelin/__tests__/runtime-linkpool.test.ts
@@ -133,7 +133,7 @@ function makeFakeConn() {
     ) => {
       // `MsgHdrs.get` returns "" for an absent key; normalize to undefined so
       // the "no header" case is distinguishable from an empty-string id.
-      const msgId = options?.headers?.get("Nats-Msg-Id") || undefined;
+      const msgId = options?.headers?.get("Nats-Msg-Id") ?? undefined;
       publishes.push({ subject, payload, msgId });
     },
   );

--- a/src/bus/nats/__tests__/connection.test.ts
+++ b/src/bus/nats/__tests__/connection.test.ts
@@ -70,7 +70,7 @@ function makeFakeConnection() {
       options?: { headers?: MsgHdrs },
     ) => {
       // `MsgHdrs.get` returns "" for an absent key; normalize to undefined.
-      const msgId = options?.headers?.get("Nats-Msg-Id") || undefined;
+      const msgId = options?.headers?.get("Nats-Msg-Id") ?? undefined;
       publishes.push({ subject, payload, msgId });
     },
   );


### PR DESCRIPTION
Two ||→?? in test files merged red via #2197 (planner gate error, logged). Lint green locally.