### PR TITLE
feat(registry): per-key sealed_secrets[] delivery — closes #1748 transport half (D2)

### DIFF
--- a/src/common/registry/__tests__/fetch-sealed-secret-array.test.ts
+++ b/src/common/registry/__tests__/fetch-sealed-secret-array.test.ts
@@ -1,0 +1,145 @@
+/**
+ * cortex#1996 D2 (RFC-0006 §8.1) — member-side selection of a per-key
+ * `sealed_secrets[]` entry, with the FULL crypto round-trip.
+ *
+ * The receive side accepts BOTH shapes: it PREFERS an array entry addressed to
+ * the joining stack's own key (the covered-2nd-stack transport path, #1748) and
+ * falls back to the legacy single `sealed_secret` slot. Fail-closed against
+ * untrusted registry data: ambiguous / malformed arrays never yield a blob.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createUser } from "nkeys.js";
+import { sealToPrincipal } from "../../crypto/seal-to-principal";
+import { encodeLeafSecretEnvelope } from "../sealed-leaf-secret";
+import { fetchSealedLeafSecret, selectSealedCiphertextForStack, type FetchLike } from "../fetch-sealed-secret";
+import { materialFromSeedString, type StackIdentityMaterial } from "../../../bus/stack-provisioning";
+
+function newMember(): StackIdentityMaterial {
+  const kp = createUser();
+  const seed = new TextDecoder().decode(kp.getSeed());
+  return materialFromSeedString(seed);
+}
+
+function fakeRegistry(rows: unknown[]): FetchLike {
+  return async (url) => {
+    if (url.endsWith("/admission-requests/mine")) {
+      return { ok: true, status: 200, json: async () => rows, text: async () => JSON.stringify(rows) };
+    }
+    return { ok: false, status: 404, json: async () => ({}), text: async () => "not found" };
+  };
+}
+
+async function sealedFor(material: StackIdentityMaterial, leafPsk: string, leafUser: string): Promise<string> {
+  return sealToPrincipal(encodeLeafSecretEnvelope({ leaf_psk: leafPsk, leaf_user: leafUser }), material.pubkeyB64);
+}
+
+describe("fetchSealedLeafSecret — per-key sealed_secrets[] selection", () => {
+  test("covered 2nd stack opens the entry addressed to ITS OWN key on a covering row", async () => {
+    // The covering row's peer_pubkey is the FIRST stack's key; the array carries
+    // the 2nd (covered) stack's own sealed creds. The 2nd stack selects its entry.
+    const firstStack = newMember();
+    const secondStack = newMember();
+    const sealedForSecond = await sealedFor(secondStack, "PSK-second", "alice");
+    const fetchImpl = fakeRegistry([
+      {
+        request_id: "r1",
+        principal_id: "alice",
+        peer_pubkey: firstStack.pubkeyB64,
+        network_id: "metafactory",
+        status: "ADMITTED",
+        sealed_secret: null,
+        sealed_secrets: [{ target_stack_pubkey: secondStack.pubkeyB64, sealed_secret: sealedForSecond }],
+      },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: secondStack, fetchImpl });
+    expect(res).toEqual({ ok: true, kind: "psk", leafPsk: "PSK-second", leafUser: "alice" });
+  });
+
+  test("PREFERS the array entry over a legacy slot sealed to a different key", async () => {
+    const member = newMember();
+    const stranger = newMember();
+    const sealedForMember = await sealedFor(member, "PSK-mine", "alice");
+    const sealedForStranger = await sealedFor(stranger, "PSK-stranger", "bob");
+    const fetchImpl = fakeRegistry([
+      {
+        request_id: "r1",
+        principal_id: "alice",
+        peer_pubkey: stranger.pubkeyB64,
+        network_id: "metafactory",
+        status: "ADMITTED",
+        sealed_secret: sealedForStranger, // legacy slot NOT for me
+        sealed_secrets: [{ target_stack_pubkey: member.pubkeyB64, sealed_secret: sealedForMember }],
+      },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok && res.kind === "psk" && res.leafPsk).toBe("PSK-mine");
+  });
+
+  test("falls back to the legacy single slot when no array entry is addressed to my key", async () => {
+    const member = newMember();
+    const other = newMember();
+    const sealedForMember = await sealedFor(member, "PSK-legacy", "alice");
+    const fetchImpl = fakeRegistry([
+      {
+        request_id: "r1",
+        principal_id: "alice",
+        peer_pubkey: member.pubkeyB64,
+        network_id: "metafactory",
+        status: "ADMITTED",
+        sealed_secret: sealedForMember,
+        sealed_secrets: [{ target_stack_pubkey: other.pubkeyB64, sealed_secret: "AAAA" }], // not for me
+      },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok && res.kind === "psk" && res.leafPsk).toBe("PSK-legacy");
+  });
+
+  test("two DISTINCT ciphertexts addressed to my key → ambiguous → soft-closed", async () => {
+    const member = newMember();
+    const a = await sealedFor(member, "PSK-a", "alice");
+    const b = await sealedFor(member, "PSK-b", "alice");
+    const fetchImpl = fakeRegistry([
+      { request_id: "r1", principal_id: "alice", peer_pubkey: "x", network_id: "metafactory", status: "ADMITTED", sealed_secret: null, sealed_secrets: [{ target_stack_pubkey: member.pubkeyB64, sealed_secret: a }] },
+      { request_id: "r2", principal_id: "alice", peer_pubkey: "y", network_id: "metafactory", status: "ADMITTED", sealed_secret: null, sealed_secrets: [{ target_stack_pubkey: member.pubkeyB64, sealed_secret: b }] },
+    ]);
+    const res = await fetchSealedLeafSecret({ registryUrl: "x", networkId: "metafactory", principalId: "alice", material: member, fetchImpl });
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe("selectSealedCiphertextForStack — pure fail-closed selection", () => {
+  test("non-array sealed_secrets is ignored; legacy slot wins", () => {
+    const rows = [{ sealed_secret: "legacy-blob", sealed_secrets: "not-an-array" as unknown }];
+    expect(selectSealedCiphertextForStack(rows, "mykey")).toBe("legacy-blob");
+  });
+
+  test("malformed entries are skipped; a valid one for my key wins", () => {
+    const rows = [
+      {
+        sealed_secret: null,
+        sealed_secrets: [
+          { target_stack_pubkey: "", sealed_secret: "x" }, // empty key
+          { target_stack_pubkey: "mykey" }, // missing blob
+          null,
+          "str",
+          { target_stack_pubkey: "mykey", sealed_secret: "good" },
+        ] as unknown,
+      },
+    ];
+    expect(selectSealedCiphertextForStack(rows, "mykey")).toBe("good");
+  });
+
+  test("same ciphertext addressed to my key across rows is NOT ambiguous (deduped)", () => {
+    const rows = [
+      { sealed_secret: null, sealed_secrets: [{ target_stack_pubkey: "mykey", sealed_secret: "same" }] as unknown },
+      { sealed_secret: null, sealed_secrets: [{ target_stack_pubkey: "mykey", sealed_secret: "same" }] as unknown },
+    ];
+    expect(selectSealedCiphertextForStack(rows, "mykey")).toBe("same");
+  });
+
+  test("no entry for my key and no legacy slot → undefined", () => {
+    const rows = [{ sealed_secret: null, sealed_secrets: [{ target_stack_pubkey: "other", sealed_secret: "x" }] as unknown }];
+    expect(selectSealedCiphertextForStack(rows, "mykey")).toBeUndefined();
+  });
+});

--- a/src/common/registry/admission-state.ts
+++ b/src/common/registry/admission-state.ts
@@ -41,6 +41,19 @@ import {
  * registry `AdmissionRequest` (a separate deploy target — same redeclare
  * rationale as the other consumer-side registry types).
  */
+/**
+ * cortex#1996 D2 / RFC-0006 §8.1 — one per-key entry of the `sealed_secrets[]`
+ * delivery array as `/admission-requests/mine` returns it. Mirrors the registry
+ * `SealedSecretEntry` (separate deploy target — same redeclare rationale as
+ * {@link AdmissionMineRow}).
+ */
+export interface SealedSecretEntry {
+  /** The covered stack's registered ed25519 pubkey (base64) the ciphertext is sealed to. */
+  target_stack_pubkey: string;
+  /** The opaque `crypto_box_seal` ciphertext (base64) for {@link target_stack_pubkey}. */
+  sealed_secret: string;
+}
+
 export interface AdmissionMineRow {
   request_id: string;
   principal_id: string;
@@ -48,6 +61,16 @@ export interface AdmissionMineRow {
   network_id: string | null;
   status: string;
   sealed_secret: string | null;
+  /**
+   * cortex#1996 D2 / RFC-0006 §8.1 — the PER-KEY delivery array. Present iff the
+   * registry carries covered-stack seals for this row; each entry addresses one
+   * covered stack's `target_stack_pubkey`. OPTIONAL on the wire: a pre-D2
+   * registry omits it entirely, so `fetchSealedLeafSecret` falls back to the
+   * single {@link sealed_secret} slot. The joining stack selects the entry keyed
+   * to its OWN pubkey — this is what lets a covered 2nd stack obtain transport
+   * (#1748 transport half).
+   */
+  sealed_secrets?: SealedSecretEntry[];
   /**
    * C-1350 (Slice 2) — ISO-8601 UTC of the row's last transition. On a REVOKED
    * row this IS the revoked-at date (`revokeAdmission` stamps `updated_at` = now

--- a/src/common/registry/fetch-sealed-secret.ts
+++ b/src/common/registry/fetch-sealed-secret.ts
@@ -97,14 +97,19 @@ export async function fetchSealedLeafSecret(
   if (!readRes.ok) return { ok: false, reason: readRes.reason };
   const rows = readRes.rows;
 
-  // 3. Select the ADMITTED row for this network carrying a sealed blob.
-  const row = rows.find(
-    (r) => r.network_id === input.networkId && r.status === "ADMITTED" && typeof r.sealed_secret === "string" && r.sealed_secret.length > 0,
+  // 3. Select the sealed ciphertext to open for THIS stack, across the ADMITTED
+  //    rows for the network. cortex#1996 D2 (RFC-0006 §8.1): PREFER a per-key
+  //    `sealed_secrets[]` entry addressed to this stack's own pubkey (the
+  //    covered-2nd-stack transport path, #1748) over the legacy single slot.
+  //    Fail-closed on a malformed/ambiguous array (see helper).
+  const admittedRows = rows.filter(
+    (r) => r.network_id === input.networkId && r.status === "ADMITTED",
   );
-  if (!row?.sealed_secret) {
+  const selected = selectSealedCiphertextForStack(admittedRows, input.material.pubkeyB64);
+  if (selected === undefined) {
     return {
       ok: false,
-      reason: `no admitted+sealed admission row for network "${input.networkId}" (not yet admitted, or no secret delivered)`,
+      reason: `no admitted+sealed admission material for network "${input.networkId}" (not yet admitted, no secret delivered, or none addressed to this stack's key)`,
     };
   }
 
@@ -113,7 +118,7 @@ export async function fetchSealedLeafSecret(
   //    §5.2 / R9/R12 — never an either-field relaxation).
   try {
     const rawSeed = rawEd25519SeedFromNkeySeed(input.material.seed);
-    const plaintextBytes = await openSealed(row.sealed_secret, rawSeed);
+    const plaintextBytes = await openSealed(selected, rawSeed);
     const env = decodeAnyLeafSecretEnvelope(new TextDecoder().decode(plaintextBytes));
     if (isLeafSecretEnvelopeV2(env)) {
       // R7 identity binding — refuse a credential minted for a DIFFERENT
@@ -157,6 +162,54 @@ export async function fetchSealedLeafSecret(
     // Generic — never echo seed/ciphertext/plaintext.
     return { ok: false, reason: `failed to open sealed leaf secret: ${errText(err)}` };
   }
+}
+
+/**
+ * cortex#1996 D2 (RFC-0006 §8.1) — pick the sealed ciphertext to open for a
+ * stack, given the ADMITTED rows the registry returned. FAIL-CLOSED against
+ * untrusted registry data:
+ *
+ *  1. Scan every row's `sealed_secrets[]` for entries addressed to `myPubkey`
+ *     (`target_stack_pubkey === myPubkey`), keeping only WELL-FORMED entries
+ *     (both fields non-empty strings; a non-array `sealed_secrets` is ignored).
+ *     - Exactly ONE distinct matching ciphertext → use it (the per-key path).
+ *     - MORE than one DISTINCT ciphertext addressed to my key → AMBIGUOUS →
+ *       refuse (`undefined`). Never guess which is authentic — a registry that
+ *       served two different blobs for my key is not to be trusted to break the
+ *       tie. `crypto_box_seal` still guarantees only my seed can open either,
+ *       but refusing is the fail-closed posture (the caller keeps its prior
+ *       transport rather than installing a possibly-substituted credential).
+ *  2. No per-key entry for my key → fall back to the legacy single
+ *     `sealed_secret` slot (own-row read ⇒ sealed to my key). First non-empty
+ *     slot wins, matching the pre-D2 selection.
+ *
+ * Returns the chosen ciphertext, or `undefined` when there is nothing safe to
+ * open. The choice is NOT the security boundary — the seal is — but selecting
+ * only my-key entries keeps a cross-stack blob from ever being handed to
+ * `openSealed` (which would just fail, but we avoid the ambiguity entirely).
+ */
+export function selectSealedCiphertextForStack(
+  rows: readonly { sealed_secret: string | null; sealed_secrets?: unknown }[],
+  myPubkey: string,
+): string | undefined {
+  const matches = new Set<string>();
+  for (const r of rows) {
+    const arr = Array.isArray(r.sealed_secrets) ? r.sealed_secrets : [];
+    for (const entry of arr) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.target_stack_pubkey !== "string" || e.target_stack_pubkey.length === 0) continue;
+      if (typeof e.sealed_secret !== "string" || e.sealed_secret.length === 0) continue;
+      if (e.target_stack_pubkey === myPubkey) matches.add(e.sealed_secret);
+    }
+  }
+  if (matches.size === 1) return [...matches][0];
+  if (matches.size > 1) return undefined; // ambiguous → fail closed
+  // Legacy single-slot fallback (own row → sealed to my key).
+  for (const r of rows) {
+    if (typeof r.sealed_secret === "string" && r.sealed_secret.length > 0) return r.sealed_secret;
+  }
+  return undefined;
 }
 
 /** The optional ADR-0019 payload-key rider, in result-field casing (one site). */

--- a/src/services/network-registry/__tests__/sealed-secrets-array.test.ts
+++ b/src/services/network-registry/__tests__/sealed-secrets-array.test.ts
@@ -1,0 +1,373 @@
+/**
+ * cortex#1996 D2 (RFC-0006 §8.1/§8.3) — per-key `sealed_secrets[]` delivery.
+ *
+ * TRUST-PATH coverage for the array delivery channel that closes the #1748
+ * transport half (a covered 2nd stack obtaining its own sealed transport):
+ *
+ *   Store layer (parse + upsert + cap + hygiene):
+ *     - parseSealedSecretsColumn fails SAFE on malformed JSON / non-array / bad
+ *       entries, dedupes by target key, caps at MAX, and returns undefined on empty
+ *     - upsertSealedSecretEntry replaces-in-place and refuses to grow past MAX
+ *     - setSealedSecretEntry only writes an ADMITTED row; revoke/depart clear it
+ *
+ *   Route layer (`POST /admission-requests/:id/sealed-secret`) — the emit side:
+ *     - flag OFF (default): a covered-stack target (peer_pubkey ≠ row.peer_pubkey)
+ *       is refused 409 identity_mismatch — M17 behaviour byte-identical to today
+ *     - flag ON: a covered-stack target is accepted → 200 + a per-key array entry
+ *     - flag ON: peer_pubkey == row.peer_pubkey stays the SINGLE-slot write
+ *     - flag ON: a peer_pubkey that is neither the row's key nor a covered live
+ *       stack → 409 identity_mismatch (fail-closed)
+ *     - a covered-stack (wide) write is NEVER counted as a narrow M13 claim
+ *     - covered-stack rotate replaces the entry in place (array stays length 1)
+ *     - revoke clears the whole array
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  makeSignedAdminDecision,
+  makeSignedAdminRead,
+  randomNonce,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import { canonicalJSON, signEd25519 } from "../src/signing";
+import {
+  InMemoryIssuanceRequestStore,
+  parseSealedSecretsColumn,
+  upsertSealedSecretEntry,
+  MAX_SEALED_SECRETS_ENTRIES,
+} from "../src/store";
+import { narrowAdmissionClaimCount } from "../src/admission-window";
+import type { AdmissionRequest } from "../src/types";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
+
+const SEALED_1 = btoa("sealed-covered-stack-ciphertext-1");
+const SEALED_2 = btoa("sealed-covered-stack-ciphertext-2");
+const SEALED_ROW = btoa("sealed-row-peer-ciphertext");
+
+// =============================================================================
+// Store-layer unit tests (no HTTP)
+// =============================================================================
+
+describe("parseSealedSecretsColumn — fail-safe parse", () => {
+  test("absent / empty → undefined", () => {
+    expect(parseSealedSecretsColumn(null)).toBeUndefined();
+    expect(parseSealedSecretsColumn(undefined)).toBeUndefined();
+    expect(parseSealedSecretsColumn("")).toBeUndefined();
+  });
+
+  test("malformed JSON → undefined (never throws)", () => {
+    expect(parseSealedSecretsColumn("{not json")).toBeUndefined();
+  });
+
+  test("non-array JSON → undefined", () => {
+    expect(parseSealedSecretsColumn(JSON.stringify({ target_stack_pubkey: "k", sealed_secret: SEALED_1 }))).toBeUndefined();
+  });
+
+  test("drops malformed entries; keeps well-formed", () => {
+    const raw = JSON.stringify([
+      { target_stack_pubkey: "k1", sealed_secret: SEALED_1 },
+      { target_stack_pubkey: "", sealed_secret: SEALED_2 }, // empty key → dropped
+      { target_stack_pubkey: "k2", sealed_secret: "" }, // empty blob → dropped
+      { target_stack_pubkey: "k3" }, // missing blob → dropped
+      "not-an-object",
+      null,
+    ]);
+    expect(parseSealedSecretsColumn(raw)).toEqual([{ target_stack_pubkey: "k1", sealed_secret: SEALED_1 }]);
+  });
+
+  test("dedupes duplicate target keys (keeps first)", () => {
+    const raw = JSON.stringify([
+      { target_stack_pubkey: "k1", sealed_secret: SEALED_1 },
+      { target_stack_pubkey: "k1", sealed_secret: SEALED_2 },
+    ]);
+    expect(parseSealedSecretsColumn(raw)).toEqual([{ target_stack_pubkey: "k1", sealed_secret: SEALED_1 }]);
+  });
+
+  test("caps at MAX_SEALED_SECRETS_ENTRIES", () => {
+    const entries = Array.from({ length: MAX_SEALED_SECRETS_ENTRIES + 10 }, (_v, i) => ({
+      target_stack_pubkey: `k${String(i)}`,
+      sealed_secret: SEALED_1,
+    }));
+    const parsed = parseSealedSecretsColumn(JSON.stringify(entries));
+    expect(parsed?.length).toBe(MAX_SEALED_SECRETS_ENTRIES);
+  });
+
+  test("all-malformed array → undefined (never an empty array on the wire)", () => {
+    expect(parseSealedSecretsColumn(JSON.stringify([{ bad: 1 }, null]))).toBeUndefined();
+  });
+});
+
+describe("upsertSealedSecretEntry — replace-in-place + cap", () => {
+  test("appends a new key", () => {
+    const out = upsertSealedSecretEntry(undefined, "k1", SEALED_1);
+    expect(out).toEqual([{ target_stack_pubkey: "k1", sealed_secret: SEALED_1 }]);
+  });
+
+  test("replaces an existing key in place (no duplicate)", () => {
+    const first = upsertSealedSecretEntry(undefined, "k1", SEALED_1);
+    const second = upsertSealedSecretEntry(first, "k1", SEALED_2);
+    expect(second).toEqual([{ target_stack_pubkey: "k1", sealed_secret: SEALED_2 }]);
+  });
+
+  test("refuses to grow a full array past the cap (new key)", () => {
+    const full = Array.from({ length: MAX_SEALED_SECRETS_ENTRIES }, (_v, i) => ({
+      target_stack_pubkey: `k${String(i)}`,
+      sealed_secret: SEALED_1,
+    }));
+    expect(upsertSealedSecretEntry(full, "new-key", SEALED_2)).toBeUndefined();
+  });
+
+  test("a REPLACE of an existing key is allowed even at the cap", () => {
+    const full = Array.from({ length: MAX_SEALED_SECRETS_ENTRIES }, (_v, i) => ({
+      target_stack_pubkey: `k${String(i)}`,
+      sealed_secret: SEALED_1,
+    }));
+    const out = upsertSealedSecretEntry(full, "k0", SEALED_2);
+    expect(out?.length).toBe(MAX_SEALED_SECRETS_ENTRIES);
+    expect(out?.find((e) => e.target_stack_pubkey === "k0")?.sealed_secret).toBe(SEALED_2);
+  });
+});
+
+describe("InMemoryIssuanceRequestStore.setSealedSecretEntry", () => {
+  test("only an ADMITTED row accepts an entry; revoke clears the array", async () => {
+    const store = new InMemoryIssuanceRequestStore();
+    const pending = await store.upsertPending("alice", "row-key", "federated.alice.>", "metafactory");
+    // PENDING → no-op.
+    expect(await store.setSealedSecretEntry(pending.request_id, "covered-key", SEALED_1)).toBeUndefined();
+    await store.transitionIssuanceRequest(pending.request_id, "ADMITTED", "admin");
+    const withEntry = await store.setSealedSecretEntry(pending.request_id, "covered-key", SEALED_1);
+    expect(withEntry?.sealed_secrets).toEqual([{ target_stack_pubkey: "covered-key", sealed_secret: SEALED_1 }]);
+    // Revoke clears both the single slot and the array.
+    const revoked = await store.revokeAdmission(pending.request_id);
+    expect(revoked?.sealed_secret).toBeNull();
+    expect(revoked?.sealed_secrets).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Route-layer tests — the emit side
+// =============================================================================
+
+let env: Env;
+let envArrayOn: Env;
+let admin: PrincipalKey;
+let hubAdmin: PrincipalKey;
+let principal: PrincipalKey; // the row's peer key (stack 1)
+let coveredStack: PrincipalKey; // a covered 2nd stack of the SAME principal
+let strangerKey: PrincipalKey; // an unrelated key (not a stack of the principal)
+
+async function post(path: string, body: unknown, e: Env): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    e,
+  );
+}
+
+async function get(path: string, e: Env, headers: Record<string, string> = {}): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`, { headers }), e);
+}
+
+/** Register alice with TWO stacks (row peer = stack1; coveredStack = stack2), return the row. */
+async function registerTwoStackPending(): Promise<AdmissionRequest> {
+  const body = await makeSignedRegistration("alice", principal, {
+    stacks: [
+      { stack_id: "alice/main", stack_pubkey: principal.publicKeyB64 },
+      { stack_id: "alice/second", stack_pubkey: coveredStack.publicKeyB64 },
+    ],
+    networkId: "metafactory",
+  });
+  const res = await post(`/principals/alice/register`, body, env);
+  expect(res.status).toBe(201);
+  const signedRead = await makeSignedAdminRead(admin);
+  const listRes = await get(`/admission-requests?status=PENDING`, env, { "x-admin-signed": JSON.stringify(signedRead) });
+  const list = (await listRes.json()) as AdmissionRequest[];
+  const found = list.find((r) => r.principal_id === "alice");
+  expect(found).toBeDefined();
+  // The admission row keys on the FIRST stack's pubkey (#1748).
+  expect(found!.peer_pubkey).toBe(principal.publicKeyB64);
+  return found!;
+}
+
+async function admit(requestId: string, e: Env): Promise<void> {
+  const res = await post(`/admission-requests/${requestId}/admit`, await makeSignedAdminDecision(requestId, "admit", admin), e);
+  expect(res.status).toBe(200);
+}
+
+/** Build a sealed-secret write claim, optionally binding peer_pubkey (wide). */
+async function makeSealedWrite(
+  requestId: string,
+  opts: { sealed?: string; peerPubkey?: string } = {},
+): Promise<{ claim: Record<string, unknown>; signature: string }> {
+  const claim: Record<string, unknown> = {
+    request_id: requestId,
+    sealed_secret: opts.sealed ?? SEALED_1,
+    ...(opts.peerPubkey !== undefined && { peer_pubkey: opts.peerPubkey }),
+    hub_admin_pubkey: hubAdmin.publicKeyB64,
+    issued_at: new Date().toISOString(),
+    nonce: randomNonce(),
+  };
+  const signature = await signEd25519(hubAdmin.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  return { claim, signature };
+}
+
+/** Member PoP-read of alice's rows for the network. */
+async function readMine(e: Env): Promise<AdmissionRequest | undefined> {
+  const claim = { principal_id: "alice", peer_pubkey: principal.publicKeyB64, issued_at: new Date().toISOString() };
+  const signature = await signEd25519(principal.privateKeyB64, new TextEncoder().encode(canonicalJSON(claim)));
+  const res = await get(`/admission-requests/mine`, e, { "x-pop-signed": JSON.stringify({ claim, signature }) });
+  expect(res.status).toBe(200);
+  const rows = (await res.json()) as AdmissionRequest[];
+  return rows.find((r) => r.network_id === "metafactory");
+}
+
+beforeEach(async () => {
+  resetStores();
+  _resetRateLimitBucketsForTest();
+  const reg = await makeRegistryKey();
+  admin = await makePrincipalKey();
+  hubAdmin = await makePrincipalKey();
+  principal = await makePrincipalKey();
+  coveredStack = await makePrincipalKey();
+  strangerKey = await makePrincipalKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    REGISTRY_ADMIN_PUBKEYS: admin.publicKeyB64,
+    REGISTRY_HUB_ADMIN_PUBKEYS: hubAdmin.publicKeyB64,
+    ENVIRONMENT: "test",
+  };
+  envArrayOn = { ...env, SEALED_SECRETS_ARRAY_EMIT: "true" };
+});
+
+describe("sealed-secret array emit — flag OFF (default, byte-identical to M17)", () => {
+  test("covered-stack target (peer_pubkey ≠ row key) → 409 identity_mismatch", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, env);
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: coveredStack.publicKeyB64 }),
+      env,
+    );
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("identity_mismatch");
+    // No array written.
+    expect((await readMine(env))?.sealed_secrets).toBeUndefined();
+  });
+
+  test("row-key target still writes the SINGLE slot (M17 pass)", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, env);
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: principal.publicKeyB64, sealed: SEALED_ROW }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const mine = await readMine(env);
+    expect(mine?.sealed_secret).toBe(SEALED_ROW);
+    expect(mine?.sealed_secrets).toBeUndefined();
+  });
+});
+
+describe("sealed-secret array emit — flag ON", () => {
+  test("covered-stack target → 200 + per-key array entry addressed to that key", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, envArrayOn);
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: coveredStack.publicKeyB64, sealed: SEALED_2 }),
+      envArrayOn,
+    );
+    expect(res.status).toBe(200);
+    const mine = await readMine(envArrayOn);
+    // Single slot untouched; the array carries exactly the covered-stack entry.
+    expect(mine?.sealed_secret).toBeNull();
+    expect(mine?.sealed_secrets).toEqual([{ target_stack_pubkey: coveredStack.publicKeyB64, sealed_secret: SEALED_2 }]);
+  });
+
+  test("row-key target stays the SINGLE-slot write even with the flag on", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, envArrayOn);
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: principal.publicKeyB64, sealed: SEALED_ROW }),
+      envArrayOn,
+    );
+    expect(res.status).toBe(200);
+    const mine = await readMine(envArrayOn);
+    expect(mine?.sealed_secret).toBe(SEALED_ROW);
+    expect(mine?.sealed_secrets).toBeUndefined();
+  });
+
+  test("a key that is neither the row's nor a covered live stack → 409 identity_mismatch", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, envArrayOn);
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: strangerKey.publicKeyB64 }),
+      envArrayOn,
+    );
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe("identity_mismatch");
+    expect((await readMine(envArrayOn))?.sealed_secrets).toBeUndefined();
+  });
+
+  test("covered-stack write is NOT counted as a narrow M13 claim (it is wide)", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, envArrayOn);
+    const before = narrowAdmissionClaimCount();
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: coveredStack.publicKeyB64 }),
+      envArrayOn,
+    );
+    expect(res.status).toBe(200);
+    expect(narrowAdmissionClaimCount()).toBe(before);
+  });
+
+  test("covered-stack rotate replaces the entry in place (array stays length 1)", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, envArrayOn);
+    await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: coveredStack.publicKeyB64, sealed: SEALED_1 }),
+      envArrayOn,
+    );
+    const res = await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: coveredStack.publicKeyB64, sealed: SEALED_2 }),
+      envArrayOn,
+    );
+    expect(res.status).toBe(200);
+    const mine = await readMine(envArrayOn);
+    expect(mine?.sealed_secrets).toEqual([{ target_stack_pubkey: coveredStack.publicKeyB64, sealed_secret: SEALED_2 }]);
+  });
+
+  test("covered-stack AND row-key seals coexist (multi-stack transport)", async () => {
+    const req = await registerTwoStackPending();
+    await admit(req.request_id, envArrayOn);
+    await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: principal.publicKeyB64, sealed: SEALED_ROW }),
+      envArrayOn,
+    );
+    await post(
+      `/admission-requests/${req.request_id}/sealed-secret`,
+      await makeSealedWrite(req.request_id, { peerPubkey: coveredStack.publicKeyB64, sealed: SEALED_2 }),
+      envArrayOn,
+    );
+    const mine = await readMine(envArrayOn);
+    expect(mine?.sealed_secret).toBe(SEALED_ROW);
+    expect(mine?.sealed_secrets).toEqual([{ target_stack_pubkey: coveredStack.publicKeyB64, sealed_secret: SEALED_2 }]);
+  });
+});

--- a/src/services/network-registry/migrations/0015_admission_sealed_secrets_array.sql
+++ b/src/services/network-registry/migrations/0015_admission_sealed_secrets_array.sql
@@ -1,0 +1,41 @@
+-- cortex#1996 D2 (RFC-0006 §8.1) — per-key `sealed_secrets[]` delivery array.
+--
+-- Background
+-- ──────────
+-- An admission is PER-PRINCIPAL (one row, §7), but the leaf-secret seal is a
+-- PER-STACK write (§8.1): a principal may federate more than one covered stack
+-- under a single admission, and each covered stack holds its OWN key + subject
+-- isolation (ADR-0023). The single `sealed_secret` column (migration 0010) seals
+-- to exactly ONE key — the covering row's `peer_pubkey` — so a covered 2nd stack
+-- with a different key cannot obtain transport (the #1748 transport half).
+--
+-- This migration adds `sealed_secrets`, a nullable JSON-TEXT column holding an
+-- array of per-key entries `[{ target_stack_pubkey, sealed_secret }, ...]`, each
+-- `crypto_box_seal`'d to one covered stack's key. The joining stack selects the
+-- entry addressed to its own pubkey; the registry never reads the ciphertext
+-- (same opaque-blob posture as the single `sealed_secret` slot). NULL = no array
+-- delivered — the default for every row, including every pre-0015 row.
+--
+-- Shape: nullable, no CHECK constraint touched (this doesn't extend an enum) — a
+-- plain `ALTER TABLE ... ADD COLUMN`, the SAME shape as migrations 0011
+-- (`admin_pubkeys`) and 0013 (`hub_authorized_at`).
+--
+-- DEPLOY ORDERING — MIGRATION-BEFORE-CODE IS MANDATORY (NOT optional):
+-- ────────────────────────────────────────────────────────────────────
+-- This ADD COLUMN is backward-compatible for READS (a pre-0015 isolate never
+-- sees the column; `rowToAdmissionRequest` coalesces a missing value to absent).
+-- But the D2 code has a HARD dependency on the column at the WRITE path:
+-- `setSealedSecretEntry` reads + rewrites `sealed_secrets`, and
+-- `revokeAdmission` / `departAdmission` now emit `SET ... sealed_secrets = NULL`.
+-- If the NEW code is deployed BEFORE this migration runs, those writes throw
+-- "no such column: sealed_secrets" → 500.
+--
+-- Therefore: APPLY THIS MIGRATION TO THE REGISTRY DB *BEFORE* DEPLOYING THE
+-- cortex#1996 D2 WORKER. It is NOT safe to ship the code first. (Same load-bearing
+-- ordering as migration 0013's incremental ADD against a live schema.)
+--
+-- Apply (migration FIRST, then deploy the code):
+--   bunx wrangler d1 migrations apply cortex-network-registry-dev --env dev --remote
+--   bunx wrangler d1 migrations apply cortex-network-registry      --env production --remote
+
+ALTER TABLE admission_requests ADD COLUMN sealed_secrets TEXT;

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -91,7 +91,36 @@ export interface Env extends RateLimitEnv, StoreEnv {
    * authorities must diverge.
    */
   REGISTRY_HUB_ADMIN_PUBKEYS?: string;
+  /**
+   * cortex#1996 D2 (RFC-0006 §8.1) — ERA FLAG for per-key `sealed_secrets[]`
+   * delivery, DEFAULT OFF. When OFF (the default), the sealed-secret write route
+   * behaves byte-identically to today: it only ever writes the SINGLE
+   * `sealed_secret` slot, and a claim addressing any key other than the row's own
+   * `peer_pubkey` is refused `409 identity_mismatch` (M17 unchanged). When ON, a
+   * hub-admin write whose bound `peer_pubkey` is a COVERED live stack of the
+   * row's principal (≠ the row's `peer_pubkey`) is accepted and appended to the
+   * per-key array — the covered-2nd-stack transport path (#1748). The RECEIVE
+   * side (reading + selecting an array entry) is ALWAYS on and is harmless while
+   * the array is empty; this flag gates only the wire-observable EMIT-acceptance.
+   * The D7 require-present flip is a SEPARATE, dated, gated step — NOT this flag.
+   *
+   * Accepted truthy values: `"true"`, `"1"`, `"on"` (case-insensitive). Anything
+   * else — unset, blank, `"false"`, junk — is OFF (fail-closed default).
+   */
+  SEALED_SECRETS_ARRAY_EMIT?: string;
   ENVIRONMENT?: string;
+}
+
+/**
+ * cortex#1996 D2 — is the per-key `sealed_secrets[]` array-EMIT era enabled?
+ * Fail-closed: only an explicit truthy token flips it on; the default (unset /
+ * blank / anything unrecognised) is OFF, so the single-slot path stays live.
+ */
+export function isSealedSecretsArrayEmitEnabled(env: Env): boolean {
+  const raw = env.SEALED_SECRETS_ARRAY_EMIT;
+  if (typeof raw !== "string") return false;
+  const v = raw.trim().toLowerCase();
+  return v === "true" || v === "1" || v === "on";
 }
 
 /**

--- a/src/services/network-registry/src/routes/admission-requests.ts
+++ b/src/services/network-registry/src/routes/admission-requests.ts
@@ -50,8 +50,21 @@
  */
 
 import { Hono, type Context } from "hono";
-import { parseAdminPubkeys, parseHubAdminPubkeys, parseNetworkAdminPubkeys, type Env } from "../index";
-import { getNonceCache, getIssuanceStore, getStore, AlreadyDecidedError, withDerivedStackId } from "../store";
+import {
+  parseAdminPubkeys,
+  parseHubAdminPubkeys,
+  parseNetworkAdminPubkeys,
+  isSealedSecretsArrayEmitEnabled,
+  type Env,
+} from "../index";
+import {
+  getNonceCache,
+  getIssuanceStore,
+  getStore,
+  AlreadyDecidedError,
+  withDerivedStackId,
+  MAX_SEALED_SECRETS_ENTRIES,
+} from "../store";
 import {
   validateSignedAdmissionDecision,
   validateAdmissionDecisionClaim,
@@ -548,6 +561,15 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
   app.post("/admission-requests/:request_id/sealed-secret", async (c) => {
     const requestId = c.req.param("request_id") ?? "";
     const store = getIssuanceStore(c.env);
+    // cortex#1996 D2 — the per-key array-EMIT era flag (default OFF). OFF keeps
+    // this route byte-identical to today (single-slot only, M17 unchanged).
+    const arrayEmitEnabled = isSealedSecretsArrayEmitEnabled(c.env);
+    // Set by the identity check ONLY when the bound `peer_pubkey` addresses a
+    // COVERED live stack (≠ the row's own `peer_pubkey`): the per-key array-write
+    // target. Left undefined for every single-slot write, so the dispatch below
+    // falls to `setSealedSecret` exactly as before.
+    let arrayWriteTarget: string | undefined;
+
     const gate = await verifyHubAdminWrite(
       c,
       requestId,
@@ -555,28 +577,63 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
       validateSealedSecretClaim,
       // M17 (cortex#2188, RFC-0006 §8.3) — IDENTITY BINDING, run BEFORE the nonce
       // record. When the hub-admin binds `peer_pubkey` it MUST equal the row's
-      // stored peer_pubkey → else 409 identity_mismatch, so a sealed blob can
-      // never land on the wrong member's row. Enforced only when the row exists
-      // (a missing row 404s at the write below).
+      // stored peer_pubkey (single slot) OR — under the D2 array-emit era — a
+      // COVERED live stack of the row's principal (the per-key array target);
+      // anything else is 409 identity_mismatch, so a sealed blob can never land
+      // on the wrong member's row. Enforced only when the row exists (a missing
+      // row 404s at the write below).
       async (claim) => {
         if (claim.peer_pubkey === undefined) return null;
         const row = await store.getIssuanceRequest(requestId);
-        if (row && claim.peer_pubkey !== row.peer_pubkey) {
-          return c.json(
-            { error: "identity_mismatch", details: { field: "peer_pubkey" } },
-            409,
-          );
+        if (!row) return null; // no identity to compare — the write below 404s.
+        // Single-slot write: the bound key IS the row's own key (M17, unchanged).
+        if (claim.peer_pubkey === row.peer_pubkey) return null;
+        // The bound key differs from the row's own key. OFF (default): refuse it
+        // exactly as M17 does today. ON: accept iff it is a COVERED live stack of
+        // the row's principal — the RFC-0006 §8.1 per-key array target (#1748
+        // transport half). A key that is neither the row's own nor a covered
+        // stack (a hub-admin fumbling the target, or sealing to an unrelated key)
+        // is refused. crypto_box_seal is the primary guarantee; this binding is
+        // the §8.3 defense-in-depth + intent signal.
+        if (!arrayEmitEnabled) {
+          return c.json({ error: "identity_mismatch", details: { field: "peer_pubkey" } }, 409);
         }
+        const principal = await getStore(c.env).getPrincipal(row.principal_id);
+        const covered = (principal?.stacks ?? []).some(
+          (s) => s.retired_at === undefined && s.stack_pubkey === claim.peer_pubkey,
+        );
+        if (!covered) {
+          return c.json({ error: "identity_mismatch", details: { field: "peer_pubkey" } }, 409);
+        }
+        arrayWriteTarget = claim.peer_pubkey;
         return null;
       },
     );
     if (!gate.ok) return gate.response;
 
-    const updated = await store.setSealedSecret(requestId, gate.claim.sealed_secret);
+    // cortex#1996 D2 — dispatch: a covered-stack target (array-emit era, validated
+    // above) appends to the per-key `sealed_secrets[]`; every other write is the
+    // unchanged single-slot `setSealedSecret`.
+    const updated = arrayWriteTarget !== undefined
+      ? await store.setSealedSecretEntry(requestId, arrayWriteTarget, gate.claim.sealed_secret)
+      : await store.setSealedSecret(requestId, gate.claim.sealed_secret);
     if (!updated) {
-      // Row missing OR not ADMITTED — distinguish for the caller.
+      // Row missing OR not ADMITTED OR (array write) the per-key cap is hit.
       const existing = await store.getIssuanceRequest(requestId);
       if (!existing) return c.json({ error: "not_found" }, 404);
+      // An array write that failed against an ADMITTED row can only be the
+      // MAX_SEALED_SECRETS_ENTRIES cap (not-found + not-admitted are handled
+      // above/below) — surface it distinctly rather than as a misleading
+      // not_admitted.
+      if (arrayWriteTarget !== undefined && existing.status === "ADMITTED") {
+        return c.json(
+          {
+            error: "too_many_sealed_entries",
+            details: `sealed_secrets[] is capped at ${String(MAX_SEALED_SECRETS_ENTRIES)} entries per row`,
+          },
+          409,
+        );
+      }
       return c.json(
         { error: "not_admitted", details: `request ${requestId} is ${existing.status}, not ADMITTED — cannot deliver a sealed secret` },
         409,
@@ -587,7 +644,8 @@ export function admissionRequestRoutes(): Hono<{ Bindings: Env }> {
     // write is CONFIRMED (updated truthy), for the same anti-poisoning reason as
     // the decision route: an unauthorised / replayed / not-admitted narrow claim
     // must never increment the zero-narrow flip gate (PR #2194 adversarial
-    // BLOCKER). Still honoured during the window; deprecation-warned.
+    // BLOCKER). Still honoured during the window; deprecation-warned. An array
+    // write always carries a bound `peer_pubkey` (wide), so it is never counted.
     if (gate.claim.peer_pubkey === undefined) {
       recordNarrowAdmissionClaim("sealed-secret", requestId);
     }

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -33,8 +33,79 @@ import type {
   NetworkRecord,
   NetworkRoster,
   PrincipalRecord,
+  SealedSecretEntry,
   StackIdentity,
 } from "./types";
+
+/**
+ * cortex#1996 D2 — hard cap on `sealed_secrets[]` entries per admission row.
+ * One entry per COVERED STACK a principal federates under a single admission;
+ * a real principal runs a handful of stacks, so 64 is generous headroom while
+ * bounding row growth (defense-in-depth against a hostile hub-admin stuffing
+ * the array). The route + the store both enforce it.
+ */
+export const MAX_SEALED_SECRETS_ENTRIES = 64;
+
+/**
+ * cortex#1996 D2 — parse the stored `sealed_secrets` JSON-TEXT column into a
+ * clean, deduped, bounded `SealedSecretEntry[]`, or `undefined` when the column
+ * is absent/empty/malformed. FAIL-SAFE (never throws): this column is written
+ * only by {@link IssuanceRequestStore.setSealedSecretEntry} (which validates
+ * every entry), so a malformed value is a data-integrity anomaly, not a request
+ * error — degrade to "no array" so one bad row can't take down a read, mirroring
+ * `parseJsonArray` for the principals columns.
+ *
+ * Every entry must carry two non-empty string fields; anything else is dropped.
+ * Duplicate `target_stack_pubkey`s keep the FIRST occurrence (writes dedupe, so
+ * a duplicate is itself an anomaly). The result is capped at
+ * {@link MAX_SEALED_SECRETS_ENTRIES}. Empty after cleaning ⇒ `undefined` (never
+ * an empty array on the wire — absence is the single canonical "no delivery").
+ */
+export function parseSealedSecretsColumn(raw: string | null | undefined): SealedSecretEntry[] | undefined {
+  if (typeof raw !== "string" || raw.length === 0) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_err) {
+    return undefined; // data-integrity anomaly in a column we solely own — degrade to absent.
+  }
+  if (!Array.isArray(parsed)) return undefined;
+  const seen = new Set<string>();
+  const out: SealedSecretEntry[] = [];
+  for (const item of parsed) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+    const e = item as Record<string, unknown>;
+    if (typeof e.target_stack_pubkey !== "string" || e.target_stack_pubkey.length === 0) continue;
+    if (typeof e.sealed_secret !== "string" || e.sealed_secret.length === 0) continue;
+    if (seen.has(e.target_stack_pubkey)) continue;
+    seen.add(e.target_stack_pubkey);
+    out.push({ target_stack_pubkey: e.target_stack_pubkey, sealed_secret: e.sealed_secret });
+    if (out.length >= MAX_SEALED_SECRETS_ENTRIES) break;
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * cortex#1996 D2 — upsert one entry into an in-memory `sealed_secrets[]`,
+ * replace-in-place by `target_stack_pubkey`. Returns the new array, or
+ * `undefined` when adding a NEW key would exceed {@link MAX_SEALED_SECRETS_ENTRIES}
+ * (a replace of an existing key never grows the array, so it is always allowed).
+ * Shared by both store backends so the cap + dedupe are enforced identically.
+ */
+export function upsertSealedSecretEntry(
+  existing: SealedSecretEntry[] | undefined,
+  targetStackPubkey: string,
+  sealedSecret: string,
+): SealedSecretEntry[] | undefined {
+  const base = existing ?? [];
+  const idx = base.findIndex((e) => e.target_stack_pubkey === targetStackPubkey);
+  if (idx === -1 && base.length >= MAX_SEALED_SECRETS_ENTRIES) return undefined;
+  const next = base.slice();
+  const entry: SealedSecretEntry = { target_stack_pubkey: targetStackPubkey, sealed_secret: sealedSecret };
+  if (idx === -1) next.push(entry);
+  else next[idx] = entry;
+  return next;
+}
 
 // Back-compat aliases used in a few existing tests that import by the old names.
 /** @deprecated Use AdmissionRequest */
@@ -250,6 +321,32 @@ export interface IssuanceRequestStore {
   ): Promise<AdmissionRequest | undefined>;
 
   /**
+   * cortex#1996 D2 (RFC-0006 §8.1) — upsert ONE per-key entry into the
+   * `sealed_secrets[]` delivery array of an ADMITTED row, keyed by
+   * `targetStackPubkey`. This is the PER-STACK seal write that the single-slot
+   * {@link setSealedSecret} cannot serve: a covered 2nd stack (a live stack of
+   * the row's principal whose key differs from the row's `peer_pubkey`) gets its
+   * `crypto_box_seal` ciphertext appended here, addressed to its own key, so it
+   * can fetch + open its own transport credential (#1748 transport half).
+   *
+   * Replace-in-place semantics: if an entry for `targetStackPubkey` already
+   * exists, its ciphertext is REPLACED (rotation), never duplicated — the array
+   * carries at most one entry per key. Guarded on `status = 'ADMITTED'` exactly
+   * like {@link setSealedSecret}: a missing or non-ADMITTED row is a no-op
+   * returning `undefined` (the route maps that to 404 / 409). The store persists
+   * the opaque blob it is handed and never reads it. The route validates the
+   * target is a covered stack + bounds the ciphertext BEFORE calling this; the
+   * store additionally refuses to grow the array past
+   * {@link MAX_SEALED_SECRETS_ENTRIES} (defense-in-depth against unbounded row
+   * growth).
+   */
+  setSealedSecretEntry(
+    requestId: string,
+    targetStackPubkey: string,
+    sealedSecret: string,
+  ): Promise<AdmissionRequest | undefined>;
+
+  /**
    * cortex#1498 (epic #1479 follow-up) — persist the hub-owner's authorization
    * stamp onto an ADMITTED admission row (the `cortex network authorize`
    * write). Mirrors {@link setSealedSecret}'s CAS shape exactly: guarded on
@@ -408,6 +505,25 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
     return updated;
   }
 
+  async setSealedSecretEntry(
+    requestId: string,
+    targetStackPubkey: string,
+    sealedSecret: string,
+  ): Promise<AdmissionRequest | undefined> {
+    const existing = this.requests.get(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "ADMITTED") return undefined; // route → 409 not_admitted
+    const next = upsertSealedSecretEntry(existing.sealed_secrets, targetStackPubkey, sealedSecret);
+    if (next === undefined) return undefined; // route → 409 too_many_sealed_entries
+    const updated: AdmissionRequest = {
+      ...existing,
+      sealed_secrets: next,
+      updated_at: new Date().toISOString(),
+    };
+    this.requests.set(requestId, updated);
+    return updated;
+  }
+
   async markHubAuthorized(
     requestId: string,
     timestampIso: string,
@@ -435,6 +551,9 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       ...existing,
       status: "REVOKED",
       sealed_secret: null,
+      // cortex#1996 D2 — a revoked member retains NO fetchable copy: clear the
+      // per-key array alongside the single slot (same hygiene as sealed_secret).
+      sealed_secrets: undefined,
       hub_authorized_at: null,
       updated_at: new Date().toISOString(),
     };
@@ -453,6 +572,8 @@ export class InMemoryIssuanceRequestStore implements IssuanceRequestStore {
       ...existing,
       status: "DEPARTED",
       sealed_secret: null,
+      // cortex#1996 D2 — clear the per-key array too (see revoke).
+      sealed_secrets: undefined,
       hub_authorized_at: null,
       updated_at: new Date().toISOString(),
     };
@@ -617,6 +738,34 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     return { ...existing, sealed_secret: sealedSecret, updated_at: now };
   }
 
+  async setSealedSecretEntry(
+    requestId: string,
+    targetStackPubkey: string,
+    sealedSecret: string,
+  ): Promise<AdmissionRequest | undefined> {
+    const existing = await this.getIssuanceRequest(requestId);
+    if (!existing) return undefined;
+    if (existing.status !== "ADMITTED") return undefined; // route → 409 not_admitted
+    const next = upsertSealedSecretEntry(existing.sealed_secrets, targetStackPubkey, sealedSecret);
+    if (next === undefined) return undefined; // route → 409 too_many_sealed_entries
+    const now = new Date().toISOString();
+    // CAS-ish guard: only an ADMITTED row can carry a sealed entry. A concurrent
+    // revoke/depart between our read and this UPDATE flips the guard false →
+    // changes 0 → undefined (the route maps it to 409). We rewrite the WHOLE
+    // JSON array (read-modify-write) rather than mutate in place — SQLite has no
+    // portable in-place JSON element upsert, and the array is small + bounded.
+    const res = await this.db
+      .prepare(
+        `UPDATE admission_requests
+         SET sealed_secrets = ?, updated_at = ?
+         WHERE request_id = ? AND status = 'ADMITTED'`,
+      )
+      .bind(JSON.stringify(next), now, requestId)
+      .run();
+    if ((res.meta?.changes ?? 0) === 0) return undefined;
+    return { ...existing, sealed_secrets: next, updated_at: now };
+  }
+
   async markHubAuthorized(
     requestId: string,
     timestampIso: string,
@@ -651,7 +800,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     const res = await this.db
       .prepare(
         `UPDATE admission_requests
-         SET status = 'REVOKED', sealed_secret = NULL, hub_authorized_at = NULL, updated_at = ?
+         SET status = 'REVOKED', sealed_secret = NULL, sealed_secrets = NULL, hub_authorized_at = NULL, updated_at = ?
          WHERE request_id = ? AND status = 'ADMITTED'`,
       )
       .bind(now, requestId)
@@ -661,7 +810,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       const current = await this.getIssuanceRequest(requestId);
       return current;
     }
-    return { ...existing, status: "REVOKED", sealed_secret: null, hub_authorized_at: null, updated_at: now };
+    return { ...existing, status: "REVOKED", sealed_secret: null, sealed_secrets: undefined, hub_authorized_at: null, updated_at: now };
   }
 
   async departAdmission(requestId: string): Promise<AdmissionRequest | undefined> {
@@ -675,7 +824,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
     const res = await this.db
       .prepare(
         `UPDATE admission_requests
-         SET status = 'DEPARTED', sealed_secret = NULL, hub_authorized_at = NULL, updated_at = ?
+         SET status = 'DEPARTED', sealed_secret = NULL, sealed_secrets = NULL, hub_authorized_at = NULL, updated_at = ?
          WHERE request_id = ? AND status = 'ADMITTED'`,
       )
       .bind(now, requestId)
@@ -691,7 +840,7 @@ export class D1IssuanceRequestStore implements IssuanceRequestStore {
       if (current.status === "DEPARTED") return current;
       throw new AlreadyDecidedError(current);
     }
-    return { ...existing, status: "DEPARTED", sealed_secret: null, hub_authorized_at: null, updated_at: now };
+    return { ...existing, status: "DEPARTED", sealed_secret: null, sealed_secrets: undefined, hub_authorized_at: null, updated_at: now };
   }
 }
 
@@ -708,11 +857,16 @@ interface AdmissionRequestRow {
   granted_by: string | null;
   /** ADR-0018 b′ — opaque sealed ciphertext; NULL until add-member delivers it. */
   sealed_secret: string | null;
+  /** cortex#1996 D2 — JSON-TEXT array of per-key sealed entries; NULL/absent until a covered-stack seal write. */
+  sealed_secrets?: string | null;
   /** cortex#1498 — ISO-8601 UTC hub-owner authorization stamp; NULL until `authorize`. */
   hub_authorized_at: string | null;
 }
 
 function rowToAdmissionRequest(row: AdmissionRequestRow): AdmissionRequest {
+  // cortex#1996 D2 — a row read from a pre-0015 isolate (column absent) parses to
+  // `undefined`; `parseSealedSecretsColumn` fails safe on any malformed JSON.
+  const sealedSecrets = parseSealedSecretsColumn(row.sealed_secrets);
   return {
     request_id: row.request_id,
     principal_id: row.principal_id,
@@ -725,6 +879,9 @@ function rowToAdmissionRequest(row: AdmissionRequestRow): AdmissionRequest {
     granted_by: row.granted_by,
     // A row read from a pre-0010 isolate (column absent) coalesces to null.
     sealed_secret: row.sealed_secret ?? null,
+    // Spread only when present so the field is OMITTED (not `undefined`) on rows
+    // with no array, keeping the wire shape identical to a pre-D2 row.
+    ...(sealedSecrets !== undefined && { sealed_secrets: sealedSecrets }),
     // A row read from a pre-0013 isolate (column absent) coalesces to null.
     hub_authorized_at: row.hub_authorized_at ?? null,
   };
@@ -1319,7 +1476,9 @@ export function rosterFromAdmissions(
       // is a boolean DELIVERY signal (`sealed_secret !== null` — NEVER the
       // ciphertext); `hub_authorized_at` is the cortex#1498 authorize timestamp.
       admission_state: "ADMITTED",
-      sealed: row.sealed_secret !== null,
+      // cortex#1996 D2 — the boolean DELIVERY signal now reflects EITHER the
+      // single slot OR a non-empty per-key array (never the ciphertext).
+      sealed: row.sealed_secret !== null || (row.sealed_secrets?.length ?? 0) > 0,
       hub_authorized_at: row.hub_authorized_at,
       ...(stackId !== undefined && { stack_id: stackId }),
     });

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -366,6 +366,37 @@ export interface CapabilityHit {
 export type AdmissionStatus = "PENDING" | "ADMITTED" | "REJECTED" | "REVOKED" | "DEPARTED";
 
 /**
+ * cortex#1996 D2 / RFC-0006 §8.1 — one per-key entry of the `sealed_secrets[]`
+ * delivery array. An admission is PER-PRINCIPAL (one row, §7), but the seal is a
+ * PER-STACK write: a principal may federate more than one covered stack under a
+ * single admission, and each covered stack holds its OWN key + subject isolation
+ * (ADR-0023). A single `sealed_secret` slot can therefore only ever serve ONE
+ * stack — the covering row's `peer_pubkey` — leaving a covered 2nd stack unable
+ * to obtain transport (the #1748 transport half). This array closes that: each
+ * entry is `crypto_box_seal`'d to exactly one covered stack's
+ * `target_stack_pubkey`, and the joining stack selects the entry matching its
+ * own key.
+ *
+ * The registry stores only the opaque ciphertext (never reads it), exactly as it
+ * does the single-slot {@link AdmissionRequest.sealed_secret}. A shared,
+ * principal-wide seal is FORBIDDEN (RFC-0006 §8.1): it would collapse per-stack
+ * subject isolation.
+ */
+export interface SealedSecretEntry {
+  /**
+   * The covered stack's registered Ed25519 pubkey (base64) the ciphertext is
+   * sealed to — the addressing key the joiner matches against its own pubkey.
+   * §8.3 binds this into the hub-admin write claim (`claim.peer_pubkey`).
+   */
+  target_stack_pubkey: string;
+  /**
+   * The opaque `crypto_box_seal` ciphertext (base64) sealed to
+   * {@link target_stack_pubkey}. Useless to anyone but the holder of that key.
+   */
+  sealed_secret: string;
+}
+
+/**
  * A persisted admission request — the metadata record that a verified
  * registration creates. No secrets; no credentials; mints nothing.
  * The gate controls roster membership for the target network.
@@ -418,6 +449,21 @@ export interface AdmissionRequest {
    * schema change. The registry never interprets the bytes either way.
    */
   sealed_secret: string | null;
+  /**
+   * cortex#1996 D2 / RFC-0006 §8.1 — the PER-KEY sealed-secret delivery array.
+   * Each entry carries one covered stack's `crypto_box_seal` ciphertext, keyed
+   * by `target_stack_pubkey`. This is the multi-stack transport channel that the
+   * single {@link sealed_secret} slot cannot serve (it seals to ONE key only):
+   * a covered 2nd stack federating under this principal's admission fetches the
+   * entry addressed to ITS key (#1748 transport half).
+   *
+   * ADDITIVE + OPTIONAL: absent on every pre-D2 row (the single slot remains the
+   * live path). The receive/read side accepts BOTH shapes; the emit side (a
+   * covered-stack array write) is gated behind `SEALED_SECRETS_ARRAY_EMIT`
+   * (default OFF). Cleared to `undefined` on revoke/depart alongside
+   * {@link sealed_secret} (a departed member retains no fetchable copy).
+   */
+  sealed_secrets?: SealedSecretEntry[];
   /**
    * cortex#1498 (epic #1479 follow-up) — ISO-8601 UTC timestamp the HUB OWNER
    * stamps (via `cortex network authorize`, hub-admin authority — the SAME


### PR DESCRIPTION
RFC-0006 §8.1/§8.3 · TRUST-PATH. Per-key `sealed_secrets[]` delivery so a covered 2nd stack obtains its own sealed transport. Receive side (always on) selects the entry addressed to the joiner's key, fail-closed; emit side gated behind `SEALED_SECRETS_ARRAY_EMIT` (default OFF) — OFF is byte-identical to today. Does not disturb #2194 M9/M12/M13/M17. D7 flip out of scope.

Part of #1996 — D2. Refs myelin#286 Wave 3. Needs adversarial review before merge.