### PR TITLE
fix(quickstart): sync scaffolded configs with runtime + web adapter, surface bus-connect failures; bump 6.10.2

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.10.1"
+version: "6.10.2"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin layer model"

--- a/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-make-live-cli.test.ts
@@ -356,4 +356,24 @@ describe("cortex network make-live — credsPath write-back (v5.30.2, C-1265c)",
     expect(res.exitCode).toBe(0);
     expect(configWrites).toHaveLength(0);
   });
+
+  // cortex#2264 REGRESSION GUARD: Fix 1 removed the LIVE `nats.credsPath` from
+  // the `cortex stack create` scaffold, so a from-scratch federation-ready stack
+  // now reaches make-live with `config.nats` carrying NO credsPath (exactly the
+  // UNSEEDED_CREDS fixture). Federation MUST still end up with a credsPath —
+  // make-live derives the `-bot` default AND persists it. This asserts the scaffold
+  // change does NOT regress the federation write-back path.
+  test("cortex#2264: a stack scaffolded WITHOUT credsPath still gets one minted + written on make-live --apply", async () => {
+    const { factory, configWrites } = fakeFactory();
+    const res = await run(
+      ["make-live", "community", "--config", "/x/community.yaml", "--apply"],
+      UNSEEDED_CREDS, // the post-Fix-1 scaffold state: config.nats has NO credsPath
+      factory,
+    );
+    expect(res.exitCode).toBe(0);
+    // Federation is NOT regressed: exactly one credsPath write-back, carrying the
+    // derived `-bot` bus/bot path — the daemon config ends up WITH a credsPath.
+    expect(configWrites).toHaveLength(1);
+    expect(configWrites[0]?.credsPath).toBe(BUS_CREDS_DEFAULT);
+  });
 });

--- a/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
@@ -520,11 +520,21 @@ describe("detectBusConnectFailure (cortex#2264)", () => {
     expect(surfaced).toContain("ENOENT");
   });
 
-  test("BUS_CONNECT_FAILURE_MARKER matches runtime.ts's literal marker", () => {
+  test("BUS_CONNECT_FAILURE_MARKER matches runtime.ts's PRIMARY-down marker", () => {
     expect("myelin-runtime: failed to connect — continuing without NATS: x".includes(BUS_CONNECT_FAILURE_MARKER)).toBe(
       true,
     );
     expect("myelin-runtime: connected to nats at …".includes(BUS_CONNECT_FAILURE_MARKER)).toBe(false);
+  });
+
+  // cortex#2264 — the marker must NOT over-match a per-network LEAF failure
+  // (runtime.ts:1039), which is a NON-fatal degradation ("primary unaffected").
+  // Tripping the gate on it would false-fail an otherwise-healthy primary bus.
+  test("does NOT match a non-fatal LEAF connect failure (primary unaffected)", () => {
+    const leafLine =
+      'myelin-runtime: failed to connect leaf "halden" (network=halden) at nats://10.0.0.9:4222 — that network is dark; primary unaffected; scheduling background reconnect: ECONNREFUSED';
+    expect(leafLine.includes(BUS_CONNECT_FAILURE_MARKER)).toBe(false);
+    expect(detectBusConnectFailure(["Stack: x", leafLine, "connected to nats"].join("\n"))).toBeUndefined();
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart-lib.test.ts
@@ -16,11 +16,15 @@ import { describe, test, expect, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { parse as parseYaml } from "yaml";
 
 import {
+  BUS_CONNECT_FAILURE_MARKER,
   CTX_REQUIRED_KEYS,
   CTX_WEB_REQUIRED_KEYS,
+  daemonErrorLogPath,
   daemonLogPath,
+  detectBusConnectFailure,
   evaluateHealthyBootGate,
   gatePassed,
   natsConfPath,
@@ -36,6 +40,7 @@ import {
   validateWebEnvContract,
   writeWebSurfacesYaml,
 } from "../quickstart-lib";
+import { WebBindingSchema } from "../../../../adapters/__tests__/fixtures/metafactory-cortex-adapter-web/src/schema";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -480,6 +485,50 @@ test("daemonLogPath matches §5's target path shape", () => {
 });
 
 // =============================================================================
+// cortex#2264 — daemonErrorLogPath + bus-connect-failure detection
+// =============================================================================
+
+describe("daemonErrorLogPath (cortex#2264)", () => {
+  test("is the .error.log SIBLING of daemonLogPath (matches the cortex@.service StandardError path)", () => {
+    expect(daemonErrorLogPath("/home/andreas", "work")).toBe(
+      "/home/andreas/.local/state/metafactory/cortex/logs/cortex-work.error.log",
+    );
+    // Sibling invariant: same dir, `.error.log` where the gate log is `.log`.
+    expect(daemonErrorLogPath("/home/andreas", "work")).toBe(
+      daemonLogPath("/home/andreas", "work").replace(/\.log$/, ".error.log"),
+    );
+  });
+});
+
+describe("detectBusConnectFailure (cortex#2264)", () => {
+  test("undefined log (error-log not written) → no failure detected", () => {
+    expect(detectBusConnectFailure(undefined)).toBeUndefined();
+  });
+
+  test("an error log with no connect-failure marker → no failure detected", () => {
+    expect(detectBusConnectFailure("some unrelated stderr noise\nanother line\n")).toBeUndefined();
+  });
+
+  test("surfaces the FULL failure line (marker + underlying error on one console.error line)", () => {
+    // The exact shape runtime.ts logs via console.error — marker + err on one line.
+    const line =
+      'myelin-runtime: failed to connect — continuing without NATS: ENOENT: no such file or directory, open \'~/.config/nats/work-bot.creds\'';
+    const errorLog = ["some earlier boot noise", line, "trailing line"].join("\n");
+    const surfaced = detectBusConnectFailure(errorLog);
+    expect(surfaced).toBe(line);
+    // The surfaced line carries the actual root-cause error, not just the marker.
+    expect(surfaced).toContain("ENOENT");
+  });
+
+  test("BUS_CONNECT_FAILURE_MARKER matches runtime.ts's literal marker", () => {
+    expect("myelin-runtime: failed to connect — continuing without NATS: x".includes(BUS_CONNECT_FAILURE_MARKER)).toBe(
+      true,
+    );
+    expect("myelin-runtime: connected to nats at …".includes(BUS_CONNECT_FAILURE_MARKER)).toBe(false);
+  });
+});
+
+// =============================================================================
 // cortex#2153 — web surface env contract
 // =============================================================================
 
@@ -604,6 +653,30 @@ describe("renderWebSurfacesYaml", () => {
     expect(yaml).toContain(`token: "${WEB_SECRET}"`);
     // NO discord binding is written.
     expect(yaml).not.toContain("discord:");
+  });
+
+  // cortex#2264 — the web adapter schema REQUIRES broadcastUrl (http/https, min
+  // length 1). The scaffold must emit it, derived from the ingress host/port.
+  test("cortex#2264: emits a broadcastUrl derived from host/port", () => {
+    const yaml = renderWebSurfacesYaml(WEB_INPUTS);
+    expect(yaml).toContain("broadcastUrl: http://127.0.0.1:8090/broadcast");
+  });
+
+  test("cortex#2264: the rendered binding PASSES the real WebBindingSchema (broadcastUrl present + http/https)", () => {
+    const yaml = renderWebSurfacesYaml(WEB_INPUTS);
+    const parsed = parseYaml(yaml) as {
+      surfaces: { web: { binding: Record<string, unknown> }[] };
+    };
+    const binding = parsed.surfaces.web[0]?.binding;
+    // The authoritative cross-check: validate the scaffolded binding against the
+    // metafactory-cortex-adapter-web bundle's own WebBindingSchema (the schema the
+    // daemon's registry pass runs at boot). Pre-fix this FAILED on the missing
+    // required broadcastUrl.
+    const result = WebBindingSchema.safeParse(binding);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.broadcastUrl).toMatch(/^https?:\/\/.+/);
+    }
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -182,7 +182,10 @@ interface FakeOverrides {
   daemonReload?: () => CommandResult;
   enableNow?: (units: string[]) => CommandResult;
   provisionSeed?: () => CommandResult;
-  readLog?: () => string | undefined;
+  // cortex#2264 — takes the polled path so a test can return DIFFERENT content
+  // for the main `.log` vs the `.error.log` sibling. Existing zero-arg lambdas
+  // stay assignable (a `() => T` satisfies `(p: string) => T`).
+  readLog?: (logPath: string) => string | undefined;
   fetchHealthz?: () => Promise<boolean>;
 }
 
@@ -494,6 +497,71 @@ describe("dispatchQuickstart — step 8 gate", () => {
     expect(res.stdout).toContain("timed out after 5000ms");
     expect(res.stdout).toContain("✗ Stack:");
     expect(res.stdout).toContain("✗ nats /healthz");
+  });
+
+  // cortex#2264 — a bus-connect failure lands in the .error.log SIBLING, not
+  // the polled .log. The gate must FAIL FAST surfacing the real error, never
+  // silently burn the whole timeout window.
+  test("cortex#2264: a bus-connect failure in the .error.log fast-fails and surfaces the real error", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const FAILURE_LINE =
+      "myelin-runtime: failed to connect — continuing without NATS: ENOENT: no such file or directory, open '~/.config/nats/work-bot.creds'";
+    let sleepCalls = 0;
+    const res = await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(
+        // A LONG timeout: a pre-fix silent-wait would burn the full window.
+        ["--config-dir", configDir, "--nats-dir", natsDir, "--gate-timeout-ms", "600000"],
+        () => {
+          const ports = fakePorts({
+            // Main .log carries a PARTIAL boot (no "connected to nats" — the
+            // connect failed), so the success gate never passes; the .error.log
+            // sibling carries the real failure. nats-server itself is up →
+            // healthz true (exactly the bench repro: bus dark, nats alive).
+            readLog: (p: string) => (p.endsWith(".error.log") ? FAILURE_LINE : "Stack: andreas/work\npolicy-engine active\n"),
+            fetchHealthz: () => Promise.resolve(true),
+          });
+          // Count sleeps to prove we did NOT poll the full window.
+          const origSleep = ports.gate.sleep;
+          ports.gate.sleep = (ms: number) => {
+            sleepCalls++;
+            return origSleep(ms);
+          };
+          return ports;
+        },
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    // FAST-FAIL: not the silent timeout message.
+    expect(res.stdout).not.toContain("timed out after");
+    // The ACTUAL error is surfaced, with its root cause.
+    expect(res.stdout).toContain("bus connect FAILED");
+    expect(res.stdout).toContain(FAILURE_LINE);
+    expect(res.stdout).toContain(".error.log");
+    // It fast-failed on the FIRST poll — no wait-window burn.
+    expect(sleepCalls).toBe(0);
+  });
+
+  // cortex#2264 staleness guard — a healthy current boot must PASS even if a
+  // stale prior-boot failure lingers in the appended .error.log.
+  test("cortex#2264: a healthy boot PASSES even with a stale failure in the appended .error.log", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const STALE_FAILURE = "myelin-runtime: failed to connect — continuing without NATS: (a PRIOR boot's failure)";
+    const res = await withEnv(validCtxEnv(), () =>
+      dispatchQuickstart(
+        ["--config-dir", configDir, "--nats-dir", natsDir, "--gate-timeout-ms", "5000"],
+        () =>
+          fakePorts({
+            // Main log is fully healthy; the error log still holds a stale failure.
+            readLog: (p: string) => (p.endsWith(".error.log") ? STALE_FAILURE : FULL_HEALTHY_LOG),
+            fetchHealthz: () => Promise.resolve(true),
+          }),
+      ),
+    );
+    // The success gate is checked FIRST, so the stale failure never masks it.
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).not.toContain("bus connect FAILED");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -38,6 +38,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { dispatchQuickstart } from "../quickstart";
+import { daemonErrorLogPath } from "../quickstart-lib";
 import type {
   CommandResult,
   GatePort,
@@ -181,6 +182,9 @@ interface FakeOverrides {
   unitFileExists?: (unit: string) => boolean;
   daemonReload?: () => CommandResult;
   enableNow?: (units: string[]) => CommandResult;
+  // cortex#2264 — records the error-log truncation step 7 performs before the
+  // (re)start (so a test can assert it ran, with what path, and in what order).
+  truncateErrorLog?: (errorLogPath: string) => void;
   provisionSeed?: () => CommandResult;
   // cortex#2264 — takes the polled path so a test can return DIFFERENT content
   // for the main `.log` vs the `.error.log` sibling. Existing zero-arg lambdas
@@ -199,6 +203,7 @@ function fakePorts(overrides: FakeOverrides = {}): QuickstartPorts {
   const service: ServicePort = {
     unitFileExists: overrides.unitFileExists ?? (() => true),
     daemonReload: overrides.daemonReload ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
+    truncateErrorLog: overrides.truncateErrorLog ?? (() => {}),
     enableNow: overrides.enableNow ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
   };
   const provision: ProvisionPort = {
@@ -542,26 +547,78 @@ describe("dispatchQuickstart — step 8 gate", () => {
     expect(sleepCalls).toBe(0);
   });
 
-  // cortex#2264 staleness guard — a healthy current boot must PASS even if a
-  // stale prior-boot failure lingers in the appended .error.log.
-  test("cortex#2264: a healthy boot PASSES even with a stale failure in the appended .error.log", async () => {
+  // cortex#2264 STALENESS (the realistic window the adversarial review caught):
+  // a fresh boot the gate actually WAITS on — main log partial on poll 1, healthy
+  // on poll 2 — with a STALE prior-boot failure line in the append-mode
+  // .error.log. Step 7 truncates that .error.log before the (re)start, so the gate
+  // must PASS on poll 2 and NEVER fast-fail on the stale line at poll 1.
+  test("cortex#2264: a fresh boot with a partial→healthy log PASSES despite a stale .error.log failure (step 7 truncated it)", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
     const STALE_FAILURE = "myelin-runtime: failed to connect — continuing without NATS: (a PRIOR boot's failure)";
-    const res = await withEnv(validCtxEnv(), () =>
-      dispatchQuickstart(
-        ["--config-dir", configDir, "--nats-dir", natsDir, "--gate-timeout-ms", "5000"],
-        () =>
-          fakePorts({
-            // Main log is fully healthy; the error log still holds a stale failure.
-            readLog: (p: string) => (p.endsWith(".error.log") ? STALE_FAILURE : FULL_HEALTHY_LOG),
-            fetchHealthz: () => Promise.resolve(true),
-          }),
+    // Append-mode error log: starts with the stale prior-boot failure. Step 7's
+    // truncate clears it before the daemon (re)starts.
+    let errorLogContent = STALE_FAILURE;
+    let mainPolls = 0;
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--gate-timeout-ms", "600000"],
+          () =>
+            fakePorts({
+              // Step 7 (Linux) truncates the append-mode error log before restart.
+              truncateErrorLog: () => {
+                errorLogContent = "";
+              },
+              readLog: (p: string) => {
+                if (p.endsWith(".error.log")) return errorLogContent;
+                mainPolls++;
+                // Poll 1: fresh daemon not yet connected (partial). Poll 2+: healthy.
+                return mainPolls >= 2 ? FULL_HEALTHY_LOG : "Stack: andreas/work\npolicy-engine active\n";
+              },
+              // nats-server up throughout (bench repro shape).
+              fetchHealthz: () => Promise.resolve(true),
+            }),
+        ),
       ),
     );
-    // The success gate is checked FIRST, so the stale failure never masks it.
+    // Truncation cleared the stale line before the gate ran → no false fast-fail;
+    // the gate waits one poll and PASSES on the now-healthy boot.
     expect(res.exitCode).toBe(0);
     expect(res.stdout).not.toContain("bus connect FAILED");
+    expect(res.stdout).toContain("Healthy-boot gate ✓");
+  });
+
+  // cortex#2264 — step 7 truncates the daemon's append-mode .error.log at the
+  // EXACT daemonErrorLogPath, BEFORE it (re)starts the daemon (enable --now).
+  test("cortex#2264: step 7 truncates the .error.log (correct path) before enable --now", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const calls: string[] = [];
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              truncateErrorLog: (p: string) => calls.push(`truncate:${p}`),
+              enableNow: (u: string[]) => {
+                calls.push(`enable:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    const expectedPath = daemonErrorLogPath(process.env.HOME ?? "", "work");
+    // Truncation happened, targeting the exact daemonErrorLogPath…
+    expect(calls).toContain(`truncate:${expectedPath}`);
+    // …and it happened BEFORE the (re)start.
+    const truncIdx = calls.findIndex((c) => c.startsWith("truncate:"));
+    const enableIdx = calls.findIndex((c) => c.startsWith("enable:"));
+    expect(truncIdx).toBeGreaterThanOrEqual(0);
+    expect(enableIdx).toBeGreaterThan(truncIdx);
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -11,6 +11,7 @@ import { describe, test, expect, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { parse as parseYaml } from "yaml";
 
 import {
   discoverStacks,
@@ -145,18 +146,36 @@ describe("renderScaffold", () => {
     expect(stack?.contents).toContain("assistant");
   });
 
-  test("system/system.yaml seeds the bus/bot credsPath (~/.config/nats/<slug>-bot.creds), distinct from the federation default", () => {
-    // v5.30.2 (C-1265c): a from-scratch stack carries nats.credsPath explicitly,
-    // so `cortex network make-live` needs no --creds flag. The path is the
-    // daemon's OWN bus/bot creds under the agents account. The `-bot` suffix is
-    // load-bearing: it keeps this DISTINCT from provision's federation-user
-    // default `~/.config/nats/<slug>.creds` (different NATS account → must be a
-    // different file, or the second mint clobbers the first).
+  test("system/system.yaml does NOT emit a LIVE bus/bot credsPath a single-stack never mints (cortex#2264)", () => {
+    // cortex#2264: a from-scratch, NON-federated scaffold must NOT ship an
+    // active `nats.credsPath` — a single-stack quickstart never runs
+    // `cortex network make-live`, so `<slug>-bot.creds` is never minted, and a
+    // live path made the runtime fail the bus connect ENOENT (silent bus death
+    // behind the boot gate). The key is DOCUMENTED (commented) with a note that
+    // make-live adds it back; it must not appear as a live YAML mapping.
     const files = renderScaffold(inputs);
     const system = files.find((f) => f.relPath === "system/system.yaml");
-    expect(system?.contents).toContain("credsPath: ~/.config/nats/demo-bot.creds");
-    // The bus path must NOT equal the federation default for the same slug.
-    expect(system?.contents).not.toContain("credsPath: ~/.config/nats/demo.creds");
+    // No ACTIVE (uncommented, indented mapping) credsPath key.
+    expect(system?.contents).not.toMatch(/^\s*credsPath:/m);
+    // The bot-creds path is still documented as a commented reference so
+    // make-live's derivation + the `-bot` distinction stay discoverable.
+    expect(system?.contents).toContain("# credsPath: ~/.config/nats/demo-bot.creds");
+    // The commented reference names make-live as the thing that adds it back.
+    expect(system?.contents).toMatch(/make-live/);
+    // Guardrail: the bus path (if ever uncommented) must stay DISTINCT from the
+    // federation default `~/.config/nats/<slug>.creds` for the same slug.
+    expect(system?.contents).not.toMatch(/^\s*credsPath: ~\/\.config\/nats\/demo\.creds/m);
+  });
+
+  test("the PARSED system.yaml the daemon loads has no nats.credsPath (cortex#2264)", () => {
+    // The runtime only attempts creds-auth when `nats.credsPath` is a set value
+    // (runtime.ts: `...(nats.credsPath ? { credsPath } : {})`). Prove the daemon's
+    // loaded VIEW carries no such key — a commented line must not parse to one.
+    const files = renderScaffold(inputs);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    const parsed = parseYaml(system?.contents ?? "") as { nats?: { credsPath?: unknown } };
+    expect(parsed.nats).toBeDefined();
+    expect(parsed.nats?.credsPath).toBeUndefined();
   });
 
   test("does NOT inline any signing seed material (key auto-provisioned later)", () => {

--- a/src/cli/cortex/commands/quickstart-adapters.ts
+++ b/src/cli/cortex/commands/quickstart-adapters.ts
@@ -14,9 +14,9 @@
  * failing is an ordinary, expected outcome for quickstart, not a bug.
  */
 
-import { existsSync, readFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 
 import type {
   CommandResult,
@@ -91,6 +91,20 @@ export function buildServicePort(): ServicePort {
     },
     daemonReload(): CommandResult {
       return runSync(["systemctl", "--user", "daemon-reload"]);
+    },
+    truncateErrorLog(errorLogPath: string): void {
+      // cortex#2264 — clear the append-mode `.error.log` before the (re)start so
+      // the gate reads only CURRENT-boot content. Best-effort: a failure here
+      // must NOT block the restart — the gate simply degrades to its timeout
+      // path (never a false-fail). mkdir -p first so a first-install run (log
+      // dir not yet created by the daemon) still lands an empty file.
+      try {
+        mkdirSync(dirname(errorLogPath), { recursive: true });
+        writeFileSync(errorLogPath, "");
+      } catch (_err) {
+        // Swallow — see above; the gate never depends on this succeeding. Safe
+        // to ignore.
+      }
     },
     enableNow(units: string[]): CommandResult {
       return runSync(["systemctl", "--user", "enable", "--now", ...units]);

--- a/src/cli/cortex/commands/quickstart-lib.ts
+++ b/src/cli/cortex/commands/quickstart-lib.ts
@@ -749,11 +749,17 @@ export function daemonErrorLogPath(home: string, slug: string): string {
 /**
  * The marker the myelin runtime logs (to stderr → the `.error.log`) when the
  * PRIMARY bus connect fails and the runtime degrades to disabled
- * (`runtime.ts`: `myelin-runtime: failed to connect — continuing without
+ * (`runtime.ts:834`: `myelin-runtime: failed to connect — continuing without
  * NATS: <err>`). `console.error` renders the marker and the underlying error
  * on ONE line, so the whole line is the surfaceable diagnostic. cortex#2264.
+ *
+ * The marker is the PRIMARY-specific phrase `failed to connect — continuing
+ * without NATS`, NOT the bare `failed to connect`: a per-network LEAF failure
+ * (`runtime.ts:1039`: `failed to connect leaf "…" … primary unaffected`) is a
+ * NON-fatal degradation the gate must NOT trip on — the primary bus is fine.
+ * The `continuing without NATS` clause is unique to the primary-down path.
  */
-export const BUS_CONNECT_FAILURE_MARKER = "myelin-runtime: failed to connect";
+export const BUS_CONNECT_FAILURE_MARKER = "failed to connect — continuing without NATS";
 
 /**
  * Scan the daemon `.error.log` text for a bus-connect failure and return the
@@ -762,9 +768,12 @@ export const BUS_CONNECT_FAILURE_MARKER = "myelin-runtime: failed to connect";
  * caller (quickstart Step 8's gate) decides whether to fast-fail on a non-
  * `undefined` result. cortex#2264 (surface + fast-fail; the daemon's degraded-
  * continue posture is intentionally UNCHANGED — that fail-closed decision is
- * deferred). Returns the FIRST match: on a re-run the systemd unit APPENDS, so
- * a stale prior-boot failure can linger — the caller mitigates this by checking
- * the success gate FIRST (a healthy current boot passes before this is read).
+ * deferred).
+ *
+ * SAFE to fast-fail on the FIRST match because step 7 TRUNCATES this
+ * append-mode `.error.log` immediately before it (re)starts the daemon
+ * (`truncateErrorLog`), so anything present here is CURRENT-boot content — a
+ * stale prior-boot failure line can no longer linger and cause a false-fail.
  */
 export function detectBusConnectFailure(errorLogText: string | undefined): string | undefined {
   if (errorLogText === undefined) return undefined;

--- a/src/cli/cortex/commands/quickstart-lib.ts
+++ b/src/cli/cortex/commands/quickstart-lib.ts
@@ -601,7 +601,16 @@ export interface WebSurfaceInputs {
  *  inputs — the byte-identical fixed point a re-run compares against for the
  *  "second run mutates nothing" guarantee. `port` is emitted UNQUOTED so YAML
  *  parses it as a number (matching the real web binding shape). `token` is the
- *  secret — quoted, and NEVER echoed anywhere but this file. */
+ *  secret — quoted, and NEVER echoed anywhere but this file. `broadcastUrl` is
+ *  REQUIRED by the web adapter's schema (cortex#2264): the
+ *  `metafactory-cortex-adapter-web` bundle's `WebBindingSchema` mandates it as
+ *  a non-empty http/https URL (`schema.ts` — `.min(1)` + `/^https?:\/\/.+/`).
+ *  Omitting it made the daemon's registry pass FATAL at boot
+ *  (`surfaces.web[0].binding is invalid: broadcastUrl … expected string,
+ *  received undefined`). Derived from the ingress host/port as
+ *  `http://<host>:<port>/broadcast` (the WS Durable-Object `/broadcast`
+ *  endpoint shape the adapter documents); edit it to your real push endpoint
+ *  when the broadcast server is not co-located with the ingress. */
 export function renderWebSurfacesYaml(opts: WebSurfaceInputs): string {
   return `# =============================================================================
 # surfaces/surfaces.yaml — web/gateway surface binding (cortex#2153)
@@ -619,6 +628,10 @@ surfaces:
         instanceId: ${opts.instanceId}
         host: ${opts.host}
         port: ${opts.port}
+        # broadcastUrl — REQUIRED by the web adapter schema (http/https). Derived
+        # from the ingress host/port; point it at your real broadcast/push
+        # endpoint if it is not co-located with the ingress (cortex#2264).
+        broadcastUrl: http://${opts.host}:${opts.port}/broadcast
         token: "${opts.token}"            # web auth secret (chmod 600 the file)
 `;
 }
@@ -717,4 +730,49 @@ export function gatePassed(lines: GateLineResult[], healthzOk: boolean): boolean
  *  grep targets. */
 export function daemonLogPath(home: string, slug: string): string {
   return join(home, ".local", "state", "metafactory", "cortex", "logs", `cortex-${slug}.log`);
+}
+
+/**
+ * The `.error.log` SIBLING of {@link daemonLogPath} —
+ * `~/.local/state/metafactory/cortex/logs/cortex-<slug>.error.log` — where the
+ * daemon's `console.error` output lands (the `cortex@.service` systemd unit
+ * routes `StandardError` here: `append:%h/.local/state/metafactory/cortex/logs/
+ * cortex-%i.error.log`). The bus-connect failure the gate must surface
+ * (`myelin-runtime: failed to connect …`, runtime.ts) is a `console.error`, so
+ * it NEVER reaches the `.log` the healthy-boot gate greps — it reaches THIS
+ * file. cortex#2264.
+ */
+export function daemonErrorLogPath(home: string, slug: string): string {
+  return join(home, ".local", "state", "metafactory", "cortex", "logs", `cortex-${slug}.error.log`);
+}
+
+/**
+ * The marker the myelin runtime logs (to stderr → the `.error.log`) when the
+ * PRIMARY bus connect fails and the runtime degrades to disabled
+ * (`runtime.ts`: `myelin-runtime: failed to connect — continuing without
+ * NATS: <err>`). `console.error` renders the marker and the underlying error
+ * on ONE line, so the whole line is the surfaceable diagnostic. cortex#2264.
+ */
+export const BUS_CONNECT_FAILURE_MARKER = "myelin-runtime: failed to connect";
+
+/**
+ * Scan the daemon `.error.log` text for a bus-connect failure and return the
+ * first matching line (trimmed) — the actual error to surface — or `undefined`
+ * when the log is absent/unwritten or carries no failure marker. Pure; the
+ * caller (quickstart Step 8's gate) decides whether to fast-fail on a non-
+ * `undefined` result. cortex#2264 (surface + fast-fail; the daemon's degraded-
+ * continue posture is intentionally UNCHANGED — that fail-closed decision is
+ * deferred). Returns the FIRST match: on a re-run the systemd unit APPENDS, so
+ * a stale prior-boot failure can linger — the caller mitigates this by checking
+ * the success gate FIRST (a healthy current boot passes before this is read).
+ */
+export function detectBusConnectFailure(errorLogText: string | undefined): string | undefined {
+  if (errorLogText === undefined) return undefined;
+  for (const rawLine of errorLogText.split("\n")) {
+    if (rawLine.includes(BUS_CONNECT_FAILURE_MARKER)) {
+      const line = rawLine.trim();
+      if (line.length > 0) return line;
+    }
+  }
+  return undefined;
 }

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -72,6 +72,19 @@ export interface ServicePort {
   unitFileExists(unitTemplate: string): boolean;
   /** `systemctl --user daemon-reload`. */
   daemonReload(): CommandResult;
+  /**
+   * cortex#2264 — truncate the daemon's append-mode `.error.log` to EMPTY,
+   * immediately before the (re)start below, so step 8's gate only ever reads
+   * CURRENT-boot content. The `cortex@.service` unit routes `StandardError` with
+   * `append:` (never truncates), so a failure line from a PRIOR boot would
+   * otherwise persist and make the gate fast-fail on a stale line before the
+   * fresh boot has even connected. Called ONLY in the Linux branch that actually
+   * (re)starts the daemon (never on macOS, where arc/launchd owns the restart).
+   * Best-effort: never throws — a failure here degrades the gate to its honest
+   * timeout path, never a false-fail. `errorLogPath` is the exact path
+   * `daemonErrorLogPath()` computes.
+   */
+  truncateErrorLog(errorLogPath: string): void;
   /** `systemctl --user enable --now <units...>`. */
   enableNow(units: string[]): CommandResult;
 }

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -678,6 +678,17 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
   }
   lines.push("  ✓ systemctl --user daemon-reload");
 
+  // cortex#2264 — clear the daemon's append-mode `.error.log` IMMEDIATELY before
+  // the (re)start, so step 8's gate only ever sees CURRENT-boot content. Without
+  // this, a bus-connect failure line from a PRIOR boot would linger (systemd
+  // StandardError=append never truncates) and make the gate fast-fail on stale
+  // content before the fresh daemon connects — breaking the "fix creds and
+  // re-run" recovery. Best-effort (the port swallows fs errors); done here,
+  // gated on this Linux branch actually (re)starting the daemon.
+  const errorLogPath = daemonErrorLogPath(process.env.HOME ?? "", opts.slug);
+  ports.service.truncateErrorLog(errorLogPath);
+  lines.push(`  ✓ cleared prior-boot error log (${errorLogPath})`);
+
   const enable = ports.service.enableNow([`nats@${opts.slug}`, `cortex@${opts.slug}`]);
   if (enable.exitCode !== 0) {
     lines.push(`  ✗ systemctl --user enable --now nats@${opts.slug} cortex@${opts.slug} failed: ${enable.stderr.trim()}`);
@@ -722,15 +733,15 @@ async function runGate(
     const logText = ports.gate.readLog(logPath);
     const gateLines = evaluateHealthyBootGate(logText);
     const healthzOk = await ports.gate.fetchHealthz(healthzUrl, 3_000);
-    // Check the SUCCESS gate FIRST: a healthy current boot passes before the
-    // error-log is consulted, so an APPENDED stale failure from a prior boot
-    // never masks a genuinely-healthy re-run (cortex#2264 staleness guard).
     if (gatePassed(gateLines, healthzOk)) {
       return step("8. Healthy-boot gate", true, [renderGateTable(gateLines, healthzOk)]);
     }
     // cortex#2264 — a surfaced bus-connect failure is TERMINAL for this boot:
     // fail fast with the actual error line rather than burning the full
-    // timeout. SCOPE: surface + fast-fail only — the daemon still degrades and
+    // timeout. This is safe on the FIRST poll (before success is logged) because
+    // step 7 TRUNCATED this append-mode `.error.log` right before the daemon
+    // (re)started — so any line here is from THIS boot, never a stale prior-boot
+    // failure. SCOPE: surface + fast-fail only — the daemon still degrades and
     // continues (its fail-closed-abort posture is a separate, deferred call).
     const busFailure = detectBusConnectFailure(ports.gate.readLog(errorLogPath));
     if (busFailure !== undefined) {

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -71,7 +71,9 @@ import { expandTilde } from "../../../common/config/loader";
 import { buildQuickstartPorts } from "./quickstart-adapters";
 import type { QuickstartPorts } from "./quickstart-ports";
 import {
+  daemonErrorLogPath,
   daemonLogPath,
+  detectBusConnectFailure,
   evaluateHealthyBootGate,
   gatePassed,
   natsConfPath,
@@ -706,7 +708,13 @@ async function runGate(
       "  ○ --container passed — skipping healthy-boot gate (container health is compose restart: + nats healthcheck)",
     ]);
   }
-  const logPath = daemonLogPath(process.env.HOME ?? "", opts.slug);
+  const home = process.env.HOME ?? "";
+  const logPath = daemonLogPath(home, opts.slug);
+  // cortex#2264 — the bus-connect failure the daemon logs on a dead bus is a
+  // `console.error`, so it lands in the `.error.log` SIBLING, NEVER the `.log`
+  // the healthy-boot gate greps. Poll it too and FAIL FAST (surfacing the real
+  // error) instead of silently waiting out the whole timeout window.
+  const errorLogPath = daemonErrorLogPath(home, opts.slug);
   const healthzUrl = `http://127.0.0.1:${opts.monitorPort}/healthz`;
   const deadline = ports.gate.now() + opts.timeoutMs;
 
@@ -714,8 +722,24 @@ async function runGate(
     const logText = ports.gate.readLog(logPath);
     const gateLines = evaluateHealthyBootGate(logText);
     const healthzOk = await ports.gate.fetchHealthz(healthzUrl, 3_000);
+    // Check the SUCCESS gate FIRST: a healthy current boot passes before the
+    // error-log is consulted, so an APPENDED stale failure from a prior boot
+    // never masks a genuinely-healthy re-run (cortex#2264 staleness guard).
     if (gatePassed(gateLines, healthzOk)) {
       return step("8. Healthy-boot gate", true, [renderGateTable(gateLines, healthzOk)]);
+    }
+    // cortex#2264 — a surfaced bus-connect failure is TERMINAL for this boot:
+    // fail fast with the actual error line rather than burning the full
+    // timeout. SCOPE: surface + fast-fail only — the daemon still degrades and
+    // continues (its fail-closed-abort posture is a separate, deferred call).
+    const busFailure = detectBusConnectFailure(ports.gate.readLog(errorLogPath));
+    if (busFailure !== undefined) {
+      return step("8. Healthy-boot gate", false, [
+        renderGateTable(gateLines, healthzOk),
+        `  ✗ bus connect FAILED — the daemon could not reach NATS (surfaced from ${errorLogPath}):`,
+        `    ${busFailure}`,
+        `  (failing fast — not waiting out the ${String(opts.timeoutMs)}ms gate; fix the bus/creds and re-run)`,
+      ]);
     }
     if (ports.gate.now() >= deadline) {
       return step("8. Healthy-boot gate", false, [

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -427,13 +427,26 @@ nats:
   name: cortex-${slug}
   subjects: []
   # credsPath — the daemon's OWN bus/bot creds, minted under the \`agents\` account
-  # by \`cortex network make-live\` (via add-bot). The \`-bot\` suffix is LOAD-BEARING:
-  # it keeps this path DISTINCT from stacks/${slug}.yaml's
-  # \`stack.nats_infra.creds_path\` (the FEDERATION creds, minted at
-  # \`cortex network join\` under a DIFFERENT account, conventional default
-  # \`~/.config/nats/${slug}.creds\`). Two different NATS accounts MUST be two
-  # different files — a shared path would clobber on the second mint.
-  credsPath: ~/.config/nats/${slug}-bot.creds
+  # by \`cortex network make-live\` (via add-bot). LEFT UNSET (commented) on a
+  # from-scratch single-stack scaffold ON PURPOSE (cortex#2264): a NON-FEDERATED
+  # quickstart never runs make-live, so no \`<slug>-bot.creds\` file is ever
+  # minted. Shipping a LIVE \`credsPath\` here made the runtime try to load a
+  # file that does not exist → the bus connect failed ENOENT and the whole
+  # loopback bus went dark (silently, behind the boot gate). A single-stack
+  # loopback bus connects fine PLAINTEXT with no creds — bench-proven. \`cortex
+  # network make-live\` ADDS this key back when federation is provisioned: it
+  # DEFAULTS the path to \`~/.config/nats/<slug>-bot.creds\`
+  # (deriveMakeLiveInputs → credsPathDefaulted, network.ts) and persists it into
+  # THIS file (writeBusCredsPath, network-make-live-lib.ts step 3.5), so leaving
+  # it unset here does NOT regress federation — it merely triggers the defaulted
+  # write-back path. The \`-bot\` suffix is LOAD-BEARING: it keeps this path
+  # DISTINCT from stacks/${slug}.yaml's \`stack.nats_infra.creds_path\` (the
+  # FEDERATION creds, minted at \`cortex network join\` under a DIFFERENT account,
+  # conventional default \`~/.config/nats/${slug}.creds\`). Two different NATS
+  # accounts MUST be two different files — a shared path would clobber on the
+  # second mint. Uncomment ONLY to point this stack at a pre-existing
+  # operator-mode bus whose bot creds already exist on disk.
+  # credsPath: ~/.config/nats/${slug}-bot.creds
   # NKey identity for envelope signing is PER-STACK and lives in
   # stacks/${slug}.yaml — \`stack.nkey_seed_path\` + \`stack.nkey_pub\`, which
   # \`arc upgrade cortex\` auto-provisions on first install (seed at


### PR DESCRIPTION
Closes #2264. Bumps cortex to **6.10.2**.

Fixes the tester-reported `cortex quickstart` "60 s hang" and two same-class scaffold/adapter-sync bugs. Diagnosed on a faithful Linux bench (Ubuntu, bun 1.3.14, cortex current main, nats-server 2.10.22), co-diagnosed with the tester.

## Root cause
`quickstart` scaffolds configs out of sync with what the runtime + adapters need, and the boot gate hid the failure:
1. Scaffolded `system.yaml` set `nats.credsPath: ~/.config/nats/<slug>-bot.creds` — a **federation-account** creds file minted only by `cortex network make-live`. A single-stack quickstart never mints it → bus connect fails `ENOENT`.
2. That failure is a `console.error` → `.error.log`, but Step 8's gate polls the `.log` for `"connected to nats"` (`DEFAULT_GATE_TIMEOUT_MS = 60_000`) → success never comes, failure is in the other file → **silent 60 s timeout**. (Downstream: disabled runtime → dispatch falls back to the direct-sync path, which is why the assistant still replied while the bus was dead.)

## The three fixes
1. **`credsPath`** — single-stack scaffold no longer emits a live `credsPath` (commented reference). **Federation not regressed:** `cortex network make-live` already defaults + write-backs `nats.credsPath` when unseeded (`network.ts` / `network-make-live-adapters.ts writeBusCredsPath`) — verified end-to-end, with a regression-guard test.
2. **Boot gate** — detects a bus-connect failure in the `.error.log` sibling and **fast-fails surfacing the real error** instead of the silent timeout. `.error.log` is systemd `append:`, so step 7 **truncates it before (re)starting the daemon** → the gate only ever reads current-boot content (no stale false-fail). Failure marker scoped to the primary-down line (`"failed to connect — continuing without NATS"`), not the non-fatal leaf failure.
3. **web `broadcastUrl`** — `--surface web` scaffold now emits the `broadcastUrl` the web adapter's schema requires (was FATAL-ing on the missing field).

## Validation
- **Bench, end-to-end (real Linux):** fresh scaffold on this branch → `myelin-runtime: connected to nats at nats://127.0.0.1:4223` → gate line present, no `broadcastUrl` FATAL, daemon reaches running state.
- **Adversarial review, twice:** first pass caught a gate staleness false-fail (fast-fail on a stale prior-boot `.error.log` line during the connect window); fixed via truncate-before-start; re-review confirmed closed (reviewer re-ran the repro).
- **Tests:** 149 scoped pass / 0 fail, revert-checked (credsPath, gate staleness, marker over-match, truncation-order). `tsc` + `lint` clean.
- The 12 full-suite failures are pre-existing `startCortex` boot-wiring failures on clean `main`, unrelated (this diff touches none of those files).

## Deliberately out of scope (flagged for separate follow-up)
- Recovery re-run doesn't force-restart the daemon (`enable --now` no-op on a running daemon) → "fix config and re-run" won't pick up the change.
- macOS plist logs (`~/.config/cortex/logs/`) ≠ the gate's path (`~/.local/state/…`) → gate inert on macOS (pre-existing; Linux is the target).
- fail-closed-abort-on-bus-failure posture (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
