### PR TITLE
ci: automate build-gated ARC_REF bumps (scheduled arc-release check → PR)

### DIFF
--- a/.github/workflows/arc-ref-bump.yml
+++ b/.github/workflows/arc-ref-bump.yml
@@ -1,0 +1,211 @@
+# arc-ref-bump — automated, build-gated bumps of the L4 container's ARC_REF pin
+# (cortex#2246).
+#
+# WHY
+# ---
+# deploy/compose/Dockerfile.cortex pins `ARG ARC_REF=<tag>` for reproducible
+# builds. arc releases move and adapter manifests evolve with arc, so a pinned
+# OLDER arc eventually can't parse NEWER adapter manifests and `arc install`
+# fails in the container (cortex#2243: v0.40.2 predated the `{host,reason}`
+# manifest shape). The principal decision is to KEEP the pin (un-pinning to
+# `main` sacrifices reproducibility + adds supply-chain exposure) and instead
+# AUTOMATE the bump dependabot/renovate-style: this workflow proposes bumps as
+# reviewable, BUILD-GATED PRs.
+#
+# HOW
+# ---
+#   1. Resolve arc's latest RELEASE tag — `gh api …/releases/latest`, falling
+#      back to the highest semver git tag. NEVER tracks raw `main`.
+#   2. scripts/arc-ref-bump.ts (unit-tested: semver compare + ARG rewrite)
+#      compares it to the current ARC_REF and decides whether to bump.
+#   3. On a newer release: apply the bump and GATE on a real `docker build` of
+#      Dockerfile.cortex with the new arc — the build runs the `arc install
+#      <adapter>` step that failed in #2243, so a green build is the proof the
+#      newer arc is compatible.
+#   4. Green build  -> open a labeled PR (old->new + link to arc's release).
+#      Red build    -> open a tracking issue so a human sees the incompatibility
+#                      (never a silent stale pin, never a silent no-op).
+#
+# The docker-build gate needs a runner with Docker + network. The scheduled run
+# and a manual `workflow_dispatch` are the real end-to-end confirmation; the
+# sandbox that authored this can't run docker (egress blocked), so the gate is
+# confirmed by a real CI run.
+name: arc-ref-bump
+
+on:
+  schedule:
+    # Weekly, Mondays 06:00 UTC — dependabot-style cadence. Off-hours so a
+    # build-gate run doesn't contend with weekday CI.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      force_latest:
+        description: "Override the resolved arc release tag (e.g. v0.42.1) — for testing the gate. Leave blank to resolve from arc releases."
+        required: false
+        type: string
+
+# Least privilege: the job needs to push a branch (contents), open a PR
+# (pull-requests), and open a tracking issue on a red gate (issues).
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  # One bump attempt at a time; a newer scheduled run supersedes an in-flight one.
+  group: arc-ref-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Resolve, gate, and propose ARC_REF bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cortex
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      # ── 1. Resolve arc's latest RELEASE tag (fallback: highest semver git tag) ──
+      # NEVER raw `main`. `workflow_dispatch` may override via force_latest.
+      - name: Resolve latest arc release tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE_LATEST: ${{ github.event.inputs.force_latest }}
+        run: |
+          set -euo pipefail
+          if [ -n "${FORCE_LATEST:-}" ]; then
+            latest="${FORCE_LATEST}"
+            echo "Using workflow_dispatch override: ${latest}"
+          else
+            # Primary: the GitHub "latest release" (excludes drafts/prereleases).
+            latest="$(gh api repos/the-metafactory/arc/releases/latest --jq '.tag_name' 2>/dev/null || true)"
+            if [ -z "${latest}" ] || [ "${latest}" = "null" ]; then
+              echo "releases/latest unavailable — falling back to highest semver git tag."
+              # Fallback: highest semver tag by version sort (vMAJOR.MINOR.PATCH only).
+              latest="$(gh api repos/the-metafactory/arc/tags --jq '.[].name' \
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | sort -V | tail -1)"
+            fi
+          fi
+          if [ -z "${latest}" ] || [ "${latest}" = "null" ]; then
+            echo "::error::could not resolve any arc release tag (releases/latest and tag fallback both empty)"
+            exit 1
+          fi
+          echo "Resolved latest arc release: ${latest}"
+          echo "latest=${latest}" >> "$GITHUB_OUTPUT"
+
+      # ── 2. Decide + apply the bump (unit-tested core; --write edits the file) ──
+      - name: Compute + apply ARC_REF bump
+        id: bump
+        run: |
+          set -euo pipefail
+          bun scripts/arc-ref-bump.ts \
+            --latest "${{ steps.resolve.outputs.latest }}" \
+            --write --github-output
+
+      - name: No bump needed
+        if: steps.bump.outputs.bumped != 'true'
+        run: echo "ARC_REF is already >= the latest arc release — nothing to do."
+
+      # ── 3. BUILD GATE — build Dockerfile.cortex with the new arc; this runs the
+      #      `arc install <adapter>` step that failed in #2243. Green = compatible.
+      #      continue-on-error so a red build routes to the issue path below
+      #      rather than aborting the job (no silent no-op on incompatibility).
+      - name: Build gate (docker build exercises `arc install`)
+        id: buildgate
+        if: steps.bump.outputs.bumped == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          echo "Building Dockerfile.cortex with ARC_REF=${{ steps.bump.outputs.new }} …"
+          docker build \
+            --build-arg "ARC_REF=${{ steps.bump.outputs.new }}" \
+            --file deploy/compose/Dockerfile.cortex \
+            --tag cortex-arc-ref-gate:${{ steps.bump.outputs.new }} \
+            deploy/compose
+
+      # ── 4a. GREEN → open a labeled PR with the bump ──
+      - name: Open bump PR (green gate)
+        if: steps.bump.outputs.bumped == 'true' && steps.buildgate.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OLD_REF: ${{ steps.bump.outputs.old }}
+          NEW_REF: ${{ steps.bump.outputs.new }}
+        run: |
+          set -euo pipefail
+          branch="ci/arc-ref-bump-${NEW_REF}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # If a bump PR for this exact ref already exists, don't duplicate it.
+          if gh pr list --state open --head "${branch}" --json number --jq '.[0].number' | grep -q '[0-9]'; then
+            echo "A bump PR for ${NEW_REF} (${branch}) already exists — skipping."
+            exit 0
+          fi
+
+          git checkout -b "${branch}"
+          git add deploy/compose/Dockerfile.cortex
+          commit_msg="$(printf '%s\n' \
+            "ci(deploy): bump L4 container ARC_REF ${OLD_REF} -> ${NEW_REF}" \
+            "" \
+            "Automated, build-gated bump (cortex#2246). The docker build of" \
+            "Dockerfile.cortex with arc ${NEW_REF} passed -- including the" \
+            "\`arc install <adapter>\` step that failed in cortex#2243 -- so the" \
+            "newer arc parses the current adapter manifests." \
+            "" \
+            "arc release: https://github.com/the-metafactory/arc/releases/tag/${NEW_REF}")"
+          git commit -m "${commit_msg}"
+          git push --set-upstream origin "${branch}"
+
+          pr_body="$(printf '%s\n' \
+            "Automated ARC_REF bump (cortex#2246)." \
+            "" \
+            "- **arc:** \`${OLD_REF}\` -> \`${NEW_REF}\`" \
+            "- **arc release:** https://github.com/the-metafactory/arc/releases/tag/${NEW_REF}" \
+            "- **Build gate:** PASSED -- \`docker build\` of \`deploy/compose/Dockerfile.cortex\` with the new arc succeeded, exercising the \`arc install <adapter>\` step that failed in cortex#2243. A green build is the proof the newer arc parses the current adapter manifests." \
+            "" \
+            "Reproducibility preserved: \`ARC_REF\` stays a pinned tag; this is a reviewable, build-gated bump, not an unpinned build-time fetch.")"
+          gh pr create \
+            --title "ci(deploy): bump L4 container ARC_REF ${OLD_REF} -> ${NEW_REF}" \
+            --body "${pr_body}" \
+            --label infrastructure \
+            --label next
+
+      # ── 4b. RED → open a tracking issue (never a silent stale pin) ──
+      - name: Open incompatibility issue (red gate)
+        if: steps.bump.outputs.bumped == 'true' && steps.buildgate.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OLD_REF: ${{ steps.bump.outputs.old }}
+          NEW_REF: ${{ steps.bump.outputs.new }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="arc ${NEW_REF} fails the L4 container build gate -- ARC_REF bump blocked"
+          # Don't spam: reuse an open issue with the same title if one exists.
+          existing="$(gh issue list --state open --search "in:title ${title}" --json number --jq '.[0].number' || true)"
+          body="$(printf '%s\n' \
+            "The scheduled ARC_REF bump (cortex#2246) tried to move the L4 container from \`${OLD_REF}\` to arc's latest release \`${NEW_REF}\`, but the **container build gate FAILED**." \
+            "" \
+            "The \`docker build\` of \`deploy/compose/Dockerfile.cortex\` with arc \`${NEW_REF}\` did not pass -- most likely the \`arc install <adapter>\` step (the exact failure class as cortex#2243). The pin stays at \`${OLD_REF}\` until this is resolved." \
+            "" \
+            "- **Build log:** ${RUN_URL}" \
+            "- **arc release:** https://github.com/the-metafactory/arc/releases/tag/${NEW_REF}" \
+            "" \
+            "A human needs to investigate the arc/adapter incompatibility rather than let the pin silently go stale.")"
+          if [ -n "${existing}" ]; then
+            echo "Reusing open issue #${existing}."
+            gh issue comment "${existing}" --body "Re-observed on a later run: arc ${NEW_REF} still fails the build gate. ${RUN_URL}"
+          else
+            gh issue create --title "${title}" --body "${body}" --label infrastructure --label next
+          fi
+          # Fail the job so the red gate is visible in the Actions UI, not just as an issue.
+          echo "::error::arc ${NEW_REF} failed the container build gate — see the tracking issue."
+          exit 1

--- a/.github/workflows/arc-ref-bump.yml
+++ b/.github/workflows/arc-ref-bump.yml
@@ -104,10 +104,19 @@ jobs:
       # ── 2. Decide + apply the bump (unit-tested core; --write edits the file) ──
       - name: Compute + apply ARC_REF bump
         id: bump
+        env:
+          # Route the resolved tag through env — NEVER inline `${{ }}` into a
+          # run: shell, where it is expanded to raw text before the shell parses
+          # (quotes give no protection). This value is attacker-influenceable:
+          # it comes from another repo's release tag (supply-chain) and from the
+          # raw workflow_dispatch force_latest input. parseSemver rejects a bad
+          # value, but only AFTER the shell — so the guard must be at the shell
+          # layer. As a quoted shell var it is inert data, never code.
+          LATEST: ${{ steps.resolve.outputs.latest }}
         run: |
           set -euo pipefail
           bun scripts/arc-ref-bump.ts \
-            --latest "${{ steps.resolve.outputs.latest }}" \
+            --latest "$LATEST" \
             --write --github-output
 
       - name: No bump needed
@@ -122,13 +131,19 @@ jobs:
         id: buildgate
         if: steps.bump.outputs.bumped == 'true'
         continue-on-error: true
+        env:
+          # Env-indirection for defense-in-depth/consistency: NEW is post-
+          # semver-validation (charset-constrained, no metacharacters), so this
+          # is lower risk than the LATEST step above — but no `${{ }}` belongs
+          # inside a run: shell regardless.
+          NEW: ${{ steps.bump.outputs.new }}
         run: |
           set -euo pipefail
-          echo "Building Dockerfile.cortex with ARC_REF=${{ steps.bump.outputs.new }} …"
+          echo "Building Dockerfile.cortex with ARC_REF=${NEW} …"
           docker build \
-            --build-arg "ARC_REF=${{ steps.bump.outputs.new }}" \
+            --build-arg "ARC_REF=${NEW}" \
             --file deploy/compose/Dockerfile.cortex \
-            --tag cortex-arc-ref-gate:${{ steps.bump.outputs.new }} \
+            --tag "cortex-arc-ref-gate:${NEW}" \
             deploy/compose
 
       # ── 4a. GREEN → open a labeled PR with the bump ──

--- a/scripts/__tests__/arc-ref-bump.test.ts
+++ b/scripts/__tests__/arc-ref-bump.test.ts
@@ -1,0 +1,224 @@
+// Tests for the ARC_REF bump core (cortex#2246).
+//
+// Pure-logic coverage — no network, no docker. The workflow
+// (.github/workflows/arc-ref-bump.yml) owns the side effects (resolve latest
+// release via `gh api`, docker-build gate, open the PR); this suite pins the
+// decision + byte-level rewrite the workflow depends on:
+//   - semver compare (newer / equal / older / prerelease precedence)
+//   - readArcRef targets the ARG DEFINITION line, not the bare re-declaration
+//   - rewriteArcRef bumps to a newer tag + is idempotent + preserves the pin
+//   - malformed / missing ARG line is handled (null, no phantom rewrite)
+//   - main(): newer -> rewrite w/ --write; equal/older -> no-op; missing -> 3
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  parseSemver,
+  compareSemver,
+  readArcRef,
+  rewriteArcRef,
+  decideBump,
+  main,
+} from "../arc-ref-bump";
+
+// A minimal but structurally faithful stand-in for Dockerfile.cortex: it has
+// BOTH the `ARG ARC_REF=<value>` definition (before FROM) and the bare
+// `ARG ARC_REF` re-declaration (in the build stage), exactly like the real file.
+function fixtureDockerfile(ref: string): string {
+  return [
+    "# syntax=docker/dockerfile:1",
+    "ARG CORTEX_REF=v6.10.0",
+    `ARG ARC_REF=${ref}`,
+    "ARG CORTEX_SURFACES=discord",
+    "",
+    "FROM debian:bookworm-slim",
+    "ARG CORTEX_REF",
+    "ARG ARC_REF",
+    "ARG CORTEX_SURFACES",
+    "",
+    'RUN git clone --depth 1 --branch "${ARC_REF}" https://github.com/the-metafactory/arc /opt/arc',
+    "",
+  ].join("\n");
+}
+
+function tmpDockerfile(ref: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
+  const path = join(dir, "Dockerfile.cortex");
+  writeFileSync(path, fixtureDockerfile(ref));
+  return path;
+}
+
+describe("parseSemver", () => {
+  test("parses vX.Y.Z and X.Y.Z", () => {
+    expect(parseSemver("v0.42.1")).toEqual({ major: 0, minor: 42, patch: 1, prerelease: [] });
+    expect(parseSemver("1.2.3")).toEqual({ major: 1, minor: 2, patch: 3, prerelease: [] });
+  });
+  test("parses prerelease + ignores build metadata", () => {
+    expect(parseSemver("v1.2.3-rc.1")).toEqual({ major: 1, minor: 2, patch: 3, prerelease: ["rc", "1"] });
+    expect(parseSemver("v1.2.3+build.5")?.prerelease).toEqual([]);
+  });
+  test("rejects malformed", () => {
+    expect(parseSemver("main")).toBeNull();
+    expect(parseSemver("v1.2")).toBeNull();
+    expect(parseSemver("")).toBeNull();
+    expect(parseSemver("v1.2.x")).toBeNull();
+  });
+});
+
+describe("compareSemver", () => {
+  const p = (s: string) => parseSemver(s)!;
+  test("orders core versions", () => {
+    expect(compareSemver(p("v0.42.1"), p("v0.40.2"))).toBe(1);
+    expect(compareSemver(p("v0.40.2"), p("v0.42.1"))).toBe(-1);
+    expect(compareSemver(p("v1.0.0"), p("v1.0.0"))).toBe(0);
+    expect(compareSemver(p("v1.2.0"), p("v1.1.9"))).toBe(1);
+  });
+  test("prerelease precedence (semver §11)", () => {
+    expect(compareSemver(p("v1.0.0"), p("v1.0.0-rc.1"))).toBe(1); // final > prerelease
+    expect(compareSemver(p("v1.0.0-rc.1"), p("v1.0.0-rc.2"))).toBe(-1);
+    expect(compareSemver(p("v1.0.0-alpha"), p("v1.0.0-beta"))).toBe(-1);
+  });
+});
+
+describe("readArcRef", () => {
+  test("reads the ARG definition line, not the bare re-declaration", () => {
+    expect(readArcRef(fixtureDockerfile("v0.40.2"))).toBe("v0.40.2");
+  });
+  test("returns null when the definition line is missing/malformed", () => {
+    // Only the bare re-declaration, no `=<value>` definition.
+    const df = "FROM debian:bookworm-slim\nARG ARC_REF\n";
+    expect(readArcRef(df)).toBeNull();
+    // Empty value is not \S+ -> treated as malformed.
+    expect(readArcRef("ARG ARC_REF=\n")).toBeNull();
+  });
+});
+
+describe("rewriteArcRef", () => {
+  test("newer release -> rewrite happens with the correct new value", () => {
+    const df = fixtureDockerfile("v0.40.2");
+    const r = rewriteArcRef(df, "v0.42.1");
+    expect(r.changed).toBe(true);
+    expect(r.oldRef).toBe("v0.40.2");
+    expect(readArcRef(r.content)).toBe("v0.42.1");
+    // The bare re-declaration is untouched (still exactly one, no `=`).
+    expect((r.content.match(/^ARG[ \t]+ARC_REF$/m) || []).length).toBe(1);
+    // Still a PINNED tag — never converted to an unpinned fetch.
+    expect(r.content).toContain("ARG ARC_REF=v0.42.1");
+  });
+  test("idempotent: same value -> no change", () => {
+    const df = fixtureDockerfile("v0.42.1");
+    const r = rewriteArcRef(df, "v0.42.1");
+    expect(r.changed).toBe(false);
+    expect(r.content).toBe(df);
+  });
+  test("missing/malformed ARG line -> oldRef null, no rewrite", () => {
+    const df = "FROM debian:bookworm-slim\nARG ARC_REF\n";
+    const r = rewriteArcRef(df, "v0.42.1");
+    expect(r.oldRef).toBeNull();
+    expect(r.changed).toBe(false);
+    expect(r.content).toBe(df);
+  });
+});
+
+describe("decideBump", () => {
+  test("newer -> bump; equal/older -> no bump", () => {
+    expect(decideBump("v0.40.2", "v0.42.1").shouldBump).toBe(true);
+    expect(decideBump("v0.42.1", "v0.42.1").shouldBump).toBe(false);
+    expect(decideBump("v0.42.1", "v0.40.2").shouldBump).toBe(false);
+  });
+  test("throws on unparseable input (loud, never silent)", () => {
+    expect(() => decideBump("v0.40.2", "main")).toThrow();
+    expect(() => decideBump("garbage", "v0.42.1")).toThrow();
+  });
+});
+
+describe("main (CLI)", () => {
+  test("newer release + --write rewrites the file, exit 0", () => {
+    const path = tmpDockerfile("v0.40.2");
+    try {
+      const code = main(["--latest", "v0.42.1", "--dockerfile", path, "--write"]);
+      expect(code).toBe(0);
+      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.42.1");
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("newer release WITHOUT --write is a dry-run (file unchanged)", () => {
+    const path = tmpDockerfile("v0.40.2");
+    try {
+      const code = main(["--latest", "v0.42.1", "--dockerfile", path]);
+      expect(code).toBe(0);
+      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.40.2");
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("equal/older release is a no-op, exit 0, file unchanged", () => {
+    const path = tmpDockerfile("v0.42.1");
+    try {
+      expect(main(["--latest", "v0.42.1", "--dockerfile", path, "--write"])).toBe(0);
+      expect(main(["--latest", "v0.40.2", "--dockerfile", path, "--write"])).toBe(0);
+      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.42.1");
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("missing --latest -> usage error (exit 2)", () => {
+    const path = tmpDockerfile("v0.40.2");
+    try {
+      expect(main(["--dockerfile", path])).toBe(2);
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("unreadable Dockerfile -> exit 3 (loud)", () => {
+    expect(main(["--latest", "v0.42.1", "--dockerfile", "/nonexistent/Dockerfile.cortex"])).toBe(3);
+  });
+
+  test("malformed ARG line -> exit 3 (loud, no phantom bump)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
+    const path = join(dir, "Dockerfile.cortex");
+    writeFileSync(path, "FROM debian:bookworm-slim\nARG ARC_REF\n");
+    try {
+      expect(main(["--latest", "v0.42.1", "--dockerfile", path, "--write"])).toBe(3);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unparseable --latest -> exit 3 (never track main)", () => {
+    const path = tmpDockerfile("v0.40.2");
+    try {
+      expect(main(["--latest", "main", "--dockerfile", path, "--write"])).toBe(3);
+      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.40.2");
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("--github-output writes bumped/old/new to $GITHUB_OUTPUT", () => {
+    const path = tmpDockerfile("v0.40.2");
+    const outDir = mkdtempSync(join(tmpdir(), "arc-ref-out-"));
+    const outFile = join(outDir, "gh_output");
+    writeFileSync(outFile, "");
+    const prev = process.env.GITHUB_OUTPUT;
+    process.env.GITHUB_OUTPUT = outFile;
+    try {
+      main(["--latest", "v0.42.1", "--dockerfile", path, "--write", "--github-output"]);
+      const out = readFileSync(outFile, "utf8");
+      expect(out).toContain("bumped=true");
+      expect(out).toContain("old=v0.40.2");
+      expect(out).toContain("new=v0.42.1");
+    } finally {
+      if (prev === undefined) delete process.env.GITHUB_OUTPUT;
+      else process.env.GITHUB_OUTPUT = prev;
+      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/arc-ref-bump.ts
+++ b/scripts/arc-ref-bump.ts
@@ -1,0 +1,291 @@
+#!/usr/bin/env bun
+/**
+ * arc-ref-bump.ts — the version-compare + Dockerfile ARG-rewrite core for the
+ * automated `ARC_REF` bump workflow (cortex#2246).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The L4 container (`deploy/compose/Dockerfile.cortex`) pins
+ * `ARG ARC_REF=<tag>` for reproducibility. arc releases move, and adapter
+ * manifests evolve with arc — so a pinned OLDER arc eventually can't parse
+ * NEWER adapter manifests and `arc install` fails in the container (exactly
+ * cortex#2243: v0.40.2 predated the `{host,reason}` manifest shape). The
+ * principal decision is to KEEP the pin (reproducible builds; un-pinning to
+ * `main` sacrifices reproducibility + adds supply-chain exposure) but AUTOMATE
+ * the bump dependabot/renovate-style: a scheduled workflow proposes bumps as
+ * reviewable, build-gated PRs.
+ *
+ * This module is the small, UNIT-TESTABLE core the workflow (.github/workflows/
+ * arc-ref-bump.yml) shells out to — semver compare + ARG rewrite — so that
+ * logic is NOT buried in inline YAML. The workflow owns the side effects
+ * (resolve latest release via `gh api`, `docker build` gate, open the PR); this
+ * script owns the pure decision + the exact byte-level Dockerfile edit.
+ *
+ * REPRODUCIBILITY INVARIANT: this script only ever rewrites the ARG to another
+ * PINNED TAG. It never converts the Dockerfile to an unpinned build-time fetch.
+ *
+ * Usage:
+ *   bun scripts/arc-ref-bump.ts --latest <tag> [--dockerfile <path>] [--write]
+ *                               [--github-output]
+ *
+ *   --latest <tag>        REQUIRED. arc's latest release tag (e.g. v0.42.1),
+ *                         resolved by the workflow via `gh api …/releases/latest`.
+ *   --dockerfile <path>   Dockerfile to read/rewrite. Defaults to
+ *                         deploy/compose/Dockerfile.cortex relative to CWD.
+ *   --write               Actually rewrite the file when a bump is warranted.
+ *                         Without it the script is a dry-run (decision only).
+ *   --github-output       Append bumped/old/new to $GITHUB_OUTPUT (for the
+ *                         workflow to gate its build + PR steps on).
+ *
+ * Exit codes:
+ *   0  decision made cleanly (whether or not a bump was warranted)
+ *   2  usage error (missing --latest, bad flag)
+ *   3  Dockerfile unreadable, or its ARG ARC_REF= line is missing/malformed,
+ *      or --latest is not a parseable semver tag — fail LOUD, never silent.
+ */
+
+import { readFileSync, writeFileSync, appendFileSync } from "fs";
+import { resolve } from "path";
+
+export interface Semver {
+  major: number;
+  minor: number;
+  patch: number;
+  /** Dot-separated prerelease identifiers, or [] for a final release. */
+  prerelease: string[];
+}
+
+export const DEFAULT_DOCKERFILE = "deploy/compose/Dockerfile.cortex";
+
+/**
+ * Parse a semver tag with an optional leading `v`. Returns null for anything
+ * that is not a clean MAJOR.MINOR.PATCH[-prerelease] (build metadata after `+`
+ * is ignored per semver §10). Deliberately strict: a malformed value must be
+ * detectable so the caller can fail loud rather than "bump" to garbage.
+ */
+export function parseSemver(input: string): Semver | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim().replace(/^v/, "");
+  // core [+ optional -prerelease] [+ optional +build]; build is discarded.
+  const m = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(trimmed);
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    prerelease: m[4] ? m[4].split(".") : [],
+  };
+}
+
+/**
+ * Compare two semver values. Returns -1 if a<b, 0 if equal, 1 if a>b.
+ * Prerelease handling follows semver §11: a version WITH a prerelease has
+ * LOWER precedence than the same core version WITHOUT one; identifiers are
+ * compared left-to-right (numeric < alphanumeric; numeric compared as ints).
+ */
+export function compareSemver(a: Semver, b: Semver): -1 | 0 | 1 {
+  for (const k of ["major", "minor", "patch"] as const) {
+    if (a[k] !== b[k]) return a[k] < b[k] ? -1 : 1;
+  }
+  // Core equal — a final release outranks any prerelease of the same core.
+  const ap = a.prerelease;
+  const bp = b.prerelease;
+  if (ap.length === 0 && bp.length === 0) return 0;
+  if (ap.length === 0) return 1; // a is final, b is prerelease
+  if (bp.length === 0) return -1; // a is prerelease, b is final
+  const len = Math.min(ap.length, bp.length);
+  for (let i = 0; i < len; i++) {
+    // i < len <= both lengths, so both are defined (noUncheckedIndexedAccess).
+    const x = ap[i] as string;
+    const y = bp[i] as string;
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn && yn) {
+      const nx = Number(x);
+      const ny = Number(y);
+      if (nx !== ny) return nx < ny ? -1 : 1;
+    } else if (xn !== yn) {
+      return xn ? -1 : 1; // numeric identifiers have lower precedence
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  if (ap.length !== bp.length) return ap.length < bp.length ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Extract the current pinned value of the `ARG ARC_REF=<value>` line — the ARG
+ * DEFINITION that carries a default, NOT the bare `ARG ARC_REF` re-declaration
+ * inside the build stage (which has no `=` and no value). Returns null when no
+ * definition line with a value is present (malformed / missing).
+ */
+export function readArcRef(dockerfile: string): string | null {
+  const m = /^ARG[ \t]+ARC_REF=(\S+)[ \t]*$/m.exec(dockerfile);
+  return m ? (m[1] ?? null) : null;
+}
+
+export interface RewriteResult {
+  /** The (possibly unchanged) Dockerfile content. */
+  content: string;
+  /** True only when the ARG value actually changed. */
+  changed: boolean;
+  /** The value before rewrite (null if the ARG line was missing/malformed). */
+  oldRef: string | null;
+}
+
+/**
+ * Rewrite the `ARG ARC_REF=<value>` definition line to `newRef`. Idempotent:
+ * if the current value already equals newRef, content is returned unchanged
+ * with changed=false. If the ARG definition line is missing/malformed, oldRef
+ * is null and nothing is rewritten (the caller must fail loud).
+ *
+ * Only the DEFINITION line (with `=<value>`) is touched; the bare re-declaration
+ * `ARG ARC_REF` is left intact so the build stage still inherits the default.
+ */
+export function rewriteArcRef(dockerfile: string, newRef: string): RewriteResult {
+  const oldRef = readArcRef(dockerfile);
+  if (oldRef === null) return { content: dockerfile, changed: false, oldRef: null };
+  if (oldRef === newRef) return { content: dockerfile, changed: false, oldRef };
+  const content = dockerfile.replace(
+    /^(ARG[ \t]+ARC_REF=)\S+([ \t]*)$/m,
+    `$1${newRef}$2`,
+  );
+  return { content, changed: content !== dockerfile, oldRef };
+}
+
+export interface Decision {
+  oldRef: string;
+  latestRef: string;
+  /** True when latestRef is strictly newer than oldRef. */
+  shouldBump: boolean;
+}
+
+/**
+ * Pure decision: given the current pinned ref and the latest release ref,
+ * should we bump? Throws on unparseable input so the CLI can exit 3 (loud).
+ */
+export function decideBump(oldRef: string, latestRef: string): Decision {
+  const cur = parseSemver(oldRef);
+  const latest = parseSemver(latestRef);
+  if (!cur) throw new Error(`current ARC_REF is not a parseable semver tag: "${oldRef}"`);
+  if (!latest) throw new Error(`--latest is not a parseable semver tag: "${latestRef}"`);
+  return { oldRef, latestRef, shouldBump: compareSemver(latest, cur) > 0 };
+}
+
+interface ParsedArgs {
+  latest?: string;
+  dockerfile: string;
+  write: boolean;
+  githubOutput: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = { dockerfile: DEFAULT_DOCKERFILE, write: false, githubOutput: false };
+  const value = (i: number, flag: string): string => {
+    const v = argv[i];
+    if (v === undefined) throw new Error(`${flag} requires a value`);
+    return v;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--latest":
+        out.latest = value(++i, "--latest");
+        break;
+      case "--dockerfile":
+        out.dockerfile = value(++i, "--dockerfile");
+        break;
+      case "--write":
+        out.write = true;
+        break;
+      case "--github-output":
+        out.githubOutput = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${a}`);
+    }
+  }
+  return out;
+}
+
+function emitGithubOutput(kv: Record<string, string>): void {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file) return;
+  const body = Object.entries(kv)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+  appendFileSync(file, body + "\n");
+}
+
+export function main(argv: string[]): number {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (e) {
+    process.stderr.write(`arc-ref-bump: ${(e as Error).message}\n`);
+    return 2;
+  }
+  if (!args.latest) {
+    process.stderr.write("arc-ref-bump: --latest <tag> is required\n");
+    return 2;
+  }
+
+  const path = resolve(args.dockerfile);
+  let dockerfile: string;
+  try {
+    dockerfile = readFileSync(path, "utf8");
+  } catch {
+    process.stderr.write(`arc-ref-bump: cannot read Dockerfile at ${path}\n`);
+    return 3;
+  }
+
+  const oldRef = readArcRef(dockerfile);
+  if (oldRef === null) {
+    process.stderr.write(
+      `arc-ref-bump: no 'ARG ARC_REF=<value>' definition line found in ${path} (missing/malformed)\n`,
+    );
+    return 3;
+  }
+
+  let decision: Decision;
+  try {
+    decision = decideBump(oldRef, args.latest);
+  } catch (e) {
+    process.stderr.write(`arc-ref-bump: ${(e as Error).message}\n`);
+    return 3;
+  }
+
+  if (!decision.shouldBump) {
+    process.stdout.write(
+      `arc-ref-bump: no bump — pinned ${oldRef} is already >= latest release ${args.latest}.\n`,
+    );
+    if (args.githubOutput) emitGithubOutput({ bumped: "false", old: oldRef, new: oldRef });
+    return 0;
+  }
+
+  const { content, changed } = rewriteArcRef(dockerfile, args.latest);
+  if (!changed) {
+    // shouldBump was true but the rewrite was a no-op — treat as loud failure
+    // rather than silently reporting a phantom bump.
+    process.stderr.write(
+      `arc-ref-bump: decided to bump ${oldRef} -> ${args.latest} but the ARG rewrite made no change (malformed line?)\n`,
+    );
+    return 3;
+  }
+
+  if (args.write) {
+    writeFileSync(path, content);
+    process.stdout.write(`arc-ref-bump: bumped ARC_REF ${oldRef} -> ${args.latest} in ${path}.\n`);
+  } else {
+    process.stdout.write(
+      `arc-ref-bump: WOULD bump ARC_REF ${oldRef} -> ${args.latest} (dry-run; pass --write to apply).\n`,
+    );
+  }
+  if (args.githubOutput) emitGithubOutput({ bumped: "true", old: oldRef, new: args.latest });
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
Closes #2246. Addresses the drift the L4 container's pinned `ARC_REF` keeps causing (cortex#2243 was the latest instance).

## Why

`ARG ARC_REF` is pinned for reproducibility, but arc releases move and adapter manifests evolve with them — so a pinned older arc eventually can't parse newer adapter manifests and the container's `arc install` fails. Manual bumping always lags. Decision (principal): **keep the pin (reproducible builds) but automate the bump** — never un-pin to a build-time `main` fetch (that sacrifices reproducibility + adds supply-chain exposure).

## What

A scheduled (weekly) + `workflow_dispatch` GitHub Actions workflow that:
1. Resolves arc's latest **release** tag (`gh api …/releases/latest`, fallback: highest `vX.Y.Z` git tag — never raw `main`).
2. If newer than the current `ARG ARC_REF`, bumps it via a small, unit-tested script (`scripts/arc-ref-bump.ts` — semver-compare + pin-preserving ARG rewrite, fail-loud on malformed input).
3. **Gates on a real container build** (`docker build --build-arg ARC_REF=<new>` on `Dockerfile.cortex`) that exercises the `arc install <adapter>` step which failed in #2243.
4. Green → opens a labeled PR (old→new + arc release link, dedups). Red → opens/updates a tracking issue and fails loudly. No silent no-op.

Reproducibility invariant preserved: `ARC_REF` stays a pinned tag; bumps arrive only as reviewable, build-gated PRs.

## Review — a real vulnerability was caught and fixed

This went through an adversarial security review. It found a **command-injection**: the resolved arc tag (from another repo's release / a raw `workflow_dispatch` input) was inlined into a `run:` shell via `${{ }}`, which expands to raw text before the shell parses — a crafted tag could execute arbitrary commands with the job's write-scoped `GITHUB_TOKEN`. `actionlint` did **not** flag it (it only catches known untrusted contexts, not derived step outputs). Fixed by routing every such value through `env:` and referencing quoted shell vars; re-review confirmed **zero `${{ }}` inside any `run:` block** (all 13 occurrences are on `env:` keys or in comments).

## Validation

- `scripts/arc-ref-bump.ts`: 20 unit tests (newer→rewrite, equal/older→no-op, malformed→fail-loud, `$GITHUB_OUTPUT` contract), revert-verified.
- `bunx tsc --noEmit`, `bun run lint:errors`, `actionlint` all clean; least-privilege `permissions:` (contents/PRs/issues write only).
- **Caveat:** the docker-build gate can't run in the review sandbox (no docker/egress) — confirmed by the first real scheduled/`workflow_dispatch` run. The first run will attempt a real `v0.42.0 → v0.42.1` bump.
- Note: 12 unrelated full-suite failures (startCortex/SurfaceContext.hook) were independently confirmed pre-existing (identical on clean `main`; this branch is purely additive — 3 new files, no imports into existing code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
