### PR TITLE
docs(compose): fix the secrets-verify troubleshooting entry (compose config shows runtime values by design)

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -156,6 +156,9 @@ Refresh procedure: regenerate with `claude setup-token`, update `.env`, and
 - **No reply to @mention** — confirm the bot has the Message Content intent, is
   in the guild, and that `CTX_MY_DISCORD_ID` is *your* id (the principal-only
   gate stays silent for non-principals by design).
-- **Verify no secrets in the image** — `docker history cortex:local` and
-  `docker compose config` should show zero tokens (they arrive via `env_file`
-  at runtime only).
+- **Verify no secrets in the image** — `docker history cortex:local` shows zero
+  tokens: secrets are never baked into an image layer; they arrive via
+  `env_file` at **runtime** only. Note that `docker compose config` **will**
+  print your tokens — it renders the *runtime* configuration with your `.env`
+  values interpolated. That output is local to your shell and expected; it is
+  not evidence of a secret baked into the image.


### PR DESCRIPTION
Tester-reported (v6.10.3 retest thread): the troubleshooting entry said `docker compose config` should show zero tokens. That command renders the **runtime** config with `.env` interpolated, so credentials appear in its output **by design** — meaning a correct setup looks wrong to a careful reader (exactly what happened).

Fix: the baked-secret invariant is `docker history` only; the entry now says that, and explains why the `docker compose config` output is expected, local to the operator's shell, and not evidence of a baked secret.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH
