### PR TITLE
feat(runner): model-placement execute gate — enforce frontier_ok/model_class (Closes #2195)

### DIFF
--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1510,6 +1510,12 @@ export type SystemDispatchStage =
   // when `policy.admission` is configured — absent config skips the stage
   // entirely (CO-4 inertness).
   | "admission-checked"
+  // cortex#2195 (RFC-0005 §2.5) — the model-placement gate between harness
+  // selection and the spawn. `pass` = placement conforms; `fail` = a
+  // frontier-placement harness was refused a local-only-required envelope
+  // (`policy_denied` terminal emitted, no spawn). Only emitted when
+  // `execution.model_placement` is configured — absent config skips the stage.
+  | "placement-checked"
   | "session-spawning"
   | "started";
 

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -728,6 +728,20 @@ export const AgentConfigSchema = z.object({
       type: z.enum(["cloudflare", "e2b", "ssh", "custom"]),
       endpoint: z.string(),
     })).default([]),
+    /**
+     * cortex#2195 (RFC-0005 §2.5) — the model-placement EXECUTE gate map.
+     * MIRROR of `CortexConfigSchema.execution.model_placement` (cortex-config.ts).
+     * When present, the dispatch listener refuses (`policy_denied`/term) any
+     * dispatch whose selected harness is `frontier`-placement but whose envelope
+     * demands local execution. Config-declared; no hardcoded model list — a
+     * harness id absent from `harnesses` falls to `default` (fail-closed
+     * `frontier`). OMITTED ⇒ the gate is inert. See
+     * `src/runner/model-placement-gate.ts`.
+     */
+    model_placement: z.object({
+      harnesses: z.record(z.string(), z.enum(["frontier", "local"])).default({}),
+      default: z.enum(["frontier", "local"]).default("frontier"),
+    }).optional(),
   }).default(emptyDefault()),
 
   /**

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1648,9 +1648,25 @@ export const ExecutionConfigSchema = z.object({
     type: z.enum(["cloudflare", "e2b", "ssh", "custom"]),
     endpoint: z.string(),
   })).default([]),
+  /**
+   * cortex#2195 (RFC-0005 §2.5) — the model-placement EXECUTE gate map. When
+   * present, the dispatch listener refuses (`policy_denied`/term) any dispatch
+   * whose selected harness is `frontier`-placement but whose envelope demands
+   * local execution (`frontier_ok`/`model_class`). Config-declared; there is NO
+   * hardcoded model list — a harness id absent from `harnesses` falls to
+   * `default` (fail-closed `frontier`). OMITTED ⇒ the gate is inert (dispatch is
+   * byte-identical). See `src/runner/model-placement-gate.ts`.
+   */
+  model_placement: z.object({
+    /** Selected `SessionHarness.id` → placement class. */
+    harnesses: z.record(z.string(), z.enum(["frontier", "local"])).default({}),
+    /** Placement for an id absent from `harnesses`. Fail-closed default. */
+    default: z.enum(["frontier", "local"]).default("frontier"),
+  }).optional(),
 });
 
 export type ExecutionConfig = z.infer<typeof ExecutionConfigSchema>;
+export type ModelPlacementSchemaConfig = NonNullable<ExecutionConfig["model_placement"]>;
 
 // =============================================================================
 // Inference — model-provider config (API-P0.2, epic #2055, Phase 0, D6)

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3806,6 +3806,14 @@ export async function startCortex(
     // optional fields: an unconfigured stack passes NO gate and the listener's
     // admission stage is skipped entirely (CO-4 inertness).
     ...(admissionGate !== undefined && { admissionGate }),
+    // cortex#2195 (RFC-0005 §2.5) — model-placement execute gate. Spread-guarded
+    // like admission: absent `execution.model_placement` ⇒ the placement stage
+    // is skipped (CO-4 inertness, byte-identical dispatch). When present, a
+    // frontier-placement harness running a local-only-required envelope is
+    // refused `policy_denied`/term before the spawn.
+    ...(config.execution.model_placement !== undefined && {
+      modelPlacement: config.execution.model_placement,
+    }),
   };
   if (chatAgents.length >= 2) {
     // Multi-agent: each chat-capable agent gets its OWN listener on its OWN

--- a/src/runner/__tests__/dispatch-listener-placement.test.ts
+++ b/src/runner/__tests__/dispatch-listener-placement.test.ts
@@ -1,0 +1,209 @@
+/**
+ * cortex#2195 — enforcement-point tests: the MODEL-PLACEMENT gate stage inside
+ * `handleDispatchEnvelope` (after harness selection, before the spawn —
+ * RFC-0005 §2.5 consumer half). Mirrors the fixtures of
+ * `dispatch-listener-admission.test.ts` (recording runtime, canonical
+ * Tasks-Domain subject, fake CC factory; no trustResolver).
+ *
+ * The default dispatch resolves to the `claude-code` harness (no
+ * agentRuntimesById), and `makeReceivedEnvelope` defaults to a LOCAL-ONLY
+ * sovereignty block — so a `{ "claude-code": "frontier" }` placement map refuses
+ * it; a frontier-cleared envelope, or a `local` placement, is admitted.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { SystemEventSource } from "../../bus/system-events";
+import {
+  createDispatchListener,
+  type CCSessionFactory,
+  type DispatchTaskReceivedPayload,
+} from "../dispatch-listener";
+import type { CCSessionResult } from "../cc-session";
+import { PolicyEngine } from "../../common/policy/engine";
+import type { ModelPlacementConfig } from "../model-placement-gate";
+
+const SOURCE: SystemEventSource = { principal: "metafactory", agent: "cortex", instance: "local" };
+const SUBJECT = "local.metafactory.tasks.@did-mf-cortex.chat";
+const TASK_ID = "11111111-1111-4111-8111-111111111111";
+
+const TERMINAL_TYPES = new Set([
+  "dispatch.task.completed",
+  "dispatch.task.failed",
+  "dispatch.task.aborted",
+  "system.access.denied",
+]);
+
+async function settle(published: () => readonly Envelope[]): Promise<void> {
+  const tick = () => new Promise<void>((r) => setTimeout(r, 2));
+  const observeUntil = Date.now() + 250;
+  while (Date.now() < observeUntil && !published().some((e) => TERMINAL_TYPES.has(e.type))) {
+    await tick();
+  }
+  const idleUntil = Date.now() + 25;
+  while (Date.now() < idleUntil) await tick();
+}
+
+function recordingRuntime(): {
+  runtime: MyelinRuntime;
+  published: Envelope[];
+  trigger: (env: Envelope, subject: string) => void;
+} {
+  const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+  const published: Envelope[] = [];
+  return {
+    runtime: {
+      enabled: true,
+      onEnvelope: (handler) => {
+        handlers.add(handler);
+        return { unregister: () => handlers.delete(handler) };
+      },
+      publish: async (env) => {
+        published.push(env);
+      },
+      subscribe: async (pattern) =>
+        ({ pattern, ready: Promise.resolve(), stop: async () => {} }) as unknown as Awaited<
+          ReturnType<NonNullable<MyelinRuntime["subscribe"]>>
+        >,
+      stop: async () => {},
+    },
+    published,
+    trigger: (env, subject) => {
+      for (const h of handlers) h(env, subject);
+    },
+  };
+}
+
+/** `local` demands local execution; `frontier` clears it. */
+function makeReceivedEnvelope(placement: "local" | "frontier"): Envelope {
+  const payload: DispatchTaskReceivedPayload = { task_id: TASK_ID, agent_id: "cortex", prompt: "hi" };
+  const sovereignty: Envelope["sovereignty"] =
+    placement === "local"
+      ? { classification: "local", data_residency: "NZ", max_hop: 0, frontier_ok: false, model_class: "local-only" }
+      : { classification: "public", data_residency: "NZ", max_hop: 3, frontier_ok: true, model_class: "any" };
+  return {
+    id: "00000000-0000-4000-8000-000000000000",
+    source: "metafactory.dispatch-handler.local",
+    type: "dispatch.task.received",
+    distribution_mode: "direct",
+    target_assistant: "did:mf:cortex",
+    timestamp: "2026-05-09T12:00:00Z",
+    correlation_id: TASK_ID,
+    sovereignty,
+    payload: payload as unknown as Record<string, unknown>,
+  };
+}
+
+function fakeFactory(): { factory: CCSessionFactory; spawnCount: () => number } {
+  let spawns = 0;
+  const result: CCSessionResult = { success: true, response: "Hi!", exitCode: 0, durationMs: 5, sessionId: "s" };
+  const factory: CCSessionFactory = () => {
+    spawns++;
+    const session = { start() { return session; }, async wait() { return result; } };
+    return session;
+  };
+  return { factory, spawnCount: () => spawns };
+}
+
+function engineGranting(capabilities: readonly string[]): PolicyEngine {
+  return new PolicyEngine({
+    principals: [{ id: "cortex", home_principal: "andreas", home_stack: "andreas/research", role: ["operator"], trust: [] }],
+    roles: [{ id: "operator", capabilities }],
+  });
+}
+
+const FRONTIER_MAP: ModelPlacementConfig = { harnesses: { "claude-code": "frontier" } };
+
+describe("dispatch-listener — model-placement gate (cortex#2195, RFC-0005 §2.5)", () => {
+  test("INERT without modelPlacement: a local-only envelope still spawns (byte-identical)", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory();
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      // no modelPlacement — the gate is skipped entirely.
+    });
+    await listener.start();
+    r.trigger(makeReceivedEnvelope("local"), SUBJECT);
+    await settle(() => r.published);
+    await listener.stop();
+
+    expect(spawnCount()).toBe(1);
+    expect(r.published.map((e) => e.type)).toContain("dispatch.task.completed");
+  });
+
+  test("REFUSED: only a frontier harness for a local-only envelope → policy_denied/term, NO spawn", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory();
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      modelPlacement: FRONTIER_MAP,
+    });
+    await listener.start();
+    r.trigger(makeReceivedEnvelope("local"), SUBJECT);
+    await settle(() => r.published);
+    await listener.stop();
+
+    // Never spawned.
+    expect(spawnCount()).toBe(0);
+
+    const failed = r.published.find((e) => e.type === "dispatch.task.failed");
+    expect(failed).toBeDefined();
+    expect(failed?.correlation_id).toBe(TASK_ID);
+    const p = failed?.payload as { reason?: { kind?: string; deny?: Record<string, unknown> } };
+    // The RFC-0010 PERMANENT shape — never the transient not_now.
+    expect(p.reason?.kind).toBe("policy_denied");
+    expect(p.reason?.deny?.harness).toBe("claude-code");
+    expect(p.reason?.deny?.placement).toBe("frontier");
+
+    // No started/completed for the refused task.
+    expect(r.published.some((e) => e.type === "dispatch.task.started")).toBe(false);
+    expect(r.published.some((e) => e.type === "dispatch.task.completed")).toBe(false);
+  });
+
+  test("ALLOWED: a frontier-cleared envelope on the frontier harness spawns normally", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory();
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      modelPlacement: FRONTIER_MAP,
+    });
+    await listener.start();
+    r.trigger(makeReceivedEnvelope("frontier"), SUBJECT);
+    await settle(() => r.published);
+    await listener.stop();
+
+    expect(spawnCount()).toBe(1);
+    const types = r.published.map((e) => e.type);
+    expect(types).toContain("dispatch.task.completed");
+    expect(types.some((t) => t === "dispatch.task.failed")).toBe(false);
+  });
+
+  test("ALLOWED: a local-placement harness runs a local-only envelope", async () => {
+    const r = recordingRuntime();
+    const { factory, spawnCount } = fakeFactory();
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      modelPlacement: { harnesses: { "claude-code": "local" } },
+    });
+    await listener.start();
+    r.trigger(makeReceivedEnvelope("local"), SUBJECT);
+    await settle(() => r.published);
+    await listener.stop();
+
+    expect(spawnCount()).toBe(1);
+    expect(r.published.map((e) => e.type)).toContain("dispatch.task.completed");
+  });
+});

--- a/src/runner/__tests__/model-placement-gate.test.ts
+++ b/src/runner/__tests__/model-placement-gate.test.ts
@@ -1,0 +1,102 @@
+/**
+ * cortex#2195 — the model-placement execute gate (RFC-0005 §2.5 consumer half).
+ * Unit coverage for the pure decision logic: config-declared harness→placement
+ * resolution (fail-closed on unknown) + the frontier/local refusal rule read via
+ * the myelin `parseSovereignty` reader.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  evaluateModelPlacement,
+  resolvePlacementClass,
+  type ModelPlacementConfig,
+  type PlacementSovereignty,
+} from "../model-placement-gate";
+
+/** A sovereignty block that DEMANDS local execution (frontier_ok false). */
+const LOCAL_ONLY: PlacementSovereignty = {
+  classification: "confidential",
+  data_residency: "NZ",
+  max_hop: 0,
+  frontier_ok: false,
+  model_class: "local-only",
+};
+
+/** A sovereignty block that CLEARS frontier (frontier_ok + not local-only). */
+const FRONTIER_OK: PlacementSovereignty = {
+  classification: "public",
+  data_residency: "NZ",
+  max_hop: 3,
+  frontier_ok: true,
+  model_class: "any",
+};
+
+const env = (sovereignty: PlacementSovereignty) => ({ sovereignty });
+
+describe("resolvePlacementClass — config-declared, fail-closed on unknown", () => {
+  const config: ModelPlacementConfig = {
+    harnesses: { "claude-code": "frontier", "local-llm": "local" },
+  };
+
+  test("a mapped harness resolves to its declared class", () => {
+    expect(resolvePlacementClass("claude-code", config)).toBe("frontier");
+    expect(resolvePlacementClass("local-llm", config)).toBe("local");
+  });
+
+  test("an UNKNOWN harness fails closed to frontier (the unsafe direction)", () => {
+    // No hardcoded model list — an unmapped id must not silently be treated as
+    // local; the default fail-closed is `frontier` so a local-only envelope
+    // never runs on an unclassified harness.
+    expect(resolvePlacementClass("mystery-harness", config)).toBe("frontier");
+  });
+
+  test("an explicit config default overrides the built-in fail-closed", () => {
+    const withLocalDefault: ModelPlacementConfig = { harnesses: {}, default: "local" };
+    expect(resolvePlacementClass("anything", withLocalDefault)).toBe("local");
+  });
+});
+
+describe("evaluateModelPlacement — RFC-0005 §2.5 enforcement", () => {
+  const config: ModelPlacementConfig = {
+    harnesses: { "claude-code": "frontier", "local-llm": "local" },
+  };
+
+  test("frontier harness + local-only envelope → REFUSED", () => {
+    const d = evaluateModelPlacement(env(LOCAL_ONLY), "claude-code", config);
+    expect(d.allow).toBe(false);
+    if (!d.allow) {
+      expect(d.placement).toBe("frontier");
+      expect(d.detail).toContain("claude-code");
+    }
+  });
+
+  test("frontier harness + frontier-cleared envelope → allowed", () => {
+    const d = evaluateModelPlacement(env(FRONTIER_OK), "claude-code", config);
+    expect(d.allow).toBe(true);
+    if (d.allow) expect(d.placement).toBe("frontier");
+  });
+
+  test("local harness runs ANY envelope (cannot leak to frontier) → allowed", () => {
+    expect(evaluateModelPlacement(env(LOCAL_ONLY), "local-llm", config).allow).toBe(true);
+    expect(evaluateModelPlacement(env(FRONTIER_OK), "local-llm", config).allow).toBe(true);
+  });
+
+  test("UNKNOWN harness + local-only envelope → REFUSED (fail-closed)", () => {
+    // The acceptance scenario: only an unclassified/frontier harness is
+    // available for a local-only-demanding envelope → refuse.
+    const d = evaluateModelPlacement(env(LOCAL_ONLY), "unmapped", config);
+    expect(d.allow).toBe(false);
+    if (!d.allow) expect(d.placement).toBe("frontier");
+  });
+
+  test("frontier harness + missing frontier_ok is treated as not-cleared → REFUSED", () => {
+    // parseSovereignty: canReachFrontier = frontier_ok && model_class !== local-only.
+    // A falsy/absent frontier_ok fails closed.
+    const noClearance = { ...FRONTIER_OK, frontier_ok: false } as PlacementSovereignty;
+    expect(evaluateModelPlacement(env(noClearance), "claude-code", config).allow).toBe(false);
+  });
+
+  test("frontier harness + model_class local-only (even with frontier_ok true) → REFUSED", () => {
+    const localClass = { ...FRONTIER_OK, model_class: "local-only" } as PlacementSovereignty;
+    expect(evaluateModelPlacement(env(localClass), "claude-code", config).allow).toBe(false);
+  });
+});

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -110,6 +110,10 @@ import { extractAgentIdFromDid } from "../common/policy/did";
 // R26 P1 (cortex#1371) — the substrate admission gate (KV-arbitrated rate
 // limiting) + the anonymous public principal id it fails closed for.
 import type { AdmissionGate, AdmissionLease } from "../bus/admission";
+import {
+  evaluateModelPlacement,
+  type ModelPlacementConfig,
+} from "./model-placement-gate";
 import { PUBLIC_PRINCIPAL_ID } from "../common/policy/factory";
 import { deriveMcpGrants, intersectMcpGrants } from "../common/policy/resolve-access";
 import { isUuid } from "../common/types/uuid";
@@ -578,6 +582,17 @@ export interface DispatchListenerOptions {
    * byte-identical behaviour, zero admission reads.
    */
   admissionGate?: AdmissionGate;
+  /**
+   * cortex#2195 (RFC-0005 §2.5) — the model-placement EXECUTE gate map
+   * (`execution.model_placement`). When supplied, every dispatch is checked
+   * AFTER harness selection and BEFORE `harness.dispatch`: a `frontier`-placement
+   * harness running a local-only-required envelope is refused with a terminal
+   * `dispatch.task.failed { kind: "policy_denied" }` (the RFC-0010 permanent
+   * shape) and never spawns. `cortex.ts` supplies this ONLY when the config
+   * block is present — `undefined` (the default) is inert: byte-identical
+   * dispatch, zero placement reads.
+   */
+  modelPlacement?: ModelPlacementConfig;
 }
 
 export interface DispatchListener {
@@ -850,6 +865,7 @@ export function createDispatchListener(
     bashAllowlist,
     bashGuardDisabled,
     admissionGate,
+    modelPlacement,
     adapterId = "runner-dispatch-listener",
   } = opts;
   // v2.0.2 default: structural trust + ed25519 crypto verification.
@@ -935,6 +951,7 @@ export function createDispatchListener(
         bashAllowlist,
         bashGuardDisabled,
         admissionGate,
+        modelPlacement,
       });
     } catch (err) {
       process.stderr.write(
@@ -1418,6 +1435,11 @@ interface DispatchHandlerContext {
    * inertness). See {@link DispatchListenerOptions.admissionGate}.
    */
   admissionGate: AdmissionGate | undefined;
+  /**
+   * cortex#2195 — the model-placement gate map. `undefined` ⇒ inert (the
+   * placement check is skipped). See {@link DispatchListenerOptions.modelPlacement}.
+   */
+  modelPlacement: ModelPlacementConfig | undefined;
 }
 
 async function handleDispatchEnvelope(
@@ -1449,6 +1471,7 @@ async function handleDispatchEnvelope(
     bashAllowlist,
     bashGuardDisabled,
     admissionGate,
+    modelPlacement,
   } = ctx;
   // cortex#492 — pre-parse trace context from CLEARTEXT METADATA ONLY. M3
   // (cortex#1241, ADR-0019) reorder: NOTHING reads the payload before
@@ -2245,6 +2268,67 @@ async function handleDispatchEnvelope(
     receivingAgent,
     envelope.distribution_mode,
   );
+
+  // cortex#2195 (RFC-0005 §2.5) — MODEL-PLACEMENT EXECUTE GATE. The myelin half
+  // (myelin#260/PR#265) only validated the sovereignty block + exported the
+  // `parseSovereignty` reader; enforcement at execution lives HERE, the consumer.
+  // AFTER harness selection (so we know the ACTUAL placement about to run) and
+  // BEFORE `harness.dispatch` (the spawn): if the selected harness is
+  // frontier-placement but the envelope demands local execution, refuse
+  // permanently — `policy_denied`/term (the RFC-0010 permanent shape, same as the
+  // keySegment refusal), never the transient `not_now`. Inert when
+  // `modelPlacement` is unconfigured (CO-4 posture: byte-identical dispatch).
+  if (modelPlacement !== undefined) {
+    const placement = evaluateModelPlacement(envelope, harness.id, modelPlacement);
+    if (!placement.allow) {
+      trace(
+        traceDispatch,
+        runtime,
+        source,
+        "placement-checked",
+        "fail",
+        traceCtx,
+        `harness=${harness.id} placement=${placement.placement} (frontier-blocked)`,
+      );
+      process.stderr.write(
+        `[runner/dispatch-listener] model-placement REFUSED envelope ${envelope.id} ` +
+          `(correlation_id=${envelope.correlation_id ?? "<none>"} task_id=${payload.task_id}): ` +
+          `${placement.detail}\n`,
+      );
+      const now = new Date();
+      const failed = createDispatchTaskFailedEvent({
+        source,
+        taskId: payload.task_id,
+        agentId: payload.agent_id,
+        startedAt: now,
+        failedAt: now,
+        errorSummary: "refused — model placement violates sovereignty (local-only)",
+        reason: {
+          kind: "policy_denied",
+          deny: {
+            model_placement: placement.detail,
+            harness: harness.id,
+            placement: placement.placement,
+          },
+        },
+      });
+      await runtime.publish(failed);
+      // Refund the admission lease we acquired above — this dispatch never spawns.
+      if (admissionLease !== undefined && admissionGate !== undefined) {
+        await admissionGate.release(admissionLease);
+      }
+      return;
+    }
+    trace(
+      traceDispatch,
+      runtime,
+      source,
+      "placement-checked",
+      "pass",
+      traceCtx,
+      `harness=${harness.id} placement=${placement.placement}`,
+    );
+  }
 
   // cortex#492 — emitted SYNCHRONOUSLY immediately before draining the
   // harness (the CC spawn). `harness.dispatch(req)` is the long-running

--- a/src/runner/model-placement-gate.ts
+++ b/src/runner/model-placement-gate.ts
@@ -1,0 +1,125 @@
+/**
+ * cortex#2195 — the model-placement EXECUTE gate (RFC-0005 §2.5 consumer half).
+ *
+ * myelin#260 / PR #265 shipped the PRODUCER half: it rejects the unsatisfiable
+ * `frontier_ok:false` + `model_class:"frontier"` combo and exports the advisory
+ * `parseSovereignty` reader (`canReachFrontier`). But nothing ENFORCED placement
+ * at execution — no execute path lives in myelin. This gate is that enforcement:
+ * at cortex's dispatch/execute decision point it refuses (`policy_denied`/term,
+ * the RFC-0010 permanent shape) any dispatch whose SELECTED harness would run a
+ * local-only-required envelope on a frontier model.
+ *
+ * ## Placement class — config-declared, fail-closed on unknown
+ *
+ * The map from a selected harness id to its placement class (`frontier` vs
+ * `local`) is CONFIG-DECLARED (`execution.model_placement`). There is NO
+ * hardcoded model list — the only built-in is the fail-closed default: a harness
+ * id ABSENT from the map is treated as `frontier` (the unsafe direction), so a
+ * local-only envelope never silently runs on an unclassified harness. Declaring
+ * a harness `local` is an explicit, auditable config act.
+ *
+ * ## The rule (RFC-0005 §2.5, via the myelin reader)
+ *
+ *   - `local` placement → ALWAYS allowed: a local model cannot leak a local-only
+ *     payload to a frontier model.
+ *   - `frontier` placement → allowed ONLY when the envelope clears frontier
+ *     (`parseSovereignty(env).canReachFrontier`, i.e. `frontier_ok &&
+ *     model_class !== "local-only"`). Otherwise REFUSED.
+ *
+ * The reader is imported from the `@the-metafactory/myelin` package (the pinned
+ * dep exports it) — NOT re-vendored (the drift class this epic kills).
+ */
+
+import { parseSovereignty } from "@the-metafactory/myelin";
+
+/** A selected harness's execution placement. */
+export type PlacementClass = "frontier" | "local";
+
+/**
+ * `execution.model_placement` — the config-declared harness→placement map. Inert
+ * when absent (the gate is skipped; byte-identical dispatch).
+ */
+export interface ModelPlacementConfig {
+  /**
+   * Selected-harness id (`SessionHarness.id`: `claude-code` / `api-agent` /
+   * `agent-team`, …) → placement class. Config-declared; no hardcoded models.
+   */
+  readonly harnesses: Readonly<Record<string, PlacementClass>>;
+  /**
+   * Placement for a harness id ABSENT from `harnesses`. FAIL-CLOSED: defaults to
+   * `frontier` so an unclassified harness cannot run a local-only envelope.
+   */
+  readonly default?: PlacementClass;
+}
+
+/** The sovereignty fields the myelin `parseSovereignty` reader consumes. */
+export interface PlacementSovereignty {
+  readonly classification: string;
+  readonly data_residency: string;
+  readonly max_hop: number;
+  readonly frontier_ok: boolean;
+  readonly model_class: string;
+}
+
+/** The minimal envelope shape the gate needs — only `.sovereignty` is read (via
+ * the myelin reader). Structural so the gate is unit-testable without a full
+ * signed envelope, and so cortex's `Envelope` (which structurally carries a
+ * richer, but compatible, sovereignty block) passes without a call-site cast —
+ * the vendored-vs-package envelope-type drift this epic ultimately kills. */
+interface PlacementEnvelope {
+  readonly sovereignty: PlacementSovereignty;
+}
+
+export type ModelPlacementDecision =
+  | { readonly allow: true; readonly placement: PlacementClass }
+  | {
+      readonly allow: false;
+      readonly placement: PlacementClass;
+      /** Operator-facing explanation for the `policy_denied` refusal. */
+      readonly detail: string;
+    };
+
+/** Resolve a selected harness id to its placement class (fail-closed on
+ * unknown → `frontier`). */
+export function resolvePlacementClass(
+  harnessId: string,
+  config: ModelPlacementConfig,
+): PlacementClass {
+  return config.harnesses[harnessId] ?? config.default ?? "frontier";
+}
+
+/**
+ * Evaluate whether the SELECTED harness may execute this envelope under
+ * RFC-0005 §2.5. Never throws.
+ *
+ * @param envelope  the dispatch envelope (only `.sovereignty` is read, via the
+ *   myelin `parseSovereignty` reader).
+ * @param harnessId the resolved `SessionHarness.id` about to run the dispatch.
+ * @param config    the config-declared placement map.
+ */
+export function evaluateModelPlacement(
+  envelope: PlacementEnvelope,
+  harnessId: string,
+  config: ModelPlacementConfig,
+): ModelPlacementDecision {
+  const placement = resolvePlacementClass(harnessId, config);
+  if (placement === "local") {
+    // A local placement cannot leak a local-only payload to a frontier model.
+    return { allow: true, placement };
+  }
+  // Frontier placement — permitted only if the envelope clears frontier. The
+  // reader reads only `.sovereignty`; cast bridges the structural
+  // `PlacementEnvelope` to the package's `MyelinEnvelope` param (safe — the
+  // sovereignty fields are identical).
+  const { canReachFrontier } = parseSovereignty(
+    envelope as unknown as Parameters<typeof parseSovereignty>[0],
+  );
+  if (canReachFrontier) return { allow: true, placement };
+  return {
+    allow: false,
+    placement,
+    detail:
+      `harness "${harnessId}" is frontier-placement but the envelope demands ` +
+      `local execution (RFC-0005 §2.5: frontier_ok/model_class) — refusing`,
+  };
+}


### PR DESCRIPTION
RFC-0005 §2.5 consumer half. Gate at dispatch (after harness select, before spawn): frontier-placement harness + local-only envelope → policy_denied/term, no spawn. Harness→placement map config-declared (execution.model_placement), fail-closed on unknown. Reader imported from @the-metafactory/myelin (verified exported). Inert without config. Fail-before verified. No merge.