### PR TITLE
chore(deps): pin myelin v0.7.0 + mark ./wire de-dup sites (prereq for #2034)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@nats-io/jwt": "^0.0.11",
         "@octokit/webhooks": "^14.2.0",
         "@octokit/webhooks-methods": "^6.0.0",
-        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1",
+        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#v0.7.0",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -99,7 +99,7 @@
 
     "@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#a69ecd7", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/nats-core": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-a69ecd7"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#0d11664", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/nats-core": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-0d11664"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@nats-io/jwt": "^0.0.11",
     "@octokit/webhooks": "^14.2.0",
     "@octokit/webhooks-methods": "^6.0.0",
-    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1",
+    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#v0.7.0",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/bus/agent-network/federation-reconciler.ts
+++ b/src/bus/agent-network/federation-reconciler.ts
@@ -450,6 +450,12 @@ function rosterPeerToWireIdentity(peer: RosterPeer): FederatedWireIdentity {
  * back to `default` (mirrors `roster-read`'s `stackSlugOf` and the CLI's
  * `peerToWireIdentity`, so the accept-list segment matches the peer view).
  */
+// TODO(#2034/flag-day): replace this hand-rolled `{principal}/{stack}` split +
+// fabricated `default` with @the-metafactory/myelin/wire parseStackId (which is
+// fail-loud and NEVER fabricates a `default`, cortex#1812) once the RFC-0001
+// grammar cut lands (blocked-on #1996/#2016/#2020). Behavior-preserving until
+// then: the fabricated-`default` fallback is a current wire behavior, and
+// swapping to the fail-loud codec is a flag-day change, not a drop-in.
 function peerToWireIdentity(
   peer: PolicyFederatedNetwork["peers"][number],
 ): FederatedWireIdentity {

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -454,6 +454,15 @@ export interface DispatchTaskFailedOpts extends DispatchTaskCommonOpts {
  * `docs/design-pilot-restructure.md` §4.4 + §6.2 PR-A.0a (pilot-side
  * consumption + this PR's scope), `docs/design-pi-dev-review-agent.md`
  * §4 (envelope grammar).
+ *
+ * TODO(#2034/flag-day): the #2034 inventory names this enum (and the NAK
+ * spelling mirrors in the review/release/dev consumers) as a de-dup target
+ * against @the-metafactory/myelin/wire's refusal enums. Deferred: (a) ./wire's
+ * `resolveNakReason` is an unimplemented conformance stub (throws
+ * NotImplemented, myelin#233 — RFC-0007 flag-day-R not landed yet), and (b)
+ * this taxonomy is a DIFFERENT domain (CC substrate failure modes) from
+ * ./wire's RFC-0010 admission/rate refusals. Revisit at the flag-day
+ * (blocked-on #233) — not a behavior-preserving swap today.
  */
 export type DispatchTaskFailedReason =
   | {

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -28,6 +28,9 @@ import { TrustResolver } from "../../../common/agents/trust-resolver";
 import type { Agent } from "../../../common/types/cortex-config";
 import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { type: "json" };
 import invalidMissingSovereignty from "../vendor/__fixtures__/invalid-missing-sovereignty.json" with { type: "json" };
+// The vendored schema this module validates against — byte-compared below
+// against the installed package schema (cortex#366 stale-install guard).
+import vendoredSchema from "../vendor/envelope.schema.json" with { type: "json" };
 
 describe("envelope-validator", () => {
   test("schema source commit is recorded for upgrade audit", () => {
@@ -591,47 +594,39 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
   // ergonomic side of Echo's suggestion without dragging upstream noise
   // into this PR.
 
-  test("schema source commit points at the vocabulary-migration transition pin", () => {
-    // Lock the pin so future bumps surface in a code review.
-    // Updated at cortex G1 (PR-8) — bump from 3ec0ace to e37b347 to pick
-    // up the myelin vocabulary migration 2026-05 transition release:
-    //   • PR-6 (#169) envelope wire transition (signed_by[].identity,
-    //     originator.identity, target_assistant, distribution_mode "offer")
-    //   • PR-7..PR-13 (#170–#176) the per-cluster downstream landings
-    // The transition schema accepts BOTH the deprecated and the renamed
-    // form so pre-migration / JetStream-replayed envelopes still validate.
-    //
-    // cortex#436 / cortex#81 / PR-R10 — bumped 4c54b8e → f5ec865 (myelin
-    // main post-#184) to land the breaking cut on the routing target field:
-    // `target_principal` is no longer accepted on the wire (the deprecated
-    // key is now rejected as `additionalProperties`); direct/delegate
-    // envelopes must carry `target_assistant`. This is a lockstep companion
-    // to the earlier signed_by[].principal cut (R11). The vendored schema
-    // tracks f5ec865 structurally (verified identical to the npm dep's
-    // schema). The matching cortex-side reader shim drop (getTargetAssistant
-    // no longer dual-reads) ships here per
-    // docs/migrations/0002-vocabulary-finish-2026-05.md §R10.
+  test("schema source commit points at the v0.7.0 tag's commit (breadcrumb lock)", () => {
+    // Lock the provenance breadcrumb so future bumps surface in a code review.
+    // History: 3ec0ace → e37b347 (vocabulary migration 2026-05 transition) →
+    // 4c54b8e → f5ec865 (cortex#436/#81/PR-R10, `target_principal` breaking cut)
+    // → a69ecd7 (v0.6.0). Now the commit that the **v0.7.0** tag dereferences to
+    // (cortex#2034 de-dup prereq — package.json pins the `v0.7.0` tag per
+    // design-rfc-alignment.md D4, carrying the ./wire library). The vendored
+    // schema is byte-unchanged across this bump (loose-flat DID pattern; the
+    // ./wire class-explicit schema is a SEPARATE flag-day, deferred). This is a
+    // cheap constant lock; the real freshness guard is the byte-compare below.
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1",
+      "c534a0b9ea66066d5fe2731c2dc62a27561a9e56",
     );
   });
 
-  test("SCHEMA_SOURCE_COMMIT matches the @the-metafactory/myelin pin in package.json (Sage R2 drift guard)", async () => {
-    // The schema is vendored at `SCHEMA_SOURCE_COMMIT` AND the runtime
-    // `deriveSubject` implementation is pulled from the same myelin commit
-    // via the npm dep. If a future bump updates one but forgets the other,
-    // cortex would run new grammar against an old schema (or vice versa).
-    // This test reads package.json's myelin dep ref and asserts equality.
-    const pkgPath = new URL("../../../../package.json", import.meta.url);
-    const pkg = (await import(pkgPath.pathname, { with: { type: "json" } })) as {
-      default: { dependencies?: Record<string, string> };
-    };
-    const myelinDep = pkg.default.dependencies?.["@the-metafactory/myelin"];
-    expect(myelinDep).toBeDefined();
-    // Format: "github:the-metafactory/myelin#<40-char-sha>"
-    const match = /#([0-9a-f]{40})$/.exec(myelinDep!);
-    expect(match).not.toBeNull();
-    expect(match![1]).toBe(SCHEMA_SOURCE_COMMIT);
+  test("vendored schema is byte-identical to the installed package schema (cortex#366 stale-install guard)", async () => {
+    // The FRESHNESS/DRIFT contract, pin-format-agnostic (cortex#2034 prereq).
+    // Replaces the old "SCHEMA_SOURCE_COMMIT === the 40-char SHA in the
+    // package.json pin" assertion, which could not survive the switch to a
+    // legible `v0.7.0` **tag** pin (D4). This is the STRONGER guard: it does not
+    // trust a hand-copied SHA string — it byte-compares the vendored copy this
+    // module validates against with the schema that ships in the INSTALLED
+    // `@the-metafactory/myelin` package (the same tree the runtime
+    // `deriveSubject` / signing grammar is pulled from). If a future dep bump
+    // (or a stale `node_modules`, the exact cortex#366 P1 footgun) drifts the
+    // installed schema away from the vendored copy, this fails at test time —
+    // cortex can never silently validate new-grammar envelopes against an old
+    // vendored schema, or vice versa.
+    const installed = (await import(
+      "@the-metafactory/myelin/schemas/envelope.schema.json",
+      { with: { type: "json" } }
+    )) as { default: typeof vendoredSchema };
+    expect(vendoredSchema).toEqual(installed.default);
   });
 });
 

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -64,10 +64,26 @@ import {
   deriveSubject,
   subjectPrefixAligns,
 } from "@the-metafactory/myelin/subjects";
+// TODO(#2034/flag-day): replace this vendored (loose-flat DID pattern) schema
+// with @the-metafactory/myelin/wire's generated class-explicit schema once the
+// RFC-0001 grammar cut lands (blocked-on #1996/#2016/#2020/#233). Deleting the
+// vendored copy pre-flag-day would (a) tighten the DID pattern on the wire and
+// (b) reopen the cortex#366 stale-install class — deferred by design.
 import schema from "./vendor/envelope.schema.json" with { type: "json" };
 
 /**
- * Pin so future maintainers know which myelin commit the schema was lifted from.
+ * Provenance breadcrumb: the myelin commit the vendored schema was lifted from.
+ *
+ * `package.json` now pins the `@the-metafactory/myelin` dep at the legible
+ * **`v0.7.0` tag** (de-dup prereq for cortex#2034 — replaces the raw
+ * `a69ecd7…` v0.6.0 SHA per design-rfc-alignment.md D4). This constant records
+ * the commit that `v0.7.0` dereferences to, so a maintainer can still see at a
+ * glance which upstream tree the schema string tracks. It is a breadcrumb, not
+ * the drift guard: the freshness contract is now enforced by a **byte-compare of
+ * this vendored copy against the installed package schema** (see the
+ * `vendored schema is byte-identical to the installed package schema` test),
+ * which is pin-format-agnostic and keeps the cortex#366 stale-install guard
+ * intact regardless of whether the pin is a tag or a SHA.
  *
  * Upstream issue/PR numbering note: myelin#160 is the design issue for the
  * envelope `originator` field; myelin#161 is the merged PR. The vendored
@@ -76,7 +92,7 @@ import schema from "./vendor/envelope.schema.json" with { type: "json" };
  * comments + tests use `myelin#161` to point at the merge that landed the
  * feature — they're the same change, different ticket facets.
  */
-export const SCHEMA_SOURCE_COMMIT = "a69ecd7d760434fd5e2f27b2e3de3b3bcd510be1";
+export const SCHEMA_SOURCE_COMMIT = "c534a0b9ea66066d5fe2731c2dc62a27561a9e56";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather

--- a/src/bus/probe-responder.ts
+++ b/src/bus/probe-responder.ts
@@ -430,6 +430,10 @@ export function decideProbeResponse(
     // the spec's "originator.method = federated" maps to this) marks the claim
     // as relayed cross-principal.
     originator: {
+      // TODO(#2034/flag-day): replace this hand-rolled flat-form DID encoder
+      // with @the-metafactory/myelin/wire renderDid once RFC-0001 lands
+      // (blocked-on #1996/#2016/#2020) — emits the OLD loose grammar; ./wire's
+      // class-explicit dot-form is a flag-day change, not a drop-in.
       identity: `did:mf:${inputs.source.principal}-${inputs.stack}`,
       attribution: "federated",
     },

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -1452,6 +1452,14 @@ export function parseRequesterFromOriginator(
   // hyphens). `did:mf:andreas-meta-factory` → principal `andreas`, stack
   // `meta-factory`. The exact inverse of pilot's
   // `encodeRequesterDid` = `did:mf:${principal}-${stack}` (= stack.id `/`→`-`).
+  //
+  // TODO(#2034/flag-day): replace this first-hyphen guesser with
+  // @the-metafactory/myelin/wire decodeDidSegment/parseDid once the RFC-0001
+  // class-explicit grammar cut lands (blocked-on #1996/#2016/#2020). This is
+  // the TRUST-PATH decoder: cortex is still on the OLD loose flat form
+  // (`did:mf:{principal}-{stack}`); ./wire's parseDid expects the class-explicit
+  // dot-form (`did:mf:stack.{principal}.{stack}`) and would REJECT every DID
+  // cortex accepts today. Swapping is a flag-day behavior change, NOT a drop-in.
   const hyphen = body.indexOf("-");
   if (hyphen <= 0 || hyphen === body.length - 1) {
     // No hyphen, leading hyphen, or trailing hyphen → can't split an
@@ -1472,6 +1480,10 @@ export function parseRequesterFromOriginator(
  */
 export const OFFER_DISPATCH_REVIEWER = "capability-dispatch";
 
+// NOTE(#2034): this `SEGMENT_RE` is listed in the #2034 item-2 inventory but is
+// GitHub/GitLab owner+repo validation (mixed-case, dots), NOT a did:mf segment
+// terminal — it is NOT a ./wire candidate. Do not swap it for a wire terminal at
+// flag-day; it validates forge paths, not identity segments.
 const SEGMENT_RE = /^[A-Za-z0-9][\w.-]*$/;
 const OWNER_REPO_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
 

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -254,6 +254,8 @@ const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 // S5 — capability id grammar (`<domain>.<entity>`, matches the schema's
 // announce_capabilities[] rule) + principal-id grammar for the allowlist.
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire capability
+// terminal once RFC-0001 lands (blocked-on #2020 capability-regex tightening).
 const CAPABILITY_ID_RE = /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$/;
 
 const SPEC: SubcommandSpec<NetworkSubcommand> = {
@@ -3835,6 +3837,10 @@ export type MakeLivePortsFactory = (mutate: boolean) => MakeLivePorts;
 
 const DEFAULT_MAKE_LIVE_PORTS_FACTORY: MakeLivePortsFactory = (mutate) => buildLiveMakeLivePorts(mutate);
 
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire STACK_SLUG_RE
+// once the RFC-0001 grammar cut lands (blocked-on #1996/#2016/#2020). ./wire is
+// kebab-strict; this local copy is looser (accepts `_`, trailing/consecutive
+// `-`), so swapping now would tighten wire behavior — deferred to flag-day.
 const STACK_SLUG_RE = /^[a-z][a-z0-9_-]*$/;
 
 /** Build the {@link MakeLiveInputs} from config + flags, or a usage reason. */

--- a/src/cli/cortex/commands/offer.ts
+++ b/src/cli/cortex/commands/offer.ts
@@ -128,6 +128,8 @@ function defaultConfigDir(): string {
 
 /** Capability id grammar — mirrors CO-1's `OfferingCapabilityIdSchema` (the
  *  `*` quantifier admits SINGLE-segment ids like `chat`). */
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire capability
+// terminal once RFC-0001 lands (blocked-on #2020 capability-regex tightening).
 const CAPABILITY_ID_RE = /^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$/;
 
 /**

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -85,6 +85,9 @@ export { type ExitResult } from "./_shared/exit-result";
 type ProvisionSubcommand = "generate" | "claim" | "register" | "retire";
 
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire STACK_ID_RE
+// once RFC-0001 lands (blocked-on #1996/#2016/#2020). ./wire is kebab-strict;
+// this local copy is looser (accepts `_`), so swapping now tightens the wire.
 const STACK_ID_RE = /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/;
 /** ADR-0018 Gap-A — network id grammar (mirrors the registry's NETWORK_ID_RE). */
 const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -74,6 +74,9 @@ type StackSubcommand = "create" | "list" | "delete";
  * no-underscore form. Born-aligning to that schema is the whole point (#808):
  * we never write a stack.id the loader would later reject.
  */
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire STACK_SLUG_RE
+// once RFC-0001 lands (blocked-on #1996/#2016/#2020). ./wire is kebab-strict;
+// this local copy is looser, so swapping now would tighten wire behavior.
 const SLUG_RE = /^[a-z][a-z0-9_-]*$/;
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 

--- a/src/common/types/capability.ts
+++ b/src/common/types/capability.ts
@@ -169,6 +169,9 @@ export type CapabilityCost = z.infer<typeof CapabilityCostSchema>;
  * this grammar so a fragment can never smuggle a `>`/`*` wildcard into a pull
  * filter and claim tasks beyond its declared capability.
  */
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire capability
+// terminal once RFC-0001 lands (blocked-on #2020 capability-regex tightening).
+// ./wire is kebab-strict; this local copy is looser (accepts `_`).
 export const CAPABILITY_ID_REGEX = /^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$/;
 
 const CapabilityIdSchema = z

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1063,6 +1063,11 @@ export async function startCortex(
       // consecutive-hyphen guard. Collapse `--` runs to avoid the
       // silent per-publish sign failure that would otherwise downgrade
       // every outbound envelope to unsigned (Echo cortex#211 round 1).
+      // TODO(#2034/flag-day): replace this hand-rolled `/`→`-` + `--`-collapse
+      // DID encoder with @the-metafactory/myelin/wire renderDid/encodeDidSegment
+      // once RFC-0001 lands (blocked-on #1996/#2016/#2020). This emits the OLD
+      // loose flat form; ./wire emits the class-explicit dot-form — a flag-day
+      // change, not a drop-in (paired with the review-consumer decoder swap).
       const principal = `did:mf:${derivedStack.id
         .replace("/", "-")
         .replace(/-+/g, "-")}`;

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -47,9 +47,13 @@ import type {
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 
 /** `{principal_id}/{stack_slug}` — both parts follow principal grammar. */
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire STACK_ID_RE
+// once RFC-0001 lands (blocked-on #1996/#2016/#2020) — ./wire is kebab-strict.
 const STACK_ID_RE = /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/;
 
 /** Phase A.6 capability grammar — `<domain>.<entity>`. */
+// TODO(#2034/flag-day): replace with @the-metafactory/myelin/wire capability
+// terminal once RFC-0001 lands (blocked-on #2020 capability-regex tightening).
 const CAPABILITY_ID_RE = /^[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*$/;
 
 /** Standard base64 alphabet + padding. We don't accept URL-safe here. */


### PR DESCRIPTION
Part of #2034 (prereq — de-dup deferred to flag-day; see the reclassification comment on #2034). Behavior-preserving, does NOT close #2034.

Pin @the-metafactory/myelin → v0.7.0 tag (D4, replaces raw SHA); reworked the vendored-schema drift guard to byte-compare against the installed package schema (keeps the cortex#366 stale-install guard, pin-format-agnostic); TODO(#2034/flag-day) markers at the 5 deferred sites. No wire behavior change — the ./wire swaps are the RFC-0001 flag-day. Verified: v0.7.0 resolves, drift-guard 61/0, tsc clean, vocab gate pass.