### PR TITLE
docs(readme): overhaul README to launch grade — Soma-class shape (#2286)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,65 @@
-# cortex
+<!--
+  cortex
+-->
 
-**Talk to your AI agents from Discord. Watch them work on a dashboard. Let them
-collaborate across machines — and across people.**
+<!-- hero: pending art — replace this comment with the illustration when it lands:
+<p align="center">
+  <img src="docs/diagrams/cortex-hero.jpg" alt="cortex, the collaboration surface" width="320" />
+</p>
+-->
 
-cortex is the collaboration surface of the [metafactory](https://github.com/the-metafactory)
-ecosystem. It runs named AI assistants (powered by Claude Code and other
-substrates), connects them to the chat platforms you already use, routes work to
-them over a message bus, and makes everything they do visible in one place.
+<h1 align="center">cortex</h1>
 
-## What can you do with it?
+<p align="center">
+  <strong>Your assistant, on your surfaces — a collaboration bus for principals and their agents.</strong>
+</p>
 
-- **Chat-dispatch work.** Mention an assistant in a Discord (or Mattermost,
-  or Slack) channel — "fix the failing test in #cortex", "review PR 54" — and
-  cortex spawns a Claude Code session, streams its progress back to the thread,
-  and posts the result. Prefix with `async:` for fire-and-forget tasks or
-  `team:` to spawn a multi-agent team.
+<p align="center">
+  Named AI assistants in the chat channels you already use, doing real work on your machines —<br />
+  dispatched, supervised, and observed over one message bus.
+</p>
+
+<p align="center">
+  <img alt="Version" src="https://img.shields.io/badge/version-6.10.3-2A3F6A?labelColor=0E1726" />
+  <img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-2A3F6A?labelColor=0E1726" />
+  <img alt="Runs on" src="https://img.shields.io/badge/runs%20on-macOS%20%C2%B7%20Debian%20%C2%B7%20container-2A3F6A?labelColor=0E1726" />
+</p>
+
+<p align="center">
+  cortex is <a href="https://meta-factory.ai">Meta Factory</a>'s second Arc-distributed package.<br />
+  Join the Meta Factory community on <a href="https://discord.gg/32xa5ev6Tq">Discord</a>.
+</p>
+
+---
+
+## Why this project?
+
+A coding agent in a terminal is a solo instrument. The moment your assistant
+does real work — fixing tests, reviewing PRs, running long tasks — you want to
+reach it from wherever you are, see what it is doing without scrolling a
+terminal, and let more than one agent share the load. Chat platforms give you
+reach but no structure; dashboards give you visibility but no dispatch; and
+none of it composes across machines.
+
+cortex closes that gap by putting a **message bus between you and your
+agents**. You (the **principal** — the human who owns the deployment) run a
+**stack**: a cortex deployment with its own config, signing identity, and bus
+namespace. A stack hosts **assistants** — named beings like Luna, Echo, or Ivy
+with a persona and a chat identity. All communication is **envelopes on a NATS
+message bus**: a Discord mention becomes a signed dispatch envelope, an
+assistant's runtime picks it up, executes it on a substrate (usually a Claude
+Code session), and emits lifecycle events that the chat adapter and the
+dashboard both render. Because the bus — not the chat platform — is the medium,
+the same work can be dispatched from chat, from the dashboard, from a GitHub
+webhook, or from another agent entirely.
+
+What that buys you in practice:
+
+- **Chat-dispatch work.** Mention an assistant in a Discord channel — "fix the
+  failing test in #cortex", "review PR 54" — and cortex spawns a Claude Code
+  session, streams its progress back to the thread, and posts the result.
+  Prefix with `async:` for fire-and-forget tasks or `team:` to spawn a
+  multi-agent team.
 - **Watch everything on Mission Control.** A web dashboard shows every running
   session, task queue, attention items needing your input, and GitHub activity
   (issues, PRs, checks) — so chat doesn't have to choose between "flood the
@@ -24,23 +69,6 @@ them over a message bus, and makes everything they do visible in one place.
   the verdict — no point-to-point wiring between requester and reviewer.
 - **Instrument your own terminal sessions.** Set one environment variable and
   your local Claude Code session's events appear live on the dashboard.
-- **Federate with other people.** Your stack and a collaborator's stack can
-  join the same network: their assistant can answer in a shared channel, claim
-  work you offer, and reply to yours — each side keeping its own keys, policy,
-  and data.
-
-## How it works, in one paragraph
-
-You (the **principal** — the human who owns the deployment) run one or more
-**stacks**: cortex deployments with their own config, signing identity, and
-message-bus namespace. A stack hosts **assistants** — named beings like Luna,
-Echo, or Ivy with a persona and a Discord identity. All communication is
-**envelopes on a NATS message bus**: a Discord mention becomes a signed dispatch
-envelope, an assistant's runtime picks it up, executes it on a substrate
-(usually a Claude Code session), and emits lifecycle events that the chat
-adapter and the dashboard both render. Because the bus — not Discord — is the
-medium, the same work can be dispatched from chat, from the dashboard, from a
-GitHub webhook, or from another agent entirely.
 
 Work reaches an assistant in one of three **dispatch modes**:
 
@@ -50,25 +78,62 @@ Work reaches an assistant in one of three **dispatch modes**:
 | **Offer** | You publish to a capability (`code-review.typescript`); exactly one capable assistant claims it. |
 | **Delegate** | You name an assistant that orchestrates a multi-step outcome via a multi-agent team. |
 
-## Where cortex sits
+---
+
+## The shape
+
+```text
+  principal (you)
+      |
+      |  @mention · dashboard · webhook
+      v
++---------------------+
+|      surfaces       |   Discord adapter · web adapter · Mission Control
++----------+----------+
+           |  signed envelopes
+           v
++---------------------+
+|        bus          |   NATS + the myelin protocol layers (M2–M6)
++----------+----------+
+           |  dispatch · lifecycle events
+           v
++---------------------+
+|   agents / daemon   |   assistant runtimes -> Claude Code sessions
++---------------------+
+```
 
 cortex is the top layer (M7) of the **Myelin layer model** — an OSI-style stack
 where the protocol layers below are owned by the sibling
 [myelin](https://github.com/the-metafactory/myelin) project:
 
-```
+```text
 M7  SURFACES      cortex (this repo) · pilot · signal · future apps
 M6  COMPOSITION   myelin — interaction patterns
 M5  DISCOVERY     myelin — capability registry
 M4  IDENTITY      myelin — verifiable sender per envelope
 M3  ENVELOPE      myelin — message format + sovereignty metadata
 M2  TRANSPORT     myelin — abstract bus (NATS underneath)
-M1  CONNECTIVITY  TCP/TLS · federation topology (NATS leaf nodes)
+M1  CONNECTIVITY  TCP/TLS · cross-stack topology (NATS leaf nodes)
 ```
 
 cortex consumes the contracts of M2–M6 and owns none of them. That separation
 is what lets several M7 applications (cortex for collaboration, signal for
 telemetry, pilot for review loops) share one bus without sharing code.
+
+cortex deliberately does not own:
+
+- **the model provider** — execution runs on a substrate (a
+  [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session by
+  default); the model relationship and credentials stay yours
+- **the package manager** — installation and upgrades belong to
+  [arc](https://github.com/the-metafactory/arc)
+- **the assistant's memory and identity home** — that is
+  [soma](https://github.com/the-metafactory/soma)'s job; cortex hosts the
+  runtime, not the durable self
+- **the chat UI** — Discord (and the other platforms) keep their own clients;
+  cortex only joins them as an adapter
+- **the protocol layers** — envelope, identity, discovery, and transport
+  contracts are [myelin](https://github.com/the-metafactory/myelin)'s
 
 The full picture — event architecture, visibility tiers, the agent/assistant
 model, internal componentisation — lives in
@@ -76,7 +141,118 @@ model, internal componentisation — lives in
 (what exactly a *stack*, *capability*, or *dispatch sink* is) lives in
 [`CONTEXT.md`](CONTEXT.md).
 
-## A small glossary
+---
+
+## See it work (~10 minutes)
+
+The fastest way to understand cortex is to stand up one stack with one
+assistant and @mention it. Three host paths below — macOS, Debian, container —
+all driven by the same `CTX_*` env contract and the same idempotent
+`cortex quickstart` command.
+
+### Prerequisites (all hosts)
+
+**Arc.** cortex is distributed as an Arc package. If you do not have `arc`
+yet, install the Arc CLI first:
+
+https://meta-factory.ai/download
+
+If your Arc setup requires authentication, run `arc login` before installing
+cortex.
+
+**A Discord bot** (one-time, manual — the Developer Portal has no API for it).
+Create an application + bot, enable the **Message Content intent**, invite it
+to your server, and copy the bot token. Full walkthrough:
+[`README-AGENTS.md`](README-AGENTS.md) Appendix A / §3.
+
+**Native hosts additionally need:** [Bun](https://bun.sh), a
+[NATS server](https://nats.io) binary on PATH, and a Claude Code install
+logged in to Anthropic (the default execution substrate). The container path
+bundles all of these in the image.
+
+**The env contract.** Every path is driven by the same small set of `CTX_*`
+variables — your principal id, a stack slug, bus ports, and the Discord ids
+(placeholders only; never commit real values):
+
+```bash
+# cortex.env — fill in your own values
+CTX_PRINCIPAL=ada-lovelace          # your principal id
+CTX_SLUG=mystack                    # this stack's slug
+CTX_NATS_PORT=4222
+CTX_NATS_MON=8222
+CTX_GUILD_ID=<REPLACE_ME>           # Discord snowflakes: right-click → Copy ID
+CTX_CHANNEL_ID=<REPLACE_ME>
+CTX_LOG_CHANNEL_ID=<REPLACE_ME>
+CTX_MY_DISCORD_ID=<REPLACE_ME>
+CTX_DISCORD_TOKEN=<REPLACE_ME>      # bot token — keep out of git
+```
+
+### macOS
+
+```bash
+# 1. Install with arc (by git URL; use the latest release tag).
+#    The surface plugins (Discord adapter and friends) install
+#    automatically via the manifest's depends_on.
+arc install https://github.com/the-metafactory/cortex --pin v6.10.3
+
+# 2. Provision the stack from the env contract (idempotent; re-run freely)
+set -a; . ./cortex.env; set +a
+cortex quickstart
+
+# 3. Load the launchd agents for the newly scaffolded stack
+#    (service management on macOS is arc's job, not quickstart's)
+arc upgrade cortex
+
+# 4. Green light: re-run quickstart and watch step 8
+cortex quickstart
+```
+
+**Green light:** quickstart's step 8 — the healthy-boot gate — prints its
+✓ table (daemon log lines + NATS `/healthz`). Then @mention your assistant in
+the bound channel and watch it answer.
+
+### Debian
+
+Same contract, one command — quickstart enables the systemd user units itself
+(step 7) and then runs the gate in the same pass:
+
+```bash
+arc install https://github.com/the-metafactory/cortex --pin v6.10.3
+
+set -a; . ./cortex.env; set +a
+cortex quickstart
+```
+
+**Green light:** step 8's healthy-boot gate passes in the same run —
+`systemctl --user status nats@$CTX_SLUG cortex@$CTX_SLUG` shows both active,
+and your assistant answers an @mention.
+
+### Container
+
+`docker compose up -d` = a running assistant. Everything lives in
+[`deploy/compose/`](deploy/compose/):
+
+```bash
+cd deploy/compose
+cp .env.example .env        # fill in every <REPLACE_ME> + the two secrets
+docker compose up -d
+```
+
+The container is headless, so `.env` also needs `CLAUDE_CODE_OAUTH_TOKEN` —
+generate it on a machine already logged into Claude Code with
+`claude setup-token`.
+
+**Green light:** `docker compose ps` shows the `cortex` service **healthy**.
+The healthcheck watches the daemon's actual bus connection (not just a
+liveness ping), so healthy means the assistant is really on the bus. Verify
+end-to-end with `docker compose logs cortex | grep -E "Stack:|connected"` and
+an @mention.
+
+**Reset:** `docker compose down -v` wipes the named volumes (stack identity,
+seeds, sessions) for a from-scratch re-provision; plain `down`/`restart`
+preserves them. Details: [`deploy/compose/README.md`](deploy/compose/README.md).
+
+### A small glossary
 
 | Term | Meaning |
 |---|---|
@@ -86,35 +262,71 @@ model, internal componentisation — lives in
 | **Agent** | The long-lived runtime that hosts an assistant on the bus. |
 | **Capability** | A bus-routable ability an assistant declares (`chat`, `code-review.typescript`). |
 | **Envelope** | The signed wrapper every bus message travels in. |
-| **Network** | A federation of principals whose stacks interconnect at the NATS layer. |
+| **Network** | A group of principals whose stacks interconnect at the NATS layer. |
 | **Mission Control** | The principal-facing dashboard surface. |
 
-## Getting started
+---
 
-The short version (full procedure in
-[`README-AGENTS.md`](README-AGENTS.md) and
-[`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md)):
+## Install
+
+**With Arc (preferred).** cortex is not published to the Arc registry by name
+yet — install by git URL (the repo ships an `arc-manifest.yaml`, so arc
+installs it directly). Use the latest tag from the
+[releases page](https://github.com/the-metafactory/cortex/releases):
 
 ```bash
-# Scaffold a stack config (dry-run by default; --apply writes it)
-cortex stack create mystack --principal yourname --apply
-
-# Fill in the <REPLACE_ME> secrets (Discord token, guild + channel ids)
-$EDITOR ~/.config/metafactory/cortex/mystack/stacks/mystack.yaml
-
-# Validate, then start
-cortex start --config ~/.config/metafactory/cortex/mystack/mystack.yaml --dry-run
-cortex start --config ~/.config/metafactory/cortex/mystack/mystack.yaml
+arc install https://github.com/the-metafactory/cortex --pin v6.10.3
 ```
 
-Then @mention your assistant in the bound Discord guild and watch it answer.
-The Mission Control dashboard runs at `localhost:8767` locally (hosted
-deployments serve it via Cloudflare).
+This installs the released package, pulls in the first-party surface plugins
+(Discord, web, Mattermost, Slack adapters and the PagerDuty renderer) via the
+manifest's `depends_on`, and renders the service files for your platform
+(launchd agents on macOS, systemd user units on Linux). Track new releases
+with `arc upgrade cortex`.
 
-You will need: [Bun](https://bun.sh), a local
-[NATS server](https://nats.io) with JetStream, a Discord bot token (or
-Mattermost/Slack credentials), and an Anthropic-authenticated Claude Code
-install for the default execution substrate.
+**From source** (contributors / the fork-and-PR workflow):
+
+```bash
+git clone https://github.com/the-metafactory/cortex
+cd cortex
+bun install
+bun link                  # puts `cortex` on PATH via ~/.bun/bin
+cortex --version          # confirm it resolves
+./scripts/postinstall.sh  # scaffold runtime dirs, relay policy, service files
+```
+
+Do not skip `./scripts/postinstall.sh` — the arc path runs it automatically
+via the manifest lifecycle; a manual clone does not, and without it the daemon
+starts against missing scaffolding.
+
+Then provision a stack (`cortex quickstart`, above) or follow the manual
+procedure in [`README-AGENTS.md`](README-AGENTS.md) and
+[`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md).
+
+---
+
+## Status
+
+cortex is a **community preview (beta)**. What that means, concretely:
+
+- **Single principal.** A stack serves one principal; the principal-only gate
+  means only you can drive your assistant.
+- **Discord is the preview surface.** A web chat adapter exists in the
+  codebase, but the preview claim is Discord: mention → dispatch → threaded
+  reply, plus the Mission Control dashboard.
+- **Federation is experimental and unreleased.** Connecting stacks across
+  principals into a shared network is designed and under active development,
+  but it is not part of this preview — no setup instructions are provided or
+  supported yet.
+- **The wire protocol is still evolving.** The envelope and identity contracts
+  (the myelin RFCs) are pre-1.0; breaking changes between releases are
+  possible. `cortex migrate-config` covers config migrations, but expect to
+  read release notes before upgrading.
+
+See the [release notes](https://github.com/the-metafactory/cortex/releases)
+for what changed in each version.
+
+---
 
 ## What's in this repo
 
@@ -128,18 +340,24 @@ install for the default execution substrate.
 | `src/taps/` | Publishers onto the bus — Claude Code hook events, GitHub webhooks. |
 | `src/cli/` | CLIs — `cortex` (stack + network management), `discord` (post/read from terminal). |
 | `src/renderers/` | Dispatch sinks — dashboard renderer, PagerDuty fail-safe. |
+| `deploy/compose/` | The L4 container path — compose file, image, entrypoint, env contract. |
 | `docs/` | Architecture spec, design docs, SOPs, ADRs, the config template (`docs/config-layout/`). |
 
-## Documentation map
+---
+
+## Documentation
 
 - [`docs/architecture.md`](docs/architecture.md) — canonical architecture reference
 - [`CONTEXT.md`](CONTEXT.md) — domain glossary (one canonical term per concept)
 - [`README-AGENTS.md`](README-AGENTS.md) — install + configure guide for AI agents (and impatient humans)
 - [`docs/config-layout/`](docs/config-layout/) — the copy-and-fill config template
+- [`deploy/compose/README.md`](deploy/compose/README.md) — the container path, end to end
 - [`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) — stand up a new stack, end to end
-- [`docs/sop-network-join.md`](docs/sop-network-join.md) — federate a stack onto a network
+- [`docs/sop-network-join.md`](docs/sop-network-join.md) — connect a stack to a shared network (experimental — see Status)
 - [`docs/sop-bus-review.md`](docs/sop-bus-review.md) — the bus code-review path
 - [`docs/design-collaboration-surface.md`](docs/design-collaboration-surface.md) — why a collaboration surface, the framing
+
+---
 
 ## Provenance
 
@@ -148,6 +366,8 @@ before that, `grove`), completed through the phased plan in
 [`docs/plan-cortex-migration.md`](docs/plan-cortex-migration.md). You may still
 see `grove` in a few hostnames (the dashboard at `grove.meta-factory.ai`) and
 historical docs; the product is cortex.
+
+---
 
 ## Contributing
 
@@ -158,10 +378,14 @@ branching, PR review, versioning, worktree discipline, design process.
 *on* this codebase and is fully generated (`arc upgrade compass`) — never
 hand-edit it.
 
+---
+
 ## Authors
 
 - Andreas Astrom
 - Jens-Christian Fischer
+
+---
 
 ## License
 
@@ -170,3 +394,11 @@ metafactory stack; the AGPL's network-use copyleft (§13) keeps modifications
 shared when cortex is run as a service. See
 [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md) for incorporated upstream
 patterns and code.
+
+---
+
+<p align="center">
+  <sub>A <a href="https://meta-factory.ai">Meta Factory</a> project, by
+  <a href="https://github.com/mellanon">Andreas Aaström</a> and
+  <a href="https://github.com/jcfischer">Jens-Christian Fischer</a>.</sub>
+</p>


### PR DESCRIPTION
Closes #2286 (epic #2281, wave 1 C-lane).

Rebuilds the README in the Soma shape: hero block (art pending — placeholder contract) · thesis + badges (version 6.10.3 / AGPL-3.0 / runs-on) · second-Arc-package line + Discord invite · Why → The shape (with an explicit *deliberately does not own* list) · **See it work (~10 min)** for macOS / Debian / container, arc-install-first · Install (arc primary, source fallback) · honest **Status** (community preview (beta) · single principal · Discord surface · federation experimental/unreleased · wire protocol evolving).

Review notes:
- **Honesty deviation, correct call:** `arc install cortex` (registry name) is not yet true — verified `arc search cortex` returns nothing pre-publish. Walkthroughs use the pinned git-URL form; swap to the registry name when #2288 lands (tracked there).
- **Thesis line flagged for principal wordsmithing** — current: *"Your assistant, on your surfaces — a collaboration bus for principals and their agents."* Two alternates in #2286 comments.
- Pre-existing private compass link in Contributing kept (out of scope; flagged).
- Verified: federation appears ONLY in the Status caveat; all relative links resolve; placeholders only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH