### PR TITLE
fix(boot): provision BRAIN_TASKS + brain durables under their own exec-brain gate (Closes #2247)

### DIFF
--- a/src/__tests__/cortex.brain-only-stack-boot.test.ts
+++ b/src/__tests__/cortex.brain-only-stack-boot.test.ts
@@ -1,0 +1,349 @@
+/**
+ * cortex#2247 — brain-ONLY stack boot provisioning.
+ *
+ * A stack whose only agents are exec-brain (`runtime.brain.kind: exec`, zero
+ * review-capable agents) must provision the BRAIN_TASKS stream AND its
+ * per-capability brain durables at boot on a virgin broker, then subscribe.
+ * Pre-fix, BRAIN_TASKS + the brain durables rode the `reviewJsm !== null`
+ * gate — `resolveReviewProvisioningJsm` returns `null` with zero
+ * review-capable agents, so a brain-only stack booted its brain consumer
+ * DORMANT and every inbound surface mention was published onto a subject no
+ * stream captured, then silently dropped (first live repro: the first
+ * brain-only stack ever deployed; the coupling was self-documented at the
+ * provisioning site as "not reachable today").
+ *
+ * Test infrastructure mirrors `cortex.dev-stream-boot.test.ts` (recording
+ * runtime + recording JSM + captured logs), extended to record
+ * `consumers.add` calls so the per-capability durable provisioning is
+ * observable too. No real NATS, Discord, filesystem-watcher, or `claude`
+ * spawning. All ids are obviously-fake, non-numeric placeholders
+ * (confidentiality gate).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import { AgentSchema, type Agent } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+import type { ProvisionJsm } from "../bus/jetstream/types";
+import type { ConsumerInfo, StreamInfo, StreamConfig, ConsumerConfig } from "nats";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-brain-only-boot-test-published" },
+    ...overrides,
+  });
+}
+
+/** Records every `streams.add` AND `consumers.add` so the boot test can read
+ *  back both the provisioned stream configs and the per-capability durables.
+ *  Stream/consumer `info` always 404s (virgin broker) so the provisioning
+ *  helpers take the create path. */
+interface JsmRecorder {
+  jsm: ProvisionJsm;
+  streamAdds: Partial<StreamConfig>[];
+  consumerAdds: { stream: string; config: Partial<ConsumerConfig> }[];
+}
+
+function makeRecordingJsm(): JsmRecorder {
+  const streamAdds: Partial<StreamConfig>[] = [];
+  const consumerAdds: { stream: string; config: Partial<ConsumerConfig> }[] = [];
+  const notFound = (kind: "stream" | "consumer"): Error => {
+    const err = new Error(`${kind} not found`);
+    (err as unknown as { api_error: { err_code: number } }).api_error = {
+      err_code: kind === "stream" ? 10059 : 10014,
+    };
+    return err;
+  };
+  const jsm: ProvisionJsm = {
+    streams: {
+      info: async () => {
+        throw notFound("stream");
+      },
+      add: async (cfg) => {
+        streamAdds.push(cfg);
+        return { config: cfg } as unknown as StreamInfo;
+      },
+    },
+    consumers: {
+      info: async () => {
+        throw notFound("consumer");
+      },
+      add: async (stream, cfg) => {
+        consumerAdds.push({ stream, config: cfg });
+        return { name: cfg.durable_name } as unknown as ConsumerInfo;
+      },
+      update: async (_stream, durable, cfg) =>
+        ({ name: durable, config: cfg } as unknown as ConsumerInfo),
+      delete: async () => true,
+    },
+  };
+  return { jsm, streamAdds, consumerAdds };
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  onEnvelopeHandlers: Set<EnvelopeHandler>;
+  published: Envelope[];
+  subscribePullCalls: MyelinSubscribePullOpts[];
+}
+
+function createRecordingRuntime(opts: { jsm?: ProvisionJsm }): RecordingRuntime {
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  const runtime: RecordingRuntime = {
+    enabled: true,
+    onEnvelopeHandlers,
+    published,
+    subscribePullCalls,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return {
+        unregister: () => {
+          onEnvelopeHandlers.delete(handler);
+        },
+      };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    subscribePull: (o: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(o);
+      return {
+        pattern: o.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {},
+      } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+  if (opts.jsm !== undefined) {
+    runtime.jetstreamManager = async () => opts.jsm!;
+  }
+  return runtime;
+}
+
+/** A minimal, valid, per-task exec-brain agent — the ONLY agent on the stack
+ *  (zero review-capable agents), mirroring the live brain-only repro shape
+ *  (a single `kind: exec` agent with capabilities `[chat]`). */
+function makeBrainOnlyAgent(personaPath: string): Agent {
+  return AgentSchema.parse({
+    id: "escort-like",
+    displayName: "EscortLike",
+    persona: personaPath,
+    trust: [],
+    presence: {},
+    runtime: {
+      mode: "in-process",
+      capabilities: ["chat"],
+      brain: {
+        kind: "exec",
+        run: "bun {pack}/brain/main.ts",
+        lifecycle: "per-task",
+      },
+    },
+  });
+}
+
+function withCapturedConsoleLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; logs: string[] }> {
+  const original = console.log.bind(console);
+  const logs: string[] = [];
+  console.log = (...args: unknown[]): void => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+  return fn()
+    .then((result) => {
+      console.log = original;
+      return { result, logs };
+    })
+    .catch((err: unknown) => {
+      console.log = original;
+      throw err;
+    });
+}
+
+const PRINCIPAL = "test-op";
+const STACK = "default";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startCortex — brain-only stack boot provisioning (cortex#2247)", () => {
+  test("a brain-only stack (zero review-capable agents) provisions BRAIN_TASKS + its per-capability durable and subscribes on a virgin broker", async () => {
+    const { jsm, streamAdds, consumerAdds } = makeRecordingJsm();
+    const runtime = createRecordingRuntime({ jsm });
+    const tmpDir = mkdtempSync(join(tmpdir(), "cortex-brain-only-boot-"));
+    const personaPath = join(tmpDir, "escort-like.md");
+    writeFileSync(personaPath, "# EscortLike persona\n", "utf-8");
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: join(tmpDir, "agents.d"),
+        injectRuntime: runtime,
+        inlineAgents: [makeBrainOnlyAgent(personaPath)],
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    // The review lane is dormant (zero review-capable agents) — CODE_REVIEW /
+    // REVIEW_LIFECYCLE / DEV_IMPLEMENT are NOT provisioned…
+    const byName = new Map(streamAdds.map((c) => [c.name, c]));
+    expect(byName.has("CODE_REVIEW")).toBe(false);
+    expect(byName.has("REVIEW_LIFECYCLE")).toBe(false);
+    expect(byName.has("DEV_IMPLEMENT")).toBe(false);
+
+    // …but BRAIN_TASKS IS — the cortex#2247 independent gate, keyed on
+    // exec-brain-agent presence.
+    expect(byName.has("BRAIN_TASKS")).toBe(true);
+    const brain = byName.get("BRAIN_TASKS")!;
+    expect(brain.subjects).toEqual([`local.${PRINCIPAL}.${STACK}.brain.>`]);
+    // Config posture mirrors CODE_REVIEW (Interest retention, File storage).
+    expect(String(brain.retention)).toBe("interest");
+    expect(String(brain.storage)).toBe("file");
+
+    // The per-capability brain durable is provisioned against BRAIN_TASKS with
+    // the exact filter subject the consumer binds.
+    const brainDurables = consumerAdds.filter((c) => c.stream === "BRAIN_TASKS");
+    expect(brainDurables).toHaveLength(1);
+    expect(brainDurables[0]!.config.durable_name).toBe(
+      `cortex-brain-consumer-${PRINCIPAL}-escort-like-chat`,
+    );
+    expect(brainDurables[0]!.config.filter_subject).toBe(
+      `local.${PRINCIPAL}.${STACK}.brain.chat`,
+    );
+
+    // The consumer actually SUBSCRIBED (not dormant): the pull subscription
+    // binds the durable on BRAIN_TASKS…
+    const brainSub = runtime.subscribePullCalls.find(
+      (c) => c.pattern === `local.${PRINCIPAL}.${STACK}.brain.chat`,
+    );
+    expect(brainSub).toBeDefined();
+    expect(brainSub!.stream).toBe("BRAIN_TASKS");
+    expect(brainSub!.durable).toBe(`cortex-brain-consumer-${PRINCIPAL}-escort-like-chat`);
+
+    // …and the boot log says READY with the capability subscribed — the exact
+    // line the live brain-only stack only produced after the manual workaround.
+    const readyLog = logs.find(
+      (l) =>
+        l.includes("brain consumer ready for agent=escort-like") &&
+        l.includes("subscribed=[chat]"),
+    );
+    expect(readyLog).toBeDefined();
+    const dormantLog = logs.find((l) =>
+      l.includes("brain consumer DORMANT for agent=escort-like"),
+    );
+    expect(dormantLog).toBeUndefined();
+
+    await handle.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("a MIXED stack (review + brain agents) provisions BRAIN_TASKS exactly once — unchanged behaviour, no double-provisioning", async () => {
+    const { jsm, streamAdds, consumerAdds } = makeRecordingJsm();
+    const runtime = createRecordingRuntime({ jsm });
+    const tmpDir = mkdtempSync(join(tmpdir(), "cortex-brain-mixed-boot-"));
+    const personaPath = join(tmpDir, "escort-like.md");
+    writeFileSync(personaPath, "# EscortLike persona\n", "utf-8");
+    const reviewer = AgentSchema.parse({
+      id: "echo",
+      displayName: "Echo",
+      persona: join(tmpDir, "echo.md"),
+      trust: [],
+      presence: {},
+      runtime: {
+        substrate: "claude-code",
+        mode: "in-process",
+        capabilities: ["code-review.typescript"],
+      },
+    });
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: join(tmpDir, "agents.d"),
+        injectRuntime: runtime,
+        inlineAgents: [reviewer, makeBrainOnlyAgent(personaPath)],
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    // Review lane provisions as before…
+    const names = streamAdds.map((c) => c.name);
+    expect(names).toContain("CODE_REVIEW");
+    // …and BRAIN_TASKS is provisioned EXACTLY once (the brain gate reuses the
+    // already-resolved review JSM; no second streams.add).
+    expect(names.filter((n) => n === "BRAIN_TASKS")).toHaveLength(1);
+
+    // The brain durable + subscription still wire.
+    expect(
+      consumerAdds.some(
+        (c) =>
+          c.stream === "BRAIN_TASKS" &&
+          c.config.durable_name === `cortex-brain-consumer-${PRINCIPAL}-escort-like-chat`,
+      ),
+    ).toBe(true);
+    expect(
+      logs.some(
+        (l) =>
+          l.includes("brain consumer ready for agent=escort-like") &&
+          l.includes("subscribed=[chat]"),
+      ),
+    ).toBe(true);
+
+    await handle.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("dormant runtime (no jetstreamManager) — a brain-only stack provisions nothing and the consumer stays dormant in lockstep", async () => {
+    // No JSM stub at all: any accidental provisioning attempt would throw.
+    const runtime = createRecordingRuntime({});
+    const tmpDir = mkdtempSync(join(tmpdir(), "cortex-brain-only-dormant-"));
+    const personaPath = join(tmpDir, "escort-like.md");
+    writeFileSync(personaPath, "# EscortLike persona\n", "utf-8");
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: join(tmpDir, "agents.d"),
+        injectRuntime: runtime,
+        inlineAgents: [makeBrainOnlyAgent(personaPath)],
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    const brainProvisionLogs = logs.filter((l) =>
+      l.includes('JetStream stream "BRAIN_TASKS"'),
+    );
+    expect(brainProvisionLogs).toHaveLength(0);
+
+    await handle.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -6425,7 +6425,7 @@ function structuralEqual(a: unknown, b: unknown): boolean {
 async function resolveReviewProvisioningJsm(
   runtime: MyelinRuntime,
   gatingAgents: readonly Agent[],
-  lane: string = "review",
+  lane = "review",
 ): Promise<import("./bus/jetstream/types").ProvisionJsm | null> {
   if (gatingAgents.length === 0 || !runtime.jetstreamManager) {
     return null;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2090,6 +2090,24 @@ export async function startCortex(
   // try/catch and aborted boot (sage review on #338, round 2).
   const reviewJsm = await resolveReviewProvisioningJsm(runtime, reviewCapableAgents);
 
+  // cortex#2247 — the BRAIN lane's provisioning JSM, resolved INDEPENDENTLY
+  // of review capabilities. The BRAIN_TASKS stream + per-capability brain
+  // durables used to ride the `reviewJsm !== null` gate (the self-documented
+  // "KNOWN COUPLING" below at the DEV_IMPLEMENT/BRAIN_TASKS provisioning
+  // sites) — so a brain-ONLY stack (exec-brain agents, zero review-capable
+  // agents) booted its brain consumer DORMANT and silently dropped every
+  // inbound mention ("not reachable today" was reached by the first live
+  // brain-only stack). Resolution order:
+  //   - `reviewJsm` already resolved (review-capable agents present) → reuse
+  //     it (ONE `jetstreamManager()` resolution; also preserves today's
+  //     behaviour on review stacks, including a brain agent hot-added via
+  //     `agents.d/` to a stack that booted with zero brain agents — the
+  //     stream exists and the captured JSM is live).
+  //   - otherwise resolve over `brainAgents` — non-null iff at least one
+  //     exec-brain agent is present AND the runtime is not dormant.
+  const brainJsm =
+    reviewJsm ?? (await resolveReviewProvisioningJsm(runtime, brainAgents, "brain"));
+
   // cortex#686 — the CODE_REVIEW stream's subject filter carries BOTH the
   // local and (when federation is configured) the federated code-review
   // patterns, so an inbound `federated.{me}.{stack}.tasks.code-review.…`
@@ -2324,17 +2342,24 @@ export async function startCortex(
     }
     // ── /F-2.2 provision DEV_IMPLEMENT ──────────────────────────────────────
 
-    // ── B-3 (cortex#1021) provision BRAIN_TASKS ─────────────────────────────
-    // Same `reviewJsm !== null` gate + posture as CODE_REVIEW / DEV_IMPLEMENT
-    // (Interest retention, File storage, idempotent ensure). The exec-brain
-    // consumer binds its durable here; the inbound dispatch publishes onto
-    // `…brain.{capability}`. A failure does NOT abort boot. Same KNOWN COUPLING
-    // as DEV_IMPLEMENT: the gate is review-capability presence, so a
-    // brain-ONLY stack would skip provisioning — not reachable today (the
-    // switch stack runs sage); the independent-gate fix is the same follow-up.
+  }
+
+  // ── B-3 (cortex#1021) provision BRAIN_TASKS ───────────────────────────────
+  // Same posture as CODE_REVIEW / DEV_IMPLEMENT (Interest retention, File
+  // storage, idempotent ensure). The exec-brain consumer binds its durable
+  // here; the inbound dispatch publishes onto `…brain.{capability}`. A
+  // failure does NOT abort boot.
+  // cortex#2247 — gated on `brainJsm` (its OWN gate), no longer on
+  // `reviewJsm`: the former "KNOWN COUPLING" (review-capability presence)
+  // left a brain-ONLY stack without the stream its brain consumer binds,
+  // silently dropping every inbound mention. `brainJsm` reuses `reviewJsm`
+  // when review agents are present (identical behaviour to before on review
+  // stacks, `exists` path idempotent), and resolves independently over the
+  // exec-brain agents otherwise.
+  if (brainJsm !== null) {
     try {
       const brainOutcome = await provisionReviewStream({
-        jsm: reviewJsm,
+        jsm: brainJsm,
         name: brainTasksStream,
         subjects: brainTasksStreamSubjects,
         maxAgeNs: reviewStreamMaxAgeNs,
@@ -2355,8 +2380,8 @@ export async function startCortex(
           `${err instanceof Error ? err.message : String(err)}\n`,
       );
     }
-    // ── /B-3 provision BRAIN_TASKS ──────────────────────────────────────────
   }
+  // ── /B-3 provision BRAIN_TASKS ──────────────────────────────────────────
 
   // S7 (epic #1514, cortex#1521) — the per-agent review-consumer
   // construction now lives in `wireReviewConsumers` (review-consumer-boot.ts),
@@ -2608,7 +2633,10 @@ export async function startCortex(
     brainPresenceHolder,
     brainConsumers,
     daemonBrainHosts,
-    reviewJsm,
+    // cortex#2247 — the brain lane's OWN provisioning JSM (see the `brainJsm`
+    // resolution above), so per-capability brain durables provision on a
+    // brain-only stack too.
+    brainJsm,
     brainTasksStream,
     reviewConsumerMaxDeliver,
     agentPlatformAdapters,
@@ -6396,16 +6424,17 @@ function structuralEqual(a: unknown, b: unknown): boolean {
  */
 async function resolveReviewProvisioningJsm(
   runtime: MyelinRuntime,
-  reviewCapableAgents: readonly Agent[],
+  gatingAgents: readonly Agent[],
+  lane: string = "review",
 ): Promise<import("./bus/jetstream/types").ProvisionJsm | null> {
-  if (reviewCapableAgents.length === 0 || !runtime.jetstreamManager) {
+  if (gatingAgents.length === 0 || !runtime.jetstreamManager) {
     return null;
   }
   try {
     return await runtime.jetstreamManager();
   } catch (err) {
     process.stderr.write(
-      `cortex: jetstreamManager() resolution failed — review provisioning skipped: ` +
+      `cortex: jetstreamManager() resolution failed — ${lane} provisioning skipped: ` +
         `${err instanceof Error ? err.message : String(err)}\n`,
     );
     return null;

--- a/src/runner/__tests__/brain-consumer-boot.test.ts
+++ b/src/runner/__tests__/brain-consumer-boot.test.ts
@@ -85,7 +85,7 @@ function baseOpts(overrides: Partial<WireBrainConsumersOpts> = {}): WireBrainCon
     brainPresenceHolder: { producer: null },
     brainConsumers: [],
     daemonBrainHosts: [],
-    reviewJsm: null,
+    brainJsm: null,
     brainTasksStream: "BRAIN_TASKS",
     reviewConsumerMaxDeliver: 5,
     agentPlatformAdapters: new Map(),

--- a/src/runner/brain-consumer-boot.ts
+++ b/src/runner/brain-consumer-boot.ts
@@ -48,7 +48,7 @@
  * closure used to be defined) and before either call site runs: `runtime`
  * (a `let`) is assigned once from either `options.injectRuntime` or
  * `startMyelinRuntime(...)`, well before the boot loop or any hot-reload
- * event. `surfacePrincipalGate`, `brainPackBaseDir`, `reviewJsm`,
+ * event. `surfacePrincipalGate`, `brainPackBaseDir`, `brainJsm`,
  * `brainTasksStream`, `reviewConsumerMaxDeliver`, `reviewPrincipalId`, and
  * `systemEventSource` are all `const`s assigned exactly once, earlier in
  * boot. The old closure only ever READ these — it never reassigned any of
@@ -194,8 +194,14 @@ export interface WireBrainConsumersOpts {
    * (hot-swap drain + unconditional shutdown stop).
    */
   daemonBrainHosts: DaemonBrainHost[];
-  /** Resolved JetStream manager, or `null` when the runtime is dormant. */
-  reviewJsm: ProvisionJsm | null;
+  /**
+   * Resolved JetStream manager, or `null` when the runtime is dormant.
+   * cortex#2247 — this is the BRAIN lane's own provisioning JSM (resolved in
+   * `cortex.ts` independently of review-capability presence), so a brain-only
+   * stack provisions its per-capability durables too. Renamed from
+   * `reviewJsm`, whose name encoded the former review-gate coupling.
+   */
+  brainJsm: ProvisionJsm | null;
   /** BRAIN_TASKS stream name (B-3, cortex#1021). */
   brainTasksStream: string;
   /** Durable max-deliver, shared with the review/release lanes. */
@@ -530,14 +536,13 @@ export function wireBrainConsumers(
       const brainPatternFor = (capability: string): string =>
         `local.${opts.reviewPrincipalId}.${opts.stack}.${BRAIN_TASK_SUBJECT_FAMILY}.${capability}`;
 
-      if (opts.reviewJsm !== null) {
+      if (opts.brainJsm !== null) {
         // Hoisted to a local `const` — a narrowed PROPERTY access
-        // (`opts.reviewJsm`) does not survive into the nested `async`
+        // (`opts.brainJsm`) does not survive into the nested `async`
         // closure below (TS drops property narrowing across closure
         // boundaries), while a narrowed `const` binding does. Mirrors the
-        // pre-extraction closure, which narrowed a plain top-level `const
-        // reviewJsm`.
-        const jsm = opts.reviewJsm;
+        // pre-extraction closure, which narrowed a plain top-level `const`.
+        const jsm = opts.brainJsm;
         // Independent durables — provision in one parallel wave (sage
         // cortex#1033 round 2); still awaited as a whole BEFORE start().
         await Promise.all(


### PR DESCRIPTION
Closes #2247

## Problem

A stack whose only agents are exec-brain never provisioned the BRAIN_TASKS stream or its per-capability durables: provisioning rode the `reviewJsm !== null` gate, and `resolveReviewProvisioningJsm` returns `null` when zero agents declare code-review capabilities. The brain consumer booted DORMANT and every inbound surface mention was published onto a subject no stream captured — total silence, no error. The coupling was self-documented at the provisioning site ("KNOWN COUPLING ... not reachable today"); the first live brain-only stack reached it.

## Fix

- `cortex.ts`: resolve a **brain-lane JSM** (`brainJsm`) independently of review capabilities: `reviewJsm ?? resolveReviewProvisioningJsm(runtime, brainAgents, "brain")`.
  - Review/mixed stacks: `reviewJsm` is reused — ONE `jetstreamManager()` resolution, byte-identical behaviour, no double-provisioning (BRAIN_TASKS `streams.add` happens exactly once). This also preserves the hot-reload path: a brain agent hot-added via `agents.d/` to a stack that booted with review agents but zero brain agents still finds the stream provisioned and a live captured JSM.
  - Brain-only stacks: the JSM resolves over `brainAgents` — BRAIN_TASKS + durables provision at boot on a virgin broker; the consumer subscribes and logs `brain consumer ready ... subscribed=[...]`.
- BRAIN_TASKS provisioning moved out of the `reviewJsm !== null` block into its own `brainJsm !== null` gate (config posture unchanged: Interest retention, File storage, idempotent ensure — a hand-provisioned stream/durable resolves as `exists`, so the live manual workaround stays compatible).
- `brain-consumer-boot.ts`: opts field renamed `reviewJsm` -> `brainJsm` (the old name encoded the coupling); durable provisioning now keys on the brain-lane JSM.
- `resolveReviewProvisioningJsm`: param generalised to `gatingAgents` + a `lane` label for the failure log (it was already reused by the release lane).

## Acceptance criteria (issue #2247)

- [x] Brain-only stack provisions BRAIN_TASKS + durables at boot on a virgin broker — pinned by the new test.
- [x] Boot log shows `brain consumer ready ... subscribed=[...]` on such a stack — pinned by the new test.
- [x] Mixed stacks unchanged; no double-provisioning; `exists` path idempotent — pinned by the new mixed-stack test + existing `cortex.dev-stream-boot.test.ts` BRAIN_TASKS test (unmodified, still green).
- [x] Typecheck + scoped tests green; integration-style boot test added (`src/__tests__/cortex.brain-only-stack-boot.test.ts`).

## Testing

- `bunx tsc --noEmit` clean.
- New suite: 3 tests (brain-only provisions + subscribes; mixed provisions exactly once; dormant runtime provisions nothing).
- Related suites green: `cortex.dev-stream-boot`, `cortex.lifecycle-stream-boot`, `brain-consumer-boot`, `cortex.brain-daemon-thread-boot`, `bus/brain-consumer` (56 tests).
- Full local run: 12 failures are pre-existing on origin/main and machine-local (the plugin-loader loads this machine's installed arc adapter bundles inside tests, which don't exist in CI) — unrelated to this change; will file a hermeticity issue.

Note: a stack with zero brain agents AND zero review agents that later hot-adds its FIRST exec-brain agent still boots the added consumer dormant (the JSM is captured at boot) — same pre-existing shape as the review lane's own hot-add-first-agent path; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01247nwyEPNLjDJJXU9fqZAD
