### PR TITLE
fix(brain): confidentiality-gate violation left in main by PR #2214's merge race

### DIFF
--- a/src/brain/__tests__/protocol.test.ts
+++ b/src/brain/__tests__/protocol.test.ts
@@ -630,7 +630,7 @@ describe("create_private_thread schema", () => {
       v: 1,
       type: "thread_created",
       task_id: "t1",
-      thread_id: "912345678901234567",
+      thread_id: "fake-thread-id-for-test",
     } as const;
     const parsed = parseBrainEvent(encodeBrainEvent(ev));
     expect(parsed.kind).toBe("ok");


### PR DESCRIPTION
PR #2214 (cortex#2206) merged using an earlier commit than intended -- the actual CI-green fix reached the branch one push later, but the branch was auto-deleted on merge before that push registered, silently orphaning it. Net effect: `main` currently has a test in `src/brain/__tests__/protocol.test.ts` (the `thread_created` round-trip test) failing the confidentiality-gate's tier2:platform-snowflake check, because it used a digit string shaped like a real platform id where an obviously-fake placeholder was intended. That was already fixed once and lost in the merge race above.

This PR re-applies exactly that one-line fix (swaps the digit-shaped placeholder for a non-numeric one -- the field only requires a non-empty string, no digit-shape constraint). Separately verified: the generated surface-sdk `.d.ts` sync gap I originally thought was also lost has since self-resolved via an unrelated later commit on main -- the new brain-effect type additions from #2214 are present in the current generated artifact, confirmed by regenerating locally and diffing (no changes produced). So this PR is scoped to just the confidentiality fix.

Verification:
```
bun test src/brain/__tests__/protocol.test.ts  -> 88 pass, 0 fail
bunx tsc --noEmit                               -> clean
```
