### PR TITLE
fix(deploy): pre-create compose named-volume mount points as cortex — fix container EACCES boot loop (#2269)

### DIFF
--- a/deploy/compose/Dockerfile.cortex
+++ b/deploy/compose/Dockerfile.cortex
@@ -137,6 +137,19 @@ RUN git clone --depth 1 --branch "${CORTEX_REF}" \
 #    tolerant fallback so a scaffolding hiccup never hard-fails the build.
 USER cortex
 WORKDIR /home/cortex
+
+# 8a. Pre-create the compose named-volume mount points, owned by cortex. Docker
+#     copies the image dir's ownership into a FRESH named volume on first mount;
+#     if the path is absent from the image the volume comes up root:root and the
+#     non-root cortex user cannot write (EACCES at runNatsConf — cortex#2269).
+#     These three paths are exactly the named volumes in docker-compose.yaml.
+#     Running as cortex, `mkdir -p` creates the whole chain cortex-owned — no
+#     chown needed. Must run before postinstall so nothing writes first.
+RUN mkdir -p \
+      ~/.config/metafactory/cortex \
+      ~/.config/nats \
+      ~/.local/state/metafactory/cortex
+
 RUN cd /opt/cortex && ./scripts/postinstall.sh || \
     echo "cortex: postinstall.sh returned non-zero (systemd-less container) — continuing"
 


### PR DESCRIPTION
Closes #2269.

## Problem
The L4 compose container boot-loops with **EACCES** at provisioning: a Debian/L4 tester (after overriding the stale `CORTEX_REF`, separately fixed in #2268) hit

```
EACCES: permission denied, open '/home/cortex/.config/nats/<slug>.conf'
    at runNatsConf (src/cli/cortex/commands/quickstart.ts:405)
cortex-entrypoint: quickstart failed before the healthy-boot gate — aborting boot.
```

## Root cause
`docker-compose.yaml` declares three named volumes mounted into the cortex container:
`cortex-config → ~/.config/metafactory/cortex`, `cortex-state → ~/.local/state/metafactory/cortex`, `cortex-nats → ~/.config/nats`.

Docker copies the image directory's ownership into a **fresh** named volume on first mount **only if the path exists in the image**; otherwise the mountpoint is created `root:root`. The image (`Dockerfile.cortex` step 8, `postinstall.sh`) creates `.local/state/...` and `.local/share/...events/...` but **never `.config/nats`** — so that volume comes up `root:root` and the non-root `cortex` (uid 1000) user cannot write it. `runNatsConf`'s `mkdirSync(recursive)` is a no-op on the mounted dir and does not fix ownership, so `writeFileSync` fails EACCES. It surfaces on nats first because nats.conf is written early in quickstart.

## Fix
Pre-create the three named-volume mount points in the image, owned by `cortex`, before `postinstall.sh` (step 8a). Running as `cortex`, `mkdir -p` makes the chain cortex-owned, so each fresh volume inherits cortex ownership — no chown needed. Dockerfile-only, +13 lines.

## Validation (real Linux docker, `debian:bookworm-slim` base)
A faithful minimal repro (same uid-1000 non-root user, same `.config/nats` path, same named-volume mount):

| | user | fresh volume owner | write `.config/nats/<slug>.conf` |
|---|---|---|---|
| **pre-fix** (origin/main) | 1000:1000 | **0:0 (root)** | **EACCES — Permission denied** (reproduces the report) |
| **with #2269** | 1000:1000 | **1000:1000 (cortex)** | **WROTE_OK** |

Confirmed the three `mkdir -p` paths exactly match the three container-side named-volume targets in `docker-compose.yaml`, and that the new step sits after `USER cortex` (so ownership is cortex) and before `postinstall.sh` (so nothing writes first).

## Note for existing installs
The image fix affects **fresh** volumes only. Anyone who already built the broken image has a stale `root:root` volume; they must `docker compose down -v` (recreating the volumes) before rebuilding. A clearer entrypoint error for that case was considered and deliberately left as a possible follow-up.

## Out of scope
- The `CORTEX_REF` pin staleness (fixed in #2268) — independent; this bug still bites after that.
- Entrypoint self-heal / preflight for pre-existing root-owned volumes (optional follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
