### PR TITLE
fix(brain): retarget a task's post routing to its created private thread (Closes #2248)

### DIFF
--- a/src/brain/__tests__/daemon-brain-host.test.ts
+++ b/src/brain/__tests__/daemon-brain-host.test.ts
@@ -88,6 +88,9 @@ function makeHooks(over: Partial<BrainTaskHooks> = {}): BrainTaskHooks & {
       }),
     onDispatch: over.onDispatch ?? ((d) => void dispatches.push(d)),
     onLog: over.onLog ?? (() => {}),
+    // cortex#2248 — optional retarget hook; forwarded only when a test
+    // supplies one (the default hooks omit it, mirroring per-task callers).
+    ...(over.onThreadCreated !== undefined && { onThreadCreated: over.onThreadCreated }),
   };
 }
 
@@ -964,6 +967,158 @@ describe("DaemonBrainHost — create_private_thread (cortex#2206)", () => {
 
     const result = await runP;
     expect(result.result.status).toBe("complete"); // NOT "failed"/timeout
+    await host.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// create_private_thread → onThreadCreated retarget hook (cortex#2248)
+// ---------------------------------------------------------------------------
+
+describe("DaemonBrainHost — onThreadCreated retarget hook (cortex#2248)", () => {
+  test("a successful create_private_thread fires hooks.onThreadCreated with the created thread id BEFORE the brain hears thread_created", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "agent-own-channel",
+      createPrivateThread: threadFn,
+      anonReachable: true,
+    });
+    await host.start();
+
+    // Record the hook firing AND whether `thread_created` had already been
+    // sent to the brain at that moment — the ordering is load-bearing: the
+    // retarget must land before the brain can react to the event with a
+    // `post`, or that post races into the parent channel.
+    const hookCalls: { threadId: string; threadCreatedAlreadySent: boolean }[] = [];
+    const hooks = makeHooks({
+      onThreadCreated: (threadId: string): void => {
+        hookCalls.push({
+          threadId,
+          threadCreatedAlreadySent: brain.hasEvent("thread_created"),
+        });
+      },
+    });
+
+    const runP = host.runTask(
+      makeTask({
+        task_id: "rt1",
+        source: { surface: "discord", channel: "arrivals", thread: "", user: "newcomer-a" },
+      }),
+      hooks,
+    );
+    await until(() => brain.lastTask()?.task_id === "rt1");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "rt1",
+        name: "welcome newcomer-a",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("thread_created"));
+
+    expect(hookCalls).toEqual([
+      { threadId: "thread-1", threadCreatedAlreadySent: false },
+    ]);
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "rt1", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test("a FAILED create_private_thread (adapter failure) never fires onThreadCreated", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn(() => ({ ok: false, detail: "platform exploded" }));
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "agent-own-channel",
+      createPrivateThread: threadFn,
+      anonReachable: true,
+    });
+    await host.start();
+
+    const hookCalls: string[] = [];
+    const hooks = makeHooks({
+      onThreadCreated: (threadId: string): void => void hookCalls.push(threadId),
+    });
+
+    const runP = host.runTask(makeTask({ task_id: "rt2" }), hooks);
+    await until(() => brain.lastTask()?.task_id === "rt2");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "rt2",
+        name: "will fail",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("effect_rejected"));
+
+    expect(hookCalls).toEqual([]);
+    expect(brain.hasEvent("thread_created")).toBe(false);
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "rt2", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test("a THROWING onThreadCreated hook is contained: logged, and thread_created still reaches the brain (the thread exists)", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const threadFn = makeThreadFn();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      agentChannelId: "agent-own-channel",
+      createPrivateThread: threadFn,
+      anonReachable: true,
+    });
+    await host.start();
+
+    const hooks = makeHooks({
+      onThreadCreated: (): void => {
+        throw new Error("consumer routing update blew up");
+      },
+    });
+
+    const runP = host.runTask(makeTask({ task_id: "rt3" }), hooks);
+    await until(() => brain.lastTask()?.task_id === "rt3");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: "rt3",
+        name: "hook throws",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("thread_created"));
+
+    const created = brain.received.find((e) => e.type === "thread_created");
+    expect(created).toMatchObject({ type: "thread_created", task_id: "rt3", thread_id: "thread-1" });
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "rt3", status: "complete" }));
+    await runP;
     await host.stop();
   });
 });

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -1112,6 +1112,25 @@ export class DaemonBrainHost {
             return;
           }
 
+          // cortex#2248 — HOST-SIDE RETARGET: inform the consumer that this
+          // task's conversation moved into the created thread, BEFORE the
+          // brain hears `thread_created`. Effects are handled off the socket
+          // sequentially per line, but ordering the retarget first
+          // guarantees any `post` the brain emits on seeing the event
+          // already routes to the thread — never racing a post into the
+          // parent channel. The hook is optional (per-task runners and
+          // routing-agnostic tests omit it) and guarded: a hook failure is
+          // logged, and `thread_created` still ships — the thread EXISTS,
+          // so the brain must learn its id regardless.
+          try {
+            await record.hooks.onThreadCreated?.(outcome.threadId);
+          } catch (hookErr) {
+            process.stderr.write(
+              `daemon-brain-host: onThreadCreated hook failed for agent="${this.agentId}" ` +
+                `task=${e.task_id}: ${hookErr instanceof Error ? hookErr.message : String(hookErr)}\n`,
+            );
+          }
+
           await this.sendToConn(
             encodeBrainEvent({
               v: 1,

--- a/src/brain/exec-brain-runner.ts
+++ b/src/brain/exec-brain-runner.ts
@@ -163,6 +163,21 @@ export interface BrainTaskHooks {
 
   /** A `log` effect — diagnostic; not surfaced to the principal. */
   onLog(log: LogEffect): void | Promise<void>;
+
+  /**
+   * cortex#2248 — the host successfully created a private thread for THIS
+   * task (`create_private_thread`, cortex#2206). OPTIONAL: the BrainConsumer
+   * uses it to RETARGET the task's subsequent `post` routing into the
+   * created thread — the conversation moves into the thread the host itself
+   * created and verified; without it the posts kept landing in the parent
+   * channel and the thread stayed empty. §5 property 1 is preserved: the
+   * brain STILL never names a target — `threadId` is host-derived (the
+   * adapter's create result), never brain-supplied wire input. Only the
+   * `lifecycle: daemon` host wires `create_private_thread`, so the per-task
+   * runner never fires this hook; it is optional so per-task callers (and
+   * tests that don't care about routing) omit it.
+   */
+  onThreadCreated?(threadId: string): void | Promise<void>;
 }
 
 export type BrainDispatchOutcome =

--- a/src/bus/__tests__/brain-consumer.thread-retarget.test.ts
+++ b/src/bus/__tests__/brain-consumer.thread-retarget.test.ts
@@ -1,0 +1,287 @@
+/**
+ * cortex#2248 — post-after-create_private_thread retargeting, integration
+ * level: REAL `BrainConsumer` (its real `makeHooks` post routing) + REAL
+ * `DaemonBrainHost` (its real `create_private_thread` policy/success path) +
+ * a fake brain and a fake adapter thread-create seam. No real NATS, socket,
+ * subprocess, or Discord.
+ *
+ * The bug (first live repro: the guildhall escort's onboarding flow): after a
+ * successful `create_private_thread`, the task's subsequent `post` effects
+ * still routed to the task's ORIGINAL source — `onPost` publishes with a
+ * per-task frozen `brainPostSource` — so the "private" greeting posted
+ * publicly into the parent channel and the created thread stayed empty.
+ *
+ * The fix is a HOST-SIDE retarget (`hooks.onThreadCreated`): on success the
+ * host tells the consumer, which repoints the task's post source at the
+ * created thread. §5 property 1 holds throughout — `PostEffect` stays
+ * target-less; the only routing values ever used are host-derived.
+ *
+ * The envelope driven here is built with `buildBrainTaskPayload` +
+ * `buildDispatchTaskEnvelope(family: "brain")` — the EXACT construction the
+ * inbound @-mention path (`dispatchInboundToBrain`, cortex.ts) publishes, so
+ * this is the mention → create → post flow end-to-end minus the wire.
+ *
+ * All ids are obviously-fake, non-numeric placeholders (confidentiality
+ * gate — never a realistic-looking digit snowflake).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  BrainConsumer,
+  buildBrainTaskPayload,
+  buildDispatchTaskEnvelope,
+  type BrainConsumerAgent,
+} from "../brain-consumer";
+import type { Envelope } from "../myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../myelin/runtime";
+import type { SystemEventSource } from "../system-events";
+import { DaemonBrainHost } from "../../brain/daemon-brain-host";
+import {
+  FakeDaemonBrain,
+  singleFakeDaemonTransport,
+} from "../../brain/__tests__/fake-daemon-brain";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SOURCE: SystemEventSource = {
+  principal: "test-op",
+  agent: "cortex",
+  instance: "local",
+};
+
+const FAKE_ARRIVALS_CHANNEL = "arrivals-channel-fake-for-test";
+const FAKE_ADAPTER_INSTANCE = "escort-discord";
+const FAKE_AGENT_CHANNEL = "agent-channel-fake-for-test";
+const FAKE_THREAD_ID = "created-thread-fake-for-test";
+const FAKE_NEWCOMER = "newcomer-fake-for-test";
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  const handlers = new Set<EnvelopeHandler>();
+  return {
+    enabled: false,
+    published,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
+function buildAgent(): BrainConsumerAgent {
+  return {
+    id: "escort-like",
+    capabilities: ["chat"],
+    dispatchCapabilities: [],
+  };
+}
+
+/** The mention-shaped brain task envelope `dispatchInboundToBrain` publishes. */
+function mentionEnvelope(): Envelope {
+  return buildDispatchTaskEnvelope({
+    source: SOURCE,
+    capability: "chat",
+    family: "brain",
+    payload: buildBrainTaskPayload({
+      text: "hello, I just arrived",
+      user: FAKE_NEWCOMER,
+      surface: "discord",
+      channel: FAKE_ARRIVALS_CHANNEL,
+      // Top-level mention: the inbound path keys thread = channel when the
+      // message has no native thread (cortex.ts `thread = threadId ?? channelId`).
+      thread: FAKE_ARRIVALS_CHANNEL,
+      adapterInstance: FAKE_ADAPTER_INSTANCE,
+    }),
+  });
+}
+
+/** Wait until `cond()` is true (poll), or throw after `timeoutMs`. */
+async function until(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("until() timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+function posts(runtime: RecordingRuntime): Envelope[] {
+  return runtime.published.filter((e) => e.type === "dispatch.task.post");
+}
+
+function routingOf(e: Envelope | undefined): Record<string, unknown> | undefined {
+  const r = e?.payload.response_routing;
+  return r !== null && typeof r === "object" ? (r as Record<string, unknown>) : undefined;
+}
+
+/** A consumer + daemon host + fake brain wired like the escort deployment. */
+async function makeStack(opts: { withThreadCapability: boolean }): Promise<{
+  runtime: RecordingRuntime;
+  brain: FakeDaemonBrain;
+  consumer: BrainConsumer;
+  host: DaemonBrainHost;
+  threadCalls: { channelId: string; name: string; memberIds: string[] }[];
+}> {
+  const runtime = createRecordingRuntime();
+  const brain = new FakeDaemonBrain();
+  const threadCalls: { channelId: string; name: string; memberIds: string[] }[] = [];
+  const host = new DaemonBrainHost({
+    agentId: "escort-like",
+    run: "bun b.ts",
+    packDir: "/p",
+    transport: singleFakeDaemonTransport(brain),
+    ...(opts.withThreadCapability && {
+      agentChannelId: FAKE_AGENT_CHANNEL,
+      anonReachable: true,
+      // The fake ADAPTER seam — stands in for the Discord adapter's
+      // createPrivateThread (REST create + add-member), same seam the boot
+      // wiring injects via `makeCreatePrivateThreadFn`.
+      createPrivateThread: async (callOpts: {
+        channelId: string;
+        name: string;
+        memberIds: string[];
+      }) => {
+        threadCalls.push({ ...callOpts });
+        return { ok: true as const, threadId: FAKE_THREAD_ID };
+      },
+    }),
+  });
+  await host.start();
+  const consumer = new BrainConsumer({
+    agent: buildAgent(),
+    source: SOURCE,
+    runtime,
+    daemonHost: host,
+  });
+  return { runtime, brain, consumer, host, threadCalls };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("brain-consumer — post routing after create_private_thread (cortex#2248)", () => {
+  test("mention → create_private_thread → post: the post lands IN THE CREATED THREAD, not the parent channel; a pre-thread post still lands at the source", async () => {
+    const { runtime, brain, consumer, threadCalls } = await makeStack({
+      withThreadCapability: true,
+    });
+
+    const decisionP = consumer.processEnvelope(mentionEnvelope(), "subj", null, "chat");
+    await until(() => brain.hasTask());
+    const tid = brain.taskId();
+
+    // 1. A post BEFORE any thread exists routes to the original source —
+    // exactly as today.
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: tid, text: "one moment…" }));
+    await until(() => posts(runtime).length === 1);
+    expect(routingOf(posts(runtime)[0])).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_ARRIVALS_CHANNEL,
+      thread_id: FAKE_ARRIVALS_CHANNEL,
+    });
+
+    // 2. The brain opens its private thread (members: "source" — the only
+    // form an anon-reachable agent may request).
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: tid,
+        name: "welcome newcomer",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("thread_created"));
+    // Host policy did its normal job: agent's OWN channel, source-resolved member.
+    expect(threadCalls).toEqual([
+      {
+        channelId: FAKE_AGENT_CHANNEL,
+        name: "welcome newcomer",
+        memberIds: [FAKE_NEWCOMER],
+      },
+    ]);
+
+    // 3. THE FIX — the subsequent post routes into the created thread. Same
+    // adapter instance and channel family, but thread_id is now the HOST-
+    // created thread, so the dispatch sink posts there and the greeting is
+    // no longer public.
+    brain.emit(
+      JSON.stringify({ v: 1, type: "post", task_id: tid, text: "welcome! this is your private thread" }),
+    );
+    await until(() => posts(runtime).length === 2);
+    expect(routingOf(posts(runtime)[1])).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_ARRIVALS_CHANNEL,
+      thread_id: FAKE_THREAD_ID,
+    });
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: tid, status: "complete" }));
+    const decision = await decisionP;
+    expect(decision).toEqual({ kind: "ack" });
+    await consumer.stop();
+  });
+
+  test("a task that never creates a thread posts exactly as today — every post keeps the original routing", async () => {
+    const { runtime, brain, consumer } = await makeStack({ withThreadCapability: true });
+
+    const decisionP = consumer.processEnvelope(mentionEnvelope(), "subj", null, "chat");
+    await until(() => brain.hasTask());
+    const tid = brain.taskId();
+
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: tid, text: "reply one" }));
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: tid, text: "reply two" }));
+    await until(() => posts(runtime).length === 2);
+    for (const p of posts(runtime)) {
+      expect(routingOf(p)).toEqual({
+        adapter_instance: FAKE_ADAPTER_INSTANCE,
+        channel_id: FAKE_ARRIVALS_CHANNEL,
+        thread_id: FAKE_ARRIVALS_CHANNEL,
+      });
+    }
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: tid, status: "complete" }));
+    await decisionP;
+    await consumer.stop();
+  });
+
+  test("a REFUSED create_private_thread leaves post routing untouched (agent has no thread capability wired)", async () => {
+    const { runtime, brain, consumer } = await makeStack({ withThreadCapability: false });
+
+    const decisionP = consumer.processEnvelope(mentionEnvelope(), "subj", null, "chat");
+    await until(() => brain.hasTask());
+    const tid = brain.taskId();
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: tid,
+        name: "cannot happen",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("effect_rejected"));
+
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: tid, text: "still public path" }));
+    await until(() => posts(runtime).length === 1);
+    expect(routingOf(posts(runtime)[0])).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_ARRIVALS_CHANNEL,
+      thread_id: FAKE_ARRIVALS_CHANNEL,
+    });
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: tid, status: "complete" }));
+    await decisionP;
+    await consumer.stop();
+  });
+});

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -883,6 +883,22 @@ export class BrainConsumer {
           `cortex/brain-consumer: [${log.level}] agent=${this.agent.id}: ${log.text}\n`,
         );
       },
+
+      // `thread_created` follow-through (cortex#2248) — the HOST created (and
+      // verified) a private thread for this task (`create_private_thread`,
+      // cortex#2206); retarget the task's subsequent `post` routing into it.
+      // `brainPostSource` is THIS task's own per-task copy (built above), so
+      // the mutation is task-scoped: sibling tasks are untouched, and the
+      // `ask_principal` gate keeps rendering to the ORIGINAL `source` on
+      // purpose — the gate awaits the PRINCIPAL's identity-checked reply,
+      // and a private thread (source user + agent) need not contain the
+      // principal at all; moving the gate prompt there could strand it.
+      // §5 property 1 preserved: the brain still never names a target — the
+      // only routing values ever used are host-derived (the original task
+      // source, or a thread the host itself created for this exact task).
+      onThreadCreated: (threadId: string): void => {
+        brainPostSource.thread = threadId;
+      },
     };
   }
 


### PR DESCRIPTION
Closes #2248

## Problem

After a successful `create_private_thread` (cortex#2206), a task's subsequent `post` effects still routed to the task's ORIGINAL source. Two deliberate designs composed into the gap: `PostEffect` carries no target (§5 property 1 — correct, kept), and `daemon-brain-host.ts`'s success path sent `thread_created` and updated nothing, while `brain-consumer.ts`'s `onPost` publishes with a per-task frozen `brainPostSource`. Live repro on the first real consumer: the private thread was created correctly, but the "private" onboarding greeting posted publicly into the parent channel and the thread stayed empty.

## Routing mechanism chosen: host-side retarget via a `BrainTaskHooks.onThreadCreated` hook

**ADR check (required pre-work):** cortex#2206's resolved ADR decisions (issue body, 2026-07-17) cover `members` typing, the rate limit, and the return-path shape — nothing constrains post routing, and no `docs/adr/` entry exists for it. The ADR's governing principle — *"the effect's parameters must be structurally bounded by the host, not chosen by the brain"* — argues squarely for the host-side retarget over the considered-and-rejected alternative (an optional host-validated `thread_id` on `PostEffect`), which would widen the brain-controlled wire surface for a need the actual consumer doesn't have. Wire shape unchanged; escort/yarrow/example-agent compatibility unchanged.

Mechanics (the per-task hooks seam is the codebase's existing host→consumer effect channel — `onPost`/`onAskPrincipal`/`onDispatch`/`onLog`):

- `src/brain/exec-brain-runner.ts` — `BrainTaskHooks` gains OPTIONAL `onThreadCreated?(threadId)`. Only the `lifecycle: daemon` host wires `create_private_thread`, so the per-task runner never fires it.
- `src/brain/daemon-brain-host.ts` — the `create_private_thread` success path fires the hook with the adapter-returned thread id **before** sending `thread_created`, so a `post` the brain emits on seeing the event can never race into the parent channel. A throwing hook is logged and contained — `thread_created` still ships (the thread exists; the brain must learn its id regardless).
- `src/bus/brain-consumer.ts` — `makeHooks` implements the hook by repointing the task's own `brainPostSource.thread` at the created thread. `createDispatchTaskPostEvent` then emits `response_routing.thread_id` = the created thread, and the dispatch sink delivers into it.

Deliberate scoping:
- **Task-scoped**: `brainPostSource` is this task's per-task copy — sibling tasks untouched.
- **The `ask_principal` gate keeps the ORIGINAL source** on purpose: the gate awaits the PRINCIPAL's identity-checked reply, and a private thread (source user + agent) need not contain the principal — moving the gate prompt there could strand it.
- §5 property 1 preserved end-to-end: the brain still never names a target; the only routing values ever used are host-derived (the original task source, or a thread the host itself created for this exact task).

## Acceptance criteria (issue #2248)

- [x] After a task's `create_private_thread` succeeds, its subsequent `post` effects render into the created thread, not the parent channel — pinned by the new integration suite.
- [x] A task that never creates a thread posts exactly as today — pinned.
- [x] Brain wire protocol unchanged (`PostEffect` untouched); ADR review confirmed no preference for the validated-`thread_id` alternative.
- [x] Integration-level test: fake adapter (thread-create seam), real host, real consumer — mention-shaped envelope (the exact `buildBrainTaskPayload` + `family: "brain"` construction `dispatchInboundToBrain` publishes) → create → post lands in thread (`src/bus/__tests__/brain-consumer.thread-retarget.test.ts`).
- [x] Typecheck + scoped tests green.

## Testing

- `bunx tsc --noEmit` clean; eslint clean on all touched files.
- Host unit tests (`daemon-brain-host.test.ts` +3): hook fires with the created id BEFORE the brain hears `thread_created`; never fires on adapter failure; a throwing hook is contained.
- Integration suite (+3): retarget happy path (incl. pre-thread post keeps original routing), threadless task unchanged, refused create leaves routing untouched.
- All brain-related suites: 193 tests green. Full local run: only the 12 pre-existing machine-local failures also present on origin/main (plugin-loader loads this machine's installed arc bundles inside tests; absent in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01247nwyEPNLjDJJXU9fqZAD
