### PR TITLE
fix(quickstart+deploy): --skip-gate deferral + daemon-on-bus compose healthcheck; bump 6.10.3 (#2275)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.10.2"
+version: "6.10.3"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin layer model"

--- a/deploy/compose/Dockerfile.cortex
+++ b/deploy/compose/Dockerfile.cortex
@@ -21,7 +21,7 @@
 # Every pinned version is an ARG so the image is reproducible and a rebuild can
 # bump a single component. CORTEX_REF defaults to a RELEASE TAG, never `main`.
 
-ARG CORTEX_REF=v6.10.2
+ARG CORTEX_REF=v6.10.3
 ARG BUN_VERSION=1.3.14
 ARG CLAUDE_VERSION=2.1.211
 ARG NATS_SERVER_VERSION=2.14.3

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -63,11 +63,16 @@ start`). The entrypoint therefore runs quickstart with `--skip-gate`
 (cortex#2275): step 8 is reported as an explicit skip ("deferred to supervisor
 healthcheck"), provisioning output is green when steps 1–7 pass, and **any**
 nonzero quickstart exit aborts the boot. The deferral's landing zone is the
-cortex service's compose healthcheck — it probes the same nats-monitor
-`/healthz` the native gate uses (reachable on localhost via the shared network
-namespace), so `docker compose ps` shows cortex healthy/unhealthy from the
-actual bus, and a dead bus flips it unhealthy instead of degrading silently.
-Verify with the `logs` grep in step 5 and by `@mention`.
+cortex service's compose healthcheck — it asks the nats monitor's `/connz`
+(reachable on localhost via the shared network namespace) whether the
+**daemon's own bus connection** (`cortex-<slug>`, the scaffolded `nats.name`)
+is present. That is strictly stronger than probing `/healthz`: it fails when
+the monitor is unreachable AND when the daemon's primary bus link is dead
+while the process lives (the cortex#2264 silent-degradation class, which
+`restart: unless-stopped` cannot see). So `docker compose ps` shows cortex
+healthy/unhealthy from the actual daemon↔bus link, and a dead bus or a
+degraded daemon flips it unhealthy instead of looking fine. Verify with the
+`logs` grep in step 5 and by `@mention`.
 
 ## Lifecycle
 
@@ -125,9 +130,11 @@ default Discord quickstart needs `discord`; a `web:`-only stack should build
 ## Pinned versions
 
 All are build ARGs, overridable from `.env`: `CORTEX_REF` (a release tag, **not**
-`main` — default `v6.10.0`, the first release that carries `cortex quickstart`
-and the L4 container fixes; earlier tags lack `quickstart` and abort at boot,
-cortex#2154), `BUN_VERSION`, `CLAUDE_VERSION`, `NATS_SERVER_VERSION`, `ARC_REF` (the
+`main` — default `v6.10.3`. **This compose checkout's entrypoint requires
+`CORTEX_REF` >= `v6.10.3`**: it passes `--skip-gate` (cortex#2275), which older
+`cortex` builds reject as an unknown flag, so quickstart exits 2 and the boot
+restart-loops. Tags before `v6.10.0` lack `quickstart` entirely and abort at
+boot, cortex#2154), `BUN_VERSION`, `CLAUDE_VERSION`, `NATS_SERVER_VERSION`, `ARC_REF` (the
 arc release tag used to install the surface-adapter package manager),
 `CORTEX_SURFACES` (which adapter bundle(s) to bake — see above), and the
 `NATS_IMAGE` tag. Bump one, rebuild, redeploy.

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -59,10 +59,15 @@ this binary be dropped.
 
 quickstart's step 8 greps the cortex daemon's own log for healthy-boot lines, but
 in a container the daemon only starts *after* quickstart returns (`exec cortex
-start`). The entrypoint tolerates a **lone** step-8 failure and aborts on any
-earlier one. The real health signal in a container is the running daemon under
-`restart: unless-stopped` plus the nats healthcheck — verify with the `logs`
-grep in step 5 and by `@mention`.
+start`). The entrypoint therefore runs quickstart with `--skip-gate`
+(cortex#2275): step 8 is reported as an explicit skip ("deferred to supervisor
+healthcheck"), provisioning output is green when steps 1–7 pass, and **any**
+nonzero quickstart exit aborts the boot. The deferral's landing zone is the
+cortex service's compose healthcheck — it probes the same nats-monitor
+`/healthz` the native gate uses (reachable on localhost via the shared network
+namespace), so `docker compose ps` shows cortex healthy/unhealthy from the
+actual bus, and a dead bus flips it unhealthy instead of degrading silently.
+Verify with the `logs` grep in step 5 and by `@mention`.
 
 ## Lifecycle
 

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       context: .
       dockerfile: Dockerfile.cortex
       args:
-        CORTEX_REF: ${CORTEX_REF:-v6.10.2}
+        CORTEX_REF: ${CORTEX_REF:-v6.10.3}
         BUN_VERSION: ${BUN_VERSION:-1.3.14}
         CLAUDE_VERSION: ${CLAUDE_VERSION:-2.1.211}
         NATS_SERVER_VERSION: ${NATS_SERVER_VERSION:-2.14.3}
@@ -65,6 +65,20 @@ services:
       - cortex-config:/home/cortex/.config/metafactory/cortex
       - cortex-state:/home/cortex/.local/state/metafactory/cortex
       - cortex-nats:/home/cortex/.config/nats
+    # The landing zone for quickstart's deferred healthy-boot gate (cortex#2275):
+    # the entrypoint runs `cortex quickstart --skip-services --skip-gate`, so THIS
+    # is the post-start health signal. It probes the same nats-monitor /healthz
+    # the native gate uses — reachable on 127.0.0.1 because cortex shares the
+    # nats network namespace (above) — so a dead/hung bus flips cortex unhealthy
+    # instead of silently degrading. curl is baked into the image
+    # (Dockerfile.cortex, step 1). start_period is first-boot generous: initial
+    # provisioning (scaffold + seed) runs before the daemon starts.
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "http://127.0.0.1:8222/healthz"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
     restart: unless-stopped
 
 volumes:

--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -67,14 +67,23 @@ services:
       - cortex-nats:/home/cortex/.config/nats
     # The landing zone for quickstart's deferred healthy-boot gate (cortex#2275):
     # the entrypoint runs `cortex quickstart --skip-services --skip-gate`, so THIS
-    # is the post-start health signal. It probes the same nats-monitor /healthz
-    # the native gate uses — reachable on 127.0.0.1 because cortex shares the
-    # nats network namespace (above) — so a dead/hung bus flips cortex unhealthy
-    # instead of silently degrading. curl is baked into the image
-    # (Dockerfile.cortex, step 1). start_period is first-boot generous: initial
-    # provisioning (scaffold + seed) runs before the daemon starts.
+    # is the post-start health signal. It asks the nats monitor's /connz (open
+    # connections; 200, unauthenticated, no query params needed) whether the
+    # DAEMON'S bus connection is present — the client name `cortex-<slug>` set by
+    # the scaffolded `nats.name` (stack-lib.ts → runtime.ts → connection.ts).
+    # Reachable on 127.0.0.1 because cortex shares the nats network namespace
+    # (above). Strictly stronger than probing /healthz (which only verifies the
+    # bus SERVER — the nats service's own healthcheck already does that): this
+    # also fails when the daemon's primary bus link is dead while the process
+    # lives (the cortex#2264 silent-degradation class) — the exact case
+    # `restart: unless-stopped` cannot see. ${CTX_SLUG} is compose-interpolated
+    # from .env (the same file env_file loads); the grep tolerates optional
+    # whitespace after the colon across server JSON renderings. curl + sh + grep
+    # are baked into the image (Dockerfile.cortex, step 1). start_period is
+    # first-boot generous: initial provisioning (scaffold + seed) runs before
+    # the daemon starts and its connection appears.
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "http://127.0.0.1:8222/healthz"]
+      test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8222/connz | grep -Eq '\"name\": ?\"cortex-${CTX_SLUG}\"'"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/deploy/compose/docker-entrypoint.sh
+++ b/deploy/compose/docker-entrypoint.sh
@@ -19,11 +19,12 @@
 # the daemon only starts in phase 2 (AFTER quickstart returns) — in the
 # split-container model the gate is structurally a post-start check. Step 8 is
 # reported as an explicit skip ("deferred to supervisor healthcheck"), so a
-# successful provisioning run is GREEN — no expected-error JSON. Post-start
+# successful provisioning run is GREEN — no expected-error output. Post-start
 # health is owned by the supervisor: the compose cortex-service healthcheck
-# (the same nats-monitor /healthz the native gate probes, on localhost via the
-# shared network namespace) + `restart: unless-stopped`. With the gate skipped,
-# ANY nonzero quickstart exit is a real provisioning error and aborts the boot.
+# (the daemon's own bus connection on the nats monitor's /connz, on localhost
+# via the shared network namespace) + `restart: unless-stopped`. With the gate
+# skipped, ANY nonzero quickstart exit is a real provisioning error and aborts
+# the boot.
 #
 # Secret hygiene: this script never echoes CTX_DISCORD_TOKEN or
 # CLAUDE_CODE_OAUTH_TOKEN. quickstart itself only ever prints "set"/"missing" for
@@ -54,13 +55,14 @@ POINTER="${CONFIG_DIR}/${CTX_SLUG}/${CTX_SLUG}.yaml"
 
 echo "cortex-entrypoint: provisioning stack '${CTX_SLUG}' (idempotent)…"
 
-# Run provisioning. `--json` so we can reason about WHICH step failed without
-# scraping human text. `--skip-gate` (cortex#2275): step 8 is reported as
-# deferred and quickstart exits 0 when steps 1–7 pass, so there is no
-# expected-failure case left — ANY nonzero exit is a real provisioning error
+# Run provisioning. Human step-table output (no --json): nothing here parses
+# the result anymore — the exit code is the whole contract — and the ✓/✗ table
+# reads better in `docker compose logs`. `--skip-gate` (cortex#2275): step 8 is
+# reported as deferred and quickstart exits 0 when steps 1–7 pass, so there is
+# no expected-failure case left — ANY nonzero exit is a real provisioning error
 # → abort (compose will restart us).
 set +e
-cortex quickstart --skip-services --skip-gate --json
+cortex quickstart --skip-services --skip-gate
 qs_rc=$?
 set -e
 

--- a/deploy/compose/docker-entrypoint.sh
+++ b/deploy/compose/docker-entrypoint.sh
@@ -14,13 +14,16 @@
 #      process, so compose's `restart: unless-stopped` supervises the daemon and
 #      SIGTERM on `docker compose stop` reaches it directly.
 #
-# The healthy-boot gate (quickstart step 8) is EXPECTED to fail here: it greps
-# the cortex daemon's own log for healthy-boot lines, but the daemon only starts
-# in phase 2 (AFTER quickstart returns). In the split-container model the gate is
-# structurally a post-start check, so a LONE step-8 failure is tolerated; a
-# failure at any EARLIER step (preflight, env validation, scaffold, patch) is a
-# real provisioning error and aborts the boot. The compose healthcheck + restart
-# policy is the container's actual supervision contract.
+# The healthy-boot gate (quickstart step 8) is SKIPPED here (`--skip-gate`,
+# cortex#2275): it greps the cortex daemon's own log for healthy-boot lines, but
+# the daemon only starts in phase 2 (AFTER quickstart returns) — in the
+# split-container model the gate is structurally a post-start check. Step 8 is
+# reported as an explicit skip ("deferred to supervisor healthcheck"), so a
+# successful provisioning run is GREEN — no expected-error JSON. Post-start
+# health is owned by the supervisor: the compose cortex-service healthcheck
+# (the same nats-monitor /healthz the native gate probes, on localhost via the
+# shared network namespace) + `restart: unless-stopped`. With the gate skipped,
+# ANY nonzero quickstart exit is a real provisioning error and aborts the boot.
 #
 # Secret hygiene: this script never echoes CTX_DISCORD_TOKEN or
 # CLAUDE_CODE_OAUTH_TOKEN. quickstart itself only ever prints "set"/"missing" for
@@ -52,25 +55,18 @@ POINTER="${CONFIG_DIR}/${CTX_SLUG}/${CTX_SLUG}.yaml"
 echo "cortex-entrypoint: provisioning stack '${CTX_SLUG}' (idempotent)…"
 
 # Run provisioning. `--json` so we can reason about WHICH step failed without
-# scraping human text. Capture instead of letting `set -e` abort on the expected
-# gate failure.
+# scraping human text. `--skip-gate` (cortex#2275): step 8 is reported as
+# deferred and quickstart exits 0 when steps 1–7 pass, so there is no
+# expected-failure case left — ANY nonzero exit is a real provisioning error
+# → abort (compose will restart us).
 set +e
-qs_out="$(cortex quickstart --skip-services --json 2>&1)"
+cortex quickstart --skip-services --skip-gate --json
 qs_rc=$?
 set -e
 
-printf '%s\n' "${qs_out}"
-
 if [ "${qs_rc}" -ne 0 ]; then
-  # quickstart stops at the FIRST failing step, so if the failing step is the
-  # healthy-boot gate then steps 1–7 all passed. Any other failing step means
-  # provisioning genuinely failed → abort (compose will restart us).
-  if printf '%s' "${qs_out}" | grep -q '8. Healthy-boot gate'; then
-    echo "cortex-entrypoint: provisioning complete; healthy-boot gate deferred to the daemon + compose healthcheck (expected in a container)." >&2
-  else
-    echo "cortex-entrypoint: quickstart failed before the healthy-boot gate — aborting boot." >&2
-    exit "${qs_rc}"
-  fi
+  echo "cortex-entrypoint: quickstart provisioning failed (exit ${qs_rc}) — aborting boot." >&2
+  exit "${qs_rc}"
 fi
 
 if [ ! -f "${POINTER}" ]; then

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -778,7 +778,7 @@ describe("dispatchQuickstart — --skip-gate defers the healthy-boot gate", () =
     expect(res.stdout).not.toContain("--skip-services passed");
   });
 
-  test("--json with --skip-services --skip-gate (the entrypoint shape): step 8 is ok + skipped with the deferral note, envelope is ok", async () => {
+  test("--json with --skip-services --skip-gate: step 8 is ok + skipped with the deferral note, envelope is ok", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
     const res = await withPlatform("linux", () =>

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -725,6 +725,136 @@ describe("dispatchQuickstart — --container skips the healthy-boot gate", () =>
 });
 
 // =============================================================================
+// --skip-gate — defer step 8 to the supervisor healthcheck (cortex#2275)
+// =============================================================================
+
+describe("dispatchQuickstart — --skip-gate defers the healthy-boot gate", () => {
+  test("--skip-gate skips step 8 with NO log-grep / healthz probe and exits 0", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    let readLogCalls = 0;
+    let healthzCalls = 0;
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          // A gate that would NEVER pass if it ran (empty log + failing healthz).
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--skip-gate", "--gate-timeout-ms", "5000"],
+          () =>
+            fakePorts({
+              readLog: () => {
+                readLogCalls++;
+                return undefined;
+              },
+              fetchHealthz: () => {
+                healthzCalls++;
+                return Promise.resolve(false);
+              },
+            }),
+        ),
+      ),
+    );
+    // Exit 0 even though the gate ports are rigged to fail — step 8 never ran.
+    expect(res.exitCode).toBe(0);
+    // Explicit deferral marker (mirrors step 7's --skip-services convention).
+    expect(res.stdout).toContain("--skip-gate passed — deferred to supervisor healthcheck");
+    expect(readLogCalls).toBe(0);
+    expect(healthzCalls).toBe(0);
+    expect(res.stdout).not.toContain("timed out after");
+  });
+
+  test("--skip-gate does NOT imply --skip-services (step 7 still runs — and can still fail)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--skip-gate"],
+          () => fakePorts({ unitFileExists: () => false }), // fails step 7 — proving it RAN
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("systemd template units not found");
+    expect(res.stdout).not.toContain("--skip-services passed");
+  });
+
+  test("--json with --skip-services --skip-gate (the entrypoint shape): step 8 is ok + skipped with the deferral note, envelope is ok", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--skip-services", "--skip-gate", "--json"],
+          // Rigged-to-fail gate ports + unit files absent — neither may matter.
+          () => fakePorts({ unitFileExists: () => false, readLog: () => undefined, fetchHealthz: () => Promise.resolve(false) }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as {
+      status: string;
+      items?: { step: string; ok: string; skipped?: string; note?: string }[];
+    };
+    expect(parsed.status).toBe("ok");
+    // Step 8 is present, ok, and EXPLICITLY marked deferred — never a bare
+    // green check for work that didn't run, never silently absent.
+    const gate = parsed.items?.find((i) => i.step === "8. Healthy-boot gate");
+    expect(gate).toBeDefined();
+    expect(gate?.ok).toBe("true");
+    expect(gate?.skipped).toBe("true");
+    expect(gate?.note).toBe("deferred to supervisor healthcheck");
+    // Steps 1–7 carry the pre-#2275 shape untouched (no skipped/note keys
+    // except step 7's own skip is NOT marked — only --skip-gate marks one).
+    for (const item of parsed.items ?? []) {
+      if (item.step !== "8. Healthy-boot gate") {
+        expect(item.skipped).toBeUndefined();
+        expect(item.note).toBeUndefined();
+      }
+    }
+    expect(res.stdout).not.toContain(SECRET_TOKEN);
+  });
+
+  test("WITHOUT --skip-gate the gate still runs and its JSON item carries NO skipped/note keys (default unchanged)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    let readLogCalls = 0;
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--json"],
+          () =>
+            fakePorts({
+              readLog: () => {
+                readLogCalls++;
+                return FULL_HEALTHY_LOG;
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    // The gate ran — proving --skip-gate is what suppresses it.
+    expect(readLogCalls).toBeGreaterThan(0);
+    const parsed = JSON.parse(res.stdout) as {
+      status: string;
+      items?: { step: string; ok: string; skipped?: string; note?: string }[];
+    };
+    expect(parsed.status).toBe("ok");
+    const gate = parsed.items?.find((i) => i.step === "8. Healthy-boot gate");
+    expect(gate?.ok).toBe("true");
+    expect(gate?.skipped).toBeUndefined();
+    expect(gate?.note).toBeUndefined();
+  });
+
+  test("--help documents --skip-gate", async () => {
+    const res = await dispatchQuickstart(["--help"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("--skip-gate");
+    expect(res.stdout).toContain("deferred");
+  });
+});
+
+// =============================================================================
 // --surface (cortex#2153) — web/gateway surface mode
 // =============================================================================
 

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -128,6 +128,7 @@ interface QuickstartFlags {
   force: boolean;
   json: boolean;
   skipServices: boolean;
+  skipGate: boolean;
   container: boolean;
   surface: Surface;
   gateTimeoutMs: number;
@@ -142,6 +143,7 @@ function parseQuickstartArgs(argv: string[]): QuickstartFlags {
     force: false,
     json: false,
     skipServices: false,
+    skipGate: false,
     container: false,
     // Default `discord` — byte-identical to pre-#2153 behaviour for every
     // caller that doesn't pass --surface (the entrypoint + every existing test).
@@ -178,6 +180,15 @@ function parseQuickstartArgs(argv: string[]): QuickstartFlags {
       // exercise steps 1-6+8 without a systemd host at all.
       case "--skip-services":
         flags.skipServices = true;
+        break;
+      // Skip step 8's healthy-boot gate and report it as DEFERRED (cortex#2275).
+      // Sibling of --skip-services: the container entrypoint runs quickstart
+      // BEFORE the daemon exists (`exec cortex start` is phase 2), so the gate
+      // structurally cannot pass — the supervisor's healthcheck (compose) is the
+      // real health signal. Unlike --container this does NOT imply
+      // --skip-services; the entrypoint passes both explicitly.
+      case "--skip-gate":
+        flags.skipGate = true;
         break;
       // Container mode (cortex#2155): skip step 8's healthy-boot gate. Under
       // the L4 split-container model the daemon starts only AFTER quickstart
@@ -230,6 +241,12 @@ interface StepReport {
   name: string;
   ok: boolean;
   lines: string[];
+  /** cortex#2275 — step was deliberately not executed (e.g. --skip-gate).
+   *  Surfaced in the --json items as `skipped: "true"` so an operator sees an
+   *  explicit deferral, never a green check for work that didn't run. */
+  skipped?: boolean;
+  /** Short machine-readable reason accompanying `skipped` (--json `note`). */
+  note?: string;
 }
 
 function step(name: string, ok: boolean, lines: string[]): StepReport {
@@ -706,8 +723,24 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
 
 async function runGate(
   ports: QuickstartPorts,
-  opts: { slug: string; monitorPort: string; timeoutMs: number; skip: boolean },
+  opts: { slug: string; monitorPort: string; timeoutMs: number; skip: boolean; skipGate: boolean },
 ): Promise<StepReport> {
+  // --skip-gate (cortex#2275): the gate is deliberately DEFERRED to the
+  // supervisor's healthcheck (the compose cortex-service healthcheck in the L4
+  // container). Short-circuit BEFORE any ports.gate call — no log-grep, no
+  // /healthz probe, no wall-clock wait — and report an explicit skip so the
+  // provisioning output is green when provisioning succeeded, with the
+  // deferral visible (`skipped`/`note` in --json) rather than an
+  // expected-error status:error envelope.
+  if (opts.skipGate) {
+    return {
+      ...step("8. Healthy-boot gate", true, [
+        "  ○ --skip-gate passed — deferred to supervisor healthcheck",
+      ]),
+      skipped: true,
+      note: "deferred to supervisor healthcheck",
+    };
+  }
   // Container mode (cortex#2155): the daemon isn't up yet (the entrypoint
   // `exec cortex start`s it only AFTER quickstart returns), so the gate could
   // never pass — it would only burn the whole poll window before failing.
@@ -892,6 +925,7 @@ export async function dispatchQuickstart(
     monitorPort: s.natsMon,
     timeoutMs: flags.gateTimeoutMs,
     skip: flags.container,
+    skipGate: flags.skipGate,
   });
   reports.push(gateReport);
   if (!gateReport.ok) {
@@ -906,7 +940,16 @@ function finish(reports: StepReport[], exitCode: number, json: boolean): ExitRes
     const allOk = reports.every((r) => r.ok);
     const envelope = allOk
       ? envelopeOk(
-          reports.map((r) => ({ step: r.name, ok: "true" })),
+          // cortex#2275 — a deliberately-skipped step (e.g. --skip-gate) carries
+          // `skipped: "true"` + a short `note`, so the JSON trace distinguishes
+          // "verified ok" from "deferred". Non-skipped items are byte-identical
+          // to the pre-#2275 shape.
+          reports.map((r) => ({
+            step: r.name,
+            ok: "true",
+            ...(r.skipped === true ? { skipped: "true" } : {}),
+            ...(r.note !== undefined ? { note: r.note } : {}),
+          })),
           {},
         )
       : envelopeError(
@@ -955,6 +998,14 @@ Flags:
                           .conf file (default: refuse).
   --skip-services         Skip step 7 (systemd) entirely — for CI/tests
                           without a systemd host.
+  --skip-gate             Skip step 8 (healthy-boot gate) and report it as
+                          DEFERRED (cortex#2275): step 8 shows ok + skipped
+                          ("deferred to supervisor healthcheck") and quickstart
+                          exits 0 when steps 1–7 pass. For supervised
+                          deployments (the L4 container entrypoint) where the
+                          daemon starts only AFTER quickstart returns and the
+                          supervisor's healthcheck owns post-start health.
+                          Does NOT imply --skip-services.
   --container             L4 container mode (cortex#2155): skip step 8's
                           healthy-boot gate and return after step 7. Implies
                           --skip-services. In the split-container model the


### PR DESCRIPTION
Closes #2275. Bumps cortex to **6.10.3**.

Container-tester follow-up after #2268/#2269 (both confirmed working on the tester's box): quickstart's step 8 reported `status:error` on a healthy container boot, and the "deferred" health story had no landing zone.

## The three fixes

**1. `cortex quickstart --skip-gate` — honest provisioning output.**
New flag (sibling of `--skip-services`): step 8 is reported as deferred (`ok:true, skipped:true, note:"deferred to supervisor healthcheck"`) and quickstart exits 0 when steps 1–7 pass. Without the flag, behavior is byte-identical to before (regression-guarded in tests). Rationale: in the container the daemon starts *after* quickstart returns (`exec cortex start` is phase 2 of the entrypoint), so the log-grepping gate structurally cannot pass at provisioning time — reporting that as `status:error` confused the exact tester it was built for.

**2. Entrypoint uses it; tolerance hack removed.**
`docker-entrypoint.sh` now runs `cortex quickstart --skip-services --skip-gate` (no `--json` — nothing parses the output anymore; the human step table reads better in `docker compose logs`). The old `grep '8. Healthy-boot gate'` tolerance branch is deleted: any nonzero quickstart exit is a real provisioning failure and aborts the boot.

**3. The deferral gets a real landing zone — a daemon-on-bus healthcheck.**
The cortex service gains a compose healthcheck. First cut probed the nats monitor `/healthz` — **adversarial review killed it**: that duplicates the nats service's own healthcheck (shared netns) and verifies the bus *server*, not the daemon's *connection* — the #2264 silent-degradation class (daemon alive, primary link dead, replies via direct-sync fallback) would have stayed green forever. Shipped probe instead checks connection presence:

```yaml
test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8222/connz | grep -Eq '\"name\": ?\"cortex-${CTX_SLUG}\"'"]
```

The daemon's NATS connection is named `cortex-<slug>` (scaffolded `nats.name` → `runtime.ts:801` → `connection.ts`), `${CTX_SLUG}` interpolates from the project `.env`, and `/connz` is served unauthenticated on the loopback monitor. Strictly stronger than `/healthz`: flips unhealthy on an unreachable monitor AND on a live-process/dead-bus-link daemon. `start_period: 90s` tolerates first-boot provisioning.

## Delivery (version + pins)
- `arc-manifest.yaml` → **6.10.3**; container defaults `CORTEX_REF` → **v6.10.3** in the Dockerfile ARG + compose default (lockstep).
- **Merge-ordering requirement:** the `v6.10.3` tag must be cut at the merge commit immediately after merge — the pins point at it.
- Documented floor: this checkout's entrypoint requires `CORTEX_REF >= v6.10.3` (older cortex rejects `--skip-gate` → exit 2 → loud restart-loop).

## Validation
- **Probe bench (real Linux docker, the exact pinned `nats:2.14-alpine` = v2.14.3):** named client connected → probe exit 0; wrong slug → 1; **client disconnected → 1** (the state the old probe could never see). JSON name spacing confirmed; grep tolerates both renderings.
- **Full image build at this branch ref:** `docker build --build-arg CORTEX_REF=<branch>` of `Dockerfile.cortex` — assembly proof including the `arc install` adapter step.
- **Tests:** scoped quickstart suite 47 pass / 0 fail (5 new `--skip-gate` cases incl. default-path byte-compatibility and skip-services independence); `tsc --noEmit` zero errors; lint clean; `bash -n` clean.
- **Adversarial review, two passes:** first pass BLOCKed on the duplicate-healthcheck defect + version-skew documentation + a stale comment; all three fixed; findings F3–F6 (default-path regression, exit semantics, pin lockstep, auto-bump pin-ahead tolerance, test non-tautology) explicitly REFUTED.

## Out of scope
- A daemon-liveness (vs bus-link) probe — a hung-but-alive daemon holding its NATS connection remains undetected; `restart: unless-stopped` covers process death.
- Native-host gate behavior — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
