### PR TITLE
fix(attachments): allow Office document MIME types (unblocks .docx drops)

### DIFF
--- a/src/runner/__tests__/attachments-office-mime.test.ts
+++ b/src/runner/__tests__/attachments-office-mime.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Office document attachments must pass the inbound MIME allowlist.
+ *
+ * The defect this closes: cortex's inbound-attachment allowlist
+ * (`ALLOWED_MIME_TYPES`) carried images/text/pdf/json/xml/zip but NO Office
+ * types, so a .docx dropped in chat was fetched then discarded — observed on a
+ * live daemon as:
+ *   discord-attachments: errors: …docx: Blocked file type:
+ *   application/vnd.openxmlformats-officedocument.wordprocessingml.document
+ *
+ * The fix adds the common Office MIME types (OOXML, legacy binary, ODF) to the
+ * allowlist and a container-level magic-byte signature for each: OOXML/ODF are
+ * ZIP containers (PK\x03\x04); legacy .doc/.xls/.ppt are OLE2 compound files
+ * (D0 CF 11 E0). The signature verifies the container, not the specific
+ * application — magic bytes were only ever an anti-polyglot container guard.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import { ALLOWED_MIME_TYPES } from "../attachment-types";
+import { validateMagicBytes } from "../attachments";
+
+const ZIP = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // PK\x03\x04
+const OLE2 = new Uint8Array([0xd0, 0xcf, 0x11, 0xe0]); // OLE compound file
+const NOT_A_CONTAINER = new Uint8Array([0xff, 0xd8, 0xff, 0x00]); // JPEG-ish
+
+const OOXML = [
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation", // .pptx
+];
+const ODF = [
+  "application/vnd.oasis.opendocument.text", // .odt
+  "application/vnd.oasis.opendocument.spreadsheet", // .ods
+  "application/vnd.oasis.opendocument.presentation", // .odp
+];
+const LEGACY = [
+  "application/msword", // .doc
+  "application/vnd.ms-excel", // .xls
+  "application/vnd.ms-powerpoint", // .ppt
+];
+
+describe("Office attachments pass the inbound MIME allowlist", () => {
+  test("the .docx type that was blocked on the live daemon is now allowed", () => {
+    // The exact MIME from the observed "Blocked file type" log line.
+    expect(
+      ALLOWED_MIME_TYPES.has(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ),
+    ).toBe(true);
+  });
+
+  test("every OOXML, ODF, and legacy Office MIME is on the allowlist", () => {
+    for (const mime of [...OOXML, ...ODF, ...LEGACY]) {
+      expect(ALLOWED_MIME_TYPES.has(mime)).toBe(true);
+    }
+  });
+
+  test("an unlisted type is still blocked", () => {
+    expect(ALLOWED_MIME_TYPES.has("application/x-msdownload")).toBe(false);
+    expect(ALLOWED_MIME_TYPES.has("application/octet-stream")).toBe(false);
+  });
+});
+
+describe("Office attachments pass container magic-byte validation", () => {
+  test("OOXML/ODF declared types validate against a ZIP container", () => {
+    for (const mime of [...OOXML, ...ODF]) {
+      expect(validateMagicBytes(ZIP, mime)).toBe(true);
+    }
+  });
+
+  test("legacy Office declared types validate against an OLE2 container", () => {
+    for (const mime of LEGACY) {
+      expect(validateMagicBytes(OLE2, mime)).toBe(true);
+    }
+  });
+
+  test("a file declaring .docx but not even a ZIP container is rejected (anti-polyglot)", () => {
+    expect(
+      validateMagicBytes(
+        NOT_A_CONTAINER,
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ),
+    ).toBe(false);
+  });
+
+  test("a file declaring .doc but not an OLE2 container is rejected", () => {
+    expect(validateMagicBytes(NOT_A_CONTAINER, "application/msword")).toBe(false);
+  });
+});

--- a/src/runner/__tests__/attachments-office-mime.test.ts
+++ b/src/runner/__tests__/attachments-office-mime.test.ts
@@ -75,16 +75,28 @@ describe("Office attachments pass container magic-byte validation", () => {
     }
   });
 
-  test("a file declaring .docx but not even a ZIP container is rejected (anti-polyglot)", () => {
-    expect(
-      validateMagicBytes(
-        NOT_A_CONTAINER,
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      ),
-    ).toBe(false);
+  // Anti-polyglot negatives pin EVERY signature entry. A positive assertion
+  // (right bytes → true) stays green even if a MAGIC_BYTES entry is deleted,
+  // because validateMagicBytes falls back to true when no signature exists for
+  // the MIME. A negative assertion (wrong bytes → false) can ONLY pass while
+  // the entry is present, so deleting any one of the 9 entries turns a test red.
+  const MZ_EXE = new Uint8Array([0x4d, 0x5a, 0x90, 0x00]); // MZ — not PK, not OLE2
+
+  test("every OOXML/ODF type rejects a non-ZIP header (pins each PK signature)", () => {
+    for (const mime of [...OOXML, ...ODF]) {
+      // Both headers are non-PK — either would slip through the no-signature
+      // fallback if this MIME's entry were deleted.
+      expect(validateMagicBytes(NOT_A_CONTAINER, mime)).toBe(false);
+      expect(validateMagicBytes(MZ_EXE, mime)).toBe(false);
+    }
   });
 
-  test("a file declaring .doc but not an OLE2 container is rejected", () => {
-    expect(validateMagicBytes(NOT_A_CONTAINER, "application/msword")).toBe(false);
+  test("every legacy Office type rejects a non-OLE2 header (pins each D0CF signature)", () => {
+    for (const mime of LEGACY) {
+      // ZIP bytes are the wrong container for OLE2 types — rejection is only
+      // possible while the legacy signature entry exists.
+      expect(validateMagicBytes(NOT_A_CONTAINER, mime)).toBe(false);
+      expect(validateMagicBytes(ZIP, mime)).toBe(false);
+    }
   });
 });

--- a/src/runner/attachment-types.ts
+++ b/src/runner/attachment-types.ts
@@ -59,6 +59,19 @@ export const ALLOWED_MIME_TYPES = new Set([
   "application/pdf",
   "application/json",
   "application/xml",
+  // Office documents — OOXML (ZIP containers) and legacy binary (OLE2).
+  // Without these, a .docx dropped in chat is fetched then discarded with
+  // "Blocked file type: application/vnd.openxmlformats-officedocument.wordprocessingml.document".
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // .docx
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // .xlsx
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation", // .pptx
+  "application/msword", // .doc
+  "application/vnd.ms-excel", // .xls
+  "application/vnd.ms-powerpoint", // .ppt
+  // OpenDocument (ZIP containers) — included for completeness.
+  "application/vnd.oasis.opendocument.text", // .odt
+  "application/vnd.oasis.opendocument.spreadsheet", // .ods
+  "application/vnd.oasis.opendocument.presentation", // .odp
   // Archives (read-only — Claude can't extract, but can note them)
   "application/zip",
 ]);
@@ -74,6 +87,23 @@ export const MAGIC_BYTES: { mime: string; bytes: number[]; offset?: number }[] =
   { mime: "image/webp", bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 }, // RIFF header
   { mime: "application/pdf", bytes: [0x25, 0x50, 0x44, 0x46] }, // %PDF
   { mime: "application/zip", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  // Office OOXML + OpenDocument are ZIP containers → PK\x03\x04. Keying each
+  // MIME to the ZIP signature only gates files DECLARED as that type; it admits
+  // no content application/zip did not already admit, and rejects a file that
+  // claims to be a document but isn't even a container (anti-polyglot). The
+  // signature can't distinguish .docx from .xlsx (both ZIP) — magic bytes were
+  // never a full content check, only a container guard.
+  { mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  { mime: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  { mime: "application/vnd.openxmlformats-officedocument.presentationml.presentation", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  { mime: "application/vnd.oasis.opendocument.text", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  { mime: "application/vnd.oasis.opendocument.spreadsheet", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  { mime: "application/vnd.oasis.opendocument.presentation", bytes: [0x50, 0x4b, 0x03, 0x04] },
+  // Legacy binary Office (.doc/.xls/.ppt) are OLE2 compound files → D0 CF 11 E0.
+  // Same reasoning: verifies the container, not the specific application.
+  { mime: "application/msword", bytes: [0xd0, 0xcf, 0x11, 0xe0] },
+  { mime: "application/vnd.ms-excel", bytes: [0xd0, 0xcf, 0x11, 0xe0] },
+  { mime: "application/vnd.ms-powerpoint", bytes: [0xd0, 0xcf, 0x11, 0xe0] },
 ];
 
 /** Default limits */


### PR DESCRIPTION
## What

Inbound Office document attachments (`.docx`, `.xlsx`, `.pptx`, legacy `.doc/.xls/.ppt`, ODF) were fetched then discarded at the MIME gate. Verified from a live daemon log:

```
discord-attachments: errors: …docx: Blocked file type:
application/vnd.openxmlformats-officedocument.wordprocessingml.document
```

The adapter forwards the attachment fine and cortex downloads it; `ALLOWED_MIME_TYPES` (`attachment-types.ts:41`) simply didn't include Office document types, so `processAttachment` rejected them at `attachments.ts:125`.

Adds 9 MIME types to the allowlist and a matching `MAGIC_BYTES` container signature for each:
- OOXML + ODF (ZIP containers) → `PK\x03\x04`
- legacy `.doc/.xls/.ppt` (OLE2 compound) → `D0 CF 11 E0`

## Why option (b) — signatures, not the no-signature pass-through

`validateMagicBytes` returns `true` when no signature exists for a MIME. Relying on that (option a) would let an MZ executable relabeled `.docx` land on disk with a `.docx` name. The container signature rejects that. It's honest about its granularity (verifies the container, can't tell `.docx` from `.xlsx`) — magic bytes were always a container guard, not a full content check.

## Security review (adversarial, refutation posture) — CLEAN

- **No valid-file rejection.** Every real modern Office doc has ≥1 member file → starts with `PK\x03\x04` at offset 0; `validateMagicBytes` checks offset 0 only → passes. Legacy Office 97+ is OLE2 → `D0CF11E0` → passes. The only things that fail (RTF-saved-as-`.doc`, empty/spanned zips, pre-1995 BIFF) were ALSO blocked before this change at the ALLOWED gate — no behavioral regression.
- **No loosening.** The admissible byte set is unchanged: a `PK\x03\x04` file could already enter declared `application/zip`. This adds a MIME label, not new admissible bytes. Nothing downstream trusts the Office MIME — the file lands under a randomUUID name with a regex-validated extension, and the attachment prompt only prints the type as a label with an adversarial-content warning. No auto-extract, no execution, no MIME-keyed dispatch.

## Test

- `bun test src/runner/__tests__/attachments-office-mime.test.ts` → 7 pass. Scoped run (office-mime + upload-limit + timeout) 24 pass. `tsc --noEmit` clean, eslint clean.
- Anti-polyglot negatives loop over ALL nine types (non-container header → `false`; wrong-container → `false`), so deleting ANY one of the 9 `MAGIC_BYTES` entries fails a test (mutation-verified). Shipping code (`attachment-types.ts`) is the adversarially-reviewed version; the follow-up commit strengthened tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
