### PR TITLE
feat(brain): wire create_private_thread into the boot path (Closes #2215)

### DIFF
--- a/src/__tests__/cortex.brain-daemon-thread-boot.test.ts
+++ b/src/__tests__/cortex.brain-daemon-thread-boot.test.ts
@@ -1,0 +1,428 @@
+/**
+ * cortex#2215 — `create_private_thread` (cortex#2206) boot-wiring integration
+ * test.
+ *
+ * cortex#2206/PR #2214 built `DaemonBrainHost`'s `create_private_thread`
+ * capability and unit-tested it directly against the class (constructor
+ * options: `agentChannelId` / `createPrivateThread` / `anonReachable`).
+ * Nothing wired those options for a real agent — this file proves the REAL
+ * `cortex.ts` boot path (`startCortex`) now does, for an agent declaring
+ * `openOnboarding: true` with a Discord presence binding.
+ *
+ * Scope of "real boot path" here: `startCortex` runs the actual
+ * `wireBrainConsumers` + `wireSurfaceAdapters` boot-wiring modules, in the
+ * actual order (brain consumers, THEN surface adapters) — the exact
+ * construction-ordering problem cortex#2215 names. Two test seams keep this
+ * hermetic (no real subprocess, no real Discord bundle):
+ *
+ *   - `injectDaemonBrainTransport` swaps the daemon host's real
+ *     spawn-a-subprocess transport for an in-memory fake brain
+ *     (`FakeDaemonBrain` — the SAME double `daemon-brain-host.test.ts` and
+ *     `bus/__tests__/brain-consumer.test.ts` already drive).
+ *   - `injectSurfacePluginRegistry` swaps the real (out-of-tree, arc-bundle-
+ *     loaded) Discord adapter for a construct-only fake implementing
+ *     `createPrivateThread` — mirrors `surface-adapter-boot.test.ts`'s own
+ *     `registryFromRecordingFactory` fake-plugin pattern.
+ *
+ * What's deliberately OUT of scope: driving a task to the daemon host over
+ * the real bus/JetStream pull-consumer path. That plumbing is its own,
+ * already-covered surface (`brain-consumer-boot.test.ts`'s `subscribePull`
+ * assertions; `bus/__tests__/brain-consumer.test.ts`'s consumer↔host
+ * integration). This test instead reads the REAL, boot-constructed
+ * `DaemonBrainHost` off `handle.daemonBrainHosts` (cortex#2215's new
+ * `@internal` handle field) and calls `runTask` on it directly — the
+ * assertion under test is "the wiring cortex.ts did is correct", not
+ * "the bus can deliver a task" (a different, already-tested claim).
+ *
+ * All test ids are obviously-fake, non-numeric placeholders (confidentiality
+ * gate — never a realistic-looking digit snowflake).
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { z } from "zod/v4";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import { AgentSchema, type Agent } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import { SurfacePluginRegistry, type AdapterPlugin } from "../adapters/registry";
+import type { PlatformAdapter, CreatePrivateThreadResult } from "../adapters/types";
+import {
+  FakeDaemonBrain,
+  singleFakeDaemonTransport,
+} from "../brain/__tests__/fake-daemon-brain";
+import type { TaskEvent } from "../brain/protocol";
+import type { BrainTaskHooks } from "../brain/exec-brain-runner";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Non-numeric, obviously-fake — never a realistic 17-20 digit platform
+// snowflake (confidentiality-gate self-check, per CLAUDE.md).
+const FAKE_DISCORD_TOKEN = "discord-token-fake-for-test";
+const FAKE_GUILD_ID = "guild-fake-for-test";
+const FAKE_AGENT_CHANNEL_ID = "agent-channel-fake-for-test";
+const FAKE_LOG_CHANNEL_ID = "log-channel-fake-for-test";
+const FAKE_THREAD_ID = "thread-fake-for-test";
+const FAKE_SOURCE_USER_ID = "newcomer-fake-for-test";
+
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/cortex-brain-daemon-thread-boot-test-published" },
+    ...overrides,
+  });
+}
+
+/** A construct-only fake Discord `PlatformAdapter` implementing `createPrivateThread`. */
+interface RecordedThreadCall {
+  channelId: string;
+  name: string;
+  memberIds: string[];
+}
+
+function makeFakeDiscordAdapter(
+  recordedCalls: RecordedThreadCall[],
+): PlatformAdapter & Record<string, unknown> {
+  return {
+    platform: "discord",
+    instanceId: "pier-discord",
+    start: async () => {},
+    stop: async () => {},
+    getPlatformUserId: async () => "bot-fake-for-test",
+    fetchContext: async () => [],
+    resolveAccess: () => ({ allowed: true, features: { chat: true, async: false, team: false } }),
+    postResponse: async () => {},
+    sendTyping: async () => {},
+    sendProgress: async () => {},
+    clearProgress: async () => {},
+    createThread: async () => ({ instanceId: "pier-discord", channelId: FAKE_AGENT_CHANNEL_ID }),
+    resolveLogicalTarget: async () => null,
+    notifyPrincipal: async () => {},
+    createPrivateThread: async (opts: {
+      channelId: string;
+      name: string;
+      memberIds: string[];
+    }): Promise<CreatePrivateThreadResult> => {
+      recordedCalls.push({ ...opts });
+      return { ok: true, threadId: FAKE_THREAD_ID };
+    },
+    // `surface-adapter-boot.ts`'s discord descriptor unconditionally casts to
+    // `DiscordLikeAdapter` (`PlatformAdapter & RouterRegistrable &
+    // TrustMergeable`) and runs its Pass-2 trust merge for EVERY discord
+    // instance — these members are required even though this test never
+    // exercises trust.
+    surfaceConfig: { id: "discord-pier-discord", subjects: [], render: async () => {} },
+    setTrustedBotIds: () => {},
+    attachInboundDispatch: () => {},
+    trustedBotIdCount: 0,
+  };
+}
+
+/** A `SurfacePluginRegistry` with exactly one registered "discord" plugin, delegating to `factory`. */
+function registryWithFakeDiscord(
+  factory: () => PlatformAdapter & Record<string, unknown>,
+): SurfacePluginRegistry {
+  const registry = new SurfacePluginRegistry();
+  const plugin: AdapterPlugin = {
+    kind: "adapter",
+    id: "discord",
+    platform: "discord",
+    bindingSchema: z.unknown(),
+    foldsIntoPresence: true,
+    secretFields: [],
+    demuxKey: () => "",
+    buildGatewayConstructArgs: (_group, base) => ({ instanceId: base.instanceId }),
+    createAdapter: () => factory(),
+  };
+  registry.registerAdapter(plugin);
+  return registry;
+}
+
+/** A minimal, valid, open-onboarding, `lifecycle: daemon` agent bound to Discord. */
+function makePierAgent(overrides: Partial<Record<string, unknown>> = {}): Agent {
+  return AgentSchema.parse({
+    id: "pier",
+    displayName: "Pier",
+    persona: writePersonaFile(),
+    trust: [],
+    openOnboarding: true,
+    presence: {
+      discord: {
+        enabled: true,
+        token: FAKE_DISCORD_TOKEN,
+        guildId: FAKE_GUILD_ID,
+        agentChannelId: FAKE_AGENT_CHANNEL_ID,
+        logChannelId: FAKE_LOG_CHANNEL_ID,
+      },
+    },
+    runtime: {
+      mode: "in-process",
+      capabilities: ["concierge.welcome"],
+      brain: {
+        kind: "exec",
+        run: "bun {pack}/brain/main.ts",
+        lifecycle: "daemon",
+        maxRestarts: 0,
+      },
+    },
+    ...overrides,
+  });
+}
+
+let personaDirs: string[] = [];
+function writePersonaFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), "cortex-brain-daemon-thread-boot-"));
+  personaDirs.push(dir);
+  const p = join(dir, "pier.md");
+  writeFileSync(p, "# Pier persona\n", "utf-8");
+  return p;
+}
+
+function makeTask(over: Partial<TaskEvent> = {}): TaskEvent {
+  return {
+    v: 1,
+    type: "task",
+    task_id: "welcome-1",
+    capability: "concierge.welcome",
+    payload: {},
+    source: { surface: "discord", channel: "arrivals", thread: "", user: FAKE_SOURCE_USER_ID },
+    ...over,
+  };
+}
+
+function noopHooks(): BrainTaskHooks {
+  return {
+    onPost: () => {},
+    onAskPrincipal: async () => ({ verdict: "pass", principal: "andreas" }),
+    onDispatch: () => undefined,
+    onLog: () => {},
+  };
+}
+
+/** Wait until `cond()` is true (poll), or throw after `timeoutMs`. */
+async function until(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("until() timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startCortex — create_private_thread boot wiring (cortex#2215)", () => {
+  test("an openOnboarding agent's REAL boot-constructed DaemonBrainHost has a working create_private_thread capability end-to-end against a fake adapter", async () => {
+    const recordedCalls: RecordedThreadCall[] = [];
+    const brain = new FakeDaemonBrain();
+    const config = minimalConfig({
+      discord: [
+        {
+          enabled: true,
+          token: FAKE_DISCORD_TOKEN,
+          guildId: FAKE_GUILD_ID,
+          agentChannelId: FAKE_AGENT_CHANNEL_ID,
+          logChannelId: FAKE_LOG_CHANNEL_ID,
+        },
+      ],
+    });
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-brain-daemon-thread-boot-agents-"));
+
+    const handle = await startCortex(config, {
+      disableConfigWatcher: true,
+      disableAgentsWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+      inlineAgents: [makePierAgent()],
+      principal: { id: "andreas" },
+      injectSurfacePluginRegistry: registryWithFakeDiscord(() =>
+        makeFakeDiscordAdapter(recordedCalls),
+      ),
+      injectDaemonBrainTransport: singleFakeDaemonTransport(brain),
+    });
+
+    try {
+      // The real boot path constructed exactly one lifecycle:daemon host, for
+      // "pier" — proof `wireBrainConsumers` ran and pushed onto the shared
+      // array cortex.ts owns.
+      expect(handle.daemonBrainHosts).toHaveLength(1);
+      const host = handle.daemonBrainHosts[0]!;
+      expect(host.agentId).toBe("pier");
+
+      // Drive a task directly against the REAL, boot-constructed host (see
+      // file header for why this bypasses the bus pull-consumer path).
+      const runP = host.runTask(makeTask(), noopHooks());
+      await until(() => brain.lastTask()?.task_id === "welcome-1");
+
+      // The brain requests a private thread with `members: "source"` — the
+      // only form an anon-reachable (openOnboarding) agent's brain may ever
+      // request (cortex#2206 policy).
+      brain.emit(
+        JSON.stringify({
+          v: 1,
+          type: "create_private_thread",
+          task_id: "welcome-1",
+          name: "welcome newcomer",
+          members: "source",
+        }),
+      );
+      await until(() => brain.hasEvent("thread_created"));
+
+      // The load-bearing assertion: the call reached the FAKE ADAPTER the
+      // real `wireSurfaceAdapters` boot lane constructed for "pier" —
+      // proving the agentPlatformAdapters holder-indirection actually
+      // resolves at call time, and that the channel is "pier"'s OWN bound
+      // agentChannelId (never brain-supplied).
+      expect(recordedCalls).toEqual([
+        {
+          channelId: FAKE_AGENT_CHANNEL_ID,
+          name: "welcome newcomer",
+          memberIds: [FAKE_SOURCE_USER_ID],
+        },
+      ]);
+
+      const created = brain.received.find((e) => e.type === "thread_created");
+      expect(created).toMatchObject({
+        type: "thread_created",
+        task_id: "welcome-1",
+        thread_id: FAKE_THREAD_ID,
+      });
+
+      brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "welcome-1", status: "complete" }));
+      await runP;
+    } finally {
+      await handle.stop();
+      rmSync(tmpAgentsDir, { recursive: true, force: true });
+    }
+  });
+
+  test("an agent WITHOUT openOnboarding: true gets NO create_private_thread capability — fail-safe, not fail-open", async () => {
+    const recordedCalls: RecordedThreadCall[] = [];
+    const brain = new FakeDaemonBrain();
+    const config = minimalConfig({
+      discord: [
+        {
+          enabled: true,
+          token: FAKE_DISCORD_TOKEN,
+          guildId: FAKE_GUILD_ID,
+          agentChannelId: FAKE_AGENT_CHANNEL_ID,
+          logChannelId: FAKE_LOG_CHANNEL_ID,
+        },
+      ],
+    });
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-brain-daemon-thread-boot-noopen-"));
+
+    // Same Discord binding, same daemon lifecycle — the ONLY difference is
+    // `openOnboarding` is absent (default false).
+    const handle = await startCortex(config, {
+      disableConfigWatcher: true,
+      disableAgentsWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+      inlineAgents: [makePierAgent({ openOnboarding: undefined })],
+      principal: { id: "andreas" },
+      injectSurfacePluginRegistry: registryWithFakeDiscord(() =>
+        makeFakeDiscordAdapter(recordedCalls),
+      ),
+      injectDaemonBrainTransport: singleFakeDaemonTransport(brain),
+    });
+
+    try {
+      expect(handle.daemonBrainHosts).toHaveLength(1);
+      const host = handle.daemonBrainHosts[0]!;
+
+      const runP = host.runTask(makeTask({ task_id: "no-open-1" }), noopHooks());
+      await until(() => brain.lastTask()?.task_id === "no-open-1");
+
+      brain.emit(
+        JSON.stringify({
+          v: 1,
+          type: "create_private_thread",
+          task_id: "no-open-1",
+          name: "should never open",
+          members: "source",
+        }),
+      );
+      await until(() => brain.hasEvent("effect_rejected"));
+
+      // No capability configured at all ⇒ `effect_rejected`/`cant_do`
+      // (DaemonBrainHost's "missing agentChannelId/createPrivateThread"
+      // structural path) — and, load-bearing, the fake adapter is NEVER
+      // called.
+      const rejected = brain.received.find((e) => e.type === "effect_rejected");
+      expect(rejected).toMatchObject({ type: "effect_rejected", effect: "create_private_thread" });
+      if (rejected?.type === "effect_rejected") {
+        expect(rejected.reason.kind).toBe("cant_do");
+      }
+      expect(recordedCalls).toEqual([]);
+      expect(brain.hasEvent("thread_created")).toBe(false);
+
+      brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "no-open-1", status: "complete" }));
+      await runP;
+    } finally {
+      await handle.stop();
+      rmSync(tmpAgentsDir, { recursive: true, force: true });
+    }
+  });
+
+  test("an openOnboarding agent with NO Discord presence binding boots without crashing and gets no create_private_thread capability", async () => {
+    const brain = new FakeDaemonBrain();
+    const config = minimalConfig();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-brain-daemon-thread-boot-headless-"));
+
+    // openOnboarding: true, but headless — no `presence.discord` at all.
+    // Must not crash boot (a bare `.agentChannelId` read must be `?.`-safe).
+    const handle = await startCortex(config, {
+      disableConfigWatcher: true,
+      disableAgentsWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+      inlineAgents: [makePierAgent({ presence: {} })],
+      principal: { id: "andreas" },
+      injectDaemonBrainTransport: singleFakeDaemonTransport(brain),
+    });
+
+    try {
+      expect(handle.daemonBrainHosts).toHaveLength(1);
+      const host = handle.daemonBrainHosts[0]!;
+
+      const runP = host.runTask(makeTask({ task_id: "headless-1" }), noopHooks());
+      await until(() => brain.lastTask()?.task_id === "headless-1");
+
+      brain.emit(
+        JSON.stringify({
+          v: 1,
+          type: "create_private_thread",
+          task_id: "headless-1",
+          name: "should never open",
+          members: "source",
+        }),
+      );
+      await until(() => brain.hasEvent("effect_rejected"));
+
+      const rejected = brain.received.find((e) => e.type === "effect_rejected");
+      expect(rejected).toMatchObject({ type: "effect_rejected", effect: "create_private_thread" });
+
+      brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "headless-1", status: "complete" }));
+      await runP;
+    } finally {
+      await handle.stop();
+      rmSync(tmpAgentsDir, { recursive: true, force: true });
+    }
+  });
+});
+
+afterAll(() => {
+  for (const d of personaDirs) rmSync(d, { recursive: true, force: true });
+  personaDirs = [];
+});

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -103,7 +103,7 @@ import {
   type PrincipalIdentity,
 } from "./bus/surface-principal-gate";
 import { GateReplyRouter } from "./bus/gate-reply-router";
-import { DaemonBrainHost } from "./brain/daemon-brain-host";
+import { DaemonBrainHost, type DaemonTransport } from "./brain/daemon-brain-host";
 import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import { wireReviewConsumers } from "./runner/review-consumer-boot";
 import { setActiveSubstrates, activeConfigHomeEnv } from "./common/substrates/config-home";
@@ -138,7 +138,11 @@ import {
 
 import { resolveRendererPluginAndConfig, UnimplementedRendererKindError, type Renderer } from "./renderers";
 import { assertRuntimeSystemCoverage } from "./renderers/coverage";
-import { createDefaultSurfacePluginRegistry, validateSurfacesAgainstRegistry } from "./adapters/registry";
+import {
+  createDefaultSurfacePluginRegistry,
+  validateSurfacesAgainstRegistry,
+  type SurfacePluginRegistry,
+} from "./adapters/registry";
 import { loadExternalPlugins } from "./adapters/loader";
 import { createSystemPluginLoadFailedEvent, createSystemPluginLoadedEvent } from "./bus/system-events";
 import { startPluginControlServer } from "./gateway/plugin-control-server";
@@ -511,6 +515,19 @@ export interface CortexHandle {
    * `null` when no registry was configured on this cortex instance.
    */
   readonly registryClient: RegistryClientReader | null;
+  /**
+   * cortex#2215 — the live `lifecycle: daemon` brain hosts this boot
+   * constructed (one per such agent), read-only. Exposed so an integration
+   * test can drive a REAL, boot-constructed `DaemonBrainHost.runTask(...)`
+   * directly — proving the `create_private_thread` capability wiring
+   * (`agentChannelId`/`createPrivateThread`/`anonReachable`) is correct on a
+   * host the real boot path produced, without needing to also fake the
+   * bus/JetStream pull-consumer delivery path (already covered by
+   * `brain-consumer-boot.test.ts` / `bus/__tests__/brain-consumer.test.ts`).
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  readonly daemonBrainHosts: readonly DaemonBrainHost[];
 }
 
 /** Optional test-only injection points. Production callers omit. */
@@ -542,6 +559,29 @@ export interface StartCortexOptions {
    * @internal — not part of the public API; semver does not apply.
    */
   injectRuntime?: MyelinRuntime;
+  /**
+   * cortex#2215 — inject a `SurfacePluginRegistry` instead of building the
+   * default one via `createDefaultSurfacePluginRegistry()`. Lets a test
+   * register a fake adapter plugin (e.g. a "discord" plugin whose
+   * `createAdapter` returns a fake implementing `createPrivateThread`) so a
+   * `lifecycle: daemon` agent's `create_private_thread` capability can be
+   * exercised end-to-end through the REAL boot path — no real Discord
+   * bundle, no network I/O. Production omits this. See
+   * `cortex.brain-daemon-thread-boot.test.ts`.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  injectSurfacePluginRegistry?: SurfacePluginRegistry;
+  /**
+   * cortex#2215 — inject a `DaemonTransport` for every `lifecycle: daemon`
+   * brain host this boot constructs, instead of the real
+   * `makeBunUnixTransport` (spawn-a-real-subprocess) default. Lets a test
+   * drive a daemon brain through the REAL `wireBrainConsumers` boot wiring
+   * against an in-memory fake brain. Production omits this.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  injectDaemonBrainTransport?: DaemonTransport;
   /**
    * S4 (Network Join Control Plane, epic #733) — inject a roster provider for
    * the boot-path federated-peer resolution instead of building a live
@@ -1780,6 +1820,16 @@ export async function startCortex(
   const brainPresenceHolder: { producer: AgentPresenceProducer | null } = {
     producer: null,
   };
+  // cortex#2215 — shared, mutable holder mapping `agent.id` → its
+  // constructed `PlatformAdapter`, threaded into BOTH `wireBrainConsumers`
+  // (below, runs FIRST) and `wireSurfaceAdapters` (much further down boot,
+  // runs LAST — surface adapters construct after brain consumers). A
+  // `lifecycle: daemon` agent's `create_private_thread` capability reads
+  // this map lazily, at the moment the effect actually fires, well after
+  // both boot phases complete — so declaring (and sharing) it here resolves
+  // the construction-ordering problem without reordering boot, mirroring
+  // the `brainPresenceHolder` holder-indirection idiom immediately above.
+  const agentPlatformAdapters = new Map<string, PlatformAdapter>();
   const reviewCapableAgents = mergedAgents.filter((a) => {
     // An exec-brain agent is hosted by the brain path even if it happens to
     // declare a code-review capability — the two consumers are mutually
@@ -2561,6 +2611,10 @@ export async function startCortex(
     reviewJsm,
     brainTasksStream,
     reviewConsumerMaxDeliver,
+    agentPlatformAdapters,
+    ...(options.injectDaemonBrainTransport !== undefined && {
+      daemonTransport: options.injectDaemonBrainTransport,
+    }),
   });
 
   // Boot: start review consumers for every code-review-capable agent. Same
@@ -3170,7 +3224,8 @@ export async function startCortex(
   // gateway (`startGatewayIfEnabled`). All three paths dogfood the SAME
   // in-tree registrations (ADR-0024 §3.3) — extraction later moves a plugin
   // out, it never rewires this composition.
-  const surfacePluginRegistry = createDefaultSurfacePluginRegistry();
+  const surfacePluginRegistry =
+    options.injectSurfacePluginRegistry ?? createDefaultSurfacePluginRegistry();
 
   // cortex#1792 (S6, ADR-0024 D1/D3/D4/D5, OQ9/OQ11) — discover, compat-gate,
   // import, and register out-of-tree plugin bundles into the SAME registry,
@@ -3381,6 +3436,7 @@ export async function startCortex(
     adapterCleanup,
     liveSurfaces,
     registry: surfacePluginRegistry,
+    agentPlatformAdapters,
   });
 
   // MIG-7.2d: non-agent-bound renderers (dashboard, pagerduty, …).
@@ -6273,6 +6329,9 @@ export async function startCortex(
     },
     get registryClient() {
       return registryClient;
+    },
+    get daemonBrainHosts() {
+      return daemonBrainHosts;
     },
   };
 }

--- a/src/runner/__tests__/brain-consumer-boot.test.ts
+++ b/src/runner/__tests__/brain-consumer-boot.test.ts
@@ -88,6 +88,7 @@ function baseOpts(overrides: Partial<WireBrainConsumersOpts> = {}): WireBrainCon
     reviewJsm: null,
     brainTasksStream: "BRAIN_TASKS",
     reviewConsumerMaxDeliver: 5,
+    agentPlatformAdapters: new Map(),
     ...overrides,
   };
 }

--- a/src/runner/brain-consumer-boot.ts
+++ b/src/runner/brain-consumer-boot.ts
@@ -74,12 +74,17 @@ import {
 } from "../common/agents/dispatch-state-recorder";
 import { provisionReviewConsumer, type ProvisionJsm } from "../bus/jetstream/provision";
 import { makeExecBrainRunner } from "../brain/exec-brain-runner";
-import { DaemonBrainHost } from "../brain/daemon-brain-host";
+import {
+  DaemonBrainHost,
+  type CreatePrivateThreadFn,
+  type DaemonTransport,
+} from "../brain/daemon-brain-host";
 import type { SystemEventSource } from "../bus/system-events";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { AgentPresenceProducer } from "./agent-presence-producer";
 import type { SurfacePrincipalGate } from "../bus/surface-principal-gate";
 import type { AgentModelClass } from "../bus/sovereignty-gate";
+import type { PlatformAdapter } from "../adapters/types";
 
 // ---------------------------------------------------------------------------
 // The narrow agent shape the boot wiring consumes
@@ -104,6 +109,33 @@ export interface BrainBootAgent {
    * it so the wiring can gate on it without a cast.
    */
   state?: { blueprint: string; version: string };
+  /**
+   * cortex#2215 — the Pier "open-onboarding" gate (`AgentSchema.openOnboarding`,
+   * cortex#1165). `true` ⇒ this agent is reachable by an unmapped, zero-
+   * authority anon principal, which is ALSO the (and, per the ADR, the ONLY)
+   * criterion this boot wiring uses to decide whether a `lifecycle: daemon`
+   * agent gets a live `create_private_thread` capability at all (see
+   * `startForAgent` below). Absent/`false` ⇒ no capability is wired for this
+   * agent — fail-safe: the wider "explicit member list" path for a trusted,
+   * non-anon-reachable agent is deliberately out of scope here (ADR
+   * cortex#2206 #1: "which future agents get [the wider path] is each of
+   * their own onboarding, not a blanket switch").
+   */
+  openOnboarding?: boolean;
+  /**
+   * cortex#2215 — the per-platform presence bindings this wiring reads to
+   * resolve `create_private_thread`'s parent channel. Only Discord's
+   * `agentChannelId` is consulted today (the primitive's first real
+   * consumer); other platforms are structurally absent here rather than
+   * wired to a no-op, so a future platform's own presence shape doesn't need
+   * a dead field on every agent that never uses it.
+   */
+  presence?: {
+    discord?: {
+      /** `presence.discord.agentChannelId` — the agent's own bound channel. */
+      agentChannelId?: string;
+    };
+  };
   runtime?: {
     capabilities?: readonly string[];
     maxConcurrent?: number;
@@ -178,6 +210,32 @@ export interface WireBrainConsumersOpts {
    * assert which agents are wired with a recorder without a real bundle.
    */
   makeDispatchStateRecorder?: (agent: { id: string }) => DispatchStateRecorder;
+  /**
+   * cortex#2215 — shared, mutable holder mapping `agent.id` → its constructed
+   * `PlatformAdapter`, populated by `wireSurfaceAdapters` LATER in boot
+   * (surface adapters construct AFTER brain consumers — see `cortex.ts`'s
+   * boot order). This module never iterates or reads the map at
+   * CONSTRUCTION time; a `lifecycle: daemon` agent's `createPrivateThread`
+   * closure (see `startForAgent` below) captures the map by REFERENCE and
+   * reads `.get(agentId)` LAZILY, only when the `create_private_thread`
+   * effect actually fires — which structurally cannot happen before
+   * `wireSurfaceAdapters` has run (reaching the effect requires a live task
+   * to already have been dispatched to the brain over the bus). Same
+   * holder-indirection idiom `cortex.ts` already uses for
+   * `brainPresenceHolder`; resolves the adapter-construction-ordering
+   * problem without reordering boot.
+   */
+  agentPlatformAdapters: ReadonlyMap<string, PlatformAdapter>;
+  /**
+   * Test-only seam — override the `DaemonBrainHost`'s transport instead of
+   * the real `makeBunUnixTransport` (spawn-a-real-subprocess) default. Lets
+   * an integration test drive a `lifecycle: daemon` agent through this REAL
+   * boot-wiring function against an in-memory fake brain, with no real
+   * socket/subprocess. Production omits this.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  daemonTransport?: DaemonTransport;
 }
 
 /** The callable `cortex.ts` invokes per agent, at both the boot loop and the `agents.d/` hot-reload sites. */
@@ -233,6 +291,39 @@ function loadBrainPersona(
     );
     return undefined;
   }
+}
+
+/**
+ * cortex#2215 — build the `CreatePrivateThreadFn` a `lifecycle: daemon`
+ * `DaemonBrainHost` calls for its `create_private_thread` effect. Reads
+ * `adapters` (the shared, mutable holder — see
+ * {@link WireBrainConsumersOpts.agentPlatformAdapters}) LAZILY, at call time,
+ * not at construction time — so it is correct regardless of whether
+ * `wireSurfaceAdapters` has run yet. NEVER throws: a missing adapter (no
+ * platform binding constructed for this agent — disabled instance, gateway-
+ * owned, construction failure, …) or an adapter that doesn't implement
+ * `createPrivateThread` (a bundle with no stake in this capability) both
+ * resolve `{ ok: false, detail }`, matching {@link CreatePrivateThreadFn}'s
+ * own never-throws contract (mirrors every other injected I/O seam in
+ * `daemon-brain-host.ts`).
+ */
+function makeCreatePrivateThreadFn(
+  agentId: string,
+  adapters: ReadonlyMap<string, PlatformAdapter>,
+): CreatePrivateThreadFn {
+  return async (callOpts) => {
+    const adapter = adapters.get(agentId);
+    if (adapter?.createPrivateThread === undefined) {
+      return {
+        ok: false,
+        detail:
+          adapter === undefined
+            ? `no platform adapter configured for agent "${agentId}"`
+            : `adapter "${adapter.platform}" for agent "${agentId}" does not implement createPrivateThread`,
+      };
+    }
+    return adapter.createPrivateThread(callOpts);
+  };
 }
 
 /**
@@ -327,6 +418,26 @@ export function wireBrainConsumers(
         }),
         ...(stateRecorder !== undefined && { stateRecorder }),
       };
+      // cortex#2215 — wire cortex#2206's `create_private_thread` capability
+      // for exactly the agents its ADR intends: `openOnboarding: true` (the
+      // Pier "open-onboarding" gate, `AgentSchema.openOnboarding`) AND a
+      // bound Discord `agentChannelId`. BOTH conditions are required —
+      // `openOnboarding` alone with no Discord binding has no channel to
+      // open a thread on; a Discord binding alone on a NON-open-onboarding
+      // agent is deliberately left unwired (the wider "explicit member
+      // list" path for a trusted agent is its own future onboarding
+      // decision per the ADR, not something this generic wiring grants by
+      // default). Either condition failing ⇒ `agentChannelId` /
+      // `createPrivateThread` stay UNDEFINED on the host — the fail-safe
+      // "no capability at all" state (every `create_private_thread` effect
+      // this agent's brain emits is refused `effect_rejected`/`cant_do` —
+      // DaemonBrainHost's structural "no thread-capable surface configured"
+      // path — regardless of `anonReachable`'s own true-by-default).
+      const discordAgentChannelId = agent.presence?.discord?.agentChannelId;
+      const isOpenOnboarding = agent.openOnboarding === true;
+      const wireCreatePrivateThread =
+        isOpenOnboarding && discordAgentChannelId !== undefined;
+
       let daemonHost: DaemonBrainHost | undefined;
       let consumer: BrainConsumer;
       if (brain.lifecycle === "daemon") {
@@ -337,6 +448,23 @@ export function wireBrainConsumers(
           secrets,
           maxRestarts: brain.maxRestarts,
           ...(personaText !== undefined && { persona: personaText }),
+          ...(opts.daemonTransport !== undefined && { transport: opts.daemonTransport }),
+          // cortex#2215 — see the `wireCreatePrivateThread` computation
+          // above. `anonReachable: true` is set EXPLICITLY (not left to
+          // `DaemonBrainHost`'s own safe-by-default) because it must track
+          // `isOpenOnboarding`, not just "capability configured" — an
+          // open-onboarding agent's brain may ONLY ever request
+          // `members: "source"` (cortex#2206 policy), never an explicit
+          // member list, and that gate is what `anonReachable: true` turns
+          // on inside the host.
+          ...(wireCreatePrivateThread && {
+            agentChannelId: discordAgentChannelId,
+            anonReachable: true,
+            createPrivateThread: makeCreatePrivateThreadFn(
+              agent.id,
+              opts.agentPlatformAdapters,
+            ),
+          }),
           // On degradation (restart budget exhausted) surface the agent via the
           // presence producer's capability-change signal (drop to empty caps),
           // the same path the reconcile uses (§7.4). Read the holder lazily —

--- a/src/runner/surface-adapter-boot.ts
+++ b/src/runner/surface-adapter-boot.ts
@@ -376,6 +376,18 @@ interface BootCtx {
   ) => (msg: InboundMessage) => Promise<void>;
   adapters: PlatformAdapter[];
   liveSurfaces: Set<string>;
+  /**
+   * cortex#2215 — shared, mutable holder mapping `agent.id` → its
+   * constructed `PlatformAdapter`, populated HERE (the adapter-construction
+   * boot lane) so `wireBrainConsumers` (which runs EARLIER in `cortex.ts`'s
+   * boot order) can resolve a `lifecycle: daemon` agent's `create_private_thread`
+   * capability against a live adapter reference without this module needing
+   * to run first. See `brain-consumer-boot.ts`'s
+   * `WireBrainConsumersOpts.agentPlatformAdapters` doc for the read side.
+   * Optional — a caller with no stake in `create_private_thread` (e.g. an
+   * existing test) omits it and this module simply skips the `.set(...)`.
+   */
+  agentPlatformAdapters?: Map<string, PlatformAdapter>;
 }
 
 // =============================================================================
@@ -429,6 +441,13 @@ async function bootPlatformAdapters<
       // hot-reloaded surface joins here).
       ctx.liveSurfaces.add(adapter.platform);
       ctx.adapters.push(adapter);
+      // cortex#2215 — see `BootCtx.agentPlatformAdapters`'s doc. Populated
+      // for every platform (not just Discord) uniformly, mirroring
+      // `ctx.adapters.push` above: the read side already treats a missing-
+      // `createPrivateThread` adapter as "no capability" (see
+      // `brain-consumer-boot.ts`'s `makeCreatePrivateThreadFn`), so there is
+      // no need to special-case which platform gets recorded here.
+      ctx.agentPlatformAdapters?.set(agent.id, adapter);
 
       if (descriptor.trustResolverSupport && ctx.agentRegistry.tryGetById(agent.id)) {
         try {
@@ -600,6 +619,14 @@ export interface WireSurfaceAdaptersOpts {
    * register recording `AdapterPlugin` stubs on a registry they build.
    */
   registry: SurfacePluginRegistry;
+  /**
+   * cortex#2215 — shared, mutable holder mapping `agent.id` → its
+   * constructed `PlatformAdapter`. Threaded straight through to
+   * `BootCtx.agentPlatformAdapters` (see that field's doc for the full
+   * ordering rationale) — optional so existing callers with no stake in
+   * `create_private_thread` need not pass it.
+   */
+  agentPlatformAdapters?: Map<string, PlatformAdapter>;
 }
 
 /**
@@ -639,6 +666,9 @@ export async function wireSurfaceAdapters(opts: WireSurfaceAdaptersOpts): Promis
     inboundWithGateBridge: opts.inboundWithGateBridge,
     adapters: opts.adapters,
     liveSurfaces: opts.liveSurfaces,
+    ...(opts.agentPlatformAdapters !== undefined && {
+      agentPlatformAdapters: opts.agentPlatformAdapters,
+    }),
   };
 
   // ── Discord ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #2215

## Summary

cortex#2206/PR #2214 built `DaemonBrainHost`'s `create_private_thread` capability and unit-tested it directly against the class, but nothing in `cortex.ts`'s boot path constructed a host with `agentChannelId` / `createPrivateThread` / `anonReachable` for a real agent. This PR wires it up generically, for any agent with `openOnboarding: true` and a bound Discord presence — not a guildhall-specific hack.

## What changed

- **`src/runner/brain-consumer-boot.ts`** — `wireBrainConsumers` now computes, per `lifecycle: daemon` agent: `openOnboarding === true` AND a defined `presence.discord.agentChannelId`. Both must hold for the capability to be wired at all; either missing leaves `agentChannelId`/`createPrivateThread` undefined on the host — the fail-safe "no capability" state (`DaemonBrainHost`'s own structural `cant_do` refusal handles the rest). When wired, `anonReachable: true` is set explicitly (tracking `openOnboarding`, not just "capability present") and `createPrivateThread` is a closure built by the new `makeCreatePrivateThreadFn` helper.
- **`src/runner/surface-adapter-boot.ts`** — `wireSurfaceAdapters`/`bootPlatformAdapters` now optionally populate a shared `agentPlatformAdapters: Map<agentId, PlatformAdapter>` as each platform adapter is constructed.
- **`src/cortex.ts`** — declares the shared `agentPlatformAdapters` map once (alongside the existing `brainPresenceHolder`), threads it into both `wireBrainConsumers` and `wireSurfaceAdapters`, and adds two `@internal` test seams (`injectSurfacePluginRegistry`, `injectDaemonBrainTransport`) plus a read-only `CortexHandle.daemonBrainHosts` field used only by the new integration test.
- **`src/__tests__/cortex.brain-daemon-thread-boot.test.ts`** (new) — integration test that boots a real `DaemonBrainHost` through `startCortex` (fake transport + fake Discord adapter plugin, no real subprocess/bundle) and proves `create_private_thread` reaches the fake adapter end-to-end, plus two fail-safe regression tests (an agent without `openOnboarding: true`, and an `openOnboarding: true` agent with no Discord presence at all — neither crashes boot nor gets the capability).

## Adapter-construction-ordering decision

The issue named the real problem: brain consumers (`wireBrainConsumers`) construct *before* surface adapters (`wireSurfaceAdapters`) in `cortex.ts`'s boot sequence, so a `DaemonBrainHost` can't be handed a live adapter reference at construction time.

**Chosen approach: holder-indirection, no boot reordering.** A shared, mutable `Map<agentId, PlatformAdapter>` is declared once, early in `startCortex`, and passed by reference into both boot-wiring functions. `wireSurfaceAdapters` populates it later; the `createPrivateThread` closure `wireBrainConsumers` builds captures the map by reference and calls `.get(agentId)` **lazily**, only at the moment the effect actually fires — which structurally cannot happen before both boot phases have completed (reaching the effect requires a task to already be dispatched to a connected brain). This exactly mirrors the existing `brainPresenceHolder` pattern the file already uses for the same "constructed later, needed earlier" shape, so it's consistent with the codebase's established idiom rather than a new one. Reordering the two boot phases was the alternative; it was rejected because `wireSurfaceAdapters`' own module doc has a "PRESERVE ORDER" contract tied to trust-resolver/TOCTOU invariants, and reordering it relative to brain consumers would have been a much larger, riskier change for no behavioral gain.

## Self-review notes (acceptance criteria)

- An agent **without** `openOnboarding: true` gets no capability wired at all (`agentChannelId`/`createPrivateThread` stay `undefined`) — fail-safe, not fail-open. Covered by a dedicated test.
- An `openOnboarding: true` agent with **no Discord presence binding** boots without crashing (`agent.presence?.discord?.agentChannelId` is optional-chained throughout) and likewise gets no capability. Covered by a dedicated test.
- The adapter-ordering fix works even if the adapter never gets constructed (disabled instance, gateway-owned suppression, construction failure) — the closure's `adapters.get(agentId)` simply misses and the effect resolves a structural refusal; no adapter failure can crash the boot path or the brain host.

## Verification

- `bunx tsc --noEmit` — clean.
- `bun run lint:errors` — clean.
- `bun run sdk:dts:check` — in sync (no `src/adapters/types.ts` changes in this PR).
- `bash scripts/check-carveouts.sh`, `bun scripts/check-shippable-hygiene.ts`, `bun scripts/xdg-audit.ts --repos .`, `bun scripts/check-wire-vocab.ts` — all pass locally.
- `bun test` (whole repo) — same 12 pre-existing failures present on `origin/main` before this change (confirmed via `git stash`), zero new failures. All new/touched test files green.

## Flag for follow-up review

None of the design decisions above were ambiguous enough to need a follow-up call, but two things a reviewer may want to double-check:
1. `anonReachable: true` is wired only for `openOnboarding: true` agents — a trusted, non-open-onboarding agent gets no `create_private_thread` capability at all under this PR (not even the "wider" explicit-member-list path `anonReachable: false` would unlock). That's a deliberate reading of the parent ADR ("which future agents get the wider path is each of their own onboarding, not a blanket switch") — flagging in case a reviewer reads the ADR differently.
2. `agentPlatformAdapters` is populated for every platform (Discord/Mattermost/Slack), not just Discord — harmless today since `createPrivateThread` is optional on `PlatformAdapter` and only Discord implements it, but worth a second look if a future platform adds its own thread-like capability under the same map.
