### PR TITLE
docs(grounding): apply domain-grounding standard — wire_grounding table + src/bus/CLAUDE.md + hook + vocab gate (Closes #2205)

### DIFF
--- a/.claude/hooks/wire-grounding-reminder.ts
+++ b/.claude/hooks/wire-grounding-reminder.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env bun
+// PreToolUse (Edit|Write) — emit a one-line reminder naming the governing myelin
+// RFC for a wire-implementing path (src/bus/**). Non-blocking by contract: it
+// prints additional context and always exits 0. It NEVER calls the bus, the
+// network, or blocks the edit (CLAUDE.md: hooks must stay non-blocking).
+//
+// Standard: compass/standards/domain-grounding.md §4. The dir-scoped
+// src/bus/CLAUDE.md loads when a file is opened; this hook fires when it is
+// edited — the last cheap moment to name the RFC before a wire change lands.
+// Routing table of record: repo-root CLAUDE.md `wire_grounding` slot
+// (docs/agents-md/wire-grounding.md).
+const RULES: Array<{ glob: RegExp; rfc: string }> = [
+  {
+    // Subject grammar / envelope / signing are the highest-churn bus surfaces.
+    glob: /(^|\/)src\/bus\/myelin\//,
+    rfc: "the-metafactory/myelin specs/rfc/rfc-0002-subject-namespace.md, rfc-0003-envelope.md, rfc-0004-envelope-signing.md — the vendored myelin schema is normative; import from @the-metafactory/myelin, don't hand-copy (cortex#2034)",
+  },
+  {
+    glob: /(^|\/)src\/bus\//,
+    rfc: "the-metafactory/myelin specs/rfc/ — rfc-0001 (identity/signed_by), rfc-0002 (subjects/deriveNatsSubject), rfc-0003/0004 (envelope + signing), rfc-0005 (sovereignty/federated.*), rfc-0006 (admission), rfc-0007 (transport), rfc-0008 (capability discovery), rfc-0010 (refusal). The grammar is normative for this tree",
+  },
+];
+
+const input = JSON.parse(await Bun.stdin.text());
+const path: string = input?.tool_input?.file_path ?? "";
+const hit = RULES.find((r) => r.glob.test(path));
+if (hit) {
+  // Surface as additional context on the tool call; do not block.
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: `Wire-grounding: editing ${path} — governed by ${hit.rfc}. Read the RFC before changing wire behavior.`,
+      },
+    }),
+  );
+}
+process.exit(0); // always non-blocking

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "cortex repo-scoped Claude Code settings. The PreToolUse hook is the edit-time RFC reminder from compass/standards/domain-grounding.md §4 — a non-blocking reminder that names the governing myelin wire RFC when an agent edits a wire-implementing path (src/bus/**). The hook itself scopes to src/bus/** via its RULES table; it is safe to run on every Edit|Write (it emits nothing for non-matching paths). See docs/agents-md/wire-grounding.md and src/bus/CLAUDE.md.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun .claude/hooks/wire-grounding-reminder.ts"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # check-wire-vocab.ts (added below) runs under bun.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       # WHOLE-TREE ratchet (cortex#436): the 0002 vocabulary migration is COMPLETE
       # — the v4.0.0 breaking cut (#520) removed the legacy operator readers and the
       # tree is at ZERO ungated violations. The gate now scans the whole tree (its
@@ -116,6 +121,20 @@ jobs:
       # PR happens to touch (the reason the old diff-mode forced --admin merges).
       - name: check-carveouts (whole-tree)
         run: bash scripts/check-carveouts.sh
+
+      # Wire-layer-notation rules (compass#125, standards/domain-grounding.md
+      # §5) — EXTENDS this gate with the M-notation layer-model rule set the
+      # carve-out ratchet never knew. It proved blind to the historical layer
+      # residuals fixed in compass#125 (vocab-allow: names the `L7` residual).
+      # V1–V3 (the banned layer-model aliases)
+      # are BLOCKING; V4 (bare L[1-7]) is warn-only
+      # during the L→M doc-sweep burn-in (promote with --enforce-l4). Also runs
+      # the §2.2 RFC-filename no-drift check against the myelin pack (resolved
+      # via `gh api`; skips non-blocking if myelin is unreachable).
+      - name: check-wire-vocab (layer-model notation + RFC no-drift)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun scripts/check-wire-vocab.ts
 
   # ──────────────────────────────────────────────────────────────────
   # Test — `bun test` runs the full unit/integration suite. Pre-cortex#376

--- a/agents-md.yaml
+++ b/agents-md.yaml
@@ -23,6 +23,13 @@ extra_labels:
 
 # Repo-specific sections injected at marked positions in the template
 sections:
+  # Wire-contract grounding — the `wire_grounding` slot (compass#125,
+  # standards/domain-grounding.md §2). Routes wire-touching work
+  # (src/bus/**) to the governing myelin RFC on demand. Renders empty until
+  # `arc upgrade compass` picks up the template's `after:domain-context`
+  # marker (regen is a held, principal-run step — cortex#2205).
+  - position: "after:domain-context"
+    file: docs/agents-md/wire-grounding.md
   - position: "after:description"
     file: docs/agents-md/architecture.md
   - position: "after:description"

--- a/docs/agents-md/wire-grounding.md
+++ b/docs/agents-md/wire-grounding.md
@@ -1,0 +1,30 @@
+### Wire-contract grounding (RFC routing)
+
+cortex's bus client (`src/bus/**`) implements the **client side** of the myelin wire
+contracts. The contracts themselves are **normative** and live in myelin, not here — so
+wire-touching work is routed to the governing RFC **on demand** rather than always-loaded.
+Before you touch a row's surface, **Read the RFC** it points at, then proceed grounded (same
+"trigger → Read the governing document → proceed" shape as the SOP activation table below).
+
+The RFCs are addressed **cross-repo** — they live in `the-metafactory/myelin` `specs/rfc/`,
+never a local cortex path. The routing table is a copy of a list myelin owns; a CI no-drift
+check (`scripts/check-wire-vocab.ts`) asserts every path below resolves to a real file in the
+myelin pack.
+
+| Trigger — you are touching… | Governing RFC (`the-metafactory/myelin specs/rfc/`) |
+|---|---|
+| `did:mf` identifiers, actor/agent id, `signed_by` chain construction (`verify-signed-by-chain.ts`, `envelope-builder.ts`) | `rfc-0001-identifiers.md` |
+| subjects, `deriveNatsSubject`, subject namespace/grammar, `nats.subjects` (`surface-router.ts`, `network-resolver.ts`, `nats/`) | `rfc-0002-subject-namespace.md` |
+| envelope format, headers, payload, the envelope validator (`myelin/envelope-validator.ts`, `envelope-builder.ts`) | `rfc-0003-envelope.md` |
+| envelope signing, signature verification, key material (`verify-signed-by-chain.ts`, `verifier-self-check.ts`) | `rfc-0004-envelope-signing.md` |
+| sovereignty, boundary crossing, `federated.*`, `source`/`originator`, `selectLink`, cross-principal routing (`sovereignty-gate.ts`, `network-resolver.ts`) | `rfc-0005-sovereignty-and-boundary-crossing.md` |
+| membership, admission, join/leave, admit request (`admission/`, `admit-offered-dispatch.ts`, `stack-provisioning.ts`) | `rfc-0006-membership-and-admission.md` |
+| transport, delivery modes, backoff, request-reply, reliability (`nats/`, `jetstream/`) | `rfc-0007-transport-and-reliability.md` |
+| capability discovery, signed capability advertisements (`capability-registry.ts`, `probe-responder.ts`) | `rfc-0008-capability-discovery.md` |
+| rate-limit / refusal / access-denied taxonomy (`gate-floor.ts`, `access-denied-dedup.ts`, `emit-system-access-denied.ts`) | `rfc-0010-rate-limit-and-refusal-taxonomy.md` |
+
+When work touches the economics or wire-change-control surfaces, add the matching rows
+(`rfc-0009-economics.md`, `rfc-bcp-0001-wire-change-control-and-versioning.md`). The RFC
+grammar is normative for `src/bus/**`: code conforms to the spec; a spec change is a wire
+change (governed by `rfc-bcp-0001`), a code change that diverges from the spec is a bug. See
+`compass/standards/domain-grounding.md` and `src/bus/CLAUDE.md`.

--- a/docs/design-internet-of-agentic-work.md
+++ b/docs/design-internet-of-agentic-work.md
@@ -20,7 +20,7 @@ The unit isn't the agent, isn't the stack — it's the network, and networks com
 
 ## §1 — OSI layering of the cortex stack
 
-cortex's canonical layered architecture is the **M1–M7 Myelin layer model** (`cortex/docs/architecture.md:69-105`). This document inherits that naming and refines the boundary between cortex (the M7 application) and myelin (the protocol stack M1–M6). Sibling issues land at specific layers; understanding which layer each one belongs to is the spine of this synthesis.
+cortex's canonical layered architecture is the **M1–M7 Myelin layer model** (`cortex/docs/architecture.md:69-105`). This document inherits that naming and refines the boundary between cortex (the M7 application) and myelin (the M1–M6 protocol layers). Sibling issues land at specific layers; understanding which layer each one belongs to is the spine of this synthesis.
 
 ### M1 — Raw connectivity (NATS + TLS + creds-auth)
 

--- a/docs/design-myelin-osi-scenarios.md
+++ b/docs/design-myelin-osi-scenarios.md
@@ -1,6 +1,6 @@
 # Myelin OSI Layer Model — Dispatch Scenarios
 
-**Status:** Pressure-test of the Direction A Q2 proposal against myelin's M1–M7 protocol stack. Surfaces four corrections to `docs/design-platform-adapter-dispatch-publishing.md`, adds Scenario 4 (cross-principal via shared platform surface) and Scenario 5 (bot-to-bot direct chat — the bus-native baseline). §12 has the locked answers for all four original §10 questions (Andreas, 2026-05-23 review); §14 captures the multi-subscriber / multi-surface pub-sub model.
+**Status:** Pressure-test of the Direction A Q2 proposal against myelin's M1–M7 layer model. Surfaces four corrections to `docs/design-platform-adapter-dispatch-publishing.md`, adds Scenario 4 (cross-principal via shared platform surface) and Scenario 5 (bot-to-bot direct chat — the bus-native baseline). §12 has the locked answers for all four original §10 questions (Andreas, 2026-05-23 review); §14 captures the multi-subscriber / multi-surface pub-sub model.
 **Date:** 2026-05-22 (Scenarios 1–3 + §1–§9); 2026-05-23 (Scenario 4, §11 locked answers)
 **Driver:** Andreas (pushback in #myelin → §10/§11 locked answers) + Jens-Christian (Direction A grilling)
 **Related:**

--- a/docs/mockups/mc-layouts/Vision - Internet of Agentic Work.md
+++ b/docs/mockups/mc-layouts/Vision - Internet of Agentic Work.md
@@ -1,7 +1,7 @@
 # The Internet of Agentic Work
 ### A vision for the meta-factory — cortex · myelin · soma · spawn · signal
 
-**In one line.** We're building the Internet of Agentic Work: a protocol stack and a cockpit where every person commands a swarm of assistants that never sleeps — and where the thing that endures isn't the software, it's the trust between the people who build together.
+**In one line.** We're building the Internet of Agentic Work: a layered protocol and a cockpit where every person commands a swarm of assistants that never sleeps — and where the thing that endures isn't the software, it's the trust between the people who build together.
 
 **The shift.** TCP/IP gave us the Internet — a layered stack where hosts, routers, and whole autonomous systems interoperate without anyone holding the entire thing in their head, until "the network" became something you could *map*. The meta-factory makes the same move for agents. Assistants are the hosts, stacks are the machines, networks are the trust domains, capabilities are the ports, envelopes are the packets, dispatch is the connection. The unit isn't the agent and isn't the stack — it's the network, and networks compose.
 

--- a/docs/vision-mission-control.md
+++ b/docs/vision-mission-control.md
@@ -19,7 +19,7 @@ MC is that bridge for agentic work. Underneath it: NATS leaf federation, signed 
 
 We built TCP/IP and got the Internet: a layered stack where hosts, routers, and autonomous systems interoperate without anyone holding the whole thing in their head — and "the network" became something you could **map**.
 
-The Myelin layer model (M1–M7) is the same move for **agents**. It is the protocol stack of the **Internet of Agentic Work** — and MC is its map and its network-operations center. The correspondence is exact enough to design against:
+The Myelin layer model (M1–M7) is the same move for **agents**. It is the layer model of the **Internet of Agentic Work** — and MC is its map and its network-operations center. The correspondence is exact enough to design against:
 
 | TCP/IP Internet | Internet of Agentic Work |
 |---|---|

--- a/scripts/check-wire-vocab.ts
+++ b/scripts/check-wire-vocab.ts
@@ -1,0 +1,249 @@
+#!/usr/bin/env bun
+//
+// check-wire-vocab.ts — the Myelin-layer-model vocabulary gate.
+//
+// This is the enforceable form of the notation decision (myelin#240) as
+// specified by compass/standards/domain-grounding.md §5. It EXTENDS cortex's
+// existing "Vocab carve-out gate" (scripts/check-carveouts.sh, the 0002
+// operator/bot/broadcast ratchet) with the wire-layer-notation rule set —
+// check-carveouts.sh owns the R-cluster term migration; this script owns the
+// M-notation layer-model rules the carve-out gate never knew (proven by the
+// live `L7`/`protocol stack` residuals fixed in compass#125).
+//
+// Rule set (standard §5.1). Canonical: M-notation (M1–M7); reconciled name
+// "Myelin layer model".
+//   V1  "the Myelin stack"      (banned alias — stack is a deployment unit)  → BLOCKING
+//   V2  "the seven-layer stack" (banned alias — same reason)                 → BLOCKING
+//   V3  "protocol stack"        (banned alias for the M2–M6 layers)          → BLOCKING
+//   V4  bare  \bL[1-7]\b  used as a live Myelin-layer reference              → WARN (burn-in)
+//
+// V4 is the drift-prone one (standard §5.2): L1–L7 ≡ M1–M7 is a DECLARED,
+// legal historical alias (CONTEXT-MAP), so a blanket ban is wrong. It also
+// collides with FOREIGN L-namespaces cortex legitimately uses (OSI layers,
+// arc's DD-L deployment decisions, the confidentiality program's L1/L2/L5
+// governance layers, the Rebuff prompt-injection L0/L1 scorer tiers). Cleaning
+// the ~30 genuine Myelin-layer L-refs in the historical design docs to
+// M-notation is a separate doc sweep (its own follow-up issue), so V4 ships
+// WARN-ONLY during a burn-in — the same posture cortex uses for every new
+// whole-tree gate (cf. the confidentiality-gate warn-only burn-in). Promote it
+// to blocking with --enforce-l4 (or CORTEX_WIRE_VOCAB_ENFORCE_L4=1) once the
+// sweep lands.
+//
+// §5.2 allowlist (never fails, both V1–V3 and V4):
+//   - fenced code blocks (```) and blockquotes (>) — verbatim / illustrative
+//   - a line matching a FOREIGN-namespace marker (§N, governance,
+//     data-classification, confidentiality, OSI, DD-L, compose/container,
+//     Rebuff/prompt-injection, systemd/auto-renderer) — not the Myelin model
+//   - an inline `vocab-allow: <reason>` marker (escape hatch; must name a reason)
+//
+// §2.2 no-drift check: every `specs/rfc/rfc-*.md` path named in the
+// wire_grounding routing table (docs/agents-md/wire-grounding.md) must resolve
+// to a real file in the myelin pack. Resolves myelin via $MYELIN_RFC_DIR, a
+// sibling ../myelin checkout, or `gh api` — SKIPS (non-blocking) with a notice
+// if myelin is unreachable, so CI stays green without a myelin checkout.
+//
+// Scope: tracked PROSE + CONFIG only (*.md, *.yaml, *.yml) — not code
+// identifiers, which have their own naming rules. The generated repo-root
+// CLAUDE.md is excluded (it is regenerated from the scanned section files by
+// `arc upgrade compass`; flagging it would double-flag its sources).
+//
+// Exit: 0 clean, 1 blocking violation (V1–V3, or a confirmed missing RFC path),
+// 2 usage/environment error.
+
+import { readdirSync, readFileSync, statSync, existsSync } from "fs";
+import { join, relative } from "path";
+import { execSync } from "child_process";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const ENFORCE_L4 =
+  process.argv.includes("--enforce-l4") ||
+  process.env.CORTEX_WIRE_VOCAB_ENFORCE_L4 === "1";
+
+// ── file walk ──────────────────────────────────────────────────────────────
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "coverage",
+  ".next",
+]);
+// Generated artifact — regenerated from the scanned agents-md section files.
+const EXCLUDE_FILES = new Set(["CLAUDE.md"]);
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const p = join(dir, entry);
+    let s;
+    try {
+      s = statSync(p);
+    } catch {
+      continue; // race on a deleted path; skip
+    }
+    if (s.isDirectory()) yield* walk(p);
+    else if (/\.(md|ya?ml)$/.test(entry)) yield p;
+  }
+}
+
+// ── §5.2 allowlist markers ───────────────────────────────────────────────────
+// Foreign L-namespaces + governance/quote markers. A line matching any of these
+// is exempt (it is not a Myelin-layer reference, or it is a record we must not
+// rewrite).
+const FOREIGN_MARKER =
+  /§\s*\d|governance|data-classification|confidentialit|\bOSI\b|\bDD-L\d|compose|container|\bframes\b|Rebuff|prompt-injection|scanPrompt|scorer|systemd|auto-renderer|linger|rollback|compass#8[147]|Phase L\d|\bL\d gate\b|gate \(warn|warn-only/i;
+const INLINE_ALLOW = /vocab-allow:\s*\S/i;
+
+// ── rules ────────────────────────────────────────────────────────────────────
+type Rule = {
+  id: string;
+  re: RegExp;
+  blocking: boolean;
+  canonical: string;
+};
+const RULES: Rule[] = [
+  { id: "V1", re: /the\s+Myelin\s+stack/i, blocking: true, canonical: '"the Myelin layer model"' },
+  { id: "V2", re: /the\s+seven[-\s]layer\s+stack/i, blocking: true, canonical: '"the Myelin layer model"' },
+  { id: "V3", re: /protocol\s+stack/i, blocking: true, canonical: '"M2–M6 protocol layers" / "the Myelin layer model"' },
+  { id: "V4", re: /\bL[1-7]\b/, blocking: ENFORCE_L4, canonical: "the matching M[1-7]" },
+];
+
+type Finding = { file: string; line: number; rule: Rule; text: string };
+const blockingFindings: Finding[] = [];
+const warnFindings: Finding[] = [];
+
+for (const abs of walk(REPO_ROOT)) {
+  const rel = relative(REPO_ROOT, abs);
+  if (EXCLUDE_FILES.has(rel)) continue;
+
+  const lines = readFileSync(abs, "utf8").split("\n");
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue; // fenced code — verbatim, exempt
+    if (/^\s*>/.test(line)) continue; // blockquote — quotation, exempt
+    if (INLINE_ALLOW.test(line)) continue; // explicit escape hatch
+    for (const rule of RULES) {
+      if (!rule.re.test(line)) continue;
+      // Foreign-namespace / governance / quote lines are legal (§5.2).
+      if (FOREIGN_MARKER.test(line)) continue;
+      const f: Finding = { file: rel, line: i + 1, rule, text: line.trim().slice(0, 140) };
+      (rule.blocking ? blockingFindings : warnFindings).push(f);
+    }
+  }
+}
+
+// ── §2.2 no-drift check ───────────────────────────────────────────────────────
+const TABLE = join(REPO_ROOT, "docs/agents-md/wire-grounding.md");
+let driftExit = 0;
+function resolveMyelinRfc(): { kind: "dir"; dir: string } | { kind: "gh" } | null {
+  const envDir = process.env.MYELIN_RFC_DIR;
+  if (envDir && existsSync(envDir)) return { kind: "dir", dir: envDir };
+  for (const d of [
+    join(REPO_ROOT, "..", "myelin", "specs", "rfc"),
+    join(process.env.HOME ?? "", "Developer", "myelin", "specs", "rfc"),
+  ]) {
+    if (existsSync(d)) return { kind: "dir", dir: d };
+  }
+  // gh api fallback — works when a token with myelin read access is present.
+  try {
+    execSync("gh auth status", { stdio: "ignore" });
+    return { kind: "gh" };
+  } catch {
+    return null;
+  }
+}
+
+function checkNoDrift(): void {
+  if (!existsSync(TABLE)) {
+    console.log("no-drift: no wire-grounding.md routing table — skipping.");
+    return;
+  }
+  const body = readFileSync(TABLE, "utf8");
+  // Match both the full `specs/rfc/rfc-*.md` form (standard §2.2 grep) and the
+  // bare `rfc-*.md` filename form this table uses (path prefix in the header).
+  const paths = [
+    ...new Set(
+      [...body.matchAll(/(?:specs\/rfc\/)?(rfc-[a-z0-9-]+\.md)/g)]
+        .map((m) => m[1])
+        .filter((x): x is string => Boolean(x)),
+    ),
+  ].sort();
+  if (paths.length === 0) {
+    console.log("no-drift: routing table names no RFC paths — skipping.");
+    return;
+  }
+  const src = resolveMyelinRfc();
+  if (!src) {
+    console.log(
+      `no-drift: myelin pack not reachable (set MYELIN_RFC_DIR, add a ../myelin checkout, or 'gh auth login') — SKIPPING the ${paths.length}-path drift check (non-blocking).`,
+    );
+    return;
+  }
+  let ghListing: Set<string> | null = null;
+  if (src.kind === "gh") {
+    try {
+      const out = execSync(
+        "gh api repos/the-metafactory/myelin/contents/specs/rfc --jq '.[].name'",
+        { encoding: "utf8" },
+      );
+      ghListing = new Set(out.split("\n").map((s) => s.trim()).filter(Boolean));
+    } catch {
+      console.log("no-drift: gh api call failed — SKIPPING drift check (non-blocking).");
+      return;
+    }
+  }
+  const missing: string[] = [];
+  for (const p of paths) {
+    const name = p.split("/").pop()!;
+    const ok = src.kind === "dir" ? existsSync(join(src.dir, name)) : ghListing!.has(name);
+    if (!ok) missing.push(p);
+  }
+  if (missing.length) {
+    driftExit = 1;
+    for (const m of missing) console.error(`no-drift: FAIL — routing target missing in myelin: ${m}`);
+  } else {
+    console.log(`no-drift: PASS — all ${paths.length} RFC path(s) resolve in the myelin pack.`);
+  }
+}
+
+// ── report ────────────────────────────────────────────────────────────────────
+function printGroup(title: string, findings: Finding[]): void {
+  if (!findings.length) return;
+  console.error(`\n${title}`);
+  for (const f of findings) {
+    console.error(`  ${f.file}:${f.line}  [${f.rule.id}] ${f.text}`);
+    console.error(`      → use ${f.rule.canonical}`);
+  }
+}
+
+checkNoDrift();
+
+console.log("──────────────────────────────────────────────────────────────");
+if (warnFindings.length) {
+  console.error(
+    `check-wire-vocab: WARN — ${warnFindings.length} bare L[1-7] Myelin-layer reference(s) (V4 burn-in; non-blocking until the L→M doc sweep + --enforce-l4)`,
+  );
+  printGroup("V4 (warn — convert to M-notation, or mark foreign with `vocab-allow: <reason>`):", warnFindings);
+}
+
+if (blockingFindings.length) {
+  printGroup("BLOCKING vocabulary violations (standard §5.1):", blockingFindings);
+  console.error(
+    `\ncheck-wire-vocab: FAIL — ${blockingFindings.length} blocking layer-model vocabulary violation(s).`,
+  );
+  console.error("See compass/standards/domain-grounding.md §5. Fix the wording, or (for a verbatim record) add an inline `vocab-allow: <reason>` marker.");
+  process.exit(1);
+}
+
+if (driftExit !== 0) {
+  console.error("\ncheck-wire-vocab: FAIL — RFC routing table names a path that does not exist in myelin (standard §2.2).");
+  process.exit(1);
+}
+
+console.log("check-wire-vocab: PASS — no blocking layer-model vocabulary violations.");
+process.exit(0);

--- a/src/bus/CLAUDE.md
+++ b/src/bus/CLAUDE.md
@@ -1,0 +1,11 @@
+# src/bus/ — Myelin M2–M6 wire client
+
+This tree implements the **client side** of the myelin wire contracts. The RFC grammar is
+**normative** here: code conforms to the spec; a divergence is a bug, and a spec change is a
+wire change (`the-metafactory/myelin specs/rfc/rfc-bcp-0001-wire-change-control-and-versioning.md`).
+Import wire primitives from `@the-metafactory/myelin` `./wire` — **do not hand-copy** the
+grammar/envelope/subject code into cortex (see cortex#2034).
+
+Governing RFCs (`the-metafactory/myelin specs/rfc/`; full trigger→RFC table in the repo-root `CLAUDE.md`):
+- subjects/`deriveNatsSubject` → `rfc-0002`; envelope+validator → `rfc-0003`, signing → `rfc-0004`; identity/`signed_by` → `rfc-0001`
+- sovereignty/`federated.*` → `rfc-0005`; admission → `rfc-0006`; transport → `rfc-0007`; discovery → `rfc-0008`; refusal → `rfc-0010`


### PR DESCRIPTION
Closes #2205.

Applies the compass domain-grounding standard (`standards/domain-grounding.md`, compass#125 / compass PR #138) to cortex: routes wire-touching work to the governing **myelin** RFCs (cross-repo) and gates the Myelin-layer-model vocabulary.

## Deliverables (per #2205)

**1. `wire_grounding` slot** — `docs/agents-md/wire-grounding.md` carries cortex's trigger→RFC table. RFCs are addressed **cross-repo** (`the-metafactory/myelin specs/rfc/rfc-000N-*.md`), never a local path — they live on myelin main (RFC pack merged via myelin PR #273). Wired in `agents-md.yaml` at `position: after:domain-context`. **Edits the SOURCE section file, not the generated repo-root `CLAUDE.md`.** Rows cover the wire surfaces cortex's bus client touches (identity, subjects, envelope, signing, sovereignty, admission, transport, discovery, refusal).

**2. Dir-scoped `src/bus/CLAUDE.md`** (standard §3) — ≤11 lines, names the governing RFCs cross-repo and states the grammar is normative for the M2–M6 wire client. All wire primitives referenced in the table (`verify-signed-by-chain.ts`, `envelope-builder.ts`, `surface-router.ts`, `network-resolver.ts`, `sovereignty-gate.ts`, `capability-registry.ts`, `gate-floor.ts`, …) live under `src/bus/`, so this single dir-scope covers the deliverable — matching the standard's own worked example (`cortex/src/bus/CLAUDE.md`).

**3. Edit-time hook** (standard §4) — `PreToolUse` (`Edit|Write`) reminder at `.claude/hooks/wire-grounding-reminder.ts` + registration in `.claude/settings.json`. Non-blocking by contract (emits `additionalContext`, always exits 0; never calls the bus/network — honours the repo's hooks-must-stay-non-blocking rule). Scopes to `src/bus/**` via its RULES table.

**4. Vocab gate** (standard §5) — `scripts/check-wire-vocab.ts` **extends** the existing carve-out gate (`check-carveouts.sh` owns the R-cluster term ratchet; this owns the M-notation layer-model rules the carve-out gate was blind to — the live `L7`/`protocol stack` residuals compass#125 caught). V1–V3 (banned layer-model aliases: "the Myelin stack", "the seven-layer stack", "protocol stack") are **BLOCKING**; V4 (bare `L[1-7]` as a live Myelin-layer ref) is **warn-only during an L→M doc-sweep burn-in** (promote with `--enforce-l4`). Includes the §5.2 foreign-namespace allowlist (OSI, arc DD-L, confidentiality L1/L2/L5, Rebuff L0/L1) and the §2.2 RFC-filename no-drift check against the myelin pack. Wired into `ci.yml` after `check-carveouts`.

**Alias sweeps** — cleared the banned V1–V3 aliases in existing prose (`docs/design-internet-of-agentic-work.md`, `docs/design-myelin-osi-scenarios.md`, `docs/vision-mission-control.md`, `docs/Vision - Internet of Agentic Work.md`): "protocol stack"/"the Myelin stack" → "M2–M6 protocol layers"/"the Myelin layer model".

## Gate posture (mirrors myelin#278/#285 warn-only burn-in)

The new `check-wire-vocab` gate is **clean-today on blocking rules** — zero V1–V3 violations after the sweeps. The 48 V4 `L[1-7]` residuals in historical design docs are **warn-only** (non-blocking), listed by the gate, and cleaned in a follow-up L→M doc sweep before `--enforce-l4` flips. `no-drift: PASS — all 11 RFC paths resolve in the myelin pack.`

## Regen HELD

The repo-root `CLAUDE.md` is **generated** — this PR edits only the source section files. The `wire_grounding` slot renders empty until a principal runs `arc upgrade compass`. Per the myelin#240 blast-radius note, that full regen is a **separate, held, principal-run step** and is deliberately NOT included here.

## Lanes

| Lane | Result |
|---|---|
| `bunx tsc --noEmit` | PASS |
| `bun run lint:errors` | PASS |
| `bash scripts/check-carveouts.sh` | PASS (whole-tree, no ungated violations) |
| `bun scripts/check-wire-vocab.ts` | PASS (0 blocking; 48 V4 warn burn-in; no-drift 11/11) |
| `bun test` | 12 pre-existing failures unrelated to this change |

The 12 `bun test` failures (`startCortex` boot-wiring ×8, `SurfaceContext.hook` ×4) are **pre-existing on `main`** (reproduced on baseline `8d9d0102`) and touch no file this PR changes — this PR imports into no source (docs/hook/script/ci only). They are environment-sensitive (missing NKey material / DNS) and out of scope for a docs-grounding PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
