### PR TITLE
fix(quickstart): emit canonical 'connected to nats' so boot-gate matches; bump 6.10.1

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.10.0"
+version: "6.10.1"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin layer model"

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -213,6 +213,28 @@ describe("MyelinRuntime", () => {
     await runtime.stop();
   });
 
+  test("cortex#2240 — primary-connect log satisfies quickstart's 'connected to nats' gate even for a scheme-less url", async () => {
+    // The quickstart healthy-boot gate greps the daemon log for
+    // "connected to nats" (quickstart-lib.ts HEALTHY_BOOT_PATTERNS). The
+    // quickstart-generated nats.url is host:port with NO scheme, so the old
+    // log ("connected to 127.0.0.1:4222 …") never contained "nats" → the gate
+    // never matched → `cortex quickstart` hung the full gate window (~60s).
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "127.0.0.1:4222", // scheme-less — Vincent's real config shape
+      name: "cortex",
+      subjects: [],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+    });
+    // Plain-substring match — this is exactly the token quickstart's gate greps
+    // for (HEALTHY_BOOT_PATTERNS `/connected to nats/`, quickstart-lib.ts).
+    const connectLog = logs.find((l) => l.msg.includes("connected to nats"));
+    expect(connectLog).toBeDefined();
+    await runtime.stop();
+  });
+
   test("returns disabled when NATS connect fails (logs error, doesn't throw)", async () => {
     const config = makeConfig({
       url: "nats://localhost:9999",

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -817,7 +817,13 @@ export async function startMyelinRuntime(
       jsmCache: null,
     };
     console.log(
-      `myelin-runtime: connected to ${safeUrlOf(nats.url)} as "${nats.name}" (link=primary)`,
+      // "connected to nats" is the canonical bus-ready signal quickstart's
+      // healthy-boot gate greps for (quickstart-lib.ts HEALTHY_BOOT_PATTERNS,
+      // cortex#2240). Keep the literal "nats" here regardless of whether
+      // nats.url carries a scheme — a scheme-less url (host:port, the
+      // quickstart-generated default) otherwise logged "connected to
+      // 127.0.0.1:4222", which the gate never matched → 60s quickstart hang.
+      `myelin-runtime: connected to nats at ${safeUrlOf(nats.url)} as "${nats.name}" (link=primary)`,
     );
   } catch (err) {
     // Primary down ⇒ runtime disabled, exactly as the pre-F-3b single-link
@@ -1016,7 +1022,7 @@ export async function startMyelinRuntime(
         jsmCache: null,
       });
       console.log(
-        `myelin-runtime: connected to ${safeUrlOf(network.nats.url)} as "${network.nats.name}" (link=${leafId}, network=${network.id})`,
+        `myelin-runtime: connected to nats at ${safeUrlOf(network.nats.url)} as "${network.nats.name}" (link=${leafId}, network=${network.id})`,
       );
     } catch (err) {
       // IAW Phase F-3c (cortex#662) — RATIFIED degrade-don't-crash (design


### PR DESCRIPTION
Closes #2240. Reported by a Debian tester. Also bumps cortex to **6.10.1**.

## The hang

`cortex quickstart` waited the full ~60s healthy-boot gate window on every real (non-`--container`) run, then reported step 8 failed — even with `nats-server` + `cortex` both up.

The gate (`quickstart-lib.ts` `HEALTHY_BOOT_PATTERNS`, `gatePassed` = healthz + **all five** patterns) greps the log for `"connected to nats"`. But myelin-runtime logged:
```
myelin-runtime: connected to ${safeUrlOf(nats.url)} as "<name>" (link=primary)
```
The quickstart-generated `nats.url` is `host:port` **with no scheme**, so it logged `connected to 127.0.0.1:4222 …` — no `"nats"` substring → the gate could never match. (`"connected to nats"` existed nowhere in the codebase except the gate pattern itself — it was coupled to an assumed `nats://` scheme the generated config doesn't carry. Same reason the tester's `grep -i nats` on the log couldn't find the connect line.)

## The fix (emit the canonical bus-ready line)

Emit `connected to nats at <url>` on the primary (and leaf) connect — scheme-independent — so the gate's health signal becomes real. Chosen over re-pointing/dropping the gate so it still *proves the bus came up*.

```diff
- `myelin-runtime: connected to ${safeUrlOf(nats.url)} as "${nats.name}" (link=primary)`
+ `myelin-runtime: connected to nats at ${safeUrlOf(nats.url)} as "${nats.name}" (link=primary)`
```

## Test (the missing coupling)

`runtime.test.ts` boots the runtime with a **scheme-less** `nats.url` (the tester's real config shape) and asserts the connect log contains the gate's `connected to nats` token — tying the runtime log to quickstart's gate so they can't silently drift again. That coupling was the gap: the gate's own unit tests fed hand-written sample logs *with* the `nats://` scheme, so they never exercised the real scheme-less output. **Revert-verified** genuine (fails without the fix).

## Version bump → delivery

`arc-manifest.yaml` 6.10.0 → **6.10.1**, so this plus the already-merged 6.10.x fixes become deliverable via `arc upgrade cortex` (the version was never bumped, so upgrade saw "already at 6.10.0"):
- #2185 — prompt-filter hard-fail-loud
- #2190 — content-filter repo-rename resolution
- #2230 — quickstart tilde expansion
- this — quickstart boot-gate hang

Scoped suites 129 pass / 0 fail, `tsc` + `eslint` clean, `sdk:dts` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
