### PR TITLE
fix(compose): bump L4 container ARC_REF v0.40.2 → v0.42.0 for {host,reason} manifest support

### DIFF
--- a/deploy/compose/Dockerfile.cortex
+++ b/deploy/compose/Dockerfile.cortex
@@ -25,7 +25,7 @@ ARG CORTEX_REF=v6.10.0
 ARG BUN_VERSION=1.3.14
 ARG CLAUDE_VERSION=2.1.211
 ARG NATS_SERVER_VERSION=2.14.3
-ARG ARC_REF=v0.40.2
+ARG ARC_REF=v0.42.0
 # Space-separated list of surface adapters to arc-install (short names — each
 # maps to the-metafactory/metafactory-cortex-adapter-<name>). Default `discord`
 # matches the documented README quickstart. Override e.g.


### PR DESCRIPTION
Closes #2243. Reported by a Debian tester building the L4a container.

## The bug

The L4 container build failed at the surface-adapter install step:
```
arc install ".../metafactory-cortex-adapter-discord" --yes --skip-secrets
→ Invalid arc-manifest.yaml: capabilities.network entries must be a string domain or {domain, reason}
```

## Root cause — version skew

`Dockerfile.cortex` pinned `ARG ARC_REF=v0.40.2`, which **predates** arc's `{host, reason}` network-capability shape (arc #337). The `metafactory-cortex-adapter-*` manifests use that canonical shape, so the container's old arc rejected them.

## Fix

```diff
- ARG ARC_REF=v0.40.2
+ ARG ARC_REF=v0.42.0
```
v0.42.0 is the earliest arc release containing #337, and a clean superset of v0.40.2.

## Safety — independently adversarially reviewed

v0.42.0 also carries the `arc bundle`→`arc pack` rename (#342), so this was **not** a blind bump. An independent reviewer verified against arc v0.42.0's actual code:
- The Dockerfile invokes arc only as `arc --version`, `arc install <url> --yes --skip-secrets`, and `arc list --json` — **never `bundle`/`pack`**, so the rename trap isn't triggered.
- All those commands/flags exist with identical semantics under v0.42.0; direct-URL install needs no new auth.
- The adapter `{host,reason}` manifest validates under v0.42.0 (`arc validate` → OK; no throw) — the exact thing v0.40.2 lacked.
- No regression: repos path (`~/.local/share/metafactory/arc/repos`, arc#287) unchanged and still matches cortex's loader; `arc list --json` shape still satisfies cortex's `ArcPackageSchema`; default-source changes don't affect URL installs.

**Caveat:** the end-to-end `docker compose build` was not run (the review environment blocks docker network egress). Recommend CI run the full build as the final gate — low residual risk given the above exercises v0.42.0's real read/validate/CLI paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
