### PR TITLE
brain: create_private_thread effect (cortex#2206)

### DIFF
--- a/src/adapters/mock.ts
+++ b/src/adapters/mock.ts
@@ -12,6 +12,7 @@ import type {
   ResponseTarget,
   OutboundFile,
   ContextMessage,
+  CreatePrivateThreadResult,
 } from "./types";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { SurfaceAdapter } from "../bus/surface-router";
@@ -35,6 +36,15 @@ export class MockAdapter implements PlatformAdapter {
   progressCleared: ResponseTarget[] = [];
   /** Recorded createThread calls */
   threadsCreated: { msg: InboundMessage; name: string }[] = [];
+  /** cortex#2206 — recorded createPrivateThread calls */
+  privateThreadsCreated: { channelId: string; name: string; memberIds: string[] }[] = [];
+  /**
+   * cortex#2206 — configurable return for `createPrivateThread`. Defaults to
+   * `undefined` ⇒ synthesize a deterministic `mock-private-thread-N` success,
+   * mirroring `createThread`'s counter. Tests that need to exercise the
+   * `{ ok: false }` (adapter-failure → `not_now`) path set this explicitly.
+   */
+  createPrivateThreadResult: CreatePrivateThreadResult | undefined = undefined;
   /** cortex#502 — recorded resolveLogicalTarget calls */
   logicalTargetsResolved: { surface: string; channel: string; thread?: string }[] = [];
   /**
@@ -141,6 +151,20 @@ export class MockAdapter implements PlatformAdapter {
       channelId: msg.channelId,
       threadId: `mock-thread-${this.threadCounter}`,
     };
+  }
+
+  /** cortex#2206 — see {@link createPrivateThreadResult} for the configurable-failure seam. */
+  async createPrivateThread(opts: {
+    channelId: string;
+    name: string;
+    memberIds: string[];
+  }): Promise<CreatePrivateThreadResult> {
+    this.privateThreadsCreated.push(opts);
+    if (this.createPrivateThreadResult !== undefined) {
+      return this.createPrivateThreadResult;
+    }
+    this.threadCounter++;
+    return { ok: true, threadId: `mock-private-thread-${this.threadCounter}` };
   }
 
   async notifyPrincipal(text: string): Promise<void> {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -199,6 +199,17 @@ export interface OutboundFile {
 }
 
 /**
+ * cortex#2206 — the result of a `createPrivateThread` call. NEVER a throw: a
+ * platform/API failure (or an unsupported surface) resolves `{ ok: false,
+ * detail }` so `daemon-brain-host.ts`'s `create_private_thread` handler can
+ * map it to a retryable `effect_rejected` (`not_now`) instead of an
+ * unhandled rejection.
+ */
+export type CreatePrivateThreadResult =
+  | { ok: true; threadId: string }
+  | { ok: false; detail: string };
+
+/**
  * The core adapter interface. Each platform implements this.
  * Adapters are thin I/O wrappers — all pipeline logic lives in MessageRouter.
  */
@@ -262,6 +273,46 @@ export interface PlatformAdapter {
   clearProgress(target: ResponseTarget): Promise<void>;
   /** Create a thread from a message */
   createThread(msg: InboundMessage, name: string): Promise<ResponseTarget>;
+
+  /**
+   * cortex#2206 — create a PRIVATE thread on `channelId` (a channel the
+   * CALLER already resolved — the brain-protocol host derives it from the
+   * agent's OWN presence binding, never from brain input) and add
+   * `memberIds` to it. Distinct from {@link createThread}:
+   *
+   *   - `createThread(msg, name)` — MESSAGE-anchored, always a thread the
+   *     inbound message's author (and anyone in the parent channel, for a
+   *     public thread) can already see.
+   *   - `createPrivateThread({ channelId, name, memberIds })` — CHANNEL-
+   *     anchored (no inbound message required) and PRIVATE: only the bot and
+   *     the explicitly added `memberIds` can see it.
+   *
+   * NEVER throws — a platform/API failure resolves `{ ok: false, detail }`.
+   * A surface with no private-thread-and-membership primitive resolves
+   * `{ ok: false, detail }` naming itself as unsupported, rather than
+   * throwing.
+   *
+   * OPTIONAL: most of this interface's existing consumers (the
+   * message-response pipeline, the review/dashboard surface-router face)
+   * have nothing to do with this capability at all — it exists for exactly
+   * one caller today, `daemon-brain-host.ts`'s `create_private_thread`
+   * effect handler, which already treats an absent implementation as "no
+   * capability configured" (`effect_rejected`, `not_now` — see
+   * cortex#2215, the not-yet-built boot-wiring issue) via its own
+   * `createPrivateThread` constructor option. Making this required would
+   * force every adapter bundle — including third-party ones with no stake
+   * in this feature — to implement it; optional keeps the blast radius to
+   * adapters that actually support it. cortex#2206's first real consumer
+   * (the `metafactory-cortex-adapter-discord` bundle) implements it
+   * separately, in that bundle's own repo — adapters are no longer in-tree
+   * (cortex#1797 S12, ADR-0024) so this repo has no adapter implementation
+   * to update alongside this interface addition.
+   */
+  createPrivateThread?(opts: {
+    channelId: string;
+    name: string;
+    memberIds: string[];
+  }): Promise<CreatePrivateThreadResult>;
 
   /**
    * cortex#502 — resolve a LOGICAL surface address (the review-path

--- a/src/brain/__tests__/daemon-brain-host.test.ts
+++ b/src/brain/__tests__/daemon-brain-host.test.ts
@@ -21,8 +21,10 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   DaemonBrainHost,
+  CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR,
   type DaemonTransport,
   type DaemonBrainProcess,
+  type CreatePrivateThreadFn,
 } from "../daemon-brain-host";
 import { MAX_TASK_ATTACHMENT_BYTES } from "../attachment-budget";
 import { type TaskEvent, type GateVerdictValue } from "../protocol";
@@ -87,6 +89,27 @@ function makeHooks(over: Partial<BrainTaskHooks> = {}): BrainTaskHooks & {
     onDispatch: over.onDispatch ?? ((d) => void dispatches.push(d)),
     onLog: over.onLog ?? (() => {}),
   };
+}
+
+/**
+ * cortex#2206 — a fake `create_private_thread` I/O seam. Records every call
+ * and, by default, succeeds with a deterministic incrementing thread id.
+ * Tests that need the adapter-failure path override via `result`.
+ */
+function makeThreadFn(
+  result?: (opts: { channelId: string; name: string; memberIds: string[] }) =>
+    | { ok: true; threadId: string }
+    | { ok: false; detail: string },
+): CreatePrivateThreadFn & {
+  calls: { channelId: string; name: string; memberIds: string[] }[];
+} {
+  const calls: { channelId: string; name: string; memberIds: string[] }[] = [];
+  const fn = async (opts: { channelId: string; name: string; memberIds: string[] }) => {
+    calls.push(opts);
+    if (result) return result(opts);
+    return { ok: true as const, threadId: `thread-${calls.length}` };
+  };
+  return Object.assign(fn, { calls });
 }
 
 /** Wait until `cond()` is true (poll), or throw after `timeoutMs`. */
@@ -528,6 +551,419 @@ describe("DaemonBrainHost — attachment budget (§12.5)", () => {
       JSON.stringify({ v: 1, type: "result", task_id: "big", status: "complete" }),
     );
     await runP;
+    await host.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_private_thread (cortex#2206)
+// ---------------------------------------------------------------------------
+
+describe("DaemonBrainHost — create_private_thread (cortex#2206)", () => {
+  test("members: \"source\" creates a thread on the agent's OWN channel binding, resolves the source user server-side, and answers thread_created", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "agent-own-channel",
+      createPrivateThread: threadFn,
+      anonReachable: true,
+    });
+    await host.start();
+
+    const runP = host.runTask(
+      makeTask({
+        task_id: "th1",
+        source: { surface: "discord", channel: "arrivals", thread: "", user: "newcomer-42" },
+      }),
+      makeHooks(),
+    );
+    await until(() => brain.lastTask()?.task_id === "th1");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "th1",
+        name: "welcome newcomer-42",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("thread_created"));
+
+    // Exactly the intended host call: the agent's OWN channel binding, never
+    // anything the brain could have named, and the member list resolved
+    // server-side from the task's own recorded source user.
+    expect(threadFn.calls).toEqual([
+      { channelId: "agent-own-channel", name: "welcome newcomer-42", memberIds: ["newcomer-42"] },
+    ]);
+
+    const created = brain.received.find((e) => e.type === "thread_created");
+    expect(created).toMatchObject({ type: "thread_created", task_id: "th1", thread_id: "thread-1" });
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "th1", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test("an anon-reachable agent requesting an explicit member list is refused effect_rejected/policy_denied — the adapter is NEVER called", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "agent-own-channel",
+      createPrivateThread: threadFn,
+      anonReachable: true, // e.g. AgentSchema.openOnboarding: true
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "evil" }), makeHooks());
+    await until(() => brain.lastTask()?.task_id === "evil");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "evil",
+        name: "definitely not a welcome thread",
+        members: ["some-arbitrary-platform-user-id"],
+      }),
+    );
+    await until(() => brain.hasEvent("effect_rejected"));
+
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "create_private_thread" });
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("policy_denied");
+    }
+    // The load-bearing assertion: the anon-reachable agent's explicit member
+    // list NEVER reached the adapter — the effect was refused before any I/O.
+    expect(threadFn.calls.length).toBe(0);
+    expect(brain.hasEvent("thread_created")).toBe(false);
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "evil", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test("a non-anon-reachable (trusted) agent MAY request an explicit member list", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn();
+    const host = new DaemonBrainHost({
+      agentId: "quest-master",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "quest-board-channel",
+      createPrivateThread: threadFn,
+      anonReachable: false, // explicit opt-out — this agent has no anon path
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "quest1" }), makeHooks());
+    await until(() => brain.lastTask()?.task_id === "quest1");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "quest1",
+        name: "quest party",
+        members: ["party-member-1", "party-member-2"],
+      }),
+    );
+    await until(() => brain.hasEvent("thread_created"));
+
+    expect(threadFn.calls).toEqual([
+      {
+        channelId: "quest-board-channel",
+        name: "quest party",
+        memberIds: ["party-member-1", "party-member-2"],
+      },
+    ]);
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "quest1", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test("the wire effect has no channel field — a brain-supplied `channel` is structurally ignored; the agent's own binding is always used", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "the-real-agent-channel",
+      createPrivateThread: threadFn,
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "spoof" }), makeHooks());
+    await until(() => brain.lastTask()?.task_id === "spoof");
+
+    // Raw wire line carrying an extra `channel` field — not a schema field at
+    // all (protocol.ts's CreatePrivateThreadEffectSchema has no such key), so
+    // the tolerant-ingest codec strips it before the effect ever reaches the
+    // host's switch. This is the "structurally impossible", not merely
+    // "refused", guarantee the issue calls for.
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "spoof",
+        name: "spoofed thread",
+        members: "source",
+        channel: "attacker-chosen-channel",
+      }),
+    );
+    await until(() => brain.hasEvent("thread_created"));
+
+    expect(threadFn.calls.length).toBe(1);
+    expect(threadFn.calls[0]?.channelId).toBe("the-real-agent-channel");
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "spoof", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test("no channel binding / no adapter capability configured → effect_rejected cant_do (structural, not policy)", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const host = new DaemonBrainHost({
+      agentId: "no-thread-capability",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      // agentChannelId / createPrivateThread both omitted.
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "nocap" }), makeHooks());
+    await until(() => brain.lastTask()?.task_id === "nocap");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "nocap",
+        name: "will never exist",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("effect_rejected"));
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("cant_do");
+    }
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "nocap", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test("an adapter failure maps to effect_rejected not_now (transient, not the brain's fault)", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn(() => ({ ok: false, detail: "discord API 503" }));
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "agent-own-channel",
+      createPrivateThread: threadFn,
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "fail1" }), makeHooks());
+    await until(() => brain.lastTask()?.task_id === "fail1");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "fail1",
+        name: "will fail",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("effect_rejected"));
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "create_private_thread" });
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("not_now");
+      expect(rej.reason.detail).toContain("discord API 503");
+    }
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "fail1", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test(`rate limit trips at exactly ${CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR}/hour for one agent — the next is refused, a DIFFERENT agent still succeeds`, async () => {
+    let nowMs = 1_000_000;
+    const clock = () => nowMs;
+
+    const brainA = new FakeBrain();
+    const { transport: transportA } = makeFakeTransport([brainA]);
+    const threadFnA = makeThreadFn();
+    const hostA = new DaemonBrainHost({
+      agentId: "agent-a",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport: transportA,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "channel-a",
+      createPrivateThread: threadFnA,
+      now: clock,
+    });
+    await hostA.start();
+
+    const runA = hostA.runTask(makeTask({ task_id: "rl" }), makeHooks());
+    await until(() => brainA.lastTask()?.task_id === "rl");
+
+    // Drive CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR (10) successful calls,
+    // all well within the hour window.
+    for (let i = 0; i < CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR; i++) {
+      nowMs += 1_000; // a few seconds apart — still the same window
+      brainA.emit(
+        JSON.stringify({
+          v: 1,
+          type: "create_private_thread",
+          task_id: "rl",
+          name: `thread-${i}`,
+          members: "source",
+        }),
+      );
+      await until(
+        () => brainA.received.filter((e) => e.type === "thread_created").length === i + 1,
+      );
+    }
+    expect(threadFnA.calls.length).toBe(CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR);
+
+    // The 11th within the SAME window is refused — the budget, not a fluke.
+    nowMs += 1_000;
+    brainA.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "rl",
+        name: "eleventh",
+        members: "source",
+      }),
+    );
+    await until(() => brainA.hasEvent("effect_rejected"));
+    const rej = brainA.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "create_private_thread" });
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("policy_denied");
+      expect(rej.reason.detail).toMatch(/rate|exceeded|limit/i);
+    }
+    // The 11th never reached the adapter.
+    expect(threadFnA.calls.length).toBe(CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR);
+
+    brainA.emit(JSON.stringify({ v: 1, type: "result", task_id: "rl", status: "complete" }));
+    await runA;
+    await hostA.stop();
+
+    // A DIFFERENT agent (its own DaemonBrainHost instance, its own counter)
+    // in the exact same window still succeeds — the budget is per-agent, not
+    // a global ceiling one agent's traffic can exhaust for everyone.
+    const brainB = new FakeBrain();
+    const { transport: transportB } = makeFakeTransport([brainB]);
+    const threadFnB = makeThreadFn();
+    const hostB = new DaemonBrainHost({
+      agentId: "agent-b",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport: transportB,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "channel-b",
+      createPrivateThread: threadFnB,
+      now: clock,
+    });
+    await hostB.start();
+    const runB = hostB.runTask(makeTask({ task_id: "rlb" }), makeHooks());
+    await until(() => brainB.lastTask()?.task_id === "rlb");
+
+    brainB.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "rlb",
+        name: "agent-b's first thread this hour",
+        members: "source",
+      }),
+    );
+    await until(() => brainB.hasEvent("thread_created"));
+    expect(threadFnB.calls.length).toBe(1);
+
+    brainB.emit(JSON.stringify({ v: 1, type: "result", task_id: "rlb", status: "complete" }));
+    await runB;
+    await hostB.stop();
+  });
+
+  test("an open create_private_thread call PAUSES the per-task timeout — no orphan (mirrors the ask_principal gate-pause, cortex#1073)", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    let resolveThread!: (v: { ok: true; threadId: string }) => void;
+    const slowThreadFn: CreatePrivateThreadFn = () =>
+      new Promise((resolve) => {
+        resolveThread = resolve;
+      });
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "agent-own-channel",
+      createPrivateThread: slowThreadFn,
+      taskTimeoutMs: 150, // deliberately shorter than the in-flight wait below
+    });
+    await host.start();
+
+    const runP = host.runTask(makeTask({ task_id: "slow" }), makeHooks());
+    await until(() => brain.lastTask()?.task_id === "slow");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "slow",
+        name: "slow platform round-trip",
+        members: "source",
+      }),
+    );
+
+    // The adapter call is deliberately held open far longer than
+    // taskTimeoutMs — the host must NOT fail the task while it's in flight.
+    await new Promise((r) => setTimeout(r, 300));
+    resolveThread({ ok: true, threadId: "thread-slow" });
+
+    await until(() => brain.hasEvent("thread_created"));
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "slow", status: "complete" }));
+
+    const result = await runP;
+    expect(result.result.status).toBe("complete"); // NOT "failed"/timeout
     await host.stop();
   });
 });

--- a/src/brain/__tests__/exec-brain-runner.test.ts
+++ b/src/brain/__tests__/exec-brain-runner.test.ts
@@ -283,6 +283,31 @@ for await (const ev of it) {
   });
 });
 
+describe("exec-brain-runner — create_private_thread (cortex#2206, B-1 unsupported)", () => {
+  test("create_private_thread is always refused effect_rejected — the per-task lifecycle has no adapter binding", async () => {
+    const fx = writeFixture(
+      "thread-unsupported.ts",
+      `${LINE_ITER}
+const it = lines();
+const task = (await it.next()).value;
+emit({ v: 1, type: "create_private_thread", task_id: task.task_id, name: "welcome", members: "source" });
+for await (const ev of it) {
+  if (ev.type === "effect_rejected") {
+    done({ v: 1, type: "result", task_id: task.task_id, status: "complete", summary: "rejected=" + ev.reason.kind + " effect=" + ev.effect });
+  }
+}
+`,
+    );
+    const hooks = makeHooks();
+    const out = await runner(fx)(makeTask(), hooks);
+
+    expect(out.result.status).toBe("complete");
+    if (out.result.status === "complete") {
+      expect(out.result.summary).toBe("rejected=wont_do effect=create_private_thread");
+    }
+  });
+});
+
 describe("exec-brain-runner — brain crash", () => {
   test("brain exits without result → synthesized failed (cant_do) with stderr tail", async () => {
     const fx = writeFixture(

--- a/src/brain/__tests__/protocol.test.ts
+++ b/src/brain/__tests__/protocol.test.ts
@@ -54,6 +54,12 @@ const events: BrainEvent[] = [
   { v: 1, type: "shutdown", deadline_ms: 5000 },
   {
     v: 1,
+    type: "thread_created",
+    task_id: "t1",
+    thread_id: "thread-abc123",
+  },
+  {
+    v: 1,
     type: "effect_rejected",
     task_id: "t1",
     effect: "dispatch",
@@ -105,6 +111,20 @@ const effects: BrainEffect[] = [
     task_id: "t1",
     capability: "soc.triage.email",
     payload: {},
+  },
+  {
+    v: 1,
+    type: "create_private_thread",
+    task_id: "t1",
+    name: "welcome newcomer",
+    members: "source",
+  },
+  {
+    v: 1,
+    type: "create_private_thread",
+    task_id: "t1",
+    name: "quest party",
+    members: ["u1", "u2"],
   },
   { v: 1, type: "result", task_id: "t1", status: "complete", summary: "done" },
   { v: 1, type: "result", task_id: "t1", status: "complete" },
@@ -512,6 +532,111 @@ describe("gate_verdict vocabulary", () => {
       verdict: "pass",
     });
     expect(parseBrainEvent(line).kind).toBe("invalid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_private_thread / thread_created (cortex#2206)
+// ---------------------------------------------------------------------------
+
+describe("create_private_thread schema", () => {
+  test("members accepts the literal \"source\"", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "create_private_thread",
+      task_id: "t1",
+      name: "welcome",
+      members: "source",
+    });
+    expect(parseBrainEffect(line).kind).toBe("ok");
+  });
+
+  test("members accepts an explicit string array", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "create_private_thread",
+      task_id: "t1",
+      name: "quest party",
+      members: ["u1", "u2"],
+    });
+    expect(parseBrainEffect(line).kind).toBe("ok");
+  });
+
+  test("members rejects any other string literal (only \"source\" or an array is valid)", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "create_private_thread",
+      task_id: "t1",
+      name: "welcome",
+      members: "everyone",
+    });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+
+  test("members is required", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "create_private_thread",
+      task_id: "t1",
+      name: "welcome",
+    });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+
+  test("name is required (non-empty)", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "create_private_thread",
+      task_id: "t1",
+      name: "",
+      members: "source",
+    });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+
+  // The load-bearing structural guarantee (issue cortex#2206): the wire
+  // schema has NO channel field at all. A brain that includes one is not
+  // "refused" — the field is silently stripped by the tolerant-ingest codec
+  // before the effect ever reaches host policy, so there is no code path by
+  // which a brain-named channel could influence anything downstream.
+  test("a brain-supplied `channel` field is stripped — there is no such field on the wire", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "create_private_thread",
+      task_id: "t1",
+      name: "welcome",
+      members: "source",
+      channel: "attacker-chosen-channel-id",
+    });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.effect).not.toHaveProperty("channel");
+    }
+  });
+
+  test("thread_created requires a non-empty thread_id", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "thread_created",
+      task_id: "t1",
+      thread_id: "",
+    });
+    expect(parseBrainEvent(line).kind).toBe("invalid");
+  });
+
+  test("thread_created round-trips with a real thread id", () => {
+    const ev = {
+      v: 1,
+      type: "thread_created",
+      task_id: "t1",
+      thread_id: "912345678901234567",
+    } as const;
+    const parsed = parseBrainEvent(encodeBrainEvent(ev));
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.event).toEqual(ev);
+    }
   });
 });
 

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -22,7 +22,12 @@
  *      delivery"; identity is HOST-AUTHORITATIVE);
  *   3. accepts `runTask(task, hooks)` calls — writes the `task` event, routes
  *      the brain's effects (post / ask_principal / dispatch / log / result) to
- *      the per-task hooks, and resolves when that task's `result` arrives;
+ *      the per-task hooks, and resolves when that task's `result` arrives.
+ *      `create_private_thread` (cortex#2206) is the one effect NOT routed
+ *      through the per-task hooks: it is host-POLICY (channel binding,
+ *      anon-reachable membership gate, rate limit), so this file enforces it
+ *      directly and calls an injected {@link CreatePrivateThreadFn} only for
+ *      the mechanical create-thread-and-add-members I/O;
  *   4. enforces, PER TASK (not per process): task_id correlation, scratch
  *      confinement, and the 4 MiB attachment budget (§12.5). Scratch dirs are
  *      created per TASK and removed when the task closes — confinement stays
@@ -68,6 +73,7 @@ import {
   JsonlDecoder,
   type TaskEvent,
   type ResultEffect,
+  type HostReasonKind,
 } from "./protocol";
 import {
   buildArgv,
@@ -152,6 +158,55 @@ export type DaemonTransport = (opts: {
 export const SOCKET_AUTH_TIMEOUT_MS = 2_000;
 
 // ---------------------------------------------------------------------------
+// `create_private_thread` I/O seam (cortex#2206)
+// ---------------------------------------------------------------------------
+
+/**
+ * The result of a `create_private_thread` I/O attempt. NEVER throws — a
+ * platform/API failure resolves `{ ok: false, detail }` so the host maps it
+ * to a retryable `effect_rejected` (`not_now`) instead of an unhandled
+ * rejection (mirrors every other injected seam in this file).
+ */
+export type CreatePrivateThreadOutcome =
+  | { ok: true; threadId: string }
+  | { ok: false; detail: string };
+
+/**
+ * The actual create-thread-and-add-members I/O for a `create_private_thread`
+ * effect (cortex#2206). Every POLICY decision — which channel, who gets
+ * added, whether the rate limit allows it — is made by
+ * {@link DaemonBrainHost} itself, BEFORE this function is ever called; this
+ * seam performs only the mechanical platform call under parameters the host
+ * already decided. Mirrors the `transport` seam: production wires the real
+ * Discord adapter (`src/adapters/discord/index.ts`'s `createPrivateThread`);
+ * tests inject a fake.
+ */
+export type CreatePrivateThreadFn = (opts: {
+  /** The parent channel — ALWAYS the agent's own binding, never brain input. */
+  channelId: string;
+  name: string;
+  /** Host-resolved member ids — `"source"` has already been expanded server-side. */
+  memberIds: string[];
+}) => Promise<CreatePrivateThreadOutcome>;
+
+/**
+ * Rate limit for `create_private_thread`: 10/hour, PER AGENT (ADR
+ * cortex#2206 #2). Each {@link DaemonBrainHost} instance already serves
+ * exactly one agent (`agentId` is fixed at construction), so the limiter
+ * state below is naturally per-agent without needing to key it — a second
+ * agent gets its own `DaemonBrainHost` instance and its own counter.
+ *
+ * Open follow-up (explicitly NOT required for v1, per the ADR): this budget
+ * is shared across every triggering user of an anon-reachable agent, so one
+ * bad actor can exhaust the hour's capacity for every legitimate newcomer.
+ * Per-triggering-user budgets are a fast-follow if abuse is observed.
+ */
+export const CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR = 10;
+
+/** The sliding window `CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR` is measured over. */
+const CREATE_PRIVATE_THREAD_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
 
@@ -212,6 +267,39 @@ export interface DaemonBrainHostOpts {
   onDegraded?: (agentId: string) => void;
   /** Test seam — clock for uptime accounting. Defaults to `() => Date.now()`. */
   now?: () => number;
+  /**
+   * cortex#2206 — the parent channel a `create_private_thread` effect opens
+   * its thread on. ALWAYS the agent's OWN presence binding
+   * (`presence.discord.agentChannelId` today), resolved by the CALLER at
+   * construction — never supplied by the brain (the wire effect carries no
+   * channel field at all; that absence is intentional, see `protocol.ts`'s
+   * `CreatePrivateThreadEffectSchema`). Undefined ⇒ this agent has no
+   * thread-capable surface bound; every `create_private_thread` effect is
+   * refused `effect_rejected` (`not_now`).
+   */
+  agentChannelId?: string;
+  /**
+   * cortex#2206 — the injected create-thread-and-add-members I/O
+   * ({@link CreatePrivateThreadFn}). Undefined ⇒ same `not_now` refusal as a
+   * missing `agentChannelId` (no capability configured for this agent).
+   */
+  createPrivateThread?: CreatePrivateThreadFn;
+  /**
+   * cortex#2206 — true when this agent is reachable by an unmapped,
+   * zero-authority anon principal (`AgentSchema.openOnboarding`,
+   * cortex#1165). Gates `create_private_thread`'s `members` field: while
+   * `true`, a brain requesting anything other than the literal `"source"` is
+   * refused `effect_rejected` (`policy_denied`) — an anon-reachable brain
+   * may never name its own thread membership.
+   *
+   * **Defaults to `true` — the SAFE default.** A brand-new capability like
+   * this must fail toward the MORE restrictive behaviour when the caller
+   * doesn't say otherwise; an agent must be EXPLICITLY constructed with
+   * `anonReachable: false` before its brain may request an explicit member
+   * list. (ADR cortex#2206 #1: "which future agents get [the wider path] is
+   * each of their own onboarding, not a blanket switch.")
+   */
+  anonReachable?: boolean;
 }
 
 /** Per-task tracking record (one per multiplexed task_id). */
@@ -257,6 +345,23 @@ export class DaemonBrainHost {
   private readonly makeSocketPath: (agentId: string) => string;
   private readonly onDegraded: ((agentId: string) => void) | undefined;
   private readonly now: () => number;
+  /** cortex#2206 — see {@link DaemonBrainHostOpts.agentChannelId}. */
+  private readonly agentChannelId: string | undefined;
+  /** cortex#2206 — see {@link DaemonBrainHostOpts.createPrivateThread}. */
+  private readonly createPrivateThreadFn: CreatePrivateThreadFn | undefined;
+  /** cortex#2206 — see {@link DaemonBrainHostOpts.anonReachable}. Fail-safe default: `true`. */
+  private readonly anonReachable: boolean;
+  /**
+   * cortex#2206 — sliding-window timestamps (ms) of accepted
+   * `create_private_thread` ATTEMPTS (recorded before the adapter call, not
+   * only on success — an attempt that fails at the platform still cost a
+   * real API call and must still count against the budget). Pruned lazily
+   * on each check/record; never grows past
+   * {@link CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR} entries. In-memory
+   * only — does NOT survive a daemon restart (see file header discussion in
+   * the PR/issue for why that's an accepted v1 tradeoff).
+   */
+  private threadCreateAttempts: number[] = [];
 
   /** Live process + connection for the CURRENT generation. */
   private proc: DaemonBrainProcess | null = null;
@@ -303,6 +408,9 @@ export class DaemonBrainHost {
     this.makeSocketPath = opts.makeSocketPath ?? defaultMakeSocketPath;
     this.onDegraded = opts.onDegraded;
     this.now = opts.now ?? (() => Date.now());
+    this.agentChannelId = opts.agentChannelId;
+    this.createPrivateThreadFn = opts.createPrivateThread;
+    this.anonReachable = opts.anonReachable ?? true;
   }
 
   /** True once the restart budget is exhausted — the consumer stops dispatching. */
@@ -892,6 +1000,138 @@ export class DaemonBrainHost {
         }
         return;
       }
+      case "create_private_thread": {
+        // cortex#2206 — open a private thread off THIS agent's own channel
+        // binding. Every parameter that matters (channel, membership, rate
+        // budget) is decided HERE, host-side — the effect payload carries no
+        // channel at all (intentional), and `members` is enforced, not
+        // trusted, before it ever reaches the adapter.
+        //
+        // PAUSE the per-task liveness timeout while the thread-create call
+        // is in flight — identical reasoning to `ask_principal`
+        // (cortex#1073): this is async I/O (a platform REST round-trip), not
+        // brain liveness, so a slow (but honest) platform response must
+        // never race the timeout and fail a task that isn't hung. Re-arm
+        // once every open gate (ask_principal OR create_private_thread)
+        // closes.
+        if (record.openGates === 0 && record.timeoutTimer !== undefined) {
+          clearTimeout(record.timeoutTimer);
+          record.timeoutTimer = undefined;
+        }
+        record.openGates += 1;
+        try {
+          // 1. Structural: no channel binding / no adapter capability wired
+          // for this agent ⇒ this agent simply cannot do this, full stop.
+          // cant_do (not not_now): this will never resolve on retry without
+          // a redeploy/config change, unlike the genuinely transient states
+          // (degraded, draining, adapter I/O failure) that use not_now
+          // elsewhere in this file — a brain must not burn rate-limit budget
+          // retrying a capability that can never appear (code review, PR #2214).
+          if (this.agentChannelId === undefined || this.createPrivateThreadFn === undefined) {
+            await this.rejectEffect(
+              e.task_id,
+              "create_private_thread",
+              "cant_do",
+              `agent "${this.agentId}" has no thread-capable surface binding configured`,
+            );
+            return;
+          }
+
+          // 2. Anon-reachable gate (ADR cortex#2206 #1). An agent an
+          // unmapped, zero-authority stranger can reach may NEVER have its
+          // brain name arbitrary thread members — only "source" (the
+          // triggering event's own author, resolved below in step 3) is
+          // permitted. Checked BEFORE resolving members so a violating
+          // request never even gets as far as touching the rate budget.
+          if (this.anonReachable && e.members !== "source") {
+            await this.rejectEffect(
+              e.task_id,
+              "create_private_thread",
+              "policy_denied",
+              `agent "${this.agentId}" is anon-reachable (openOnboarding); ` +
+                `members must be "source" — an explicit member list is refused`,
+            );
+            return;
+          }
+
+          // 3. Resolve membership SERVER-SIDE. "source" is ALWAYS the
+          // task's own recorded source user (record.task.source.user, set
+          // by the host when the task was created from the inbound event) —
+          // never anything the brain put on the wire. An explicit list
+          // (only reachable for a non-anon-reachable agent, per step 2) is
+          // the brain's own request, passed through as-is; per-recipient
+          // authorization for that path is future work owned by whichever
+          // trusted agent uses it, not this effect's job to second-guess
+          // (ADR cortex#2206 #1).
+          const memberIds =
+            e.members === "source" ? [record.task.source.user] : e.members;
+
+          // 4. Rate limit — 10/hour/agent (named constant), a real sliding
+          // window. Checked (and reserved) AFTER the structural/policy
+          // gates above so a request that was going to be refused anyway
+          // never burns budget.
+          if (this.isThreadCreateRateLimited()) {
+            await this.rejectEffect(
+              e.task_id,
+              "create_private_thread",
+              "policy_denied",
+              `agent "${this.agentId}" exceeded ${CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR} ` +
+                `create_private_thread calls in the past hour`,
+            );
+            return;
+          }
+          // Reserve the slot BEFORE the (possibly slow) adapter call — an
+          // attempt costs real platform-API budget whether or not it
+          // ultimately succeeds; counting only successes would let a brain
+          // that keeps hitting a failing/slow path dodge the limit entirely.
+          this.recordThreadCreateAttempt();
+
+          // 5. Perform the actual I/O. Never throws by contract
+          // (CreatePrivateThreadFn) — a platform failure comes back as
+          // `{ ok: false, detail }`, not a rejection.
+          const outcome = await this.createPrivateThreadFn({
+            channelId: this.agentChannelId,
+            name: e.name,
+            memberIds,
+          });
+
+          // The task may have been drained/cancelled while the call was in
+          // flight — never forward a result to a closed/replaced task
+          // (§7.5, same rule `ask_principal` follows for `gate_verdict`).
+          if (record.settled) return;
+
+          if (!outcome.ok) {
+            // A genuine adapter/platform failure is transient/retryable —
+            // NOT the brain's fault and NOT a policy refusal.
+            await this.rejectEffect(
+              e.task_id,
+              "create_private_thread",
+              "not_now",
+              outcome.detail,
+            );
+            return;
+          }
+
+          await this.sendToConn(
+            encodeBrainEvent({
+              v: 1,
+              type: "thread_created",
+              task_id: e.task_id,
+              thread_id: outcome.threadId,
+            }) + "\n",
+          );
+        } finally {
+          record.openGates = Math.max(0, record.openGates - 1);
+          // Last gate closed and the task is still live → re-arm the
+          // liveness timeout for the remaining (deterministic) steps.
+          if (record.openGates === 0 && !record.settled && record.timeoutTimer === undefined) {
+            record.timeoutTimer = setTimeout(() => {
+              void this.failTask(record, "timeout");
+            }, this.taskTimeoutMs);
+          }
+        }
+        return;
+      }
       case "result":
         this.settleTask(record, e);
         return;
@@ -971,11 +1211,20 @@ export class DaemonBrainHost {
     }
   }
 
-  /** Send an `effect_rejected` for a refused effect. Best-effort. */
+  /**
+   * Send an `effect_rejected` for a refused effect. Best-effort.
+   *
+   * `kind` accepts the FULL host taxonomy ({@link HostReasonKind}) — not
+   * just the 3-kind brain subset — because `create_private_thread`'s policy
+   * refusals (anon-reachable agent naming its own members; rate limit trip)
+   * are `policy_denied`, a host-only kind (cortex#2206). Every pre-existing
+   * call site keeps passing one of the original 3 kinds, so this widening is
+   * purely additive.
+   */
   private async rejectEffect(
     taskId: string,
     effect: string,
-    kind: "cant_do" | "not_now" | "wont_do",
+    kind: HostReasonKind,
     detail: string,
   ): Promise<void> {
     await this.sendToConn(
@@ -987,6 +1236,25 @@ export class DaemonBrainHost {
         reason: { kind, detail },
       }) + "\n",
     );
+  }
+
+  /**
+   * cortex#2206 — true when this agent has already made
+   * {@link CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR} `create_private_thread`
+   * ATTEMPTS within the trailing hour. Prunes expired entries first (a real
+   * sliding window, not a fixed bucket that resets on the hour boundary).
+   * Read-only — pair with {@link recordThreadCreateAttempt} to reserve a
+   * slot once the caller has decided to proceed.
+   */
+  private isThreadCreateRateLimited(): boolean {
+    const cutoff = this.now() - CREATE_PRIVATE_THREAD_RATE_LIMIT_WINDOW_MS;
+    this.threadCreateAttempts = this.threadCreateAttempts.filter((t) => t > cutoff);
+    return this.threadCreateAttempts.length >= CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR;
+  }
+
+  /** Record one `create_private_thread` attempt against this agent's sliding window. */
+  private recordThreadCreateAttempt(): void {
+    this.threadCreateAttempts.push(this.now());
   }
 
   /** Write a line to the live connection, swallowing a closed-socket error. */

--- a/src/brain/exec-brain-runner.ts
+++ b/src/brain/exec-brain-runner.ts
@@ -28,6 +28,9 @@
  *        - `post`          → `hooks.onPost`
  *        - `ask_principal` → `hooks.onAskPrincipal` → answer `gate_verdict`
  *        - `dispatch`      → `hooks.onDispatch`; may reject → `effect_rejected`
+ *        - `create_private_thread` → ALWAYS refused `effect_rejected` (this
+ *          lifecycle has no live surface-adapter binding; cortex#2206 is
+ *          daemon-lifecycle only — see `daemon-brain-host.ts`)
  *        - `log`           → `hooks.onLog`
  *        - `result`        → terminal; resolve.
  *   5. task_id correlation: any effect whose `task_id` ≠ the spawned task's id
@@ -572,6 +575,19 @@ export function makeExecBrainRunner(
               }),
             );
           }
+          return;
+        }
+        case "create_private_thread": {
+          // cortex#2206 — this capability is DAEMON-lifecycle only: it needs
+          // a live surface-adapter binding + a supervising host's rate
+          // limiter/timeout-pause machinery, none of which the per-task
+          // (B-1) runner has (this is a fresh spawn-per-task process with no
+          // standing adapter connection). Refuse rather than silently no-op.
+          await rejectEffect(
+            "create_private_thread",
+            "create_private_thread is not supported by the per-task (lifecycle: per-task) " +
+              "exec-brain runner — only daemon-lifecycle brains may open private threads (cortex#2206)",
+          );
           return;
         }
         case "result":

--- a/src/brain/protocol.ts
+++ b/src/brain/protocol.ts
@@ -12,10 +12,13 @@
  *   - **Cortex → brain (events).** Things the host tells the brain about:
  *     a `task` to run, a follow-up `message`, a host-resolved `gate_verdict`,
  *     a `cancel`, a `shutdown` drain signal, an `effect_rejected` (cortex
- *     refused one of the brain's effects), and the daemon `hello` handshake.
+ *     refused one of the brain's effects), a `thread_created` (the answer to
+ *     a `create_private_thread` effect), and the daemon `hello` handshake.
  *   - **Brain → cortex (effects).** Things the brain asks the host to do:
  *     `post` to a surface, `ask_principal` (render a gate), `dispatch` fleet
- *     work, `result` (close the task), and `log`.
+ *     work, `create_private_thread` (open a private thread off the agent's
+ *     own channel binding — cortex#2206), `result` (close the task), and
+ *     `log`.
  *
  * The brain never sees a platform token, a NATS credential, or another
  * agent's identity (§5 property 1). It *asks* for effects; cortex *performs*
@@ -203,6 +206,7 @@ export const BRAIN_EVENT_CANCEL = "cancel" as const;
 export const BRAIN_EVENT_SHUTDOWN = "shutdown" as const;
 export const BRAIN_EVENT_EFFECT_REJECTED = "effect_rejected" as const;
 export const BRAIN_EVENT_HELLO = "hello" as const;
+export const BRAIN_EVENT_THREAD_CREATED = "thread_created" as const;
 
 /**
  * `task` — start a unit of work. Per-task brains receive `persona` here (§5
@@ -250,6 +254,28 @@ export const GateVerdictEventSchema = z.object({
   principal: z.string().min(1),
 });
 export type GateVerdictEvent = z.infer<typeof GateVerdictEventSchema>;
+
+/**
+ * `thread_created` — the answer to a `create_private_thread` effect
+ * (cortex#2206), modeled directly on {@link GateVerdictEventSchema}'s shape:
+ * the brain asks for an async host effect, the host performs it, and this
+ * event carries the result back correlated by `task_id`. `thread_id` is the
+ * HOST-RESOLVED platform thread id — the brain never chose it, exactly as
+ * `gate_verdict.principal` is host-resolved, never brain-supplied.
+ *
+ * There is no failure variant of this event — a refused or failed
+ * `create_private_thread` reuses the EXISTING `effect_rejected` event
+ * verbatim (rate-limit trip and an anon-reachable agent naming its own
+ * members both map to `policy_denied`; a genuine adapter/platform failure
+ * maps to `not_now`, transient/retryable). No new failure shape was needed.
+ */
+export const ThreadCreatedEventSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EVENT_THREAD_CREATED),
+  task_id: z.string().min(1),
+  thread_id: z.string().min(1),
+});
+export type ThreadCreatedEvent = z.infer<typeof ThreadCreatedEventSchema>;
 
 /** `cancel` — abandon an in-flight task. */
 export const CancelEventSchema = z.object({
@@ -327,6 +353,7 @@ export const BrainEventSchema = z.discriminatedUnion("type", [
   ShutdownEventSchema,
   EffectRejectedEventSchema,
   HelloEventSchema,
+  ThreadCreatedEventSchema,
 ]);
 export type BrainEvent = z.infer<typeof BrainEventSchema>;
 
@@ -337,6 +364,7 @@ export type BrainEvent = z.infer<typeof BrainEventSchema>;
 export const BRAIN_EFFECT_POST = "post" as const;
 export const BRAIN_EFFECT_ASK_PRINCIPAL = "ask_principal" as const;
 export const BRAIN_EFFECT_DISPATCH = "dispatch" as const;
+export const BRAIN_EFFECT_CREATE_PRIVATE_THREAD = "create_private_thread" as const;
 export const BRAIN_EFFECT_RESULT = "result" as const;
 export const BRAIN_EFFECT_LOG = "log" as const;
 
@@ -425,6 +453,49 @@ export const DispatchEffectSchema = z.object({
 export type DispatchEffect = z.infer<typeof DispatchEffectSchema>;
 
 /**
+ * `members` on a `create_private_thread` effect (cortex#2206): either the
+ * literal `"source"` — resolve to the task's own recorded source user,
+ * SERVER-SIDE, never from anything the brain sent — or an explicit list of
+ * platform user ids the brain is requesting.
+ *
+ * The wire type stays OPEN (not narrowed to `"source"`-only) because a
+ * future trusted, principal-mapped agent (e.g. quest spaces, guildhall idea
+ * 0026) needs multi-member threads. Enforcement of WHO may use the open form
+ * is host-side policy, not a type-level restriction (ADR cortex#2206 #1): an
+ * anon-reachable agent (`AgentSchema.openOnboarding`) requesting anything
+ * other than `"source"` is refused `effect_rejected` (`policy_denied`) by
+ * the host — see `daemon-brain-host.ts`'s `create_private_thread` case.
+ */
+export const CreatePrivateThreadMembersSchema = z.union([
+  z.literal("source"),
+  z.array(z.string().min(1)),
+]);
+export type CreatePrivateThreadMembers = z.infer<
+  typeof CreatePrivateThreadMembersSchema
+>;
+
+/**
+ * `create_private_thread` — open a private thread and put specific people in
+ * it (cortex#2206; guildhall's escort onboarding seat, guildhall idea 0026's
+ * quest spaces). Deliberately carries NO channel field — that absence is
+ * intentional, not an oversight: the brain must never be able to name an
+ * arbitrary channel. The host derives the parent channel from the AGENT'S
+ * OWN binding (`presence.discord.agentChannelId` today) — see
+ * `daemon-brain-host.ts`. The answer comes back as a {@link
+ * ThreadCreatedEvent}; a refusal reuses {@link EffectRejectedEventSchema}.
+ */
+export const CreatePrivateThreadEffectSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EFFECT_CREATE_PRIVATE_THREAD),
+  task_id: z.string().min(1),
+  name: z.string().min(1),
+  members: CreatePrivateThreadMembersSchema,
+});
+export type CreatePrivateThreadEffect = z.infer<
+  typeof CreatePrivateThreadEffectSchema
+>;
+
+/**
  * `result` — closes the task. `complete` carries an optional `summary`;
  * `failed` carries the typed `reason` (cant_do | not_now | wont_do — §5
  * property 5). Modeled as a `status`-discriminated union so a `failed` result
@@ -469,6 +540,7 @@ export const BrainEffectSchema = z.discriminatedUnion("type", [
   PostEffectSchema,
   AskPrincipalEffectSchema,
   DispatchEffectSchema,
+  CreatePrivateThreadEffectSchema,
   ResultEffectSchema,
   LogEffectSchema,
 ]);
@@ -499,6 +571,7 @@ const KNOWN_EFFECT_TYPES: ReadonlySet<string> = new Set([
   BRAIN_EFFECT_POST,
   BRAIN_EFFECT_ASK_PRINCIPAL,
   BRAIN_EFFECT_DISPATCH,
+  BRAIN_EFFECT_CREATE_PRIVATE_THREAD,
   BRAIN_EFFECT_RESULT,
   BRAIN_EFFECT_LOG,
 ]);
@@ -608,6 +681,7 @@ const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
   BRAIN_EVENT_SHUTDOWN,
   BRAIN_EVENT_EFFECT_REJECTED,
   BRAIN_EVENT_HELLO,
+  BRAIN_EVENT_THREAD_CREATED,
 ]);
 
 export function parseBrainEvent(line: string): ParseBrainEventResult {


### PR DESCRIPTION
Closes #2206.

**Updated scope note (2026-07-18):** this PR originally included a concrete Discord `createPrivateThread` implementation written against `src/adapters/discord/index.ts`. While this branch was in flight, epic #1784 extracted all four in-tree adapters (Discord/Mattermost/Slack/Web) to separate plugin bundle repos, and that path no longer exists on `main`. The obsolete adapter-implementation changes have been dropped from this PR after rebasing onto current `main` — the Discord implementation is being redone as its own piece of work directly in `metafactory-cortex-adapter-discord`, tracked separately. **This PR is now the core primitive only**, which is unaffected by the extraction and was fully reviewed before the rebase.

## What this does
Adds `create_private_thread` to the `cortex-brain/v1` protocol — the primitive both the guildhall escort and future quest spaces need: open a private thread, add a bounded set of members, without the brain ever choosing the channel or an arbitrary member itself.

- `CreatePrivateThreadEffect` + `ThreadCreatedEvent` added to the protocol's discriminated unions (`type` discriminant, matching every existing effect/event).
- Host enforcement in `daemon-brain-host.ts`: parent channel always derived from the agent's own binding, never brain-supplied; `members` forced to `"source"` (server-resolved) for any anon-reachable agent, refused via `effect_rejected`/`policy_denied` otherwise; 10/hour/agent rate limit (named constant); per-task liveness timeout paused/resumed around the async call, mirroring the existing `ask_principal` pattern.
- `PlatformAdapter.createPrivateThread?` declared in `src/adapters/types.ts` — the interface any plugin adapter (Discord, or future surfaces) implements. This merged with zero conflict against the adapter extraction, since plugins still implement this same shared interface from core.
- `src/adapters/mock.ts` (the test-fake adapter used by brain-level tests) implements it for test coverage of the host logic in isolation from any real platform.

## Verification (re-run after rebasing onto current main)
```
bunx tsc --noEmit          → clean
bun test src/brain/         → 135 pass, 0 fail
```

## Reviews — both completed, both clean
- **Code review**: ready to merge with nits noted for follow-up. One real finding worth a fast-follow once a real adapter implements this: a partial member-add failure currently still reports `thread_created` success even for a single-member ("source"-only) thread. Not applicable to this PR's scope (no real adapter implements the capability yet), but worth carrying into the adapter-plugin follow-up issue.
- **Adversarial security review**: the security property holds. Tried and failed to break member spoofing, channel spoofing, rate-limit bypass, timeout-based DoS in either direction, and prompt-injection-to-source (including tracing a hypothesized dispatch-laundering attack all the way to the platform-structural `authorId` field). No exploit found.

## Known gaps — both tracked as separate follow-ups, not fixed here
1. **cortex#2215** — this capability isn't wired into the boot path yet (`brain-consumer-boot.ts` doesn't pass `agentChannelId`/`anonReachable`/a real adapter reference for any agent). Fails safe; no agent can use this live yet.
2. **Discord adapter implementation** — tracked as its own issue in `metafactory-cortex-adapter-discord` (to be filed), since the extraction moved the real implementation target there.

Nothing here runs against a live Discord guild or daemon — it structurally can't yet, pending both follow-ups above.
