### PR TITLE
fix(quickstart): expand ~ in nats-dir/config-dir — quickstart wrote a literal ~ directory

### DIFF
--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -389,6 +389,37 @@ describe("dispatchQuickstart — step 3 nats conf", () => {
     expect(res.stdout).toContain("overwritten (--force)");
     expect(readFileSync(confPath, "utf-8")).toContain("listen: 127.0.0.1:4222");
   });
+
+  // cortex#2229 — the DEFAULT nats-dir ("~/.config/nats") must be tilde-expanded.
+  // Prior tests always passed an explicit --nats-dir, so the literal-`~` default
+  // was never exercised: path.join left the `~` literal (a `./~/.config/nats`
+  // dir under cwd) and the rendered store_dir kept a `~` nats-server can't resolve.
+  test("default nats-dir expands ~ — conf lands under $HOME, not a literal ~ (cortex#2229)", async () => {
+    const configDir = freshDir();
+    // Deliberately NO --nats-dir → exercises the "~/.config/nats" default.
+    // $HOME is sandboxed (beforeAll), so it expands inside the sandbox.
+    await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(["--config-dir", configDir], () => fakePorts()),
+    );
+    const natsHome = join(process.env.HOME!, ".config", "nats");
+    const expandedConf = join(natsHome, "work.conf");
+    // The conf was written at the EXPANDED path (proves join saw an absolute dir).
+    expect(existsSync(expandedConf)).toBe(true);
+    const conf = readFileSync(expandedConf, "utf-8");
+    // store_dir is expanded — no literal `~` that nats-server would choke on.
+    expect(conf).toContain(`store_dir: ${natsHome}/work-jetstream`);
+    expect(conf).not.toContain("store_dir: ~");
+  });
+
+  test("--nats-dir given a literal ~ path is expanded (cortex#2229)", async () => {
+    const configDir = freshDir();
+    await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(["--config-dir", configDir, "--nats-dir", "~/natsq"], () => fakePorts()),
+    );
+    const expandedConf = join(process.env.HOME!, "natsq", "work.conf");
+    expect(existsSync(expandedConf)).toBe(true);
+    expect(readFileSync(expandedConf, "utf-8")).not.toContain("store_dir: ~");
+  });
 });
 
 // =============================================================================

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -66,6 +66,7 @@ import { CC_AUTH_FAILURE_MESSAGE, isCcAuthFailure } from "../../../runner/cc-fai
 import type { CCSessionResult } from "../../../runner/cc-session";
 import { resolveConfigDir } from "../../../common/config/config-path";
 import { validateConfigLoads } from "../../../common/config/validate-on-write";
+import { expandTilde } from "../../../common/config/loader";
 
 import { buildQuickstartPorts } from "./quickstart-adapters";
 import type { QuickstartPorts } from "./quickstart-ports";
@@ -753,8 +754,14 @@ export async function dispatchQuickstart(
   }
 
   const ports = portsFactory();
-  const configDir = flags.configDir ?? resolveConfigDir();
-  const natsDir = flags.natsDir ?? "~/.config/nats";
+  // Expand a leading `~` in BOTH the default and any user-supplied flag: these
+  // dirs flow into path.join (natsConfPath) and into the rendered nats.conf
+  // `store_dir` — neither path.join nor nats-server expands `~`, so an
+  // unexpanded default wrote a LITERAL `~/.config/nats` dir under cwd and a
+  // store_dir nats-server could not use (cortex#2229). Mirrors `cortex stack
+  // create` (stack.ts), which already expandTilde's these.
+  const configDir = expandTilde(flags.configDir ?? resolveConfigDir());
+  const natsDir = expandTilde(flags.natsDir ?? "~/.config/nats");
   const reports: StepReport[] = [];
 
   // --- 1. Preflight ----------------------------------------------------------

--- a/src/surface-sdk/generated/surface-sdk.d.ts
+++ b/src/surface-sdk/generated/surface-sdk.d.ts
@@ -219,6 +219,20 @@ export interface OutboundFile {
 	contentType?: string;
 }
 /**
+ * cortex#2206 — the result of a `createPrivateThread` call. NEVER a throw: a
+ * platform/API failure (or an unsupported surface) resolves `{ ok: false,
+ * detail }` so `daemon-brain-host.ts`'s `create_private_thread` handler can
+ * map it to a retryable `effect_rejected` (`not_now`) instead of an
+ * unhandled rejection.
+ */
+export type CreatePrivateThreadResult = {
+	ok: true;
+	threadId: string;
+} | {
+	ok: false;
+	detail: string;
+};
+/**
  * The core adapter interface. Each platform implements this.
  * Adapters are thin I/O wrappers — all pipeline logic lives in MessageRouter.
  */
@@ -278,6 +292,45 @@ export interface PlatformAdapter {
 	clearProgress(target: ResponseTarget): Promise<void>;
 	/** Create a thread from a message */
 	createThread(msg: InboundMessage, name: string): Promise<ResponseTarget>;
+	/**
+	 * cortex#2206 — create a PRIVATE thread on `channelId` (a channel the
+	 * CALLER already resolved — the brain-protocol host derives it from the
+	 * agent's OWN presence binding, never from brain input) and add
+	 * `memberIds` to it. Distinct from {@link createThread}:
+	 *
+	 *   - `createThread(msg, name)` — MESSAGE-anchored, always a thread the
+	 *     inbound message's author (and anyone in the parent channel, for a
+	 *     public thread) can already see.
+	 *   - `createPrivateThread({ channelId, name, memberIds })` — CHANNEL-
+	 *     anchored (no inbound message required) and PRIVATE: only the bot and
+	 *     the explicitly added `memberIds` can see it.
+	 *
+	 * NEVER throws — a platform/API failure resolves `{ ok: false, detail }`.
+	 * A surface with no private-thread-and-membership primitive resolves
+	 * `{ ok: false, detail }` naming itself as unsupported, rather than
+	 * throwing.
+	 *
+	 * OPTIONAL: most of this interface's existing consumers (the
+	 * message-response pipeline, the review/dashboard surface-router face)
+	 * have nothing to do with this capability at all — it exists for exactly
+	 * one caller today, `daemon-brain-host.ts`'s `create_private_thread`
+	 * effect handler, which already treats an absent implementation as "no
+	 * capability configured" (`effect_rejected`, `not_now` — see
+	 * cortex#2215, the not-yet-built boot-wiring issue) via its own
+	 * `createPrivateThread` constructor option. Making this required would
+	 * force every adapter bundle — including third-party ones with no stake
+	 * in this feature — to implement it; optional keeps the blast radius to
+	 * adapters that actually support it. cortex#2206's first real consumer
+	 * (the `metafactory-cortex-adapter-discord` bundle) implements it
+	 * separately, in that bundle's own repo — adapters are no longer in-tree
+	 * (cortex#1797 S12, ADR-0024) so this repo has no adapter implementation
+	 * to update alongside this interface addition.
+	 */
+	createPrivateThread?(opts: {
+		channelId: string;
+		name: string;
+		memberIds: string[];
+	}): Promise<CreatePrivateThreadResult>;
 	/**
 	 * cortex#502 — resolve a LOGICAL surface address (the review-path
 	 * `response_routing` shape) to a native {@link ResponseTarget}.


### PR DESCRIPTION
Closes #2229. Reported by a Debian tester.

## The bug

`cortex quickstart` (fresh-install path) wrote a **literal `~` directory** under cwd instead of expanding to `$HOME`:

```
❯ elat ./~
 ./~/.config/nats/gir.conf     # should be /home/gir/.config/nats/gir.conf
```

and the rendered `nats.conf` got `store_dir: ~/.config/nats/<slug>-jetstream` — **nats-server doesn't expand `~` either**, so jetstream storage couldn't land.

## Root cause

`quickstart.ts:757` defaulted `natsDir` to the string `"~/.config/nats"` and never expanded it. That value feeds `runNatsConf`, used for **both** the conf-file path (`natsConfPath` → `path.join`, no `~` expansion) **and** the conf content (`renderNatsConf` → `store_dir`). One unexpanded source → both symptoms. `configDir` (756) had the same latent gap for `--config-dir ~/…`.

The sibling `cortex stack create` already does this right (`stack.ts:545` wraps in `expandTilde`) — quickstart just missed it.

## Fix

Wrap both defaults (and any user-supplied `--nats-dir`/`--config-dir`) in `expandTilde` (`common/config/loader.ts`, idempotent on absolute paths). One source fix resolves both the path and the `store_dir`.

```diff
- const configDir = flags.configDir ?? resolveConfigDir();
- const natsDir = flags.natsDir ?? "~/.config/nats";
+ const configDir = expandTilde(flags.configDir ?? resolveConfigDir());
+ const natsDir = expandTilde(flags.natsDir ?? "~/.config/nats");
```

## Tests (the gap that let this reach a tester)

Prior tests always passed an explicit `--nats-dir <tmp>`, so the literal-`~` **default** was never exercised — which is why CI stayed green. Added two regressions:
- default nats-dir (no `--nats-dir`) → conf lands at the expanded `$HOME/.config/nats/<slug>.conf` with an expanded `store_dir` (no literal `~`);
- a literal `~` passed to `--nats-dir` is expanded.

Both **verified genuine by revert-check** — they fail (0 pass / 2 fail) with the fix reverted, pass with it in place. Scoped quickstart suites: 98 pass / 0 fail, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
