### PR TITLE
feat(capability): RFC-0008 dual-accept window — accept/match widening + presence fold-gate (cortex#2020)

### DIFF
--- a/src/bus/agent-network/__tests__/registry.test.ts
+++ b/src/bus/agent-network/__tests__/registry.test.ts
@@ -202,6 +202,33 @@ describe("AgentPresenceRegistry.apply", () => {
     expect(reg.apply(notPresence)).toBeNull();
     expect(reg.getAgents().length).toBe(0);
   });
+
+  test("cortex#2020 window: an underscore capability id STILL folds (online)", () => {
+    // RFC-0008 §4.1 excludes `_` from the ratified grammar, but the dual-accept
+    // fold-gate (capabilitiesFoldableInWindow) keeps folding underscore ids that
+    // are legal pre-flag-day, so the presence path never narrows during the
+    // window. Proves the fold-gate does not drop a legacy underscore id.
+    const reg = new AgentPresenceRegistry();
+    const rec = reg.apply(online(["code_review", "dev.implement"]));
+    expect(rec).not.toBeNull();
+    expect(reg.getAgents().length).toBe(1);
+    expect(reg.getAgents()[0]?.capabilities).toEqual(["code_review", "dev.implement"]);
+  });
+
+  test("cortex#2020 window: underscore capability id STILL folds (capabilities-changed)", () => {
+    const reg = new AgentPresenceRegistry();
+    reg.apply(online(["code-review.typescript"]));
+    const changed = createAgentCapabilitiesChangedEvent({
+      source: SOURCE,
+      identity: IDENTITY,
+      scope: SCOPE,
+      capabilities: ["code_review", "release.cut"],
+      sentAt: new Date("2026-06-10T09:20:00.000Z"),
+    });
+    const rec = reg.apply(changed);
+    expect(rec).not.toBeNull();
+    expect(reg.getAgents()[0]?.capabilities).toEqual(["code_review", "release.cut"]);
+  });
 });
 
 describe("AgentPresenceRegistry.onChange", () => {

--- a/src/bus/agent-network/envelopes.ts
+++ b/src/bus/agent-network/envelopes.ts
@@ -95,6 +95,12 @@ export type AgentPresenceType = (typeof AGENT_PRESENCE_TYPES)[number];
  * presence envelope carries only the capability IDS an agent currently
  * advertises (not the full rate/cost config envelope, which is principal-local).
  */
+// TODO(#2020/flag-day): tighten this presence-side regex to the ratified
+// RFC-0008 §4.1 converged grammar (@the-metafactory/myelin/wire/capability —
+// kebab-strict, rejects `_`). Held during the dual-accept window so underscore
+// ids keep validating; the fold-gate (registry.ts capabilitiesFoldableInWindow)
+// already routes through ./wire. Emitter-side underscore→hyphen migration lands
+// first, then this narrows.
 const PresenceCapabilityIdSchema = z
   .string()
   .min(1, "agent presence capability id is required and must be non-empty")

--- a/src/bus/agent-network/registry.ts
+++ b/src/bus/agent-network/registry.ts
@@ -83,6 +83,7 @@ import {
   AgentCapabilitiesChangedPayloadSchema,
   type AgentOfflineReason,
 } from "./envelopes";
+import { capabilityIdAcceptedInWindow } from "../../common/types/capability-window";
 
 /**
  * The liveness TTL — the maximum age (epoch-ms span) a record's
@@ -447,6 +448,9 @@ export class AgentPresenceRegistry {
     const parsed = AgentOnlinePayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
+    // RFC-0008 §7 D5 — validate capabilities through the ./wire fold-gate BEFORE
+    // folding (cortex#2020 dual-accept window; see capabilitiesFoldableInWindow).
+    if (!this.capabilitiesFoldableInWindow(envelope, p.capabilities)) return null;
     const scope = this.resolveScope(envelope, p.scope, verifiedScope);
     if (scope === null) return null; // foreign spoof (scope ≠ verified source)
     const key = recordKey(scope.principal, scope.stack, p.identity.agent_id);
@@ -554,6 +558,9 @@ export class AgentPresenceRegistry {
     const parsed = AgentCapabilitiesChangedPayloadSchema.safeParse(envelope.payload);
     if (!parsed.success) return this.dropMalformed(envelope, parsed.error);
     const p = parsed.data;
+    // RFC-0008 §7 D5 — validate capabilities through the ./wire fold-gate BEFORE
+    // folding (cortex#2020 dual-accept window; see capabilitiesFoldableInWindow).
+    if (!this.capabilitiesFoldableInWindow(envelope, p.capabilities)) return null;
     const scope = this.resolveScope(envelope, p.scope, verifiedScope);
     if (scope === null) return null; // foreign spoof (scope ≠ verified source)
     const key = recordKey(scope.principal, scope.stack, p.identity.agent_id);
@@ -585,6 +592,46 @@ export class AgentPresenceRegistry {
     this.records.set(key, record);
     this.emit(key, record);
     return record;
+  }
+
+  /**
+   * Presence trust-boundary validation gate (RFC-0008 §7 D5 — validate BEFORE
+   * fold; cortex#2020). Every advertised `capabilities[]` entry is checked
+   * through the ratified ./wire grammar in the dual-accept WINDOW
+   * ({@link capabilityIdAcceptedInWindow}) before the announcement folds into
+   * the liveness registry, closing the §9.1 fold-without-validation defect on
+   * the capability dimension.
+   *
+   * WINDOW semantics: an entry is foldable iff the ratified ./wire grammar OR
+   * the legacy underscore-permissive grammar admits it — so an underscore id
+   * (`code_review`), legal pre-flag-day, KEEPS folding. Only an id ungrammatical
+   * under BOTH grammars is log-and-dropped, and such an id already fails the
+   * payload schema's `PresenceCapabilityIdSchema` upstream, so this gate never
+   * narrows today's behavior; it is the explicit ./wire seam flag-day R flips to
+   * strict (§4.1 grammar + §4.3 reserved-tag rejection). Returns true to fold,
+   * false to drop.
+   */
+  private capabilitiesFoldableInWindow(
+    envelope: Envelope,
+    capabilities: readonly string[],
+  ): boolean {
+    // TODO(#2020/flag-day): at flag-day R this gate flips to STRICT — require the
+    // ratified ./wire grammar only (drop the legacy disjunct in
+    // capabilityIdAcceptedInWindow) AND reject §4.3 reserved tags (`dead-letter`,
+    // `@`-prefixed) from unauthorized advertisers. During the window both keep
+    // folding (they fold today), so neither is rejected here yet.
+    for (const cap of capabilities) {
+      if (!capabilityIdAcceptedInWindow(cap)) {
+        process.stderr.write(
+          `agent-presence-registry: dropping ${envelope.type} envelope ` +
+            `(id=${envelope.id}) — capability "${cap}" is ungrammatical under ` +
+            `both the ratified RFC-0008 §4.1 grammar and the legacy grammar ` +
+            `(fold-gate reject)\n`,
+        );
+        return false;
+      }
+    }
+    return true;
   }
 
   private dropMalformed(envelope: Envelope, err: unknown): null {

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -99,6 +99,7 @@ import {
 import type { CCSessionFactory, CCSessionLike } from "../substrates/claude-code/harness";
 import { CCSession, type CCSessionOpts } from "../runner/cc-session";
 import { attachHeartbeatToCCSession } from "../runner/heartbeat-ticker";
+import { anyAdvertisedSegmentPrefixMatches } from "../common/types/capability-window";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -1037,13 +1038,19 @@ export class ReviewConsumer {
     return null;
   }
 
-  /** Capability claim: exact `code-review.<flavor>` or generic `code-review`. */
+  /** Capability claim: exact `code-review.<flavor>` or generic `code-review`.
+   *  cortex#2020 dual-accept window (RFC-0008 §4.2): the ratified segment-prefix
+   *  matcher is ORed on top of today's exact/generic membership, so an agent
+   *  advertising a deeper specialization (`code-review.<flavor>.<deeper>`) also
+   *  claims the `code-review.<flavor>` request — additive, never removing a
+   *  match that lands today. */
   private claims(flavor: string): boolean {
     const exact = `code-review.${flavor}`;
     return (
       this.flavorSet.has(flavor) ||
       this.agent.capabilities.includes(exact) ||
-      this.agent.capabilities.includes("code-review")
+      this.agent.capabilities.includes("code-review") ||
+      anyAdvertisedSegmentPrefixMatches(exact, this.agent.capabilities)
     );
   }
 

--- a/src/common/types/__tests__/capability-window.test.ts
+++ b/src/common/types/__tests__/capability-window.test.ts
@@ -1,0 +1,106 @@
+/**
+ * cortex#2020 — capability dual-accept WINDOW helpers (RFC-0008 §4 follow-ups,
+ * Wave 3 of epic myelin#286).
+ *
+ * These tests pin the WINDOW invariant: the helpers only ever WIDEN. Grammar
+ * acceptance equals today's legacy behavior exactly (underscore ids still
+ * accepted); segment-prefix matching is ADDED on top of exact membership
+ * without removing any exact match. The flag-day TIGHTEN is NOT exercised here
+ * (it does not happen in this window).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  capabilityIdAcceptedInWindow,
+  capabilitySegmentPrefixMatches,
+  anyAdvertisedSegmentPrefixMatches,
+} from "../capability-window";
+import { CAPABILITY_ID_REGEX } from "../capability";
+
+describe("capabilityIdAcceptedInWindow — dual-accept grammar (RFC-0008 §4.1)", () => {
+  test("ratified kebab ids are accepted", () => {
+    expect(capabilityIdAcceptedInWindow("code-review")).toBe(true);
+    expect(capabilityIdAcceptedInWindow("code-review.typescript")).toBe(true);
+    expect(capabilityIdAcceptedInWindow("dev.implement")).toBe(true);
+  });
+
+  test("underscore ids STILL accepted during the window (legacy disjunct)", () => {
+    // The ratified ./wire grammar rejects `_`; the window keeps folding them via
+    // the legacy CAPABILITY_ID_REGEX so nothing that folds today stops folding.
+    expect(capabilityIdAcceptedInWindow("code_review")).toBe(true);
+    expect(capabilityIdAcceptedInWindow("image-gen.dall_e_3")).toBe(true);
+  });
+
+  test("window acceptance equals the legacy regex EXACTLY (subset property)", () => {
+    // The ratified grammar is a strict subset of the legacy regex, so the
+    // disjunction must never differ from the legacy regex alone — that is what
+    // makes the window a behavior-preserving no-op until flag-day R.
+    const samples = [
+      "code-review",
+      "code-review.typescript",
+      "code_review",
+      "image-gen.dall_e_3",
+      "dev.implement",
+      "a", // single char — legacy accepts, ./wire rejects (min 2); window = legacy
+      "a.b", // single-char segments — same
+      "trailing-", // legacy accepts trailing hyphen, ./wire rejects
+      "Code-Review", // uppercase — both reject
+      "code review", // whitespace — both reject
+      ".leading-dot",
+      "trailing-dot.",
+      "2d-render", // digit prefix — both reject
+      "",
+    ];
+    for (const s of samples) {
+      expect(capabilityIdAcceptedInWindow(s)).toBe(CAPABILITY_ID_REGEX.test(s));
+    }
+  });
+
+  test("ids ungrammatical under BOTH grammars are rejected", () => {
+    expect(capabilityIdAcceptedInWindow("Code-Review")).toBe(false);
+    expect(capabilityIdAcceptedInWindow("code review")).toBe(false);
+    expect(capabilityIdAcceptedInWindow("")).toBe(false);
+    expect(capabilityIdAcceptedInWindow(".leading")).toBe(false);
+  });
+});
+
+describe("capabilitySegmentPrefixMatches — ratified §4.2 directional matcher", () => {
+  test("a shallower requirement matches a deeper advertisement", () => {
+    expect(capabilitySegmentPrefixMatches("code-review", "code-review.typescript")).toBe(true);
+    expect(capabilitySegmentPrefixMatches("code-review", "code-review")).toBe(true);
+  });
+
+  test("a deeper requirement does NOT match a shallower advertisement", () => {
+    expect(capabilitySegmentPrefixMatches("code-review.typescript", "code-review")).toBe(false);
+  });
+
+  test("segment-boundary, not raw string prefix (masking case)", () => {
+    expect(capabilitySegmentPrefixMatches("code-rev", "code-review")).toBe(false);
+  });
+
+  test("malformed (underscore) ids never match here — false, not throw", () => {
+    // Underscore ids fail the ratified grammar, so the matcher yields false; the
+    // caller's exact-string membership is what keeps such ids matching today.
+    expect(capabilitySegmentPrefixMatches("code_review", "code_review")).toBe(false);
+  });
+});
+
+describe("anyAdvertisedSegmentPrefixMatches — the ADDED consumer disjunct", () => {
+  test("adds a deeper-specialization match without touching exact membership", () => {
+    const advertised = ["code-review.typescript.strict"];
+    // Today's exact membership would NOT match `code-review.typescript`…
+    expect(advertised.includes("code-review.typescript")).toBe(false);
+    // …but the added segment-prefix disjunct does (the deeper advertiser qualifies).
+    expect(anyAdvertisedSegmentPrefixMatches("code-review.typescript", advertised)).toBe(true);
+  });
+
+  test("does not fabricate a match the ratified matcher would deny", () => {
+    // A generic advertiser does NOT satisfy a specific requirement via this
+    // disjunct (that path is the consumers' bespoke `includes('code-review')`).
+    expect(anyAdvertisedSegmentPrefixMatches("code-review.typescript", ["code-review"])).toBe(false);
+  });
+
+  test("empty advertised set yields no match", () => {
+    expect(anyAdvertisedSegmentPrefixMatches("dev.implement", [])).toBe(false);
+  });
+});

--- a/src/common/types/capability-window.ts
+++ b/src/common/types/capability-window.ts
@@ -1,0 +1,92 @@
+/**
+ * Capability dual-accept WINDOW (cortex#2020 — RFC-0008 §4 follow-ups, Wave 3
+ * of epic myelin#286).
+ *
+ * RFC-0008 converged the capability-identifier grammar (§4.1) and ratified a
+ * directional SEGMENT-PREFIX match rule (§4.2), both codified in
+ * `@the-metafactory/myelin/wire/capability` (myelin PR #293 — the adversarially
+ * reviewed codec). This module is the cortex-side ADDITIVE window that routes
+ * acceptance and matching through that codec WITHOUT a flag-day break:
+ *
+ *   - {@link capabilityIdAcceptedInWindow} — an id is accepted iff the ratified
+ *     ./wire grammar admits it OR the legacy cortex `CAPABILITY_ID_REGEX`
+ *     (underscore-permissive) admits it. The ratified grammar is a strict
+ *     SUBSET of the legacy regex, so this disjunction equals today's acceptance
+ *     set EXACTLY — an underscore id (`code_review`) keeps being accepted
+ *     because the legacy disjunct still admits it. The value is the seam: at
+ *     flag-day R the legacy disjunct is dropped and acceptance narrows to the
+ *     ratified grammar in one edit.
+ *
+ *   - {@link capabilitySegmentPrefixMatches} — the ratified §4.2 matcher,
+ *     surfaced as a boolean. Callers OR it ALONGSIDE their existing
+ *     exact-membership check so a segment-prefix request is ACCEPTED without
+ *     removing any match that lands today (dual-accept). A malformed id — e.g.
+ *     an underscore id the ratified grammar rejects — yields `false` here, so
+ *     the caller's existing exact-string path is what keeps those matching
+ *     during the window.
+ *
+ * WINDOW SEMANTICS (the invariant every caller relies on): this module only
+ * ever WIDENS. It never rejects an id today's code accepts, and never removes a
+ * match today's code makes. The regex TIGHTEN (dropping the legacy disjunct)
+ * and the emitter-side underscore→hyphen migration are FLAG-DAY work — NOT done
+ * here; see the `TODO(#2020/flag-day)` markers at the grammar-validation sites.
+ */
+
+import {
+  parseCapabilityId,
+  matchCapabilityId,
+} from "@the-metafactory/myelin/wire/capability";
+
+import { CAPABILITY_ID_REGEX } from "./capability";
+
+/**
+ * Grammar acceptance under the dual-accept window (RFC-0008 §4.1).
+ *
+ * Accept iff the ratified ./wire grammar admits `id` OR the legacy
+ * underscore-permissive `CAPABILITY_ID_REGEX` admits it. Because the ratified
+ * grammar is a subset of the legacy regex, the result equals the legacy regex
+ * ALONE for every input — the window changes nothing an input is accepted or
+ * rejected on today. Kept as an explicit disjunction (rather than just calling
+ * the legacy regex) so the ./wire routing is in place and flag-day R is a
+ * one-line deletion of the legacy disjunct.
+ */
+export function capabilityIdAcceptedInWindow(id: string): boolean {
+  // TODO(#2020/flag-day): at flag-day R drop the ` || CAPABILITY_ID_REGEX.test(id)`
+  // disjunct so acceptance narrows to the ratified ./wire grammar (underscore
+  // ids stop being accepted — they migrate emitter-side first).
+  return parseCapabilityId(id).ok || CAPABILITY_ID_REGEX.test(id);
+}
+
+/**
+ * The ratified RFC-0008 §4.2 directional segment-prefix match, as a boolean.
+ *
+ * Returns true iff `required`'s segments are a WHOLE-SEGMENT prefix of
+ * `advertised`'s (`code-review` matches `code-review.typescript`; the reverse
+ * does not). Either id failing the ratified grammar is a hard non-match — an
+ * underscore id yields `false`, so callers MUST keep their existing
+ * exact-string membership check to preserve today's behavior for such ids
+ * during the window.
+ */
+export function capabilitySegmentPrefixMatches(
+  required: string,
+  advertised: string,
+): boolean {
+  const result = matchCapabilityId({ required, advertised });
+  return result.ok && result.value.match;
+}
+
+/**
+ * Convenience for the consumer accept path: does ANY entry in an agent's
+ * advertised capability set satisfy the ratified §4.2 match for `required`?
+ *
+ * This is purely the ADDED disjunct — a caller ORs it with its existing
+ * `capabilities.includes(...)` exact-membership (and any bespoke generic-parent
+ * fallback), so today's matches are untouched and segment-prefix matches are
+ * added on top.
+ */
+export function anyAdvertisedSegmentPrefixMatches(
+  required: string,
+  advertised: readonly string[],
+): boolean {
+  return advertised.some((cap) => capabilitySegmentPrefixMatches(required, cap));
+}

--- a/src/common/types/offering.ts
+++ b/src/common/types/offering.ts
@@ -69,6 +69,10 @@ import { LETTER_PREFIX_ID_REGEX } from "./id";
  * coupling the offering schema to a non-exported symbol; the cross-field check
  * on `CortexConfigSchema` enforces that the named capability actually EXISTS.
  */
+// TODO(#2020/flag-day): tighten to the ratified RFC-0008 §4.1 converged grammar
+// (@the-metafactory/myelin/wire/capability — kebab-strict, rejects `_`). Held
+// during the dual-accept window; the emitter-side underscore→hyphen migration
+// (config is [principal-hands]) lands first, then this narrows.
 const OfferingCapabilityIdSchema = z
   .string()
   .min(1, "offering.capability is required and must be non-empty")

--- a/src/runner/__tests__/dev-consumer.test.ts
+++ b/src/runner/__tests__/dev-consumer.test.ts
@@ -363,6 +363,18 @@ describe("DevConsumer.processEnvelope — F-2.1", () => {
     expect(decision).toEqual({ kind: "ack" });
   });
 
+  test("cortex#2020 window: a deeper `dev.implement.<x>` advertiser claims dev.implement", async () => {
+    // RFC-0008 §4.2 segment-prefix: an agent advertising a deeper specialization
+    // matches the shallower `dev.implement` request. Additive — the exact/family
+    // paths (tests above) are untouched; this is the ADDED disjunct.
+    const runtime = createRecordingRuntime();
+    const consumer = new DevConsumer(
+      baseOpts({ runtime, agent: buildAgent({ capabilities: ["dev.implement.strict"] }) }),
+    );
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+    expect(decision).toEqual({ kind: "ack" });
+  });
+
   test("5. gates red → cant_do (names the gate) + term; PR never opens", async () => {
     const runtime = createRecordingRuntime();
     const forge = fakeForge();

--- a/src/runner/dev-consumer.ts
+++ b/src/runner/dev-consumer.ts
@@ -79,6 +79,7 @@ import type { CCSessionOpts, CCSessionResult } from "./cc-session";
 import type { DevSessionStore } from "./dev-session-store";
 import { readLogicalRouting } from "../adapters/response-routing-delivery";
 import { decidePostSessionAction, type DevWorktreeStatus } from "./dev-worktree";
+import { anyAdvertisedSegmentPrefixMatches } from "../common/types/capability-window";
 
 // ---------------------------------------------------------------------------
 // Injected seams — the testability + authority surface
@@ -623,11 +624,16 @@ export class DevConsumer {
   // Internals
   // -------------------------------------------------------------------------
 
-  /** Capability claim: exact `dev.implement` or the bare `dev` family wildcard. */
+  /** Capability claim: exact `dev.implement` or the bare `dev` family wildcard.
+   *  cortex#2020 dual-accept window (RFC-0008 §4.2): the ratified segment-prefix
+   *  matcher is ORed on top of today's exact/family membership — additive, so an
+   *  agent advertising a deeper `dev.implement.<deeper>` also claims the
+   *  `dev.implement` request, and no match that lands today is removed. */
   private claims(): boolean {
     return (
       this.agent.capabilities.includes("dev.implement") ||
-      this.agent.capabilities.includes("dev")
+      this.agent.capabilities.includes("dev") ||
+      anyAdvertisedSegmentPrefixMatches("dev.implement", this.agent.capabilities)
     );
   }
 

--- a/src/runner/release-consumer.ts
+++ b/src/runner/release-consumer.ts
@@ -90,6 +90,7 @@ import {
   type DispatchTaskFailedReason,
 } from "../bus/dispatch-events";
 import type { GateFloorDecision } from "../bus/gate-floor";
+import { anyAdvertisedSegmentPrefixMatches } from "../common/types/capability-window";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -646,11 +647,16 @@ export class ReleaseConsumer {
   // Internals
   // -------------------------------------------------------------------------
 
-  /** Capability claim: exact `release.cut` or the generic `release`. */
+  /** Capability claim: exact `release.cut` or the generic `release`.
+   *  cortex#2020 dual-accept window (RFC-0008 §4.2): the ratified segment-prefix
+   *  matcher is ORed on top of today's exact/generic membership — additive, so an
+   *  agent advertising a deeper `release.cut.<deeper>` also claims the
+   *  `release.cut` request, and no match that lands today is removed. */
   private claims(): boolean {
     return (
       this.agent.capabilities.includes("release.cut") ||
-      this.agent.capabilities.includes("release")
+      this.agent.capabilities.includes("release") ||
+      anyAdvertisedSegmentPrefixMatches("release.cut", this.agent.capabilities)
     );
   }
 


### PR DESCRIPTION
Windowed (verifier-accept) side of #2020: route capability accept + match through `@the-metafactory/myelin/wire` additively (dual-accept), presence §7 D5 validate-before-fold gate, TODO(#2020/flag-day) markers. Receive-side only, zero emit changes. Part of #2020. Refs myelin#286 Wave 3.