### PR TITLE
fix(deploy): bump container CORTEX_REF to v6.10.2 + track it in the auto-bump (#2267)

### DIFF
--- a/.github/workflows/arc-ref-bump.yml
+++ b/.github/workflows/arc-ref-bump.yml
@@ -1,30 +1,43 @@
-# arc-ref-bump — automated, build-gated bumps of the L4 container's ARC_REF pin
-# (cortex#2246).
+# arc-ref-bump — automated, build-gated bumps of the L4 container's pinned refs
+# (cortex#2246; generalized in cortex#2267 to track BOTH ARC_REF and CORTEX_REF).
 #
 # WHY
 # ---
-# deploy/compose/Dockerfile.cortex pins `ARG ARC_REF=<tag>` for reproducible
-# builds. arc releases move and adapter manifests evolve with arc, so a pinned
+# deploy/compose/Dockerfile.cortex pins `ARG ARC_REF=<tag>` AND
+# `ARG CORTEX_REF=<tag>` for reproducible builds. Both upstreams move: a pinned
 # OLDER arc eventually can't parse NEWER adapter manifests and `arc install`
 # fails in the container (cortex#2243: v0.40.2 predated the `{host,reason}`
-# manifest shape). The principal decision is to KEEP the pin (un-pinning to
-# `main` sacrifices reproducibility + adds supply-chain exposure) and instead
-# AUTOMATE the bump dependabot/renovate-style: this workflow proposes bumps as
-# reviewable, BUILD-GATED PRs.
+# manifest shape); a pinned OLDER cortex builds a pre-fix image so a container
+# test still hits already-fixed bugs (cortex#2267). The principal decision is to
+# KEEP the pins (un-pinning to `main` sacrifices reproducibility + adds
+# supply-chain exposure) and instead AUTOMATE the bumps dependabot/renovate-
+# style: this workflow proposes each bump as a reviewable, BUILD-GATED PR.
 #
 # HOW
 # ---
-#   1. Resolve arc's latest RELEASE tag — `gh api …/releases/latest`, falling
-#      back to the highest semver git tag. NEVER tracks raw `main`.
+# A matrix runs the SAME steps per pin (arc -> ARC_REF, cortex -> CORTEX_REF):
+#   1. Resolve the component's latest RELEASE tag — `gh api …/releases/latest`,
+#      falling back to the highest matching semver git tag. NEVER tracks raw
+#      `main`.
 #   2. scripts/arc-ref-bump.ts (unit-tested: semver compare + ARG rewrite)
-#      compares it to the current ARC_REF and decides whether to bump.
+#      compares it to the current ARG value (--arg-name selects the pin) and
+#      decides whether to bump.
 #   3. On a newer release: apply the bump and GATE on a real `docker build` of
-#      Dockerfile.cortex with the new arc — the build runs the `arc install
+#      Dockerfile.cortex with the new ref — the build runs the `arc install
 #      <adapter>` step that failed in #2243, so a green build is the proof the
-#      newer arc is compatible.
-#   4. Green build  -> open a labeled PR (old->new + link to arc's release).
+#      bumped image assembles.
+#   4. Green build  -> open a labeled PR (old->new + link to the release).
 #      Red build    -> open a tracking issue so a human sees the incompatibility
 #                      (never a silent stale pin, never a silent no-op).
+#
+# SECURITY (cortex#2251 lesson): any value that is attacker-influenceable — a
+# resolved release tag from `gh api` (another repo's tag == supply chain) or the
+# raw `workflow_dispatch` inputs — is routed through `env:` and referenced as a
+# QUOTED shell var. It is NEVER inlined as `${{ }}` inside a `run:` block, where
+# it would be expanded to raw text before the shell parses it (quotes give no
+# protection). parseSemver rejects a bad value, but only AFTER the shell, so the
+# guard must also live at the shell layer: as a quoted var the value is inert
+# data, never code.
 #
 # The docker-build gate needs a runner with Docker + network. The scheduled run
 # and a manual `workflow_dispatch` are the real end-to-end confirmation; the
@@ -39,8 +52,16 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
     inputs:
+      force_component:
+        description: "Which pin the force_latest override applies to (the other resolves normally). Ignored when force_latest is blank."
+        required: false
+        default: arc
+        type: choice
+        options:
+          - arc
+          - cortex
       force_latest:
-        description: "Override the resolved arc release tag (e.g. v0.42.1) — for testing the gate. Leave blank to resolve from arc releases."
+        description: "Override the resolved release tag for force_component (e.g. v0.42.1 / v6.10.2) — for testing the gate. Leave blank to resolve from releases."
         required: false
         type: string
 
@@ -58,8 +79,23 @@ concurrency:
 
 jobs:
   bump:
-    name: Resolve, gate, and propose ARC_REF bump
+    name: "Resolve, gate, and propose ${{ matrix.arg_name }} bump"
     runs-on: ubuntu-latest
+    strategy:
+      # Don't let one pin's red gate cancel the other pin's leg.
+      fail-fast: false
+      matrix:
+        include:
+          - component: arc
+            repo: the-metafactory/arc
+            arg_name: ARC_REF
+            # Fallback tag filter: highest semver git tag.
+            tag_grep: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          - component: cortex
+            repo: the-metafactory/cortex
+            arg_name: CORTEX_REF
+            # Fallback tag filter: highest v6.* semver git tag (cortex#2267).
+            tag_grep: '^v6\.[0-9]+\.[0-9]+$'
     steps:
       - name: Checkout cortex
         uses: actions/checkout@v4
@@ -71,60 +107,71 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      # ── 1. Resolve arc's latest RELEASE tag (fallback: highest semver git tag) ──
-      # NEVER raw `main`. `workflow_dispatch` may override via force_latest.
-      - name: Resolve latest arc release tag
+      # ── 1. Resolve this component's latest RELEASE tag (fallback: highest ──
+      #      matching semver git tag). NEVER raw `main`. `workflow_dispatch` may
+      #      override via force_latest, but only for the selected force_component.
+      - name: Resolve latest release tag
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
+          # matrix.* is workflow-authored (trusted), but routing through env
+          # keeps every `run:` value a quoted shell var — no `${{ }}` in-shell.
+          REPO: ${{ matrix.repo }}
+          COMPONENT: ${{ matrix.component }}
+          TAG_GREP: ${{ matrix.tag_grep }}
+          # Attacker-influenceable (raw dispatch inputs) — MUST be env, not inline.
+          FORCE_COMPONENT: ${{ github.event.inputs.force_component }}
           FORCE_LATEST: ${{ github.event.inputs.force_latest }}
         run: |
           set -euo pipefail
-          if [ -n "${FORCE_LATEST:-}" ]; then
+          if [ -n "${FORCE_LATEST:-}" ] && [ "${FORCE_COMPONENT:-}" = "${COMPONENT}" ]; then
             latest="${FORCE_LATEST}"
-            echo "Using workflow_dispatch override: ${latest}"
+            echo "Using workflow_dispatch override for ${COMPONENT}: ${latest}"
           else
             # Primary: the GitHub "latest release" (excludes drafts/prereleases).
-            latest="$(gh api repos/the-metafactory/arc/releases/latest --jq '.tag_name' 2>/dev/null || true)"
+            latest="$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || true)"
             if [ -z "${latest}" ] || [ "${latest}" = "null" ]; then
-              echo "releases/latest unavailable — falling back to highest semver git tag."
-              # Fallback: highest semver tag by version sort (vMAJOR.MINOR.PATCH only).
-              latest="$(gh api repos/the-metafactory/arc/tags --jq '.[].name' \
-                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              echo "releases/latest unavailable for ${REPO} — falling back to highest semver git tag."
+              # Fallback: highest matching semver tag by version sort.
+              latest="$(gh api "repos/${REPO}/tags" --jq '.[].name' \
+                | grep -E "${TAG_GREP}" \
                 | sort -V | tail -1)"
             fi
           fi
           if [ -z "${latest}" ] || [ "${latest}" = "null" ]; then
-            echo "::error::could not resolve any arc release tag (releases/latest and tag fallback both empty)"
+            echo "::error::could not resolve any release tag for ${REPO} (releases/latest and tag fallback both empty)"
             exit 1
           fi
-          echo "Resolved latest arc release: ${latest}"
+          echo "Resolved latest ${COMPONENT} release: ${latest}"
           echo "latest=${latest}" >> "$GITHUB_OUTPUT"
 
       # ── 2. Decide + apply the bump (unit-tested core; --write edits the file) ──
-      - name: Compute + apply ARC_REF bump
+      - name: "Compute + apply ${{ matrix.arg_name }} bump"
         id: bump
         env:
           # Route the resolved tag through env — NEVER inline `${{ }}` into a
-          # run: shell, where it is expanded to raw text before the shell parses
-          # (quotes give no protection). This value is attacker-influenceable:
-          # it comes from another repo's release tag (supply-chain) and from the
-          # raw workflow_dispatch force_latest input. parseSemver rejects a bad
-          # value, but only AFTER the shell — so the guard must be at the shell
-          # layer. As a quoted shell var it is inert data, never code.
+          # run: shell (see the file header). This value is attacker-
+          # influenceable: another repo's release tag (supply-chain) and the raw
+          # workflow_dispatch force_latest input both flow here. As a quoted
+          # shell var it is inert data, never code; --arg-name is validated
+          # against a known allow-list inside the script.
           LATEST: ${{ steps.resolve.outputs.latest }}
+          ARG_NAME: ${{ matrix.arg_name }}
         run: |
           set -euo pipefail
           bun scripts/arc-ref-bump.ts \
             --latest "$LATEST" \
+            --arg-name "$ARG_NAME" \
             --write --github-output
 
       - name: No bump needed
         if: steps.bump.outputs.bumped != 'true'
-        run: echo "ARC_REF is already >= the latest arc release — nothing to do."
+        env:
+          ARG_NAME: ${{ matrix.arg_name }}
+        run: echo "${ARG_NAME} is already >= the latest release — nothing to do."
 
-      # ── 3. BUILD GATE — build Dockerfile.cortex with the new arc; this runs the
-      #      `arc install <adapter>` step that failed in #2243. Green = compatible.
+      # ── 3. BUILD GATE — build Dockerfile.cortex with the new ref; this runs the
+      #      `arc install <adapter>` step that failed in #2243. Green = builds.
       #      continue-on-error so a red build routes to the issue path below
       #      rather than aborting the job (no silent no-op on incompatibility).
       - name: Build gate (docker build exercises `arc install`)
@@ -137,13 +184,15 @@ jobs:
           # is lower risk than the LATEST step above — but no `${{ }}` belongs
           # inside a run: shell regardless.
           NEW: ${{ steps.bump.outputs.new }}
+          ARG_NAME: ${{ matrix.arg_name }}
+          COMPONENT: ${{ matrix.component }}
         run: |
           set -euo pipefail
-          echo "Building Dockerfile.cortex with ARC_REF=${NEW} …"
+          echo "Building Dockerfile.cortex with ${ARG_NAME}=${NEW} …"
           docker build \
-            --build-arg "ARC_REF=${NEW}" \
+            --build-arg "${ARG_NAME}=${NEW}" \
             --file deploy/compose/Dockerfile.cortex \
-            --tag "cortex-arc-ref-gate:${NEW}" \
+            --tag "cortex-${COMPONENT}-ref-gate:${NEW}" \
             deploy/compose
 
       # ── 4a. GREEN → open a labeled PR with the bump ──
@@ -151,11 +200,15 @@ jobs:
         if: steps.bump.outputs.bumped == 'true' && steps.buildgate.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
+          COMPONENT: ${{ matrix.component }}
+          ARG_NAME: ${{ matrix.arg_name }}
+          REPO: ${{ matrix.repo }}
           OLD_REF: ${{ steps.bump.outputs.old }}
           NEW_REF: ${{ steps.bump.outputs.new }}
         run: |
           set -euo pipefail
-          branch="ci/arc-ref-bump-${NEW_REF}"
+          branch="ci/${COMPONENT}-ref-bump-${NEW_REF}"
+          release_url="https://github.com/${REPO}/releases/tag/${NEW_REF}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -168,27 +221,27 @@ jobs:
           git checkout -b "${branch}"
           git add deploy/compose/Dockerfile.cortex
           commit_msg="$(printf '%s\n' \
-            "ci(deploy): bump L4 container ARC_REF ${OLD_REF} -> ${NEW_REF}" \
+            "ci(deploy): bump L4 container ${ARG_NAME} ${OLD_REF} -> ${NEW_REF}" \
             "" \
-            "Automated, build-gated bump (cortex#2246). The docker build of" \
-            "Dockerfile.cortex with arc ${NEW_REF} passed -- including the" \
-            "\`arc install <adapter>\` step that failed in cortex#2243 -- so the" \
-            "newer arc parses the current adapter manifests." \
+            "Automated, build-gated bump (cortex#2246, cortex#2267). The docker" \
+            "build of Dockerfile.cortex with ${COMPONENT} ${NEW_REF} passed --" \
+            "including the \`arc install <adapter>\` step that failed in" \
+            "cortex#2243 -- so the bumped image assembles cleanly." \
             "" \
-            "arc release: https://github.com/the-metafactory/arc/releases/tag/${NEW_REF}")"
+            "${COMPONENT} release: ${release_url}")"
           git commit -m "${commit_msg}"
           git push --set-upstream origin "${branch}"
 
           pr_body="$(printf '%s\n' \
-            "Automated ARC_REF bump (cortex#2246)." \
+            "Automated ${ARG_NAME} bump (cortex#2246, cortex#2267)." \
             "" \
-            "- **arc:** \`${OLD_REF}\` -> \`${NEW_REF}\`" \
-            "- **arc release:** https://github.com/the-metafactory/arc/releases/tag/${NEW_REF}" \
-            "- **Build gate:** PASSED -- \`docker build\` of \`deploy/compose/Dockerfile.cortex\` with the new arc succeeded, exercising the \`arc install <adapter>\` step that failed in cortex#2243. A green build is the proof the newer arc parses the current adapter manifests." \
+            "- **${COMPONENT}:** \`${OLD_REF}\` -> \`${NEW_REF}\`" \
+            "- **release:** ${release_url}" \
+            "- **Build gate:** PASSED -- \`docker build\` of \`deploy/compose/Dockerfile.cortex\` with \`${ARG_NAME}=${NEW_REF}\` succeeded, exercising the \`arc install <adapter>\` step that failed in cortex#2243. A green build is the proof the bumped image assembles." \
             "" \
-            "Reproducibility preserved: \`ARC_REF\` stays a pinned tag; this is a reviewable, build-gated bump, not an unpinned build-time fetch.")"
+            "Reproducibility preserved: \`${ARG_NAME}\` stays a pinned tag; this is a reviewable, build-gated bump, not an unpinned build-time fetch.")"
           gh pr create \
-            --title "ci(deploy): bump L4 container ARC_REF ${OLD_REF} -> ${NEW_REF}" \
+            --title "ci(deploy): bump L4 container ${ARG_NAME} ${OLD_REF} -> ${NEW_REF}" \
             --body "${pr_body}" \
             --label infrastructure \
             --label next
@@ -198,29 +251,33 @@ jobs:
         if: steps.bump.outputs.bumped == 'true' && steps.buildgate.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
+          COMPONENT: ${{ matrix.component }}
+          ARG_NAME: ${{ matrix.arg_name }}
+          REPO: ${{ matrix.repo }}
           OLD_REF: ${{ steps.bump.outputs.old }}
           NEW_REF: ${{ steps.bump.outputs.new }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          title="arc ${NEW_REF} fails the L4 container build gate -- ARC_REF bump blocked"
+          title="${COMPONENT} ${NEW_REF} fails the L4 container build gate -- ${ARG_NAME} bump blocked"
+          release_url="https://github.com/${REPO}/releases/tag/${NEW_REF}"
           # Don't spam: reuse an open issue with the same title if one exists.
           existing="$(gh issue list --state open --search "in:title ${title}" --json number --jq '.[0].number' || true)"
           body="$(printf '%s\n' \
-            "The scheduled ARC_REF bump (cortex#2246) tried to move the L4 container from \`${OLD_REF}\` to arc's latest release \`${NEW_REF}\`, but the **container build gate FAILED**." \
+            "The scheduled ${ARG_NAME} bump (cortex#2246, cortex#2267) tried to move the L4 container from \`${OLD_REF}\` to ${COMPONENT}'s latest release \`${NEW_REF}\`, but the **container build gate FAILED**." \
             "" \
-            "The \`docker build\` of \`deploy/compose/Dockerfile.cortex\` with arc \`${NEW_REF}\` did not pass -- most likely the \`arc install <adapter>\` step (the exact failure class as cortex#2243). The pin stays at \`${OLD_REF}\` until this is resolved." \
+            "The \`docker build\` of \`deploy/compose/Dockerfile.cortex\` with \`${ARG_NAME}=${NEW_REF}\` did not pass -- most likely the \`arc install <adapter>\` step (the exact failure class as cortex#2243). The pin stays at \`${OLD_REF}\` until this is resolved." \
             "" \
             "- **Build log:** ${RUN_URL}" \
-            "- **arc release:** https://github.com/the-metafactory/arc/releases/tag/${NEW_REF}" \
+            "- **${COMPONENT} release:** ${release_url}" \
             "" \
-            "A human needs to investigate the arc/adapter incompatibility rather than let the pin silently go stale.")"
+            "A human needs to investigate the incompatibility rather than let the pin silently go stale.")"
           if [ -n "${existing}" ]; then
             echo "Reusing open issue #${existing}."
-            gh issue comment "${existing}" --body "Re-observed on a later run: arc ${NEW_REF} still fails the build gate. ${RUN_URL}"
+            gh issue comment "${existing}" --body "Re-observed on a later run: ${COMPONENT} ${NEW_REF} still fails the build gate. ${RUN_URL}"
           else
             gh issue create --title "${title}" --body "${body}" --label infrastructure --label next
           fi
           # Fail the job so the red gate is visible in the Actions UI, not just as an issue.
-          echo "::error::arc ${NEW_REF} failed the container build gate — see the tracking issue."
+          echo "::error::${COMPONENT} ${NEW_REF} failed the container build gate — see the tracking issue."
           exit 1

--- a/.github/workflows/arc-ref-bump.yml
+++ b/.github/workflows/arc-ref-bump.yml
@@ -219,7 +219,14 @@ jobs:
           fi
 
           git checkout -b "${branch}"
-          git add deploy/compose/Dockerfile.cortex
+          # Stage BOTH pin locations. arc-ref-bump.ts rewrites the Dockerfile ARG
+          # default AND, in lockstep, the compose `${ARG_NAME:-<tag>}` default —
+          # the compose value is passed as --build-arg and OVERRIDES the Dockerfile
+          # default on the primary `docker compose build` path (cortex#2267), so
+          # both must move together or the deployed image builds the stale ref.
+          # For a Dockerfile-only pin (ARC_REF), the compose file is unchanged and
+          # `git add` of it is a harmless no-op — only modified files are committed.
+          git add deploy/compose/Dockerfile.cortex deploy/compose/docker-compose.yaml
           commit_msg="$(printf '%s\n' \
             "ci(deploy): bump L4 container ${ARG_NAME} ${OLD_REF} -> ${NEW_REF}" \
             "" \
@@ -227,6 +234,12 @@ jobs:
             "build of Dockerfile.cortex with ${COMPONENT} ${NEW_REF} passed --" \
             "including the \`arc install <adapter>\` step that failed in" \
             "cortex#2243 -- so the bumped image assembles cleanly." \
+            "" \
+            "Both pin locations are bumped in lockstep: the Dockerfile.cortex ARG" \
+            "default AND the docker-compose.yaml \`\${${ARG_NAME}:-<tag>}\` default" \
+            "(when present). The compose default is passed as --build-arg and" \
+            "OVERRIDES the Dockerfile default on the \`docker compose build\` path," \
+            "so leaving it stale would silently build the pre-bump ref." \
             "" \
             "${COMPONENT} release: ${release_url}")"
           git commit -m "${commit_msg}"
@@ -237,6 +250,7 @@ jobs:
             "" \
             "- **${COMPONENT}:** \`${OLD_REF}\` -> \`${NEW_REF}\`" \
             "- **release:** ${release_url}" \
+            "- **Files bumped in lockstep:** \`deploy/compose/Dockerfile.cortex\` (ARG default) AND \`deploy/compose/docker-compose.yaml\` (\`\${${ARG_NAME}:-<tag>}\` default, when present). The compose default is passed as \`--build-arg\` and OVERRIDES the Dockerfile default on the \`docker compose build\` path, so both must move together or the deployed image silently builds the stale ref (cortex#2267). A Dockerfile-only pin (e.g. \`ARC_REF\`) leaves the compose file unchanged." \
             "- **Build gate:** PASSED -- \`docker build\` of \`deploy/compose/Dockerfile.cortex\` with \`${ARG_NAME}=${NEW_REF}\` succeeded, exercising the \`arc install <adapter>\` step that failed in cortex#2243. A green build is the proof the bumped image assembles." \
             "" \
             "Reproducibility preserved: \`${ARG_NAME}\` stays a pinned tag; this is a reviewable, build-gated bump, not an unpinned build-time fetch.")"

--- a/deploy/compose/Dockerfile.cortex
+++ b/deploy/compose/Dockerfile.cortex
@@ -21,7 +21,7 @@
 # Every pinned version is an ARG so the image is reproducible and a rebuild can
 # bump a single component. CORTEX_REF defaults to a RELEASE TAG, never `main`.
 
-ARG CORTEX_REF=v6.10.0
+ARG CORTEX_REF=v6.10.2
 ARG BUN_VERSION=1.3.14
 ARG CLAUDE_VERSION=2.1.211
 ARG NATS_SERVER_VERSION=2.14.3

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       context: .
       dockerfile: Dockerfile.cortex
       args:
-        CORTEX_REF: ${CORTEX_REF:-v6.10.0}
+        CORTEX_REF: ${CORTEX_REF:-v6.10.2}
         BUN_VERSION: ${BUN_VERSION:-1.3.14}
         CLAUDE_VERSION: ${CLAUDE_VERSION:-2.1.211}
         NATS_SERVER_VERSION: ${NATS_SERVER_VERSION:-2.14.3}

--- a/scripts/__tests__/arc-ref-bump.test.ts
+++ b/scripts/__tests__/arc-ref-bump.test.ts
@@ -21,6 +21,7 @@ import {
   compareSemver,
   readRef,
   rewriteRef,
+  rewriteComposeDefault,
   decideBump,
   isKnownArgName,
   KNOWN_ARG_NAMES,
@@ -64,11 +65,38 @@ function fixtureWith(argName: ArgName, ref: string): string {
     : fixtureDockerfile(OLD.ARC_REF, ref);
 }
 
-function tmpDockerfile(argName: ArgName, ref: string): string {
+// A structurally faithful stand-in for docker-compose.yaml: it carries ONLY the
+// `${CORTEX_REF:-<tag>}` default under build.args (ARC_REF is Dockerfile-only in
+// the real system — cortex#2267), so a CORTEX_REF bump exercises the compose
+// rewrite while an ARC_REF bump exercises the "arg absent -> no-op" path.
+function fixtureCompose(cortexRef: string): string {
+  return [
+    "services:",
+    "  cortex:",
+    "    build:",
+    "      args:",
+    `        CORTEX_REF: \${CORTEX_REF:-${cortexRef}}`,
+    "        BUN_VERSION: ${BUN_VERSION:-1.3.14}",
+    "",
+  ].join("\n");
+}
+
+// The compose default a fixtureWith(argName, ref) Dockerfile should be paired
+// with: the CORTEX_REF leg carries `ref`, the ARC_REF leg leaves CORTEX at OLD.
+function composeRefFor(argName: ArgName, ref: string): string {
+  return argName === "CORTEX_REF" ? ref : OLD.CORTEX_REF;
+}
+
+// Scaffold a temp dir with BOTH a Dockerfile.cortex and a docker-compose.yaml so
+// every main() call can be pointed at an ISOLATED compose via --compose — never
+// the real repo compose. Returns the two paths (same dir, so cleanup via `..`).
+function tmpEnv(argName: ArgName, ref: string): { dockerfile: string; compose: string } {
   const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
-  const path = join(dir, "Dockerfile.cortex");
-  writeFileSync(path, fixtureWith(argName, ref));
-  return path;
+  const dockerfile = join(dir, "Dockerfile.cortex");
+  const compose = join(dir, "docker-compose.yaml");
+  writeFileSync(dockerfile, fixtureWith(argName, ref));
+  writeFileSync(compose, fixtureCompose(composeRefFor(argName, ref)));
+  return { dockerfile, compose };
 }
 
 describe("parseSemver", () => {
@@ -175,6 +203,47 @@ describe.each(ARG_NAMES)("rewriteRef (%s)", (argName) => {
   });
 });
 
+describe("rewriteComposeDefault", () => {
+  test("CORTEX_REF: rewrites the ${CORTEX_REF:-<tag>} default, preserving shape", () => {
+    const compose = fixtureCompose("v6.10.0");
+    const r = rewriteComposeDefault(compose, "CORTEX_REF", "v6.10.2");
+    expect(r.present).toBe(true);
+    expect(r.malformed).toBe(false);
+    expect(r.changed).toBe(true);
+    expect(r.oldRef).toBe("v6.10.0");
+    // Shape preserved exactly — still a pinned `${...:-<tag>}` default.
+    expect(r.content).toContain("CORTEX_REF: ${CORTEX_REF:-v6.10.2}");
+    // The other default is untouched.
+    expect(r.content).toContain("BUN_VERSION: ${BUN_VERSION:-1.3.14}");
+  });
+  test("ARC_REF: absent from compose -> clean no-op (present=false)", () => {
+    const compose = fixtureCompose("v6.10.0");
+    const r = rewriteComposeDefault(compose, "ARC_REF", "v0.42.1");
+    expect(r.present).toBe(false);
+    expect(r.malformed).toBe(false);
+    expect(r.changed).toBe(false);
+    expect(r.content).toBe(compose);
+  });
+  test("idempotent: default already at target -> no change", () => {
+    const compose = fixtureCompose("v6.10.2");
+    const r = rewriteComposeDefault(compose, "CORTEX_REF", "v6.10.2");
+    expect(r.present).toBe(true);
+    expect(r.changed).toBe(false);
+    expect(r.content).toBe(compose);
+  });
+  test("malformed empty default ${CORTEX_REF:-} -> present + malformed", () => {
+    const compose = "      args:\n        CORTEX_REF: ${CORTEX_REF:-}\n";
+    const r = rewriteComposeDefault(compose, "CORTEX_REF", "v6.10.2");
+    expect(r.present).toBe(true);
+    expect(r.malformed).toBe(true);
+    expect(r.changed).toBe(false);
+  });
+  test("throws on an unknown ARG name (regex-injection guard)", () => {
+    expect(() => rewriteComposeDefault("x", "BUN_VERSION", "1.0.0")).toThrow();
+    expect(() => rewriteComposeDefault("x", "ARC_REF|CORTEX_REF", "1.0.0")).toThrow();
+  });
+});
+
 describe.each(ARG_NAMES)("decideBump (%s)", (argName) => {
   test("newer -> bump; equal/older -> no bump", () => {
     expect(decideBump(argName, OLD[argName], NEW[argName]).shouldBump).toBe(true);
@@ -191,92 +260,193 @@ describe.each(ARG_NAMES)("main CLI (%s)", (argName) => {
   const flag = argName === "ARC_REF" ? [] : ["--arg-name", argName];
 
   test("newer release + --write rewrites the file, exit 0", () => {
-    const path = tmpDockerfile(argName, OLD[argName]);
+    const { dockerfile, compose } = tmpEnv(argName, OLD[argName]);
     try {
-      const code = main(["--latest", NEW[argName], "--dockerfile", path, "--write", ...flag]);
+      const code = main(["--latest", NEW[argName], "--dockerfile", dockerfile, "--compose", compose, "--write", ...flag]);
       expect(code).toBe(0);
-      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(NEW[argName]);
+      expect(readRef(readFileSync(dockerfile, "utf8"), argName)).toBe(NEW[argName]);
     } finally {
-      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
     }
   });
 
-  test("newer release WITHOUT --write is a dry-run (file unchanged)", () => {
-    const path = tmpDockerfile(argName, OLD[argName]);
+  test("newer release WITHOUT --write is a dry-run (files unchanged)", () => {
+    const { dockerfile, compose } = tmpEnv(argName, OLD[argName]);
+    const composeBefore = readFileSync(compose, "utf8");
     try {
-      const code = main(["--latest", NEW[argName], "--dockerfile", path, ...flag]);
+      const code = main(["--latest", NEW[argName], "--dockerfile", dockerfile, "--compose", compose, ...flag]);
       expect(code).toBe(0);
-      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(OLD[argName]);
+      expect(readRef(readFileSync(dockerfile, "utf8"), argName)).toBe(OLD[argName]);
+      expect(readFileSync(compose, "utf8")).toBe(composeBefore);
     } finally {
-      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
     }
   });
 
   test("equal/older release is a no-op, exit 0, file unchanged", () => {
-    const path = tmpDockerfile(argName, NEW[argName]);
+    const { dockerfile, compose } = tmpEnv(argName, NEW[argName]);
     try {
-      expect(main(["--latest", NEW[argName], "--dockerfile", path, "--write", ...flag])).toBe(0);
-      expect(main(["--latest", OLD[argName], "--dockerfile", path, "--write", ...flag])).toBe(0);
-      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(NEW[argName]);
+      expect(main(["--latest", NEW[argName], "--dockerfile", dockerfile, "--compose", compose, "--write", ...flag])).toBe(0);
+      expect(main(["--latest", OLD[argName], "--dockerfile", dockerfile, "--compose", compose, "--write", ...flag])).toBe(0);
+      expect(readRef(readFileSync(dockerfile, "utf8"), argName)).toBe(NEW[argName]);
     } finally {
-      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
     }
   });
 
   test("malformed ARG line -> exit 3 (loud, no phantom bump)", () => {
     const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
-    const path = join(dir, "Dockerfile.cortex");
-    writeFileSync(path, `FROM debian:bookworm-slim\nARG ${argName}\n`);
+    const dockerfile = join(dir, "Dockerfile.cortex");
+    const compose = join(dir, "docker-compose.yaml");
+    writeFileSync(dockerfile, `FROM debian:bookworm-slim\nARG ${argName}\n`);
+    writeFileSync(compose, fixtureCompose(composeRefFor(argName, OLD[argName])));
     try {
-      expect(main(["--latest", NEW[argName], "--dockerfile", path, "--write", ...flag])).toBe(3);
+      expect(main(["--latest", NEW[argName], "--dockerfile", dockerfile, "--compose", compose, "--write", ...flag])).toBe(3);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
   test("unparseable --latest -> exit 3 (never track main)", () => {
-    const path = tmpDockerfile(argName, OLD[argName]);
+    const { dockerfile, compose } = tmpEnv(argName, OLD[argName]);
     try {
-      expect(main(["--latest", "main", "--dockerfile", path, "--write", ...flag])).toBe(3);
-      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(OLD[argName]);
+      expect(main(["--latest", "main", "--dockerfile", dockerfile, "--compose", compose, "--write", ...flag])).toBe(3);
+      expect(readRef(readFileSync(dockerfile, "utf8"), argName)).toBe(OLD[argName]);
     } finally {
-      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
+    }
+  });
+});
+
+// The core of cortex#2267: the compose `${<ARG>:-<tag>}` default must move in
+// lockstep with the Dockerfile ARG, since it OVERRIDES the ARG on the primary
+// `docker compose build` path. These cases pin the Dockerfile+compose contract.
+describe("main CLI — compose lockstep (cortex#2267)", () => {
+  test("CORTEX_REF bump rewrites BOTH the Dockerfile ARG and the compose default", () => {
+    const { dockerfile, compose } = tmpEnv("CORTEX_REF", OLD.CORTEX_REF);
+    try {
+      const code = main([
+        "--latest", NEW.CORTEX_REF, "--arg-name", "CORTEX_REF",
+        "--dockerfile", dockerfile, "--compose", compose, "--write",
+      ]);
+      expect(code).toBe(0);
+      // Dockerfile ARG default moved…
+      expect(readRef(readFileSync(dockerfile, "utf8"), "CORTEX_REF")).toBe(NEW.CORTEX_REF);
+      // …AND the compose default moved in lockstep, shape preserved.
+      expect(readFileSync(compose, "utf8")).toContain(`CORTEX_REF: \${CORTEX_REF:-${NEW.CORTEX_REF}}`);
+    } finally {
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("ARC_REF bump rewrites the Dockerfile but leaves compose untouched (arg absent)", () => {
+    const { dockerfile, compose } = tmpEnv("ARC_REF", OLD.ARC_REF);
+    const composeBefore = readFileSync(compose, "utf8");
+    try {
+      const code = main([
+        "--latest", NEW.ARC_REF, "--arg-name", "ARC_REF",
+        "--dockerfile", dockerfile, "--compose", compose, "--write",
+      ]);
+      expect(code).toBe(0);
+      expect(readRef(readFileSync(dockerfile, "utf8"), "ARC_REF")).toBe(NEW.ARC_REF);
+      // Compose has no ${ARC_REF:-…} default -> clean no-op, byte-for-byte equal.
+      expect(readFileSync(compose, "utf8")).toBe(composeBefore);
+    } finally {
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("compose default already at target -> no spurious rewrite (Dockerfile still bumps)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
+    const dockerfile = join(dir, "Dockerfile.cortex");
+    const compose = join(dir, "docker-compose.yaml");
+    // Dockerfile ARG is stale (v6.10.0) but compose default is already at target.
+    writeFileSync(dockerfile, fixtureWith("CORTEX_REF", OLD.CORTEX_REF));
+    writeFileSync(compose, fixtureCompose(NEW.CORTEX_REF));
+    const composeBefore = readFileSync(compose, "utf8");
+    try {
+      const code = main([
+        "--latest", NEW.CORTEX_REF, "--arg-name", "CORTEX_REF",
+        "--dockerfile", dockerfile, "--compose", compose, "--write",
+      ]);
+      expect(code).toBe(0);
+      expect(readRef(readFileSync(dockerfile, "utf8"), "CORTEX_REF")).toBe(NEW.CORTEX_REF);
+      // Compose was already at target -> unchanged byte-for-byte (no churn).
+      expect(readFileSync(compose, "utf8")).toBe(composeBefore);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("malformed compose default ${CORTEX_REF:-} (readable file) -> exit 3", () => {
+    const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
+    const dockerfile = join(dir, "Dockerfile.cortex");
+    const compose = join(dir, "docker-compose.yaml");
+    writeFileSync(dockerfile, fixtureWith("CORTEX_REF", OLD.CORTEX_REF));
+    writeFileSync(compose, "      args:\n        CORTEX_REF: ${CORTEX_REF:-}\n");
+    try {
+      const code = main([
+        "--latest", NEW.CORTEX_REF, "--arg-name", "CORTEX_REF",
+        "--dockerfile", dockerfile, "--compose", compose, "--write",
+      ]);
+      expect(code).toBe(3);
+      // Loud failure BEFORE any write — Dockerfile ARG is left at the stale value.
+      expect(readRef(readFileSync(dockerfile, "utf8"), "CORTEX_REF")).toBe(OLD.CORTEX_REF);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("missing compose file -> non-fatal skip, Dockerfile still bumped, exit 0", () => {
+    const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
+    const dockerfile = join(dir, "Dockerfile.cortex");
+    const compose = join(dir, "does-not-exist-compose.yaml");
+    writeFileSync(dockerfile, fixtureWith("CORTEX_REF", OLD.CORTEX_REF));
+    try {
+      const code = main([
+        "--latest", NEW.CORTEX_REF, "--arg-name", "CORTEX_REF",
+        "--dockerfile", dockerfile, "--compose", compose, "--write",
+      ]);
+      expect(code).toBe(0);
+      expect(readRef(readFileSync(dockerfile, "utf8"), "CORTEX_REF")).toBe(NEW.CORTEX_REF);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });
 
 describe("main (CLI) — shared behavior", () => {
   test("missing --latest -> usage error (exit 2)", () => {
-    const path = tmpDockerfile("ARC_REF", OLD.ARC_REF);
+    const { dockerfile, compose } = tmpEnv("ARC_REF", OLD.ARC_REF);
     try {
-      expect(main(["--dockerfile", path])).toBe(2);
+      expect(main(["--dockerfile", dockerfile, "--compose", compose])).toBe(2);
     } finally {
-      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
     }
   });
 
   test("unknown --arg-name -> usage error (exit 2)", () => {
-    const path = tmpDockerfile("ARC_REF", OLD.ARC_REF);
+    const { dockerfile, compose } = tmpEnv("ARC_REF", OLD.ARC_REF);
     try {
-      expect(main(["--latest", "v1.0.0", "--arg-name", "BUN_VERSION", "--dockerfile", path])).toBe(2);
+      expect(main(["--latest", "v1.0.0", "--arg-name", "BUN_VERSION", "--dockerfile", dockerfile, "--compose", compose])).toBe(2);
     } finally {
-      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
     }
   });
 
   test("unreadable Dockerfile -> exit 3 (loud)", () => {
-    expect(main(["--latest", "v0.42.1", "--dockerfile", "/nonexistent/Dockerfile.cortex"])).toBe(3);
+    expect(main(["--latest", "v0.42.1", "--dockerfile", "/nonexistent/Dockerfile.cortex", "--compose", "/nonexistent/docker-compose.yaml"])).toBe(3);
   });
 
   test("--github-output writes bumped/old/new to $GITHUB_OUTPUT (CORTEX_REF)", () => {
-    const path = tmpDockerfile("CORTEX_REF", OLD.CORTEX_REF);
+    const { dockerfile, compose } = tmpEnv("CORTEX_REF", OLD.CORTEX_REF);
     const outDir = mkdtempSync(join(tmpdir(), "arc-ref-out-"));
     const outFile = join(outDir, "gh_output");
     writeFileSync(outFile, "");
     const prev = process.env.GITHUB_OUTPUT;
     process.env.GITHUB_OUTPUT = outFile;
     try {
-      main(["--latest", NEW.CORTEX_REF, "--arg-name", "CORTEX_REF", "--dockerfile", path, "--write", "--github-output"]);
+      main(["--latest", NEW.CORTEX_REF, "--arg-name", "CORTEX_REF", "--dockerfile", dockerfile, "--compose", compose, "--write", "--github-output"]);
       const out = readFileSync(outFile, "utf8");
       expect(out).toContain("bumped=true");
       expect(out).toContain(`old=${OLD.CORTEX_REF}`);
@@ -284,7 +454,7 @@ describe("main (CLI) — shared behavior", () => {
     } finally {
       if (prev === undefined) delete process.env.GITHUB_OUTPUT;
       else process.env.GITHUB_OUTPUT = prev;
-      rmSync(join(path, ".."), { recursive: true, force: true });
+      rmSync(join(dockerfile, ".."), { recursive: true, force: true });
       rmSync(outDir, { recursive: true, force: true });
     }
   });

--- a/scripts/__tests__/arc-ref-bump.test.ts
+++ b/scripts/__tests__/arc-ref-bump.test.ts
@@ -1,13 +1,16 @@
-// Tests for the ARC_REF bump core (cortex#2246).
+// Tests for the container ref-bump core (cortex#2246, generalized to CORTEX_REF
+// in cortex#2267).
 //
 // Pure-logic coverage — no network, no docker. The workflow
 // (.github/workflows/arc-ref-bump.yml) owns the side effects (resolve latest
 // release via `gh api`, docker-build gate, open the PR); this suite pins the
-// decision + byte-level rewrite the workflow depends on:
+// decision + byte-level rewrite the workflow depends on, for BOTH pinned ARGs
+// (ARC_REF and CORTEX_REF):
 //   - semver compare (newer / equal / older / prerelease precedence)
-//   - readArcRef targets the ARG DEFINITION line, not the bare re-declaration
-//   - rewriteArcRef bumps to a newer tag + is idempotent + preserves the pin
+//   - readRef targets the ARG DEFINITION line, not the bare re-declaration
+//   - rewriteRef bumps to a newer tag + is idempotent + preserves the pin
 //   - malformed / missing ARG line is handled (null, no phantom rewrite)
+//   - unknown ARG name is rejected (regex-injection guard)
 //   - main(): newer -> rewrite w/ --write; equal/older -> no-op; missing -> 3
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
@@ -16,20 +19,23 @@ import { tmpdir } from "os";
 import {
   parseSemver,
   compareSemver,
-  readArcRef,
-  rewriteArcRef,
+  readRef,
+  rewriteRef,
   decideBump,
+  isKnownArgName,
+  KNOWN_ARG_NAMES,
   main,
+  type ArgName,
 } from "../arc-ref-bump";
 
-// A minimal but structurally faithful stand-in for Dockerfile.cortex: it has
-// BOTH the `ARG ARC_REF=<value>` definition (before FROM) and the bare
-// `ARG ARC_REF` re-declaration (in the build stage), exactly like the real file.
-function fixtureDockerfile(ref: string): string {
+// A minimal but structurally faithful stand-in for Dockerfile.cortex: it has,
+// for BOTH pins, the `ARG <NAME>=<value>` definition (before FROM) and the bare
+// `ARG <NAME>` re-declaration (in the build stage), exactly like the real file.
+function fixtureDockerfile(arcRef: string, cortexRef: string): string {
   return [
     "# syntax=docker/dockerfile:1",
-    "ARG CORTEX_REF=v6.10.0",
-    `ARG ARC_REF=${ref}`,
+    `ARG CORTEX_REF=${cortexRef}`,
+    `ARG ARC_REF=${arcRef}`,
     "ARG CORTEX_SURFACES=discord",
     "",
     "FROM debian:bookworm-slim",
@@ -42,10 +48,26 @@ function fixtureDockerfile(ref: string): string {
   ].join("\n");
 }
 
-function tmpDockerfile(ref: string): string {
+// Per-ARG example versions so each case exercises the correct line.
+const OLD: Record<ArgName, string> = { ARC_REF: "v0.40.2", CORTEX_REF: "v6.10.0" };
+const NEW: Record<ArgName, string> = { ARC_REF: "v0.42.1", CORTEX_REF: "v6.10.2" };
+
+// Mutable, typed copy for describe.each so the callback param is ArgName (a
+// readonly tuple doesn't match the .each overload and would infer `any`).
+const ARG_NAMES: ArgName[] = [...KNOWN_ARG_NAMES];
+
+// Build a fixture where the ARG under test carries `ref` and the other pin is
+// left at its OLD value.
+function fixtureWith(argName: ArgName, ref: string): string {
+  return argName === "ARC_REF"
+    ? fixtureDockerfile(ref, OLD.CORTEX_REF)
+    : fixtureDockerfile(OLD.ARC_REF, ref);
+}
+
+function tmpDockerfile(argName: ArgName, ref: string): string {
   const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
   const path = join(dir, "Dockerfile.cortex");
-  writeFileSync(path, fixtureDockerfile(ref));
+  writeFileSync(path, fixtureWith(argName, ref));
   return path;
 }
 
@@ -53,6 +75,7 @@ describe("parseSemver", () => {
   test("parses vX.Y.Z and X.Y.Z", () => {
     expect(parseSemver("v0.42.1")).toEqual({ major: 0, minor: 42, patch: 1, prerelease: [] });
     expect(parseSemver("1.2.3")).toEqual({ major: 1, minor: 2, patch: 3, prerelease: [] });
+    expect(parseSemver("v6.10.2")).toEqual({ major: 6, minor: 10, patch: 2, prerelease: [] });
   });
   test("parses prerelease + ignores build metadata", () => {
     expect(parseSemver("v1.2.3-rc.1")).toEqual({ major: 1, minor: 2, patch: 3, prerelease: ["rc", "1"] });
@@ -73,6 +96,7 @@ describe("compareSemver", () => {
     expect(compareSemver(p("v0.40.2"), p("v0.42.1"))).toBe(-1);
     expect(compareSemver(p("v1.0.0"), p("v1.0.0"))).toBe(0);
     expect(compareSemver(p("v1.2.0"), p("v1.1.9"))).toBe(1);
+    expect(compareSemver(p("v6.10.2"), p("v6.10.0"))).toBe(1);
   });
   test("prerelease precedence (semver §11)", () => {
     expect(compareSemver(p("v1.0.0"), p("v1.0.0-rc.1"))).toBe(1); // final > prerelease
@@ -81,96 +105,160 @@ describe("compareSemver", () => {
   });
 });
 
-describe("readArcRef", () => {
-  test("reads the ARG definition line, not the bare re-declaration", () => {
-    expect(readArcRef(fixtureDockerfile("v0.40.2"))).toBe("v0.40.2");
-  });
-  test("returns null when the definition line is missing/malformed", () => {
-    // Only the bare re-declaration, no `=<value>` definition.
-    const df = "FROM debian:bookworm-slim\nARG ARC_REF\n";
-    expect(readArcRef(df)).toBeNull();
-    // Empty value is not \S+ -> treated as malformed.
-    expect(readArcRef("ARG ARC_REF=\n")).toBeNull();
+describe("isKnownArgName", () => {
+  test("accepts the two tracked pins, rejects anything else", () => {
+    expect(KNOWN_ARG_NAMES).toEqual(["ARC_REF", "CORTEX_REF"]);
+    expect(isKnownArgName("ARC_REF")).toBe(true);
+    expect(isKnownArgName("CORTEX_REF")).toBe(true);
+    expect(isKnownArgName("BUN_VERSION")).toBe(false);
+    // Would be a regex-injection vector if not gated.
+    expect(isKnownArgName("ARC_REF|CORTEX_REF")).toBe(false);
+    expect(isKnownArgName(".*")).toBe(false);
   });
 });
 
-describe("rewriteArcRef", () => {
+// Parametrized across BOTH pins so ARC_REF and CORTEX_REF get identical coverage.
+describe.each(ARG_NAMES)("readRef (%s)", (argName) => {
+  test("reads the ARG definition line, not the bare re-declaration", () => {
+    expect(readRef(fixtureWith(argName, OLD[argName]), argName)).toBe(OLD[argName]);
+  });
+  test("returns null when the definition line is missing/malformed", () => {
+    // Only the bare re-declaration, no `=<value>` definition.
+    expect(readRef(`FROM debian:bookworm-slim\nARG ${argName}\n`, argName)).toBeNull();
+    // Empty value is not \S+ -> treated as malformed.
+    expect(readRef(`ARG ${argName}=\n`, argName)).toBeNull();
+  });
+  test("does not read the OTHER pin's value", () => {
+    const df = fixtureDockerfile(NEW.ARC_REF, NEW.CORTEX_REF);
+    expect(readRef(df, argName)).toBe(NEW[argName]);
+  });
+});
+
+describe("readRef guards unknown ARG names", () => {
+  test("throws rather than splicing an arbitrary regex", () => {
+    expect(() => readRef("ARG ARC_REF=v1.0.0\n", "BUN_VERSION")).toThrow();
+    expect(() => readRef("ARG ARC_REF=v1.0.0\n", "ARC_REF|CORTEX_REF")).toThrow();
+  });
+});
+
+describe.each(ARG_NAMES)("rewriteRef (%s)", (argName) => {
   test("newer release -> rewrite happens with the correct new value", () => {
-    const df = fixtureDockerfile("v0.40.2");
-    const r = rewriteArcRef(df, "v0.42.1");
+    const df = fixtureWith(argName, OLD[argName]);
+    const r = rewriteRef(df, argName, NEW[argName]);
     expect(r.changed).toBe(true);
-    expect(r.oldRef).toBe("v0.40.2");
-    expect(readArcRef(r.content)).toBe("v0.42.1");
+    expect(r.oldRef).toBe(OLD[argName]);
+    expect(readRef(r.content, argName)).toBe(NEW[argName]);
     // The bare re-declaration is untouched (still exactly one, no `=`).
-    expect((r.content.match(/^ARG[ \t]+ARC_REF$/m) || []).length).toBe(1);
+    expect((r.content.match(new RegExp(`^ARG[ \\t]+${argName}$`, "m")) || []).length).toBe(1);
     // Still a PINNED tag — never converted to an unpinned fetch.
-    expect(r.content).toContain("ARG ARC_REF=v0.42.1");
+    expect(r.content).toContain(`ARG ${argName}=${NEW[argName]}`);
+  });
+  test("rewriting one pin leaves the OTHER untouched", () => {
+    const df = fixtureDockerfile(OLD.ARC_REF, OLD.CORTEX_REF);
+    const other: ArgName = argName === "ARC_REF" ? "CORTEX_REF" : "ARC_REF";
+    const r = rewriteRef(df, argName, NEW[argName]);
+    expect(readRef(r.content, argName)).toBe(NEW[argName]);
+    expect(readRef(r.content, other)).toBe(OLD[other]);
   });
   test("idempotent: same value -> no change", () => {
-    const df = fixtureDockerfile("v0.42.1");
-    const r = rewriteArcRef(df, "v0.42.1");
+    const df = fixtureWith(argName, NEW[argName]);
+    const r = rewriteRef(df, argName, NEW[argName]);
     expect(r.changed).toBe(false);
     expect(r.content).toBe(df);
   });
   test("missing/malformed ARG line -> oldRef null, no rewrite", () => {
-    const df = "FROM debian:bookworm-slim\nARG ARC_REF\n";
-    const r = rewriteArcRef(df, "v0.42.1");
+    const df = `FROM debian:bookworm-slim\nARG ${argName}\n`;
+    const r = rewriteRef(df, argName, NEW[argName]);
     expect(r.oldRef).toBeNull();
     expect(r.changed).toBe(false);
     expect(r.content).toBe(df);
   });
 });
 
-describe("decideBump", () => {
+describe.each(ARG_NAMES)("decideBump (%s)", (argName) => {
   test("newer -> bump; equal/older -> no bump", () => {
-    expect(decideBump("v0.40.2", "v0.42.1").shouldBump).toBe(true);
-    expect(decideBump("v0.42.1", "v0.42.1").shouldBump).toBe(false);
-    expect(decideBump("v0.42.1", "v0.40.2").shouldBump).toBe(false);
+    expect(decideBump(argName, OLD[argName], NEW[argName]).shouldBump).toBe(true);
+    expect(decideBump(argName, NEW[argName], NEW[argName]).shouldBump).toBe(false);
+    expect(decideBump(argName, NEW[argName], OLD[argName]).shouldBump).toBe(false);
   });
   test("throws on unparseable input (loud, never silent)", () => {
-    expect(() => decideBump("v0.40.2", "main")).toThrow();
-    expect(() => decideBump("garbage", "v0.42.1")).toThrow();
+    expect(() => decideBump(argName, OLD[argName], "main")).toThrow();
+    expect(() => decideBump(argName, "garbage", NEW[argName])).toThrow();
   });
 });
 
-describe("main (CLI)", () => {
+describe.each(ARG_NAMES)("main CLI (%s)", (argName) => {
+  const flag = argName === "ARC_REF" ? [] : ["--arg-name", argName];
+
   test("newer release + --write rewrites the file, exit 0", () => {
-    const path = tmpDockerfile("v0.40.2");
+    const path = tmpDockerfile(argName, OLD[argName]);
     try {
-      const code = main(["--latest", "v0.42.1", "--dockerfile", path, "--write"]);
+      const code = main(["--latest", NEW[argName], "--dockerfile", path, "--write", ...flag]);
       expect(code).toBe(0);
-      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.42.1");
+      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(NEW[argName]);
     } finally {
       rmSync(join(path, ".."), { recursive: true, force: true });
     }
   });
 
   test("newer release WITHOUT --write is a dry-run (file unchanged)", () => {
-    const path = tmpDockerfile("v0.40.2");
+    const path = tmpDockerfile(argName, OLD[argName]);
     try {
-      const code = main(["--latest", "v0.42.1", "--dockerfile", path]);
+      const code = main(["--latest", NEW[argName], "--dockerfile", path, ...flag]);
       expect(code).toBe(0);
-      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.40.2");
+      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(OLD[argName]);
     } finally {
       rmSync(join(path, ".."), { recursive: true, force: true });
     }
   });
 
   test("equal/older release is a no-op, exit 0, file unchanged", () => {
-    const path = tmpDockerfile("v0.42.1");
+    const path = tmpDockerfile(argName, NEW[argName]);
     try {
-      expect(main(["--latest", "v0.42.1", "--dockerfile", path, "--write"])).toBe(0);
-      expect(main(["--latest", "v0.40.2", "--dockerfile", path, "--write"])).toBe(0);
-      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.42.1");
+      expect(main(["--latest", NEW[argName], "--dockerfile", path, "--write", ...flag])).toBe(0);
+      expect(main(["--latest", OLD[argName], "--dockerfile", path, "--write", ...flag])).toBe(0);
+      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(NEW[argName]);
     } finally {
       rmSync(join(path, ".."), { recursive: true, force: true });
     }
   });
 
+  test("malformed ARG line -> exit 3 (loud, no phantom bump)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
+    const path = join(dir, "Dockerfile.cortex");
+    writeFileSync(path, `FROM debian:bookworm-slim\nARG ${argName}\n`);
+    try {
+      expect(main(["--latest", NEW[argName], "--dockerfile", path, "--write", ...flag])).toBe(3);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unparseable --latest -> exit 3 (never track main)", () => {
+    const path = tmpDockerfile(argName, OLD[argName]);
+    try {
+      expect(main(["--latest", "main", "--dockerfile", path, "--write", ...flag])).toBe(3);
+      expect(readRef(readFileSync(path, "utf8"), argName)).toBe(OLD[argName]);
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  });
+});
+
+describe("main (CLI) — shared behavior", () => {
   test("missing --latest -> usage error (exit 2)", () => {
-    const path = tmpDockerfile("v0.40.2");
+    const path = tmpDockerfile("ARC_REF", OLD.ARC_REF);
     try {
       expect(main(["--dockerfile", path])).toBe(2);
+    } finally {
+      rmSync(join(path, ".."), { recursive: true, force: true });
+    }
+  });
+
+  test("unknown --arg-name -> usage error (exit 2)", () => {
+    const path = tmpDockerfile("ARC_REF", OLD.ARC_REF);
+    try {
+      expect(main(["--latest", "v1.0.0", "--arg-name", "BUN_VERSION", "--dockerfile", path])).toBe(2);
     } finally {
       rmSync(join(path, ".."), { recursive: true, force: true });
     }
@@ -180,40 +268,19 @@ describe("main (CLI)", () => {
     expect(main(["--latest", "v0.42.1", "--dockerfile", "/nonexistent/Dockerfile.cortex"])).toBe(3);
   });
 
-  test("malformed ARG line -> exit 3 (loud, no phantom bump)", () => {
-    const dir = mkdtempSync(join(tmpdir(), "arc-ref-bump-"));
-    const path = join(dir, "Dockerfile.cortex");
-    writeFileSync(path, "FROM debian:bookworm-slim\nARG ARC_REF\n");
-    try {
-      expect(main(["--latest", "v0.42.1", "--dockerfile", path, "--write"])).toBe(3);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("unparseable --latest -> exit 3 (never track main)", () => {
-    const path = tmpDockerfile("v0.40.2");
-    try {
-      expect(main(["--latest", "main", "--dockerfile", path, "--write"])).toBe(3);
-      expect(readArcRef(readFileSync(path, "utf8"))).toBe("v0.40.2");
-    } finally {
-      rmSync(join(path, ".."), { recursive: true, force: true });
-    }
-  });
-
-  test("--github-output writes bumped/old/new to $GITHUB_OUTPUT", () => {
-    const path = tmpDockerfile("v0.40.2");
+  test("--github-output writes bumped/old/new to $GITHUB_OUTPUT (CORTEX_REF)", () => {
+    const path = tmpDockerfile("CORTEX_REF", OLD.CORTEX_REF);
     const outDir = mkdtempSync(join(tmpdir(), "arc-ref-out-"));
     const outFile = join(outDir, "gh_output");
     writeFileSync(outFile, "");
     const prev = process.env.GITHUB_OUTPUT;
     process.env.GITHUB_OUTPUT = outFile;
     try {
-      main(["--latest", "v0.42.1", "--dockerfile", path, "--write", "--github-output"]);
+      main(["--latest", NEW.CORTEX_REF, "--arg-name", "CORTEX_REF", "--dockerfile", path, "--write", "--github-output"]);
       const out = readFileSync(outFile, "utf8");
       expect(out).toContain("bumped=true");
-      expect(out).toContain("old=v0.40.2");
-      expect(out).toContain("new=v0.42.1");
+      expect(out).toContain(`old=${OLD.CORTEX_REF}`);
+      expect(out).toContain(`new=${NEW.CORTEX_REF}`);
     } finally {
       if (prev === undefined) delete process.env.GITHUB_OUTPUT;
       else process.env.GITHUB_OUTPUT = prev;

--- a/scripts/arc-ref-bump.ts
+++ b/scripts/arc-ref-bump.ts
@@ -1,35 +1,44 @@
 #!/usr/bin/env bun
 /**
  * arc-ref-bump.ts — the version-compare + Dockerfile ARG-rewrite core for the
- * automated `ARC_REF` bump workflow (cortex#2246).
+ * automated container ref-bump workflow (cortex#2246, generalized in
+ * cortex#2267 to also track CORTEX_REF).
  *
  * WHY THIS EXISTS
  * ---------------
- * The L4 container (`deploy/compose/Dockerfile.cortex`) pins
- * `ARG ARC_REF=<tag>` for reproducibility. arc releases move, and adapter
- * manifests evolve with arc — so a pinned OLDER arc eventually can't parse
- * NEWER adapter manifests and `arc install` fails in the container (exactly
- * cortex#2243: v0.40.2 predated the `{host,reason}` manifest shape). The
- * principal decision is to KEEP the pin (reproducible builds; un-pinning to
- * `main` sacrifices reproducibility + adds supply-chain exposure) but AUTOMATE
- * the bump dependabot/renovate-style: a scheduled workflow proposes bumps as
- * reviewable, build-gated PRs.
+ * The L4 container (`deploy/compose/Dockerfile.cortex`) pins BOTH
+ * `ARG ARC_REF=<tag>` and `ARG CORTEX_REF=<tag>` for reproducibility. Those
+ * upstreams move, and a pinned OLDER ref eventually drifts out of sync with the
+ * host — e.g. an older arc can't parse newer adapter manifests and `arc install`
+ * fails in the container (cortex#2243: v0.40.2 predated the `{host,reason}`
+ * manifest shape), or an older CORTEX_REF builds a pre-fix cortex so a container
+ * test still hits already-fixed bugs (cortex#2267). The principal decision is to
+ * KEEP the pins (reproducible builds; un-pinning to `main` sacrifices
+ * reproducibility + adds supply-chain exposure) but AUTOMATE the bump
+ * dependabot/renovate-style: a scheduled workflow proposes bumps as reviewable,
+ * build-gated PRs.
  *
  * This module is the small, UNIT-TESTABLE core the workflow (.github/workflows/
  * arc-ref-bump.yml) shells out to — semver compare + ARG rewrite — so that
  * logic is NOT buried in inline YAML. The workflow owns the side effects
  * (resolve latest release via `gh api`, `docker build` gate, open the PR); this
- * script owns the pure decision + the exact byte-level Dockerfile edit.
+ * script owns the pure decision + the exact byte-level Dockerfile edit. The core
+ * is parametrized on the ARG NAME (`ARC_REF` or `CORTEX_REF`) so the workflow
+ * runs the SAME code path for each pin.
  *
  * REPRODUCIBILITY INVARIANT: this script only ever rewrites the ARG to another
  * PINNED TAG. It never converts the Dockerfile to an unpinned build-time fetch.
  *
  * Usage:
- *   bun scripts/arc-ref-bump.ts --latest <tag> [--dockerfile <path>] [--write]
- *                               [--github-output]
+ *   bun scripts/arc-ref-bump.ts --latest <tag> [--arg-name <NAME>]
+ *                               [--dockerfile <path>] [--write] [--github-output]
  *
- *   --latest <tag>        REQUIRED. arc's latest release tag (e.g. v0.42.1),
- *                         resolved by the workflow via `gh api …/releases/latest`.
+ *   --latest <tag>        REQUIRED. The upstream's latest release tag (e.g.
+ *                         v0.42.1 for arc, v6.10.2 for cortex), resolved by the
+ *                         workflow via `gh api …/releases/latest`.
+ *   --arg-name <NAME>     Which pinned ARG to compare/rewrite. One of
+ *                         ARC_REF | CORTEX_REF. Defaults to ARC_REF for
+ *                         backward compatibility.
  *   --dockerfile <path>   Dockerfile to read/rewrite. Defaults to
  *                         deploy/compose/Dockerfile.cortex relative to CWD.
  *   --write               Actually rewrite the file when a bump is warranted.
@@ -39,9 +48,10 @@
  *
  * Exit codes:
  *   0  decision made cleanly (whether or not a bump was warranted)
- *   2  usage error (missing --latest, bad flag)
- *   3  Dockerfile unreadable, or its ARG ARC_REF= line is missing/malformed,
- *      or --latest is not a parseable semver tag — fail LOUD, never silent.
+ *   2  usage error (missing --latest, unknown --arg-name, bad flag)
+ *   3  Dockerfile unreadable, or its `ARG <NAME>=` definition line is
+ *      missing/malformed, or --latest is not a parseable semver tag — fail
+ *      LOUD, never silent.
  */
 
 import { readFileSync, writeFileSync, appendFileSync } from "fs";
@@ -56,6 +66,20 @@ export interface Semver {
 }
 
 export const DEFAULT_DOCKERFILE = "deploy/compose/Dockerfile.cortex";
+
+/** The ARG names this tool knows how to compare/rewrite. */
+export const KNOWN_ARG_NAMES = ["ARC_REF", "CORTEX_REF"] as const;
+export type ArgName = (typeof KNOWN_ARG_NAMES)[number];
+
+/**
+ * Guard: only a known, charset-safe ARG name may be spliced into the line
+ * regexes below. This both restricts the tool to the two pins we track AND
+ * closes any regex-injection surface — the name is never attacker-controlled
+ * once it has passed this gate.
+ */
+export function isKnownArgName(name: string): name is ArgName {
+  return (KNOWN_ARG_NAMES as readonly string[]).includes(name);
+}
 
 /**
  * Parse a semver tag with an optional leading `v`. Returns null for anything
@@ -115,13 +139,15 @@ export function compareSemver(a: Semver, b: Semver): -1 | 0 | 1 {
 }
 
 /**
- * Extract the current pinned value of the `ARG ARC_REF=<value>` line — the ARG
- * DEFINITION that carries a default, NOT the bare `ARG ARC_REF` re-declaration
+ * Extract the current pinned value of the `ARG <argName>=<value>` line — the ARG
+ * DEFINITION that carries a default, NOT the bare `ARG <argName>` re-declaration
  * inside the build stage (which has no `=` and no value). Returns null when no
- * definition line with a value is present (malformed / missing).
+ * definition line with a value is present (malformed / missing). Throws on an
+ * unknown argName so a caller can never inject an arbitrary regex.
  */
-export function readArcRef(dockerfile: string): string | null {
-  const m = /^ARG[ \t]+ARC_REF=(\S+)[ \t]*$/m.exec(dockerfile);
+export function readRef(dockerfile: string, argName: string): string | null {
+  if (!isKnownArgName(argName)) throw new Error(`unknown ARG name: "${argName}"`);
+  const m = new RegExp(`^ARG[ \\t]+${argName}=(\\S+)[ \\t]*$`, "m").exec(dockerfile);
   return m ? (m[1] ?? null) : null;
 }
 
@@ -135,26 +161,27 @@ export interface RewriteResult {
 }
 
 /**
- * Rewrite the `ARG ARC_REF=<value>` definition line to `newRef`. Idempotent:
+ * Rewrite the `ARG <argName>=<value>` definition line to `newRef`. Idempotent:
  * if the current value already equals newRef, content is returned unchanged
  * with changed=false. If the ARG definition line is missing/malformed, oldRef
  * is null and nothing is rewritten (the caller must fail loud).
  *
  * Only the DEFINITION line (with `=<value>`) is touched; the bare re-declaration
- * `ARG ARC_REF` is left intact so the build stage still inherits the default.
+ * `ARG <argName>` is left intact so the build stage still inherits the default.
  */
-export function rewriteArcRef(dockerfile: string, newRef: string): RewriteResult {
-  const oldRef = readArcRef(dockerfile);
+export function rewriteRef(dockerfile: string, argName: string, newRef: string): RewriteResult {
+  const oldRef = readRef(dockerfile, argName); // validates argName
   if (oldRef === null) return { content: dockerfile, changed: false, oldRef: null };
   if (oldRef === newRef) return { content: dockerfile, changed: false, oldRef };
   const content = dockerfile.replace(
-    /^(ARG[ \t]+ARC_REF=)\S+([ \t]*)$/m,
+    new RegExp(`^(ARG[ \\t]+${argName}=)\\S+([ \\t]*)$`, "m"),
     `$1${newRef}$2`,
   );
   return { content, changed: content !== dockerfile, oldRef };
 }
 
 export interface Decision {
+  argName: ArgName;
   oldRef: string;
   latestRef: string;
   /** True when latestRef is strictly newer than oldRef. */
@@ -165,23 +192,29 @@ export interface Decision {
  * Pure decision: given the current pinned ref and the latest release ref,
  * should we bump? Throws on unparseable input so the CLI can exit 3 (loud).
  */
-export function decideBump(oldRef: string, latestRef: string): Decision {
+export function decideBump(argName: ArgName, oldRef: string, latestRef: string): Decision {
   const cur = parseSemver(oldRef);
   const latest = parseSemver(latestRef);
-  if (!cur) throw new Error(`current ARC_REF is not a parseable semver tag: "${oldRef}"`);
+  if (!cur) throw new Error(`current ${argName} is not a parseable semver tag: "${oldRef}"`);
   if (!latest) throw new Error(`--latest is not a parseable semver tag: "${latestRef}"`);
-  return { oldRef, latestRef, shouldBump: compareSemver(latest, cur) > 0 };
+  return { argName, oldRef, latestRef, shouldBump: compareSemver(latest, cur) > 0 };
 }
 
 interface ParsedArgs {
   latest?: string;
+  argName: ArgName;
   dockerfile: string;
   write: boolean;
   githubOutput: boolean;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
-  const out: ParsedArgs = { dockerfile: DEFAULT_DOCKERFILE, write: false, githubOutput: false };
+  const out: ParsedArgs = {
+    argName: "ARC_REF",
+    dockerfile: DEFAULT_DOCKERFILE,
+    write: false,
+    githubOutput: false,
+  };
   const value = (i: number, flag: string): string => {
     const v = argv[i];
     if (v === undefined) throw new Error(`${flag} requires a value`);
@@ -193,6 +226,14 @@ function parseArgs(argv: string[]): ParsedArgs {
       case "--latest":
         out.latest = value(++i, "--latest");
         break;
+      case "--arg-name": {
+        const name = value(++i, "--arg-name");
+        if (!isKnownArgName(name)) {
+          throw new Error(`--arg-name must be one of ${KNOWN_ARG_NAMES.join(", ")} (got "${name}")`);
+        }
+        out.argName = name;
+        break;
+      }
       case "--dockerfile":
         out.dockerfile = value(++i, "--dockerfile");
         break;
@@ -230,6 +271,7 @@ export function main(argv: string[]): number {
     process.stderr.write("arc-ref-bump: --latest <tag> is required\n");
     return 2;
   }
+  const { argName } = args;
 
   const path = resolve(args.dockerfile);
   let dockerfile: string;
@@ -240,17 +282,17 @@ export function main(argv: string[]): number {
     return 3;
   }
 
-  const oldRef = readArcRef(dockerfile);
+  const oldRef = readRef(dockerfile, argName);
   if (oldRef === null) {
     process.stderr.write(
-      `arc-ref-bump: no 'ARG ARC_REF=<value>' definition line found in ${path} (missing/malformed)\n`,
+      `arc-ref-bump: no 'ARG ${argName}=<value>' definition line found in ${path} (missing/malformed)\n`,
     );
     return 3;
   }
 
   let decision: Decision;
   try {
-    decision = decideBump(oldRef, args.latest);
+    decision = decideBump(argName, oldRef, args.latest);
   } catch (e) {
     process.stderr.write(`arc-ref-bump: ${(e as Error).message}\n`);
     return 3;
@@ -258,28 +300,28 @@ export function main(argv: string[]): number {
 
   if (!decision.shouldBump) {
     process.stdout.write(
-      `arc-ref-bump: no bump — pinned ${oldRef} is already >= latest release ${args.latest}.\n`,
+      `arc-ref-bump: no bump — pinned ${argName}=${oldRef} is already >= latest release ${args.latest}.\n`,
     );
     if (args.githubOutput) emitGithubOutput({ bumped: "false", old: oldRef, new: oldRef });
     return 0;
   }
 
-  const { content, changed } = rewriteArcRef(dockerfile, args.latest);
+  const { content, changed } = rewriteRef(dockerfile, argName, args.latest);
   if (!changed) {
     // shouldBump was true but the rewrite was a no-op — treat as loud failure
     // rather than silently reporting a phantom bump.
     process.stderr.write(
-      `arc-ref-bump: decided to bump ${oldRef} -> ${args.latest} but the ARG rewrite made no change (malformed line?)\n`,
+      `arc-ref-bump: decided to bump ${argName} ${oldRef} -> ${args.latest} but the ARG rewrite made no change (malformed line?)\n`,
     );
     return 3;
   }
 
   if (args.write) {
     writeFileSync(path, content);
-    process.stdout.write(`arc-ref-bump: bumped ARC_REF ${oldRef} -> ${args.latest} in ${path}.\n`);
+    process.stdout.write(`arc-ref-bump: bumped ${argName} ${oldRef} -> ${args.latest} in ${path}.\n`);
   } else {
     process.stdout.write(
-      `arc-ref-bump: WOULD bump ARC_REF ${oldRef} -> ${args.latest} (dry-run; pass --write to apply).\n`,
+      `arc-ref-bump: WOULD bump ${argName} ${oldRef} -> ${args.latest} (dry-run; pass --write to apply).\n`,
     );
   }
   if (args.githubOutput) emitGithubOutput({ bumped: "true", old: oldRef, new: args.latest });

--- a/scripts/arc-ref-bump.ts
+++ b/scripts/arc-ref-bump.ts
@@ -29,9 +29,22 @@
  * REPRODUCIBILITY INVARIANT: this script only ever rewrites the ARG to another
  * PINNED TAG. It never converts the Dockerfile to an unpinned build-time fetch.
  *
+ * COMPOSE DRIFT (cortex#2267): the Dockerfile ARG default is NOT the only place a
+ * pin lives. `deploy/compose/docker-compose.yaml` also carries
+ * `build.args.<NAME>: ${<NAME>:-<tag>}`, and on the PRIMARY deploy path
+ * (`docker compose build` / `up -d`) that `build.args` value is passed as
+ * `--build-arg` and OVERRIDES the Dockerfile ARG default. So bumping ONLY the
+ * Dockerfile would leave the compose default authoritative-but-stale and the
+ * deployed image would silently build the pre-bump ref. Therefore, when `--write`
+ * bumps the Dockerfile ARG, this script ALSO rewrites the matching
+ * `${<NAME>:-<tag>}` default in the compose file — IF that token is present.
+ * `ARC_REF` is Dockerfile-only (absent from compose), so its compose sync is a
+ * clean no-op; `CORTEX_REF` is present in both and is kept in lockstep.
+ *
  * Usage:
  *   bun scripts/arc-ref-bump.ts --latest <tag> [--arg-name <NAME>]
- *                               [--dockerfile <path>] [--write] [--github-output]
+ *                               [--dockerfile <path>] [--compose <path>]
+ *                               [--write] [--github-output]
  *
  *   --latest <tag>        REQUIRED. The upstream's latest release tag (e.g.
  *                         v0.42.1 for arc, v6.10.2 for cortex), resolved by the
@@ -41,7 +54,12 @@
  *                         backward compatibility.
  *   --dockerfile <path>   Dockerfile to read/rewrite. Defaults to
  *                         deploy/compose/Dockerfile.cortex relative to CWD.
- *   --write               Actually rewrite the file when a bump is warranted.
+ *   --compose <path>      Compose file whose `${<NAME>:-<tag>}` default is kept
+ *                         in lockstep with the Dockerfile ARG. Defaults to
+ *                         deploy/compose/docker-compose.yaml relative to CWD. A
+ *                         missing/unreadable compose file is a non-fatal skip;
+ *                         an arg absent from a readable compose is a clean no-op.
+ *   --write               Actually rewrite the file(s) when a bump is warranted.
  *                         Without it the script is a dry-run (decision only).
  *   --github-output       Append bumped/old/new to $GITHUB_OUTPUT (for the
  *                         workflow to gate its build + PR steps on).
@@ -50,8 +68,9 @@
  *   0  decision made cleanly (whether or not a bump was warranted)
  *   2  usage error (missing --latest, unknown --arg-name, bad flag)
  *   3  Dockerfile unreadable, or its `ARG <NAME>=` definition line is
- *      missing/malformed, or --latest is not a parseable semver tag — fail
- *      LOUD, never silent.
+ *      missing/malformed, or --latest is not a parseable semver tag, or a
+ *      READABLE compose file carries a malformed `${<NAME>:-}` default (empty/
+ *      invalid tag) for the arg being bumped — fail LOUD, never silent.
  */
 
 import { readFileSync, writeFileSync, appendFileSync } from "fs";
@@ -66,6 +85,7 @@ export interface Semver {
 }
 
 export const DEFAULT_DOCKERFILE = "deploy/compose/Dockerfile.cortex";
+export const DEFAULT_COMPOSE = "deploy/compose/docker-compose.yaml";
 
 /** The ARG names this tool knows how to compare/rewrite. */
 export const KNOWN_ARG_NAMES = ["ARC_REF", "CORTEX_REF"] as const;
@@ -180,6 +200,63 @@ export function rewriteRef(dockerfile: string, argName: string, newRef: string):
   return { content, changed: content !== dockerfile, oldRef };
 }
 
+export interface ComposeRewriteResult {
+  /** The (possibly unchanged) compose content. */
+  content: string;
+  /** True only when the `${<argName>:-<tag>}` default actually changed. */
+  changed: boolean;
+  /** The default value before rewrite; null when the arg's default form is absent. */
+  oldRef: string | null;
+  /** True when a `${<argName>:-...}` default form is present at all. */
+  present: boolean;
+  /** True when present but the default is empty/whitespace (malformed). */
+  malformed: boolean;
+}
+
+/**
+ * Rewrite the compose `${<argName>:-<tag>}` default to `newRef`, preserving the
+ * `${...:-...}` shape EXACTLY (reproducibility invariant: only ever a pinned
+ * tag). This is the compose-side counterpart to `rewriteRef`, needed because a
+ * compose `build.args` value is passed as `--build-arg` and OVERRIDES the
+ * Dockerfile ARG default on the primary deploy path — so the two must move in
+ * lockstep or the deployed image silently builds the stale ref (cortex#2267).
+ *
+ * The three shapes a caller must distinguish:
+ *   - absent   (present=false): the arg has no `${…:-…}` default here — e.g.
+ *              ARC_REF, which is Dockerfile-only. A clean NO-OP, never an error.
+ *   - malformed (malformed=true): `${<argName>:-}` with an empty/whitespace
+ *              default. Mirrors the Dockerfile's missing/malformed discipline —
+ *              the caller fails LOUD (exit 3) rather than writing garbage.
+ *   - present + valid: rewrite to `newRef` (idempotent when already equal).
+ *
+ * Only the FIRST occurrence is targeted (compose declares each default once),
+ * mirroring the single-line discipline of the Dockerfile rewrite. Throws on an
+ * unknown argName so a caller can never splice an arbitrary regex.
+ */
+export function rewriteComposeDefault(
+  compose: string,
+  argName: string,
+  newRef: string,
+): ComposeRewriteResult {
+  if (!isKnownArgName(argName)) throw new Error(`unknown ARG name: "${argName}"`);
+  const re = new RegExp(`\\$\\{${argName}:-([^}]*)\\}`);
+  const m = re.exec(compose);
+  if (!m) {
+    return { content: compose, changed: false, oldRef: null, present: false, malformed: false };
+  }
+  const current = m[1] ?? "";
+  if (current.trim() === "") {
+    // `${<argName>:-}` — an empty/invalid pinned default. Malformed, fail loud.
+    return { content: compose, changed: false, oldRef: null, present: true, malformed: true };
+  }
+  if (current === newRef) {
+    return { content: compose, changed: false, oldRef: current, present: true, malformed: false };
+  }
+  // Function replacement so a `$` in newRef is never treated as a backreference.
+  const content = compose.replace(re, () => `\${${argName}:-${newRef}}`);
+  return { content, changed: content !== compose, oldRef: current, present: true, malformed: false };
+}
+
 export interface Decision {
   argName: ArgName;
   oldRef: string;
@@ -204,6 +281,7 @@ interface ParsedArgs {
   latest?: string;
   argName: ArgName;
   dockerfile: string;
+  compose: string;
   write: boolean;
   githubOutput: boolean;
 }
@@ -212,6 +290,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   const out: ParsedArgs = {
     argName: "ARC_REF",
     dockerfile: DEFAULT_DOCKERFILE,
+    compose: DEFAULT_COMPOSE,
     write: false,
     githubOutput: false,
   };
@@ -236,6 +315,9 @@ function parseArgs(argv: string[]): ParsedArgs {
       }
       case "--dockerfile":
         out.dockerfile = value(++i, "--dockerfile");
+        break;
+      case "--compose":
+        out.compose = value(++i, "--compose");
         break;
       case "--write":
         out.write = true;
@@ -316,13 +398,64 @@ export function main(argv: string[]): number {
     return 3;
   }
 
+  // ── Compose side: keep the `${<argName>:-<tag>}` default in lockstep with the
+  //    Dockerfile ARG (cortex#2267). Computed BEFORE any write so a malformed
+  //    compose default fails loud (exit 3) without leaving a half-applied bump.
+  const composePath = resolve(args.compose);
+  const composeToken = "${" + argName + ":-<tag>}";
+  let composeText: string | null = null;
+  try {
+    composeText = readFileSync(composePath, "utf8");
+  } catch {
+    // Compose is optional for a given arg — a missing/unreadable file is a
+    // non-fatal skip (the Dockerfile bump still stands), not an error.
+    process.stderr.write(
+      `arc-ref-bump: compose file at ${composePath} is missing/unreadable — skipping compose sync (non-fatal).\n`,
+    );
+  }
+
+  let composeContent: string | null = null;
+  let composeChanged = false;
+  if (composeText !== null) {
+    const cr = rewriteComposeDefault(composeText, argName, args.latest);
+    if (cr.malformed) {
+      process.stderr.write(
+        `arc-ref-bump: '${composeToken}' default in ${composePath} is malformed (empty/invalid tag)\n`,
+      );
+      return 3;
+    }
+    if (!cr.present) {
+      process.stdout.write(
+        `arc-ref-bump: no '${composeToken}' default in ${composePath} — compose sync is a no-op for ${argName}.\n`,
+      );
+    } else if (!cr.changed) {
+      process.stdout.write(
+        `arc-ref-bump: compose default ${argName} already at ${args.latest} in ${composePath} — no change.\n`,
+      );
+    } else {
+      composeContent = cr.content;
+      composeChanged = true;
+    }
+  }
+
   if (args.write) {
     writeFileSync(path, content);
     process.stdout.write(`arc-ref-bump: bumped ${argName} ${oldRef} -> ${args.latest} in ${path}.\n`);
+    if (composeChanged && composeContent !== null) {
+      writeFileSync(composePath, composeContent);
+      process.stdout.write(
+        `arc-ref-bump: bumped compose default ${argName} -> ${args.latest} in ${composePath}.\n`,
+      );
+    }
   } else {
     process.stdout.write(
       `arc-ref-bump: WOULD bump ${argName} ${oldRef} -> ${args.latest} (dry-run; pass --write to apply).\n`,
     );
+    if (composeChanged) {
+      process.stdout.write(
+        `arc-ref-bump: WOULD also bump compose default ${argName} -> ${args.latest} in ${composePath} (dry-run).\n`,
+      );
+    }
   }
   if (args.githubOutput) emitGithubOutput({ bumped: "true", old: oldRef, new: args.latest });
   return 0;


### PR DESCRIPTION
Closes #2267.

The L4 container pinned `ARG CORTEX_REF=v6.10.0`, so a container test builds **pre-fix** cortex and still hits the 6.10.x quickstart bugs already fixed on the host. Two changes:

## Fix 1 — bump the container `CORTEX_REF` pin → `v6.10.2`
- `deploy/compose/Dockerfile.cortex`: `ARG CORTEX_REF=v6.10.0` → `v6.10.2`.
- `deploy/compose/docker-compose.yaml`: `${CORTEX_REF:-v6.10.0}` → `${CORTEX_REF:-v6.10.2}`.
- `v6.10.2` is now a real git-tagged release, so the pin points at a release tag again (never `main`).

## Fix 2 — extend the auto-bump automation to track `CORTEX_REF` too
Generalizes the scheduled `ARC_REF` bump (#2251) into a matrix that tracks **both** pins:
- `arc → ARC_REF` (repo `the-metafactory/arc`, fallback tag filter `^v[0-9]+\.[0-9]+\.[0-9]+$`)
- `cortex → CORTEX_REF` (repo `the-metafactory/cortex`, fallback filter `^v6\.[0-9]+\.[0-9]+$`)
- `fail-fast: false` so one pin's red gate can't cancel the other leg.

Each leg resolves the upstream's latest **release** tag (`gh api .../releases/latest`, fallback = highest matching semver git tag — never raw `main`), runs the unit-tested compare/rewrite core (`scripts/arc-ref-bump.ts --arg-name <ARC_REF|CORTEX_REF>`), gates on a real `docker build --build-arg <ARG>=<new>` of `Dockerfile.cortex` (the build runs the `arc install <adapter>` step that failed in #2243), then opens a labeled PR on green or a tracking issue on red. Reproducibility invariant preserved: both pins only ever move to another pinned tag.

**Injection-safety (the #2251 lesson):** every attacker-influenceable value — release tags from `gh api` (another repo's tag = supply chain) and raw `workflow_dispatch` inputs — is routed through `env:` and referenced as a quoted shell var. No `${{ }}` is inlined into any `run:` block. `--arg-name` is validated against an allow-list before it is ever spliced into a `RegExp`.

## Drift fix (caught in adversarial review, fixed here)
First cut of Fix 2 rewrote **only** the Dockerfile ARG. But `docker-compose.yaml` carries `build.args.CORTEX_REF: ${CORTEX_REF:-<tag>}`, which Compose passes as `--build-arg` and which **overrides the Dockerfile ARG default** on the primary `docker compose build` / `up -d` path. So the next automated bump would advance the Dockerfile but leave the compose default stale — silently building the pre-bump cortex, defeating the workflow's purpose.

Fixed by keeping the two in lockstep in the automation itself:
- `scripts/arc-ref-bump.ts` gains a `--compose <path>` flag (default `deploy/compose/docker-compose.yaml`) and a `rewriteComposeDefault(compose, argName, newRef)` that rewrites the `${<ARG>:-<tag>}` default, preserving the `${...:-...}` shape exactly. Absent arg (e.g. `ARC_REF`, Dockerfile-only) → clean no-op; malformed `${<ARG>:-}` default → exit 3 (computed **before** any write, so no half-applied bump); missing/unreadable compose → non-fatal skip.
- The workflow green-PR step now stages **both** files (`git add deploy/compose/Dockerfile.cortex deploy/compose/docker-compose.yaml`).
- Build gate deliberately kept as raw `docker build --build-arg` — it correctly exercises the bumped ARG for **either** leg (a compose-based gate wouldn't test the `ARC_REF` override, since compose doesn't pass `ARC_REF`).

## Validation
- `bun test scripts/__tests__/arc-ref-bump.test.ts` → **49 pass / 0 fail** (126 assertions). New cases: both-files bump for `CORTEX_REF`, Dockerfile-only for `ARC_REF`, compose-already-current no-op, malformed compose default → exit 3, missing compose → non-fatal skip.
- Live dry-run + `--write` proof against temp copies of the real deploy files: `CORTEX_REF` moves both files; `ARC_REF` moves only the Dockerfile (compose logs a no-op).
- `tsc --noEmit`: this branch introduces **zero** new type errors vs `origin/main` (the ~15 pre-existing errors are unrelated myelin/RFC-area files this branch never touches).
- Adversarial review: sole blocker was the drift bug above (now fixed); injection surface, semver logic, `--arg-name` allow-list, PR/issue dedup, and CI matrix mechanics all cleared.

## Out of scope
- The release-tagging adherence gap (recent manifest bumps skipped `gh release create`) — process fix, tracked separately; a CI auto-release-on-version-bump is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
