### PR TITLE
feat(brain): post_log effect — brain notifies its agent's bound log channel (host-derived target)

### DIFF
--- a/docs/design-bot-packs.md
+++ b/docs/design-bot-packs.md
@@ -144,6 +144,7 @@ socket (stdio kept for logs).
 ```jsonc
 { "v": 1, "type": "post",         "task_id": "…", "text": "…",
   "attachment": { "filename": "flow.png", "b64": "…" } }                   // cortex posts to the task's surface/thread
+{ "v": 1, "type": "post_log",     "task_id": "…", "text": "…" }            // cortex posts to the AGENT'S OWN bound log channel (cortex#2256): no channel field — the host derives the target from presence.discord.logChannelId; fire-and-forget (no ack), failures via effect_rejected; daemon lifecycle only
 { "v": 1, "type": "ask_principal", "task_id": "…", "gate": "principal-ack",
   "prompt": "Run this flow?" }                                             // cortex renders the gate, enforces the PRINCIPAL
 { "v": 1, "type": "dispatch",     "task_id": "…", "capability": "soc.triage.email",

--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -189,6 +189,38 @@ describe("dispatch-sink — delivery to the originating target", () => {
     });
   });
 
+  test("cortex#2256 — honors a routing channel DIFFERENT from any task origin: a dispatch.task.post routed at a log channel (no thread) posts there", async () => {
+    // The `post_log` seam relies on routing being pure DATA: the brain
+    // consumer emits a dispatch.task.post whose `response_routing` names the
+    // agent's LOG channel — a channel the task did NOT originate from, with
+    // no thread. The sink must deliver to exactly that target (it never
+    // compares routing against an origin — this test pins that property so
+    // it cannot regress into origin-validation).
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("escort-discord");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.post", {
+        agent_id: "escort",
+        text: "newcomer is ready for review",
+        // Channel-only routing at the log channel — no thread_id at all.
+        response_routing: routing("escort-discord", "stewards-log-channel-fake"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    const sent = adapter.sentMessages[0]!;
+    expect(sent.text).toBe("newcomer is ready for review");
+    expect(sent.target).toEqual({
+      instanceId: "escort-discord",
+      channelId: "stewards-log-channel-fake",
+    });
+  });
+
   test("posts a failed reply via postResponse", async () => {
     const { runtime, trigger } = fakeRuntime();
     const adapter = new MockAdapter("discord-pai-collab");

--- a/src/brain/__tests__/daemon-brain-host.test.ts
+++ b/src/brain/__tests__/daemon-brain-host.test.ts
@@ -22,6 +22,8 @@ import { join } from "path";
 import {
   DaemonBrainHost,
   CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR,
+  POST_LOG_RATE_LIMIT_PER_HOUR,
+  POST_LOG_MAX_TEXT_CHARS,
   type DaemonTransport,
   type DaemonBrainProcess,
   type CreatePrivateThreadFn,
@@ -91,6 +93,8 @@ function makeHooks(over: Partial<BrainTaskHooks> = {}): BrainTaskHooks & {
     // cortex#2248 — optional retarget hook; forwarded only when a test
     // supplies one (the default hooks omit it, mirroring per-task callers).
     ...(over.onThreadCreated !== undefined && { onThreadCreated: over.onThreadCreated }),
+    // cortex#2256 — optional log-post hook; same forwarding rule.
+    ...(over.onPostLog !== undefined && { onPostLog: over.onPostLog }),
   };
 }
 
@@ -1119,6 +1123,331 @@ describe("DaemonBrainHost — onThreadCreated retarget hook (cortex#2248)", () =
 
     brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "rt3", status: "complete" }));
     await runP;
+    await host.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// post_log (cortex#2256)
+// ---------------------------------------------------------------------------
+
+/**
+ * cortex#2256 — a recording `onPostLog` hook. Records every gate-passing call
+ * (with the HOST-derived log channel the hook received) and, by default,
+ * succeeds. Tests that need the failed-publish path override via `result`.
+ */
+function makePostLogHook(
+  result?: () => { ok: true } | { ok: false; detail: string },
+): {
+  calls: { text: string; logChannelId: string }[];
+  onPostLog: (
+    post: { text: string },
+    logChannelId: string,
+  ) => Promise<{ ok: true } | { ok: false; detail: string }>;
+} {
+  const calls: { text: string; logChannelId: string }[] = [];
+  return {
+    calls,
+    onPostLog: async (post, logChannelId) => {
+      calls.push({ text: post.text, logChannelId });
+      return result ? result() : { ok: true };
+    },
+  };
+}
+
+describe("DaemonBrainHost — post_log (cortex#2256)", () => {
+  test("a bound agent's post_log reaches the hook with the HOST-derived log channel; success is fire-and-forget (no event back to the brain)", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const postLog = makePostLogHook();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      logChannelId: "stewards-channel-fake",
+    });
+    await host.start();
+
+    const runP = host.runTask(
+      makeTask({ task_id: "pl1" }),
+      makeHooks({ onPostLog: postLog.onPostLog }),
+    );
+    await until(() => brain.lastTask()?.task_id === "pl1");
+
+    // The wire effect names NO channel — an extra `channel` field a hostile
+    // brain smuggles on is not a schema field (protocol.ts PostLogEffectSchema)
+    // and is stripped by the tolerant-ingest codec before the host's switch:
+    // the hook can only ever receive the agent's own binding.
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "post_log",
+        task_id: "pl1",
+        text: "newcomer ready for review",
+        channel: "attacker-chosen-channel",
+      }),
+    );
+    await until(() => postLog.calls.length === 1);
+    expect(postLog.calls).toEqual([
+      { text: "newcomer ready for review", logChannelId: "stewards-channel-fake" },
+    ]);
+
+    // Fire-and-forget: no ack event of any kind went back to the brain.
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "pl1", status: "complete" }));
+    const res = await runP;
+    expect(res.result.status).toBe("complete");
+    expect(brain.hasEvent("effect_rejected")).toBe(false);
+    const eventTypes = new Set(brain.received.map((e) => e.type));
+    expect(eventTypes.has("thread_created")).toBe(false); // nothing post_log-shaped came back
+    await host.stop();
+  });
+
+  test("no log channel bound → effect_rejected cant_do (structural, not policy); the hook is never called", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const postLog = makePostLogHook();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      // no logChannelId
+    });
+    await host.start();
+
+    const runP = host.runTask(
+      makeTask({ task_id: "pl2" }),
+      makeHooks({ onPostLog: postLog.onPostLog }),
+    );
+    await until(() => brain.lastTask()?.task_id === "pl2");
+
+    brain.emit(JSON.stringify({ v: 1, type: "post_log", task_id: "pl2", text: "hello?" }));
+    await until(() => brain.hasEvent("effect_rejected"));
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "post_log" });
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("cant_do");
+    }
+    expect(postLog.calls.length).toBe(0);
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "pl2", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test(`text over ${POST_LOG_MAX_TEXT_CHARS} chars → effect_rejected wont_do; never reaches the hook and never burns rate budget`, async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const postLog = makePostLogHook();
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      logChannelId: "stewards-channel-fake",
+    });
+    await host.start();
+
+    const runP = host.runTask(
+      makeTask({ task_id: "pl3" }),
+      makeHooks({ onPostLog: postLog.onPostLog }),
+    );
+    await until(() => brain.lastTask()?.task_id === "pl3");
+
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "post_log",
+        task_id: "pl3",
+        text: "x".repeat(POST_LOG_MAX_TEXT_CHARS + 1),
+      }),
+    );
+    await until(() => brain.hasEvent("effect_rejected"));
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "post_log" });
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("wont_do");
+      expect(rej.reason.detail).toMatch(/exceeds/i);
+    }
+    expect(postLog.calls.length).toBe(0);
+
+    // A text at EXACTLY the cap still passes (boundary) — proving the
+    // over-cap refusal above did not burn a rate slot is covered by the
+    // rate-limit test's exact-budget accounting.
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "post_log",
+        task_id: "pl3",
+        text: "y".repeat(POST_LOG_MAX_TEXT_CHARS),
+      }),
+    );
+    await until(() => postLog.calls.length === 1);
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "pl3", status: "complete" }));
+    await runP;
+    await host.stop();
+  });
+
+  test(`rate limit trips at exactly ${POST_LOG_RATE_LIMIT_PER_HOUR}/hour per agent (policy_denied); over-cap refusals never counted; a DIFFERENT agent still succeeds`, async () => {
+    let nowMs = 5_000_000;
+    const clock = () => nowMs;
+
+    const brainA = new FakeBrain();
+    const { transport: transportA } = makeFakeTransport([brainA]);
+    const postLogA = makePostLogHook();
+    const hostA = new DaemonBrainHost({
+      agentId: "agent-a",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport: transportA,
+      makeScratchDir: scratchFactory,
+      logChannelId: "log-channel-a",
+      now: clock,
+    });
+    await hostA.start();
+
+    const runA = hostA.runTask(
+      makeTask({ task_id: "plr" }),
+      makeHooks({ onPostLog: postLogA.onPostLog }),
+    );
+    await until(() => brainA.lastTask()?.task_id === "plr");
+
+    // An over-cap request FIRST — refused wont_do, must NOT burn a slot
+    // (the full budget below still fits afterward).
+    brainA.emit(
+      JSON.stringify({
+        v: 1,
+        type: "post_log",
+        task_id: "plr",
+        text: "z".repeat(POST_LOG_MAX_TEXT_CHARS + 1),
+      }),
+    );
+    await until(() => brainA.hasEvent("effect_rejected"));
+
+    for (let i = 0; i < POST_LOG_RATE_LIMIT_PER_HOUR; i++) {
+      nowMs += 1_000; // seconds apart — same window
+      brainA.emit(
+        JSON.stringify({ v: 1, type: "post_log", task_id: "plr", text: `note ${i}` }),
+      );
+      await until(() => postLogA.calls.length === i + 1);
+    }
+    expect(postLogA.calls.length).toBe(POST_LOG_RATE_LIMIT_PER_HOUR);
+
+    // The next within the SAME window is refused policy_denied.
+    nowMs += 1_000;
+    brainA.emit(
+      JSON.stringify({ v: 1, type: "post_log", task_id: "plr", text: "one too many" }),
+    );
+    await until(
+      () =>
+        brainA.received.filter(
+          (e) => e.type === "effect_rejected" && e.reason.kind === "policy_denied",
+        ).length === 1,
+    );
+    const rejs = brainA.received.filter((e) => e.type === "effect_rejected");
+    const rateRej = rejs.find(
+      (e) => e.type === "effect_rejected" && e.reason.kind === "policy_denied",
+    );
+    if (rateRej?.type === "effect_rejected") {
+      expect(rateRej.reason.detail).toMatch(/exceeded|rate|limit/i);
+    }
+    // Never reached the hook.
+    expect(postLogA.calls.length).toBe(POST_LOG_RATE_LIMIT_PER_HOUR);
+
+    // Window slides: an hour later the budget is back.
+    nowMs += 60 * 60 * 1000 + 1;
+    brainA.emit(
+      JSON.stringify({ v: 1, type: "post_log", task_id: "plr", text: "next hour" }),
+    );
+    await until(() => postLogA.calls.length === POST_LOG_RATE_LIMIT_PER_HOUR + 1);
+
+    brainA.emit(JSON.stringify({ v: 1, type: "result", task_id: "plr", status: "complete" }));
+    await runA;
+    await hostA.stop();
+
+    // A DIFFERENT agent (its own host instance, its own window) in the same
+    // hour still succeeds — per-agent budget, not a global ceiling.
+    const brainB = new FakeBrain();
+    const { transport: transportB } = makeFakeTransport([brainB]);
+    const postLogB = makePostLogHook();
+    const hostB = new DaemonBrainHost({
+      agentId: "agent-b",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport: transportB,
+      makeScratchDir: scratchFactory,
+      logChannelId: "log-channel-b",
+      now: clock,
+    });
+    await hostB.start();
+    const runB = hostB.runTask(
+      makeTask({ task_id: "plrb" }),
+      makeHooks({ onPostLog: postLogB.onPostLog }),
+    );
+    await until(() => brainB.lastTask()?.task_id === "plrb");
+    brainB.emit(
+      JSON.stringify({ v: 1, type: "post_log", task_id: "plrb", text: "agent-b note" }),
+    );
+    await until(() => postLogB.calls.length === 1);
+
+    brainB.emit(JSON.stringify({ v: 1, type: "result", task_id: "plrb", status: "complete" }));
+    await runB;
+    await hostB.stop();
+  });
+
+  test("a failed publish (hook resolves ok:false) → effect_rejected not_now; a THROWING hook is contained to the same refusal", async () => {
+    const brain = new FakeBrain();
+    const { transport } = makeFakeTransport([brain]);
+    const postLog = makePostLogHook(() => ({ ok: false, detail: "bus publish failed" }));
+    const host = new DaemonBrainHost({
+      agentId: "escort",
+      run: "bun b.ts",
+      packDir: "/p",
+      transport,
+      makeScratchDir: scratchFactory,
+      logChannelId: "stewards-channel-fake",
+    });
+    await host.start();
+
+    const runP = host.runTask(
+      makeTask({ task_id: "pl5" }),
+      makeHooks({
+        onPostLog: async (post, logChannelId) => {
+          if (post.text === "throw please") throw new Error("adapter exploded");
+          return postLog.onPostLog(post, logChannelId);
+        },
+      }),
+    );
+    await until(() => brain.lastTask()?.task_id === "pl5");
+
+    // ok:false → not_now.
+    brain.emit(JSON.stringify({ v: 1, type: "post_log", task_id: "pl5", text: "will fail" }));
+    await until(() => brain.received.filter((e) => e.type === "effect_rejected").length === 1);
+    const rej1 = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej1).toMatchObject({ type: "effect_rejected", effect: "post_log" });
+    if (rej1?.type === "effect_rejected") {
+      expect(rej1.reason.kind).toBe("not_now");
+      expect(rej1.reason.detail).toMatch(/publish failed/);
+    }
+
+    // A throwing hook is contained — same not_now refusal, no crash.
+    brain.emit(JSON.stringify({ v: 1, type: "post_log", task_id: "pl5", text: "throw please" }));
+    await until(() => brain.received.filter((e) => e.type === "effect_rejected").length === 2);
+    const rej2 = brain.received.filter((e) => e.type === "effect_rejected")[1];
+    if (rej2?.type === "effect_rejected") {
+      expect(rej2.reason.kind).toBe("not_now");
+      expect(rej2.reason.detail).toMatch(/adapter exploded/);
+    }
+
+    // The task itself is untouched by the failed log notes.
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: "pl5", status: "complete" }));
+    const res = await runP;
+    expect(res.result.status).toBe("complete");
     await host.stop();
   });
 });

--- a/src/brain/__tests__/protocol.test.ts
+++ b/src/brain/__tests__/protocol.test.ts
@@ -641,6 +641,75 @@ describe("create_private_thread schema", () => {
 });
 
 // ---------------------------------------------------------------------------
+// post_log (cortex#2256)
+// ---------------------------------------------------------------------------
+
+describe("post_log schema (cortex#2256)", () => {
+  test("a minimal post_log parses ok and round-trips", () => {
+    const effect = {
+      v: 1,
+      type: "post_log",
+      task_id: "t1",
+      text: "newcomer ready for review",
+    } as const;
+    const parsed = parseBrainEffect(encodeBrainEffect(effect));
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.effect).toEqual(effect);
+    }
+  });
+
+  test("task_id is required (non-empty)", () => {
+    const line = JSON.stringify({ v: 1, type: "post_log", task_id: "", text: "x" });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+
+  test("text is required", () => {
+    const line = JSON.stringify({ v: 1, type: "post_log", task_id: "t1" });
+    expect(parseBrainEffect(line).kind).toBe("invalid");
+  });
+
+  // Same load-bearing structural guarantee as create_private_thread
+  // (cortex#2206 pattern): the wire schema has NO channel field at all. A
+  // brain that includes one is not "refused" — the field is silently
+  // stripped by the tolerant-ingest codec before the effect ever reaches
+  // host policy, so a brain-named channel cannot influence routing.
+  test("a brain-supplied `channel` field is stripped — there is no such field on the wire", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "post_log",
+      task_id: "t1",
+      text: "note",
+      channel: "attacker-chosen-channel-id",
+      thread: "attacker-chosen-thread-id",
+    });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.effect).not.toHaveProperty("channel");
+      expect(parsed.effect).not.toHaveProperty("thread");
+    }
+  });
+
+  // No attachment in v1: an attachment field is an unknown key on this type
+  // and is stripped (tolerant ingest) — never delivered.
+  test("an attachment field is stripped (no attachment on post_log in v1)", () => {
+    const line = JSON.stringify({
+      v: 1,
+      type: "post_log",
+      task_id: "t1",
+      text: "note",
+      attachment: { filename: "f.png", b64: "aaaa" },
+    });
+    const parsed = parseBrainEffect(line);
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") {
+      expect(parsed.effect).not.toHaveProperty("attachment");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // JsonlDecoder — chunked / partial-line input
 // ---------------------------------------------------------------------------
 

--- a/src/brain/daemon-brain-host.ts
+++ b/src/brain/daemon-brain-host.ts
@@ -27,7 +27,11 @@
  *      through the per-task hooks: it is host-POLICY (channel binding,
  *      anon-reachable membership gate, rate limit), so this file enforces it
  *      directly and calls an injected {@link CreatePrivateThreadFn} only for
- *      the mechanical create-thread-and-add-members I/O;
+ *      the mechanical create-thread-and-add-members I/O. `post_log`
+ *      (cortex#2256) splits the same way: the POLICY gates (log-channel
+ *      binding, length cap, rate limit) are enforced here, and only a
+ *      gate-passing effect reaches the consumer's `onPostLog` hook — with
+ *      the HOST-derived target channel as an argument, never brain input;
  *   4. enforces, PER TASK (not per process): task_id correlation, scratch
  *      confinement, and the 4 MiB attachment budget (§12.5). Scratch dirs are
  *      created per TASK and removed when the task closes — confinement stays
@@ -207,6 +211,40 @@ export const CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR = 10;
 const CREATE_PRIVATE_THREAD_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
+// `post_log` policy constants (cortex#2256)
+// ---------------------------------------------------------------------------
+
+/**
+ * Rate limit for `post_log`: 10/hour, PER AGENT (cortex#2256) — the same
+ * constant class and sliding-window mechanics as
+ * {@link CREATE_PRIVATE_THREAD_RATE_LIMIT_PER_HOUR}, and a SEPARATE budget
+ * from it (opening threads and notifying the log channel are independent
+ * capabilities; one must not starve the other). Per-agent for the same
+ * structural reason: each {@link DaemonBrainHost} serves exactly one agent.
+ *
+ * The trigger is stranger-influenced for anon-reachable (`openOnboarding`)
+ * agents — notifying humans about strangers is the PRIMARY use case, so those
+ * agents ARE allowed to use `post_log`; this window (plus the length cap) is
+ * what keeps the steward channel unspammable, matching the ADR posture that
+ * host-side enforcement, not brain trust, carries anon safety.
+ */
+export const POST_LOG_RATE_LIMIT_PER_HOUR = 10;
+
+/** The sliding window `POST_LOG_RATE_LIMIT_PER_HOUR` is measured over. */
+const POST_LOG_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Length cap on `post_log.text` (cortex#2256): 2000 chars — Discord's own
+ * message cap. For hybrid brains the text may be model-authored; the cap plus
+ * the FIXED host-derived target keeps the blast radius at "odd words in the
+ * log channel", never routing. Over-cap → `effect_rejected` (`wont_do`:
+ * the same request will never succeed on retry — mirror of the attachment
+ * budget's over-limit refusal), checked BEFORE the rate window so a
+ * refused-anyway request never burns budget.
+ */
+export const POST_LOG_MAX_TEXT_CHARS = 2000;
+
+// ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
 
@@ -285,6 +323,18 @@ export interface DaemonBrainHostOpts {
    */
   createPrivateThread?: CreatePrivateThreadFn;
   /**
+   * cortex#2256 — the log channel a `post_log` effect targets. ALWAYS the
+   * agent's OWN presence binding (`presence.discord.logChannelId` today),
+   * resolved by the CALLER at construction — never supplied by the brain
+   * (the wire effect carries no channel field at all; that absence is
+   * intentional, see `protocol.ts`'s `PostLogEffectSchema`). Undefined ⇒
+   * this agent has no log channel bound; every `post_log` effect is refused
+   * `effect_rejected` (`cant_do` — structural, never resolves on retry
+   * without a config change, same reasoning as `create_private_thread`'s
+   * missing-binding refusal).
+   */
+  logChannelId?: string;
+  /**
    * cortex#2206 — true when this agent is reachable by an unmapped,
    * zero-authority anon principal (`AgentSchema.openOnboarding`,
    * cortex#1165). Gates `create_private_thread`'s `members` field: while
@@ -362,6 +412,15 @@ export class DaemonBrainHost {
    * the PR/issue for why that's an accepted v1 tradeoff).
    */
   private threadCreateAttempts: number[] = [];
+  /** cortex#2256 — see {@link DaemonBrainHostOpts.logChannelId}. */
+  private readonly logChannelId: string | undefined;
+  /**
+   * cortex#2256 — sliding-window timestamps (ms) of accepted `post_log`
+   * ATTEMPTS. Same mechanics (and the same record-before-I/O and
+   * in-memory-only tradeoffs) as {@link threadCreateAttempts}; a SEPARATE
+   * window so log posts and thread creates never starve each other.
+   */
+  private postLogAttempts: number[] = [];
 
   /** Live process + connection for the CURRENT generation. */
   private proc: DaemonBrainProcess | null = null;
@@ -411,6 +470,7 @@ export class DaemonBrainHost {
     this.agentChannelId = opts.agentChannelId;
     this.createPrivateThreadFn = opts.createPrivateThread;
     this.anonReachable = opts.anonReachable ?? true;
+    this.logChannelId = opts.logChannelId;
   }
 
   /** True once the restart budget is exhausted — the consumer stops dispatching. */
@@ -944,6 +1004,92 @@ export class DaemonBrainHost {
         await record.hooks.onPost(e);
         return;
       }
+      case "post_log": {
+        // cortex#2256 — notify THIS agent's own bound log channel. The
+        // effect carries no channel (intentional — protocol.ts); the target
+        // is derived HERE from the agent's own binding, mirroring
+        // `create_private_thread`'s host-derived-target pattern.
+        //
+        // NO liveness-timer pause, deliberately: the pause exists for
+        // effects the BRAIN blocks on awaiting a response event
+        // (`gate_verdict`, `thread_created` — cortex#1073). `post_log` is
+        // fire-and-forget like `post`: there is no success event, the brain
+        // continues immediately, and the host-side publish is a local bus
+        // op — so brain liveness accounting is unaffected, exactly as it is
+        // for the `post` case above.
+        //
+        // 1. Structural: no log-channel binding / no publish hook wired ⇒
+        // this agent simply cannot do this, full stop. cant_do (not
+        // not_now): it will never resolve on retry without a
+        // redeploy/config change (same reasoning as the
+        // `create_private_thread` structural gate — a brain must not burn
+        // budget retrying a capability that can never appear).
+        const logChannelId = this.logChannelId;
+        // `.bind()` (not a bare method reference) so the hook keeps its own
+        // receiver — the lint-enforced unbound-method discipline.
+        const onPostLog = record.hooks.onPostLog?.bind(record.hooks);
+        if (logChannelId === undefined || onPostLog === undefined) {
+          await this.rejectEffect(
+            e.task_id,
+            "post_log",
+            "cant_do",
+            `agent "${this.agentId}" has no log channel binding configured`,
+          );
+          return;
+        }
+
+        // 2. Length cap — checked BEFORE the rate window so a refused-anyway
+        // request never burns budget. wont_do: retrying the same text will
+        // never succeed (mirror of the attachment budget's refusal kind).
+        if (e.text.length > POST_LOG_MAX_TEXT_CHARS) {
+          await this.rejectEffect(
+            e.task_id,
+            "post_log",
+            "wont_do",
+            `post_log text exceeds ${POST_LOG_MAX_TEXT_CHARS} chars ` +
+              `(got ${e.text.length}) — summarise; the log channel is a breadcrumb surface`,
+          );
+          return;
+        }
+
+        // 3. Rate limit — 10/hour/agent (named constant), a real sliding
+        // window, SEPARATE from the thread-create window. Reserved BEFORE
+        // the publish attempt: an attempt costs real delivery budget
+        // whether or not it succeeds (same reserve-before-I/O rule as
+        // `create_private_thread`).
+        if (this.isPostLogRateLimited()) {
+          await this.rejectEffect(
+            e.task_id,
+            "post_log",
+            "policy_denied",
+            `agent "${this.agentId}" exceeded ${POST_LOG_RATE_LIMIT_PER_HOUR} ` +
+              `post_log calls in the past hour`,
+          );
+          return;
+        }
+        this.recordPostLogAttempt();
+
+        // 4. Publish via the consumer hook, handing it the HOST-derived
+        // target. Fire-and-forget on success (no ack event — a lost log
+        // note is a breadcrumb; the agent-state dashboard is the durable
+        // record). A failed/throwing publish is transient ⇒ not_now.
+        let outcome: { ok: true } | { ok: false; detail: string };
+        try {
+          outcome = await onPostLog(e, logChannelId);
+        } catch (hookErr) {
+          outcome = {
+            ok: false,
+            detail: hookErr instanceof Error ? hookErr.message : String(hookErr),
+          };
+        }
+        // The task may have closed while the publish was in flight — never
+        // send a rejection to a closed/replaced task (§7.5).
+        if (record.settled) return;
+        if (!outcome.ok) {
+          await this.rejectEffect(e.task_id, "post_log", "not_now", outcome.detail);
+        }
+        return;
+      }
       case "ask_principal": {
         // PAUSE the per-task liveness timeout while a human gate is open. The
         // timeout exists to fail a HUNG BRAIN, not a thinking human — an open
@@ -1274,6 +1420,23 @@ export class DaemonBrainHost {
   /** Record one `create_private_thread` attempt against this agent's sliding window. */
   private recordThreadCreateAttempt(): void {
     this.threadCreateAttempts.push(this.now());
+  }
+
+  /**
+   * cortex#2256 — true when this agent has already made
+   * {@link POST_LOG_RATE_LIMIT_PER_HOUR} `post_log` ATTEMPTS within the
+   * trailing hour. Same sliding-window mechanics as
+   * {@link isThreadCreateRateLimited}, over its own separate window.
+   */
+  private isPostLogRateLimited(): boolean {
+    const cutoff = this.now() - POST_LOG_RATE_LIMIT_WINDOW_MS;
+    this.postLogAttempts = this.postLogAttempts.filter((t) => t > cutoff);
+    return this.postLogAttempts.length >= POST_LOG_RATE_LIMIT_PER_HOUR;
+  }
+
+  /** Record one `post_log` attempt against this agent's sliding window. */
+  private recordPostLogAttempt(): void {
+    this.postLogAttempts.push(this.now());
   }
 
   /** Write a line to the live connection, swallowing a closed-socket error. */

--- a/src/brain/exec-brain-runner.ts
+++ b/src/brain/exec-brain-runner.ts
@@ -31,6 +31,9 @@
  *        - `create_private_thread` → ALWAYS refused `effect_rejected` (this
  *          lifecycle has no live surface-adapter binding; cortex#2206 is
  *          daemon-lifecycle only — see `daemon-brain-host.ts`)
+ *        - `post_log`      → ALWAYS refused `effect_rejected` (cortex#2256 is
+ *          likewise daemon-lifecycle only — the log-channel binding + rate
+ *          limiter live on the supervising host)
  *        - `log`           → `hooks.onLog`
  *        - `result`        → terminal; resolve.
  *   5. task_id correlation: any effect whose `task_id` ≠ the spawned task's id
@@ -63,6 +66,7 @@ import {
   JsonlDecoder,
   type TaskEvent,
   type PostEffect,
+  type PostLogEffect,
   type AskPrincipalEffect,
   type DispatchEffect,
   type LogEffect,
@@ -178,6 +182,26 @@ export interface BrainTaskHooks {
    * tests that don't care about routing) omit it.
    */
   onThreadCreated?(threadId: string): void | Promise<void>;
+
+  /**
+   * cortex#2256 — a `post_log` effect that PASSED the daemon host's gates
+   * (log-channel binding present, length cap, rate limit). The BrainConsumer
+   * publishes the log-channel `dispatch.task.post` envelope routed at
+   * `logChannelId` — the HOST-derived target passed here so the single
+   * source of the binding stays the host (§5 property 1: the brain never
+   * named it; the hook receives only what the host already decided, the
+   * same shape as `onThreadCreated`'s host-resolved `threadId`).
+   *
+   * Resolves `{ ok: false, detail }` on a failed publish so the host can
+   * refuse the effect `not_now` (transient/retryable); never throws by
+   * contract. OPTIONAL: only the `lifecycle: daemon` host wires `post_log`
+   * (the per-task runner refuses it, same as `create_private_thread`), so
+   * per-task callers and routing-agnostic tests omit it.
+   */
+  onPostLog?(
+    post: PostLogEffect,
+    logChannelId: string,
+  ): Promise<{ ok: true } | { ok: false; detail: string }>;
 }
 
 export type BrainDispatchOutcome =
@@ -602,6 +626,19 @@ export function makeExecBrainRunner(
             "create_private_thread",
             "create_private_thread is not supported by the per-task (lifecycle: per-task) " +
               "exec-brain runner — only daemon-lifecycle brains may open private threads (cortex#2206)",
+          );
+          return;
+        }
+        case "post_log": {
+          // cortex#2256 — daemon-lifecycle only, same reasoning as
+          // `create_private_thread`: the log-channel binding + per-agent
+          // rate limiter live on the supervising DaemonBrainHost, which the
+          // per-task runner has no counterpart for. Refuse rather than
+          // silently no-op.
+          await rejectEffect(
+            "post_log",
+            "post_log is not supported by the per-task (lifecycle: per-task) " +
+              "exec-brain runner — only daemon-lifecycle brains may notify their log channel (cortex#2256)",
           );
           return;
         }

--- a/src/brain/protocol.ts
+++ b/src/brain/protocol.ts
@@ -15,10 +15,11 @@
  *     refused one of the brain's effects), a `thread_created` (the answer to
  *     a `create_private_thread` effect), and the daemon `hello` handshake.
  *   - **Brain → cortex (effects).** Things the brain asks the host to do:
- *     `post` to a surface, `ask_principal` (render a gate), `dispatch` fleet
- *     work, `create_private_thread` (open a private thread off the agent's
- *     own channel binding — cortex#2206), `result` (close the task), and
- *     `log`.
+ *     `post` to a surface, `post_log` (notify the agent's own bound log
+ *     channel — cortex#2256), `ask_principal` (render a gate), `dispatch`
+ *     fleet work, `create_private_thread` (open a private thread off the
+ *     agent's own channel binding — cortex#2206), `result` (close the task),
+ *     and `log`.
  *
  * The brain never sees a platform token, a NATS credential, or another
  * agent's identity (§5 property 1). It *asks* for effects; cortex *performs*
@@ -362,6 +363,7 @@ export type BrainEvent = z.infer<typeof BrainEventSchema>;
 // ---------------------------------------------------------------------------
 
 export const BRAIN_EFFECT_POST = "post" as const;
+export const BRAIN_EFFECT_POST_LOG = "post_log" as const;
 export const BRAIN_EFFECT_ASK_PRINCIPAL = "ask_principal" as const;
 export const BRAIN_EFFECT_DISPATCH = "dispatch" as const;
 export const BRAIN_EFFECT_CREATE_PRIVATE_THREAD = "create_private_thread" as const;
@@ -421,6 +423,30 @@ export const PostEffectSchema = z.object({
   attachment: PostAttachmentSchema.optional(),
 });
 export type PostEffect = z.infer<typeof PostEffectSchema>;
+
+/**
+ * `post_log` — cortex posts `text` to the AGENT'S OWN bound log channel
+ * (cortex#2256). Deliberately carries NO channel field — that absence is
+ * intentional, exactly as {@link CreatePrivateThreadEffectSchema}'s missing
+ * channel is (the cortex#2206 host-derived-target pattern): the brain must
+ * never be able to name an arbitrary channel. The host derives the target
+ * from the agent's own presence binding (`presence.discord.logChannelId`
+ * today) — see `daemon-brain-host.ts`'s `post_log` case for the gates (no
+ * binding → `cant_do`; length cap → `wont_do`; rate limit →
+ * `policy_denied`; adapter/publish failure → `not_now`).
+ *
+ * Success is FIRE-AND-FORGET, like `post` — there is no ack event. A lost
+ * log note is a breadcrumb; the agent-state dashboard stays the durable
+ * record. No attachment in v1. Failures reuse the existing
+ * {@link EffectRejectedEventSchema} verbatim (no new event type).
+ */
+export const PostLogEffectSchema = z.object({
+  v: z.literal(BRAIN_PROTOCOL_VERSION),
+  type: z.literal(BRAIN_EFFECT_POST_LOG),
+  task_id: z.string().min(1),
+  text: z.string(),
+});
+export type PostLogEffect = z.infer<typeof PostLogEffectSchema>;
 
 /**
  * `ask_principal` — render a gate. Cortex enforces the principal check; the
@@ -538,6 +564,7 @@ export type LogEffect = z.infer<typeof LogEffectSchema>;
  */
 export const BrainEffectSchema = z.discriminatedUnion("type", [
   PostEffectSchema,
+  PostLogEffectSchema,
   AskPrincipalEffectSchema,
   DispatchEffectSchema,
   CreatePrivateThreadEffectSchema,
@@ -569,6 +596,7 @@ export type ParseBrainEffectResult =
 /** The known brain → cortex effect `type` literals, for the tolerance gate. */
 const KNOWN_EFFECT_TYPES: ReadonlySet<string> = new Set([
   BRAIN_EFFECT_POST,
+  BRAIN_EFFECT_POST_LOG,
   BRAIN_EFFECT_ASK_PRINCIPAL,
   BRAIN_EFFECT_DISPATCH,
   BRAIN_EFFECT_CREATE_PRIVATE_THREAD,

--- a/src/bus/__tests__/brain-consumer.post-log.test.ts
+++ b/src/bus/__tests__/brain-consumer.post-log.test.ts
@@ -1,0 +1,277 @@
+/**
+ * cortex#2256 — `post_log` end-to-end at the consumer seam, integration
+ * level: REAL `BrainConsumer` (its real `makeHooks` post + post_log routing)
+ * + REAL `DaemonBrainHost` (its real post_log policy gates) + a fake brain.
+ * No real NATS, socket, subprocess, or Discord. Mirrors
+ * `brain-consumer.thread-retarget.test.ts`'s harness.
+ *
+ * What this proves (the issue's integration criterion): a surface-style flow
+ * lands ONE message routed at the agent's bound LOG channel while a normal
+ * `post` still routes to the task's origin thread — and the log routing is
+ * host-derived (`presence.discord.logChannelId` → `DaemonBrainHost.logChannelId`),
+ * never brain input. Also: the log note is channel-only (no thread_id) and is
+ * NOT dragged along by a cortex#2248 thread retarget.
+ *
+ * All ids are obviously-fake, non-numeric placeholders (confidentiality
+ * gate — never a realistic-looking digit snowflake).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  BrainConsumer,
+  buildBrainTaskPayload,
+  buildDispatchTaskEnvelope,
+  type BrainConsumerAgent,
+} from "../brain-consumer";
+import type { Envelope } from "../myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../myelin/runtime";
+import type { SystemEventSource } from "../system-events";
+import { DaemonBrainHost } from "../../brain/daemon-brain-host";
+import {
+  FakeDaemonBrain,
+  singleFakeDaemonTransport,
+} from "../../brain/__tests__/fake-daemon-brain";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SOURCE: SystemEventSource = {
+  principal: "test-op",
+  agent: "cortex",
+  instance: "local",
+};
+
+const FAKE_ARRIVALS_CHANNEL = "arrivals-channel-fake-for-test";
+const FAKE_ADAPTER_INSTANCE = "escort-discord";
+const FAKE_AGENT_CHANNEL = "agent-channel-fake-for-test";
+const FAKE_LOG_CHANNEL = "stewards-log-channel-fake-for-test";
+const FAKE_THREAD_ID = "created-thread-fake-for-test";
+const FAKE_NEWCOMER = "newcomer-fake-for-test";
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  const handlers = new Set<EnvelopeHandler>();
+  return {
+    enabled: false,
+    published,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
+function buildAgent(): BrainConsumerAgent {
+  return {
+    id: "escort-like",
+    capabilities: ["chat"],
+    dispatchCapabilities: [],
+  };
+}
+
+/** The mention-shaped brain task envelope `dispatchInboundToBrain` publishes. */
+function mentionEnvelope(): Envelope {
+  return buildDispatchTaskEnvelope({
+    source: SOURCE,
+    capability: "chat",
+    family: "brain",
+    payload: buildBrainTaskPayload({
+      text: "I think I'm ready",
+      user: FAKE_NEWCOMER,
+      surface: "discord",
+      channel: FAKE_ARRIVALS_CHANNEL,
+      thread: FAKE_ARRIVALS_CHANNEL,
+      adapterInstance: FAKE_ADAPTER_INSTANCE,
+    }),
+  });
+}
+
+/** Wait until `cond()` is true (poll), or throw after `timeoutMs`. */
+async function until(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("until() timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+function posts(runtime: RecordingRuntime): Envelope[] {
+  return runtime.published.filter((e) => e.type === "dispatch.task.post");
+}
+
+function routingOf(e: Envelope | undefined): Record<string, unknown> | undefined {
+  const r = e?.payload.response_routing;
+  return r !== null && typeof r === "object" ? (r as Record<string, unknown>) : undefined;
+}
+
+/** A consumer + daemon host + fake brain wired like the escort deployment. */
+async function makeStack(opts: {
+  withLogChannel: boolean;
+  withThreadCapability?: boolean;
+}): Promise<{
+  runtime: RecordingRuntime;
+  brain: FakeDaemonBrain;
+  consumer: BrainConsumer;
+  host: DaemonBrainHost;
+}> {
+  const runtime = createRecordingRuntime();
+  const brain = new FakeDaemonBrain();
+  const host = new DaemonBrainHost({
+    agentId: "escort-like",
+    run: "bun b.ts",
+    packDir: "/p",
+    transport: singleFakeDaemonTransport(brain),
+    ...(opts.withLogChannel && { logChannelId: FAKE_LOG_CHANNEL }),
+    ...(opts.withThreadCapability === true && {
+      agentChannelId: FAKE_AGENT_CHANNEL,
+      anonReachable: true,
+      createPrivateThread: async () => ({ ok: true as const, threadId: FAKE_THREAD_ID }),
+    }),
+  });
+  await host.start();
+  const consumer = new BrainConsumer({
+    agent: buildAgent(),
+    source: SOURCE,
+    runtime,
+    daemonHost: host,
+  });
+  return { runtime, brain, consumer, host };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("brain-consumer — post_log routing (cortex#2256)", () => {
+  test("surface flow: one post lands in the origin thread AND one post_log lands routed at the LOG channel (channel only, no thread)", async () => {
+    const { runtime, brain, consumer } = await makeStack({ withLogChannel: true });
+
+    const decisionP = consumer.processEnvelope(mentionEnvelope(), "subj", null, "chat");
+    await until(() => brain.hasTask());
+    const tid = brain.taskId();
+
+    // The normal in-thread reply — routed to the task's origin exactly as today.
+    brain.emit(
+      JSON.stringify({ v: 1, type: "post", task_id: tid, text: "the three things look done" }),
+    );
+    // The steward note — the brain names NO channel; the host derives it.
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "post_log",
+        task_id: tid,
+        text: "newcomer is ready for review",
+      }),
+    );
+    await until(() => posts(runtime).length === 2);
+
+    const [threadPost, logPost] = posts(runtime);
+    expect(routingOf(threadPost)).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_ARRIVALS_CHANNEL,
+      thread_id: FAKE_ARRIVALS_CHANNEL,
+    });
+    expect(threadPost?.payload.text).toBe("the three things look done");
+
+    // The log post: SAME adapter instance (the agent's own), DIFFERENT
+    // channel (the bound log channel), and NO thread_id — a log note goes
+    // to the channel, never a thread.
+    expect(routingOf(logPost)).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_LOG_CHANNEL,
+    });
+    expect(logPost?.payload.text).toBe("newcomer is ready for review");
+
+    // No rejection went back — the effect passed every gate.
+    expect(brain.hasEvent("effect_rejected")).toBe(false);
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: tid, status: "complete" }));
+    const decision = await decisionP;
+    expect(decision).toEqual({ kind: "ack" });
+    await consumer.stop();
+  });
+
+  test("a cortex#2248 thread retarget does NOT drag post_log into the created thread — log notes stay channel-only", async () => {
+    const { runtime, brain, consumer } = await makeStack({
+      withLogChannel: true,
+      withThreadCapability: true,
+    });
+
+    const decisionP = consumer.processEnvelope(mentionEnvelope(), "subj", null, "chat");
+    await until(() => brain.hasTask());
+    const tid = brain.taskId();
+
+    // Open the private thread; subsequent task posts retarget into it.
+    brain.emit(
+      JSON.stringify({
+        v: 1,
+        type: "create_private_thread",
+        task_id: tid,
+        name: "welcome newcomer",
+        members: "source",
+      }),
+    );
+    await until(() => brain.hasEvent("thread_created"));
+
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: tid, text: "in the thread" }));
+    brain.emit(JSON.stringify({ v: 1, type: "post_log", task_id: tid, text: "steward note" }));
+    await until(() => posts(runtime).length === 2);
+
+    const [threadPost, logPost] = posts(runtime);
+    // The task post followed the retarget into the created thread…
+    expect(routingOf(threadPost)).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_ARRIVALS_CHANNEL,
+      thread_id: FAKE_THREAD_ID,
+    });
+    // …but the log note did not: channel-only, at the log channel.
+    expect(routingOf(logPost)).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_LOG_CHANNEL,
+    });
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: tid, status: "complete" }));
+    await decisionP;
+    await consumer.stop();
+  });
+
+  test("no logChannelId bound → effect_rejected cant_do; no log envelope published; task posts and lifecycle unaffected", async () => {
+    const { runtime, brain, consumer } = await makeStack({ withLogChannel: false });
+
+    const decisionP = consumer.processEnvelope(mentionEnvelope(), "subj", null, "chat");
+    await until(() => brain.hasTask());
+    const tid = brain.taskId();
+
+    brain.emit(JSON.stringify({ v: 1, type: "post_log", task_id: tid, text: "goes nowhere" }));
+    await until(() => brain.hasEvent("effect_rejected"));
+    const rej = brain.received.find((e) => e.type === "effect_rejected");
+    expect(rej).toMatchObject({ type: "effect_rejected", effect: "post_log" });
+    if (rej?.type === "effect_rejected") {
+      expect(rej.reason.kind).toBe("cant_do");
+    }
+
+    // The in-thread flow is untouched by the refusal.
+    brain.emit(JSON.stringify({ v: 1, type: "post", task_id: tid, text: "still fine" }));
+    await until(() => posts(runtime).length === 1);
+    expect(routingOf(posts(runtime)[0])).toEqual({
+      adapter_instance: FAKE_ADAPTER_INSTANCE,
+      channel_id: FAKE_ARRIVALS_CHANNEL,
+      thread_id: FAKE_ARRIVALS_CHANNEL,
+    });
+
+    brain.emit(JSON.stringify({ v: 1, type: "result", task_id: tid, status: "complete" }));
+    const decision = await decisionP;
+    expect(decision).toEqual({ kind: "ack" });
+    await consumer.stop();
+  });
+});

--- a/src/bus/brain-consumer.ts
+++ b/src/bus/brain-consumer.ts
@@ -103,6 +103,7 @@ import type {
   TaskEvent,
   TaskSource,
   PostEffect,
+  PostLogEffect,
   AskPrincipalEffect,
   DispatchEffect,
   ResultEffect,
@@ -806,6 +807,51 @@ export class BrainConsumer {
           }),
           "dispatch.task.post",
         );
+      },
+
+      // `post_log` (cortex#2256) — publish a `dispatch.task.post` envelope
+      // routed at the agent's own LOG CHANNEL, not the task's origin. The
+      // daemon host already enforced every policy gate (binding present,
+      // length cap, rate limit) and passes the HOST-derived `logChannelId`
+      // — the brain never named a channel (§5 property 1). Routing details:
+      //   - channel: the log channel; thread: "" — a log note goes to the
+      //     CHANNEL, never a thread (and deliberately NOT the task's
+      //     retargetable `brainPostSource`, so a cortex#2248 thread
+      //     retarget never drags log notes into the newcomer's thread);
+      //   - adapter_instance/surface/user: from the ORIGINAL task source —
+      //     the same adapter the agent is bound to, so the chat
+      //     dispatch-sink delivers it (routing is data; the sink honors a
+      //     channel different from the task origin).
+      // Returns the publish success flag so the host can refuse `not_now`
+      // on a dropped publish — unlike `onPost` (a lost task-thread post is
+      // pure breadcrumb), the host wants to TELL the brain a log note was
+      // lost, since there is no success ack to miss.
+      onPostLog: async (
+        post: PostLogEffect,
+        logChannelId: string,
+      ): Promise<{ ok: true } | { ok: false; detail: string }> => {
+        const ok = await this.safePublish(
+          createDispatchTaskPostEvent({
+            source: this.source,
+            taskId: crypto.randomUUID(),
+            agentId: this.agent.id,
+            correlationId: post.task_id,
+            text: post.text,
+            taskSource: {
+              surface: source.surface,
+              channel: logChannelId,
+              thread: "",
+              user: source.user,
+              ...(source.adapter_instance !== undefined && {
+                adapter_instance: source.adapter_instance,
+              }),
+            },
+          }),
+          "dispatch.task.post(log)",
+        );
+        return ok
+          ? { ok: true }
+          : { ok: false, detail: "log-channel post publish failed" };
       },
 
       // `ask_principal` — resolve through the pluggable principal gate. B-1's

--- a/src/runner/brain-consumer-boot.ts
+++ b/src/runner/brain-consumer-boot.ts
@@ -134,6 +134,15 @@ export interface BrainBootAgent {
     discord?: {
       /** `presence.discord.agentChannelId` — the agent's own bound channel. */
       agentChannelId?: string;
+      /**
+       * cortex#2256 — `presence.discord.logChannelId`: the agent's bound
+       * back-office/log channel, the host-derived target of the `post_log`
+       * effect. Wired to the `DaemonBrainHost` whenever bound — unlike
+       * `create_private_thread`, NOT gated on `openOnboarding` (notifying
+       * humans is wanted for trusted and anon-reachable agents alike; the
+       * host's rate/length gates carry the anon safety).
+       */
+      logChannelId?: string;
     };
   };
   runtime?: {
@@ -443,6 +452,13 @@ export function wireBrainConsumers(
       const isOpenOnboarding = agent.openOnboarding === true;
       const wireCreatePrivateThread =
         isOpenOnboarding && discordAgentChannelId !== undefined;
+      // cortex#2256 — the `post_log` target. Wired whenever the binding
+      // exists, with NO `openOnboarding` gate (deliberate asymmetry vs
+      // `create_private_thread` above): notifying humans on the agent's own
+      // log channel is wanted for trusted and anon-reachable agents alike,
+      // and the host's rate/length gates are what carry anon safety (the
+      // effect can only ever reach this one host-derived channel).
+      const discordLogChannelId = agent.presence?.discord?.logChannelId;
 
       let daemonHost: DaemonBrainHost | undefined;
       let consumer: BrainConsumer;
@@ -470,6 +486,10 @@ export function wireBrainConsumers(
               agent.id,
               opts.agentPlatformAdapters,
             ),
+          }),
+          // cortex#2256 — see the `discordLogChannelId` computation above.
+          ...(discordLogChannelId !== undefined && {
+            logChannelId: discordLogChannelId,
           }),
           // On degradation (restart budget exhausted) surface the agent via the
           // presence producer's capability-change signal (drop to empty caps),


### PR DESCRIPTION
## What

Adds the `cortex-brain/v1` **`post_log`** effect — a daemon brain can now notify its agent's own bound back-office/log channel. Second consumer of the cortex#2206 host-derived-target pattern: the wire effect is `{ v: 1, type: "post_log", task_id, text }` with **no channel field at all**; the HOST derives the target from the agent's own `presence.discord.logChannelId` binding. First real consumer: the guildhall escort's `surface()` step (guild-side issue filed).

## How

- **`protocol.ts`** — `PostLogEffectSchema`, union + known-types registration. Tolerant ingest strips a smuggled `channel`/`thread`/`attachment` field before host policy ever sees it (structurally impossible, not merely refused — pinned by test).
- **`daemon-brain-host.ts`** — host policy gates, mirroring `create_private_thread`'s named-constant + sliding-window mechanics:
  - no `logChannelId` bound → `effect_rejected` `cant_do` (structural, never resolves on retry);
  - text over `POST_LOG_MAX_TEXT_CHARS` (2000, Discord's cap) → `wont_do`, checked before the rate window so a refused request never burns budget;
  - `POST_LOG_RATE_LIMIT_PER_HOUR` (10/hour/agent, its own separate sliding window) → `policy_denied`;
  - failed/throwing publish → `not_now`.
  - Success is **fire-and-forget** — no ack event; a lost log note is a breadcrumb, the agent-state dashboard stays the durable record.
  - **No liveness-timer pause**, verified reading: the pause (cortex#1073) exists for effects the *brain blocks on* awaiting a response event (`gate_verdict`, `thread_created`). `post_log` has no response event — the brain continues immediately and the host-side publish is a local bus op, exactly like `post`.
- **`brain-consumer.ts`** — new optional `onPostLog` hook builds the outbound `dispatch.task.post` envelope with `response_routing` at the HOST-passed log channel: channel only, **no thread**, original task source's `adapter_instance`. Deliberately not the retargetable per-task post source, so a cortex#2248 thread retarget never drags log notes into the newcomer's thread (pinned by test).
- **`brain-consumer-boot.ts`** — plumbs `presence.discord.logChannelId` → host, with **no `openOnboarding` gate** (deliberate asymmetry vs `create_private_thread`): anon-reachable agents are the primary use case; the host's rate/length gates carry anon safety per the issue/ADR posture.
- **`exec-brain-runner.ts`** — per-task lifecycle refuses `post_log` (`effect_rejected`), same as `create_private_thread`.
- **Docs** — `docs/design-bot-packs.md` wire grammar lists the new effect (CONTEXT.md carries no brain-effect enumeration — checked).
- Surface-SDK `.d.ts`: `sdk:dts:check` in sync, no regen needed.

## Dispatch-sink routing verification

The chat dispatch-sink treats `response_routing` as pure data (`readResponseRouting` → `channel_id`/`thread_id`; no origin comparison), so a routing channel different from the task origin is honored. Pinned with a new test so it cannot regress into origin-validation.

## Tests

- Host unit (daemon-brain-host.test.ts): unbound → `cant_do`; over-cap → `wont_do` (boundary at exactly 2000 passes; over-cap burns no rate slot); rate trips at exactly 10/hour per agent → `policy_denied`, window slides, second agent unaffected; failed and throwing publish → `not_now`; success fire-and-forget with the host-derived channel handed to the hook; smuggled `channel` field stripped.
- Protocol (protocol.test.ts): round-trip, required fields, channel/attachment stripping.
- Integration (new `brain-consumer.post-log.test.ts`, real consumer + real host + fake brain): surface-style flow lands ONE post routed to the origin thread AND ONE post_log routed at the log channel (channel-only); thread-retarget does not drag the log note; unbound refusal leaves the in-thread flow and lifecycle untouched.
- Dispatch-sink (dispatch-sink.test.ts): divergent-channel routing delivery.

`bunx tsc --noEmit`, `lint:errors`, carve-outs, wire-vocab, shippable-hygiene, `sdk:dts:check` all green. Full `bun test`: the only failures are the 12 pre-existing environment failures also present on a clean `origin/main` worktree (startCortex wire-up / capability-boot / SurfaceContext hook — unrelated files).

Closes #2256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01247nwyEPNLjDJJXU9fqZAD
