### PR TITLE
fix(quickstart+services): unify macOS daemon log paths so the healthy-boot gate works on macOS (#2282)

### DIFF
--- a/.specify/specs/f-6-reflex-activation-bridge/HANDOFF.md
+++ b/.specify/specs/f-6-reflex-activation-bridge/HANDOFF.md
@@ -79,7 +79,7 @@ Synthetic `reflex.activation.fired` envelope on `local.jc.default.reflex.activat
 ## GOTCHAS (from this session)
 
 - **specflow `specify`/`tasks` run headless (`claude -p`) and FAIL/rate-limit** → write `spec.md`/`plan.md`/`tasks.md` MANUALLY, then advance the phase directly: `sqlite3 .specflow/features.db "UPDATE features SET phase='plan' WHERE id='F-6';"` (values: specify→plan→tasks). `specflow edit --spec-path` does NOT advance phase; `--batch` needs enrich. `specflow validate F-6` to confirm.
-- **Sage review (pilot-review-loop):** `SAGE_STACK=default sage dispatch the-metafactory/cortex#<PR> --org jc --post --wait 300`. `--org jc` (NOT metafactory). Verdict in `result_summary`; commented/0-blockers = effective pass. Pre-flight: `tail ~/.config/cortex/logs/cortex-meta-factory.log | grep 'review consumer ready'`.
+- **Sage review (pilot-review-loop):** `SAGE_STACK=default sage dispatch the-metafactory/cortex#<PR> --org jc --post --wait 300`. `--org jc` (NOT metafactory). Verdict in `result_summary`; commented/0-blockers = effective pass. Pre-flight: `tail ~/.local/state/metafactory/cortex/logs/cortex-meta-factory.log | grep 'review consumer ready'`.
 - **Sage is sharp on doc/PR-text overclaims** (HonestOracle) — back every verification claim with embedded command+output; don't cite external issues without evidence; don't mark unrun gates "confirmed".
 - **Sage self-authored PRs** surface as COMMENTED (can't APPROVE own); `reviewDecision` empty is fine; merge gate CLEAN is the signal.
 - This branch's F-6 specflow docs (spec/plan/tasks/HANDOFF) are committed here — `git checkout spec/F-6-reflex-activation-bridge` in cortex to resume.

--- a/README-AGENTS.md
+++ b/README-AGENTS.md
@@ -244,6 +244,11 @@ Daemonised — macOS: `~/Library/LaunchAgents/ai.meta-factory.cortex.<slug>.plis
 nats@<slug> cortex@<slug>` (template units — Appendix A). Both log to
 `~/.local/state/metafactory/cortex/logs/cortex-<slug>.{log,error.log}`.
 
+> **Existing macOS installs (pre-cortex#2282):** older rendered plists pointed
+> daemon logs at `~/.config/cortex/logs/`. Re-render the plists — `arc upgrade
+> cortex` (or `./scripts/postinstall.sh` on a from-source clone) — so logs move
+> to the state tree above and quickstart's healthy-boot gate can observe them.
+
 **Healthy-boot gate** — all of these lines must appear:
 
 ```bash

--- a/scripts/lib/systemd-render.sh
+++ b/scripts/lib/systemd-render.sh
@@ -203,9 +203,12 @@ warn_systemd_linger() {
 #
 # `~/.local/state/metafactory/cortex/logs` is DELIBERATELY NOT created here,
 # even though cortex@.service needs the identical guarantee. That directory
-# is part of the CANONICAL CORTEX STATE TREE, whose creation is owned
-# end-to-end by postinstall.sh's §1b state bootstrap (migrate-state-dir-exec.ts)
-# under the XDG wave-5 gated migration (cortex#1903) — verified via
+# is part of the CANONICAL CORTEX STATE TREE. On a FRESH install it is created
+# by postinstall.sh's §1b state bootstrap (migrate-state-dir-exec.ts); on an
+# UPGRADE box §1b is deliberately inert (the XDG wave-5 gated migration,
+# cortex#1903) and the guarantee comes from postupgrade.sh's Darwin-side
+# `mkdir -p` (cortex#2282) or, on Linux, from the tree the gated migration
+# itself materializes. The §1b upgrade-inertness is verified via
 # scripts/__tests__/postinstall-state-bootstrap.sh's own invariant: on an
 # UPGRADE box (legacy grove state present, not yet migrated) postinstall must
 # write NOTHING state-related, no canonical tree at all, until the gated

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -118,6 +118,15 @@ warn_stack_identity_drift "${CONFIG_DIR}"
 # ─── 3. Re-template launchd plists (shared with postinstall.sh) ──
 if [ "$(uname)" = "Darwin" ]; then
   LAUNCH_DIR="${HOME}/Library/LaunchAgents"
+
+  # cortex#2282 — the stack + relay plists' Standard{Out,Error}Path now live
+  # under the canonical state tree. launchd does NOT create Std*Path parent
+  # directories, and on an UPGRADE box postinstall's §1b state bootstrap is
+  # deliberately inert (gated migration, cortex#1903) — so an existing macOS
+  # install re-rendered onto the new paths would otherwise restart its daemons
+  # logging nowhere. Guarantee the dir here, BEFORE the reloads below.
+  mkdir -p "${HOME}/.local/state/metafactory/cortex/logs"
+
   render_cortex_plists "${CORTEX_DIR}" "${LAUNCH_DIR}" "${CONFIG_DIR}"
 
   # ─── 4. Restart daemons ─────────────────────────────────────────

--- a/src/__tests__/xdg-migration-guard.e2e.test.ts
+++ b/src/__tests__/xdg-migration-guard.e2e.test.ts
@@ -229,8 +229,12 @@ function renderFleet(): {
   mkdirSync(configDir, { recursive: true });
   const configPath = join(configDir, `${slug}.yaml`);
   writeFileSync(configPath, "principal: {}\n");
-  mkdirSync(join(home, ".config", "cortex", "logs"), { recursive: true });
-  mkdirSync(join(home, ".claude", "logs"), { recursive: true });
+  // cortex#2282 — daemon + relay Std*Path moved onto the canonical state tree
+  // (~/.local/state/metafactory/cortex/logs), the same root cortex@.service
+  // writes and the quickstart healthy-boot gate greps. On a real install the
+  // dir comes from postinstall's §1b state bootstrap; materialize it here so a
+  // correctly-installed fleet verifies fully extant.
+  mkdirSync(join(home, ".local", "state", "metafactory", "cortex", "logs"), { recursive: true });
   // cortex#2097 — the stack plist's WorkingDirectory moved off the cortex
   // install repo (self-editing exposure) onto the per-stack workspace dir;
   // materialize it the same way `render_stack_plist` (plist-render.sh) does

--- a/src/__tests__/xdg-migration-guard.e2e.test.ts
+++ b/src/__tests__/xdg-migration-guard.e2e.test.ts
@@ -232,7 +232,9 @@ function renderFleet(): {
   // cortex#2282 — daemon + relay Std*Path moved onto the canonical state tree
   // (~/.local/state/metafactory/cortex/logs), the same root cortex@.service
   // writes and the quickstart healthy-boot gate greps. On a real install the
-  // dir comes from postinstall's §1b state bootstrap; materialize it here so a
+  // dir is guaranteed by postinstall's §1b state bootstrap on FRESH installs
+  // and by postupgrade.sh's Darwin-side `mkdir -p` on UPGRADE boxes (where §1b
+  // is deliberately inert — cortex#1903/#2282); materialize it here so a
   // correctly-installed fleet verifies fully extant.
   mkdirSync(join(home, ".local", "state", "metafactory", "cortex", "logs"), { recursive: true });
   // cortex#2097 — the stack plist's WorkingDirectory moved off the cortex

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -626,7 +626,7 @@ describe("dispatchQuickstart — step 8 gate", () => {
 // cortex#2282 — macOS: unified log paths make the gate live on darwin
 // =============================================================================
 
-describe("dispatchQuickstart — cortex#2282 macOS gate + error-log hygiene", () => {
+describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", () => {
   // The structural fix itself: the launchd stack plist template writes
   // Std{Out,Error}Path to the EXACT paths the gate greps (daemonLogPath /
   // daemonErrorLogPath). Substitute the renderer's tokens (plist-render.sh
@@ -669,82 +669,39 @@ describe("dispatchQuickstart — cortex#2282 macOS gate + error-log hygiene", ()
     expect(res.stdout).toContain("Healthy-boot gate ✓");
   });
 
-  // cortex#2282 — step 7's darwin branch truncates the .error.log (exact
-  // daemonErrorLogPath) BEFORE step 8 polls, and NEVER (re)starts services
-  // (launchd/arc owns the daemon on macOS; restart-on-re-run is A2's scope).
-  test("cortex#2282: darwin — .error.log truncated (exact path) before the gate polls, with NO service (re)start", async () => {
+  // NEGATIVE SPACE (deliberate deferral, adversarial-review round 1): darwin
+  // must NOT truncate the .error.log on this branch. quickstart never restarts
+  // the daemon on macOS, and a truncate WITHOUT a paired restart destroys
+  // current-boot failure evidence — a bus-dead daemon's one-shot `failed to
+  // connect` line would be wiped while stale healthy `.log` lines persist
+  // (append mode), turning the gate false-GREEN. The paired
+  // truncate → restart → gate lands with A2 (cortex#2283). This test moves
+  // there, inverted, when it does.
+  test("cortex#2282: darwin — .error.log is NOT truncated (deferred to A2/#2283 with restart-on-re-run)", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
-    const calls: string[] = [];
+    const truncateCalls: string[] = [];
     const res = await withPlatform("darwin", () =>
       withEnv(validCtxEnv(), () =>
         dispatchQuickstart(
           ["--config-dir", configDir, "--nats-dir", natsDir],
           () =>
             fakePorts({
-              truncateErrorLog: (p: string) => calls.push(`truncate:${p}`),
-              enableNow: (u: string[]) => {
-                calls.push(`enable:${u.join(",")}`);
-                return { exitCode: 0, stdout: "", stderr: "" };
-              },
-              readLog: (p: string) => {
-                calls.push(`poll:${p}`);
-                return FULL_HEALTHY_LOG;
-              },
+              truncateErrorLog: (p: string) => truncateCalls.push(p),
             }),
         ),
       ),
     );
     expect(res.exitCode).toBe(0);
-    const expectedPath = daemonErrorLogPath(process.env.HOME ?? "", "work");
-    expect(calls).toContain(`truncate:${expectedPath}`);
-    // Truncation happened BEFORE the gate's first log poll…
-    const truncIdx = calls.findIndex((c) => c.startsWith("truncate:"));
-    const pollIdx = calls.findIndex((c) => c.startsWith("poll:"));
-    expect(truncIdx).toBeGreaterThanOrEqual(0);
-    expect(pollIdx).toBeGreaterThan(truncIdx);
-    // …and nothing was (re)started — the launchd-skip line still reports.
-    expect(calls.some((c) => c.startsWith("enable:"))).toBe(false);
+    expect(truncateCalls).toEqual([]);
+    expect(res.stdout).not.toContain("cleared prior-boot error log");
     expect(res.stdout).toContain("non-Linux host");
   });
 
-  // The darwin mirror of the cortex#2264 staleness case: a re-run with a STALE
-  // prior-boot failure in the append-mode .error.log must NOT false-fail —
-  // step 7's darwin truncate cleared it before the gate ran.
-  test("cortex#2282: darwin re-run — stale prior-boot .error.log failure does NOT false-fail the gate", async () => {
-    const configDir = freshDir();
-    const natsDir = freshDir();
-    let errorLogContent = "myelin-runtime: failed to connect — continuing without NATS: (a PRIOR boot's failure)";
-    let mainPolls = 0;
-    const res = await withPlatform("darwin", () =>
-      withEnv(validCtxEnv(), () =>
-        dispatchQuickstart(
-          ["--config-dir", configDir, "--nats-dir", natsDir, "--gate-timeout-ms", "600000"],
-          () =>
-            fakePorts({
-              truncateErrorLog: () => {
-                errorLogContent = "";
-              },
-              readLog: (p: string) => {
-                if (p.endsWith(".error.log")) return errorLogContent;
-                mainPolls++;
-                // Poll 1: partial boot. Poll 2+: healthy.
-                return mainPolls >= 2 ? FULL_HEALTHY_LOG : "Stack: andreas/work\npolicy-engine active\n";
-              },
-              fetchHealthz: () => Promise.resolve(true),
-            }),
-        ),
-      ),
-    );
-    expect(res.exitCode).toBe(0);
-    expect(res.stdout).not.toContain("bus connect FAILED");
-    expect(res.stdout).toContain("Healthy-boot gate ✓");
-  });
-
-  // Linux ordering is byte-identical after the cortex#2282 extraction: the
-  // truncate still happens between daemon-reload and enable --now (covered in
-  // depth by the cortex#2264 tests above — this is the regression tripwire for
-  // the step-7 output line surviving the shared-helper refactor).
+  // Linux ordering is byte-identical after the cortex#2282 helper extraction:
+  // the truncate still happens between daemon-reload and enable --now (covered
+  // in depth by the cortex#2264 tests above — this is the regression tripwire
+  // for the step-7 output line surviving the shared-helper refactor).
   test("cortex#2282: linux — step 7 still emits the cleared-error-log line before enable --now", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -38,7 +38,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { dispatchQuickstart } from "../quickstart";
-import { daemonErrorLogPath } from "../quickstart-lib";
+import { daemonErrorLogPath, daemonLogPath } from "../quickstart-lib";
 import type {
   CommandResult,
   GatePort,
@@ -619,6 +619,143 @@ describe("dispatchQuickstart — step 8 gate", () => {
     const enableIdx = calls.findIndex((c) => c.startsWith("enable:"));
     expect(truncIdx).toBeGreaterThanOrEqual(0);
     expect(enableIdx).toBeGreaterThan(truncIdx);
+  });
+});
+
+// =============================================================================
+// cortex#2282 — macOS: unified log paths make the gate live on darwin
+// =============================================================================
+
+describe("dispatchQuickstart — cortex#2282 macOS gate + error-log hygiene", () => {
+  // The structural fix itself: the launchd stack plist template writes
+  // Std{Out,Error}Path to the EXACT paths the gate greps (daemonLogPath /
+  // daemonErrorLogPath). Substitute the renderer's tokens (plist-render.sh
+  // sed) and compare byte-for-byte — the three log-path authorities (launchd
+  // plist, systemd unit, gate) can no longer diverge silently on this axis.
+  test("cortex#2282: stack plist template Std{Out,Error}Path match daemonLogPath/daemonErrorLogPath after token substitution", () => {
+    const template = readFileSync(
+      join(import.meta.dir, "..", "..", "..", "..", "services", "ai.meta-factory.cortex.stack.plist"),
+      "utf-8",
+    );
+    const home = "/home/operator";
+    const slug = "work";
+    const rendered = template.split("__HOME__").join(home).split("__STACK_SLUG__").join(slug);
+    const outPath = /<key>StandardOutPath<\/key>\s*<string>([^<]+)<\/string>/.exec(rendered)?.[1];
+    const errPath = /<key>StandardErrorPath<\/key>\s*<string>([^<]+)<\/string>/.exec(rendered)?.[1];
+    expect(outPath).toBe(daemonLogPath(home, slug));
+    expect(errPath).toBe(daemonErrorLogPath(home, slug));
+  });
+
+  // Simulated healthy boot on darwin: the fake readLog is PATH-STRICT — it
+  // returns the 5 healthy lines ONLY for the exact daemonLogPath, so the test
+  // fails if the gate ever polls any other path (the pre-fix macOS symptom:
+  // polling a file launchd never wrote → silent 60s timeout).
+  test("cortex#2282: darwin — healthy lines at daemonLogPath pass the gate", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const expectedLogPath = daemonLogPath(process.env.HOME ?? "", "work");
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              readLog: (p: string) => (p === expectedLogPath ? FULL_HEALTHY_LOG : undefined),
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("Healthy-boot gate ✓");
+  });
+
+  // cortex#2282 — step 7's darwin branch truncates the .error.log (exact
+  // daemonErrorLogPath) BEFORE step 8 polls, and NEVER (re)starts services
+  // (launchd/arc owns the daemon on macOS; restart-on-re-run is A2's scope).
+  test("cortex#2282: darwin — .error.log truncated (exact path) before the gate polls, with NO service (re)start", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const calls: string[] = [];
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              truncateErrorLog: (p: string) => calls.push(`truncate:${p}`),
+              enableNow: (u: string[]) => {
+                calls.push(`enable:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              readLog: (p: string) => {
+                calls.push(`poll:${p}`);
+                return FULL_HEALTHY_LOG;
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    const expectedPath = daemonErrorLogPath(process.env.HOME ?? "", "work");
+    expect(calls).toContain(`truncate:${expectedPath}`);
+    // Truncation happened BEFORE the gate's first log poll…
+    const truncIdx = calls.findIndex((c) => c.startsWith("truncate:"));
+    const pollIdx = calls.findIndex((c) => c.startsWith("poll:"));
+    expect(truncIdx).toBeGreaterThanOrEqual(0);
+    expect(pollIdx).toBeGreaterThan(truncIdx);
+    // …and nothing was (re)started — the launchd-skip line still reports.
+    expect(calls.some((c) => c.startsWith("enable:"))).toBe(false);
+    expect(res.stdout).toContain("non-Linux host");
+  });
+
+  // The darwin mirror of the cortex#2264 staleness case: a re-run with a STALE
+  // prior-boot failure in the append-mode .error.log must NOT false-fail —
+  // step 7's darwin truncate cleared it before the gate ran.
+  test("cortex#2282: darwin re-run — stale prior-boot .error.log failure does NOT false-fail the gate", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    let errorLogContent = "myelin-runtime: failed to connect — continuing without NATS: (a PRIOR boot's failure)";
+    let mainPolls = 0;
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir, "--gate-timeout-ms", "600000"],
+          () =>
+            fakePorts({
+              truncateErrorLog: () => {
+                errorLogContent = "";
+              },
+              readLog: (p: string) => {
+                if (p.endsWith(".error.log")) return errorLogContent;
+                mainPolls++;
+                // Poll 1: partial boot. Poll 2+: healthy.
+                return mainPolls >= 2 ? FULL_HEALTHY_LOG : "Stack: andreas/work\npolicy-engine active\n";
+              },
+              fetchHealthz: () => Promise.resolve(true),
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).not.toContain("bus connect FAILED");
+    expect(res.stdout).toContain("Healthy-boot gate ✓");
+  });
+
+  // Linux ordering is byte-identical after the cortex#2282 extraction: the
+  // truncate still happens between daemon-reload and enable --now (covered in
+  // depth by the cortex#2264 tests above — this is the regression tripwire for
+  // the step-7 output line surviving the shared-helper refactor).
+  test("cortex#2282: linux — step 7 still emits the cleared-error-log line before enable --now", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cleared prior-boot error log");
+    expect(res.stdout).toContain("enable --now");
   });
 });
 

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -57,9 +57,11 @@ export interface PreflightPorts {
 // =============================================================================
 
 /**
- * The injectable systemd seam. NEVER exercised on macOS in production
- * (quickstart's orchestrator skips the whole step off `process.platform`) —
- * this interface exists so a test can inject a fake systemctl and assert the
+ * The injectable systemd seam. The systemctl-shaped members are NEVER
+ * exercised on macOS in production (quickstart's orchestrator skips them off
+ * `process.platform`); the one exception is `truncateErrorLog`, which is pure
+ * fs and (since cortex#2282) also runs in step 7's darwin branch. This
+ * interface exists so a test can inject a fake systemctl and assert the
  * exact invocations quickstart makes, without a real systemd on the test
  * host (arc's L2 pattern, referenced in cortex#2094's acceptance criteria).
  */
@@ -78,8 +80,10 @@ export interface ServicePort {
    * CURRENT-boot content. The `cortex@.service` unit routes `StandardError` with
    * `append:` (never truncates), so a failure line from a PRIOR boot would
    * otherwise persist and make the gate fast-fail on a stale line before the
-   * fresh boot has even connected. Called ONLY in the Linux branch that actually
-   * (re)starts the daemon (never on macOS, where arc/launchd owns the restart).
+   * fresh boot has even connected. Called in the Linux branch immediately
+   * before it (re)starts the daemon, AND (cortex#2282) in the darwin branch
+   * before step 8 polls — launchd's `StandardErrorPath` appends too, and on
+   * macOS arc/launchd owns the restart so quickstart never restarts there.
    * Best-effort: never throws — a failure here degrades the gate to its honest
    * timeout path, never a false-fail. `errorLogPath` is the exact path
    * `daemonErrorLogPath()` computes.

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -57,13 +57,13 @@ export interface PreflightPorts {
 // =============================================================================
 
 /**
- * The injectable systemd seam. The systemctl-shaped members are NEVER
- * exercised on macOS in production (quickstart's orchestrator skips them off
- * `process.platform`); the one exception is `truncateErrorLog`, which is pure
- * fs and (since cortex#2282) also runs in step 7's darwin branch. This
- * interface exists so a test can inject a fake systemctl and assert the
- * exact invocations quickstart makes, without a real systemd on the test
- * host (arc's L2 pattern, referenced in cortex#2094's acceptance criteria).
+ * The injectable systemd seam. NEVER exercised on macOS in production
+ * (quickstart's orchestrator skips the whole step off `process.platform`;
+ * `truncateErrorLog` — pure fs — joins the darwin path only with A2 /
+ * cortex#2283, paired with the restart it needs). This interface exists so a
+ * test can inject a fake systemctl and assert the exact invocations
+ * quickstart makes, without a real systemd on the test host (arc's L2
+ * pattern, referenced in cortex#2094's acceptance criteria).
  */
 export interface ServicePort {
   /** Absolute path a systemd user unit named `unit` would be rendered at —
@@ -80,10 +80,12 @@ export interface ServicePort {
    * CURRENT-boot content. The `cortex@.service` unit routes `StandardError` with
    * `append:` (never truncates), so a failure line from a PRIOR boot would
    * otherwise persist and make the gate fast-fail on a stale line before the
-   * fresh boot has even connected. Called in the Linux branch immediately
-   * before it (re)starts the daemon, AND (cortex#2282) in the darwin branch
-   * before step 8 polls — launchd's `StandardErrorPath` appends too, and on
-   * macOS arc/launchd owns the restart so quickstart never restarts there.
+   * fresh boot has even connected. Called ONLY in the Linux branch that
+   * actually (re)starts the daemon — a truncate is only safe paired with a
+   * restart (truncate → restart → gate), else it destroys current-boot
+   * failure evidence. launchd's `StandardErrorPath` appends too (cortex#2282
+   * unified the paths), so the darwin call arrives with A2 (cortex#2283)
+   * alongside restart-on-re-run.
    * Best-effort: never throws — a failure here degrades the gate to its honest
    * timeout path, never a false-fail. `errorLogPath` is the exact path
    * `daemonErrorLogPath()` computes.

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -661,12 +661,41 @@ function runSeedProvisioning(ports: QuickstartPorts, opts: { slug: string; confi
 // Step 7 — services (Linux only)
 // =============================================================================
 
+/**
+ * cortex#2264 / cortex#2282 — clear the daemon's append-mode `.error.log` so
+ * step 8's gate only ever sees CURRENT-boot content. Without this, a
+ * bus-connect failure line from a PRIOR boot would linger (both systemd
+ * `StandardError=append:` and launchd `StandardErrorPath` append, never
+ * truncate) and make the gate fast-fail on stale content before the fresh
+ * daemon connects — breaking the "fix creds and re-run" recovery. Best-effort
+ * (the port swallows fs errors). Shared by BOTH step-7 branches (cortex#2282
+ * extracted it from the Linux-only path so macOS re-runs get the same
+ * hygiene): Linux calls it immediately before its `enable --now` (re)start;
+ * macOS calls it in the launchd-skip branch, before step 8 polls — no restart
+ * there (arc/launchd owns the daemon; restart-on-re-run is A2's scope).
+ * Returns the human-readable step line.
+ */
+function clearPriorBootErrorLog(ports: QuickstartPorts, slug: string): string {
+  const errorLogPath = daemonErrorLogPath(process.env.HOME ?? "", slug);
+  ports.service.truncateErrorLog(errorLogPath);
+  return `  ✓ cleared prior-boot error log (${errorLogPath})`;
+}
+
 function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean }): StepReport {
   if (opts.skip) {
     return step("7. Services", true, ["  ○ --skip-services passed — skipping"]);
   }
   if (process.platform !== "linux") {
-    return step("7. Services", true, ["  ○ non-Linux host — launchd is handled by arc; skip"]);
+    const lines = ["  ○ non-Linux host — launchd is handled by arc; skip"];
+    if (process.platform === "darwin") {
+      // cortex#2282 — the launchd plist appends `.error.log` into the SAME
+      // state tree the gate polls (StandardErrorPath never truncates), so a
+      // stale prior-boot failure would false-fail step 8's fast-fail check on
+      // every re-run. Clear it here, before the gate polls. The daemon itself
+      // is NOT restarted (out of scope — A2).
+      lines.push(clearPriorBootErrorLog(ports, opts.slug));
+    }
+    return step("7. Services", true, lines);
   }
 
   const lines: string[] = [];
@@ -695,16 +724,10 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
   }
   lines.push("  ✓ systemctl --user daemon-reload");
 
-  // cortex#2264 — clear the daemon's append-mode `.error.log` IMMEDIATELY before
-  // the (re)start, so step 8's gate only ever sees CURRENT-boot content. Without
-  // this, a bus-connect failure line from a PRIOR boot would linger (systemd
-  // StandardError=append never truncates) and make the gate fast-fail on stale
-  // content before the fresh daemon connects — breaking the "fix creds and
-  // re-run" recovery. Best-effort (the port swallows fs errors); done here,
-  // gated on this Linux branch actually (re)starting the daemon.
-  const errorLogPath = daemonErrorLogPath(process.env.HOME ?? "", opts.slug);
-  ports.service.truncateErrorLog(errorLogPath);
-  lines.push(`  ✓ cleared prior-boot error log (${errorLogPath})`);
+  // cortex#2264 — clear the daemon's append-mode `.error.log` IMMEDIATELY
+  // before the (re)start (see clearPriorBootErrorLog above), so step 8's gate
+  // only ever sees CURRENT-boot content.
+  lines.push(clearPriorBootErrorLog(ports, opts.slug));
 
   const enable = ports.service.enableNow([`nats@${opts.slug}`, `cortex@${opts.slug}`]);
   if (enable.exitCode !== 0) {

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -668,12 +668,13 @@ function runSeedProvisioning(ports: QuickstartPorts, opts: { slug: string; confi
  * `StandardError=append:` and launchd `StandardErrorPath` append, never
  * truncate) and make the gate fast-fail on stale content before the fresh
  * daemon connects — breaking the "fix creds and re-run" recovery. Best-effort
- * (the port swallows fs errors). Shared by BOTH step-7 branches (cortex#2282
- * extracted it from the Linux-only path so macOS re-runs get the same
- * hygiene): Linux calls it immediately before its `enable --now` (re)start;
- * macOS calls it in the launchd-skip branch, before step 8 polls — no restart
- * there (arc/launchd owns the daemon; restart-on-re-run is A2's scope).
- * Returns the human-readable step line.
+ * (the port swallows fs errors). Extracted (cortex#2282) so it is callable
+ * host-independently, but a truncate is ONLY safe paired atomically with a
+ * (re)start — truncate → restart → gate — otherwise it destroys the
+ * current-boot failure evidence the gate's fast-fail depends on. So today
+ * ONLY the Linux branch calls it, immediately before its `enable --now`;
+ * the darwin call arrives with A2 (cortex#2283), paired with the
+ * restart-on-re-run it needs. Returns the human-readable step line.
  */
 function clearPriorBootErrorLog(ports: QuickstartPorts, slug: string): string {
   const errorLogPath = daemonErrorLogPath(process.env.HOME ?? "", slug);
@@ -686,16 +687,7 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
     return step("7. Services", true, ["  ○ --skip-services passed — skipping"]);
   }
   if (process.platform !== "linux") {
-    const lines = ["  ○ non-Linux host — launchd is handled by arc; skip"];
-    if (process.platform === "darwin") {
-      // cortex#2282 — the launchd plist appends `.error.log` into the SAME
-      // state tree the gate polls (StandardErrorPath never truncates), so a
-      // stale prior-boot failure would false-fail step 8's fast-fail check on
-      // every re-run. Clear it here, before the gate polls. The daemon itself
-      // is NOT restarted (out of scope — A2).
-      lines.push(clearPriorBootErrorLog(ports, opts.slug));
-    }
-    return step("7. Services", true, lines);
+    return step("7. Services", true, ["  ○ non-Linux host — launchd is handled by arc; skip"]);
   }
 
   const lines: string[] = [];
@@ -794,11 +786,16 @@ async function runGate(
     }
     // cortex#2264 — a surfaced bus-connect failure is TERMINAL for this boot:
     // fail fast with the actual error line rather than burning the full
-    // timeout. This is safe on the FIRST poll (before success is logged) because
-    // step 7 TRUNCATED this append-mode `.error.log` right before the daemon
-    // (re)started — so any line here is from THIS boot, never a stale prior-boot
-    // failure. SCOPE: surface + fast-fail only — the daemon still degrades and
-    // continues (its fail-closed-abort posture is a separate, deferred call).
+    // timeout. On LINUX this is safe on the FIRST poll (before success is
+    // logged) because step 7 truncated this append-mode `.error.log` AND
+    // (re)started the daemon right before the gate — so any line here is from
+    // THIS boot, never a stale prior-boot failure. On darwin neither happens
+    // yet: quickstart does not restart the daemon, so a stale prior-boot line
+    // can fast-fail a re-run here — the paired truncate → restart → gate
+    // arrives with A2 (cortex#2283; a lone truncate would instead destroy
+    // current-boot failure evidence and false-GREEN the gate). SCOPE: surface
+    // + fast-fail only — the daemon still degrades and continues (its
+    // fail-closed-abort posture is a separate, deferred call).
     const busFailure = detectBusConnectFailure(ports.gate.readLog(errorLogPath));
     if (busFailure !== undefined) {
       return step("8. Healthy-boot gate", false, [

--- a/src/services/ai.meta-factory.cortex.relay.plist
+++ b/src/services/ai.meta-factory.cortex.relay.plist
@@ -16,9 +16,13 @@
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <!-- cortex#2282: consolidated into the canonical cortex state tree (same
+         root the stack plist + systemd units + healthy-boot gate use). The old
+         ~/.claude/logs/ root was a third log location nothing else read
+         (verified by repo-wide grep before the move). -->
     <key>StandardOutPath</key>
-    <string>__HOME__/.claude/logs/cortex-relay.log</string>
+    <string>__HOME__/.local/state/metafactory/cortex/logs/cortex-relay.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.claude/logs/cortex-relay.error.log</string>
+    <string>__HOME__/.local/state/metafactory/cortex/logs/cortex-relay.error.log</string>
 </dict>
 </plist>

--- a/src/services/ai.meta-factory.cortex.stack.plist
+++ b/src/services/ai.meta-factory.cortex.stack.plist
@@ -17,10 +17,15 @@
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <!-- cortex#2282: SAME tree the systemd unit (cortex@.service) writes and the
+         quickstart step-8 healthy-boot gate greps (daemonLogPath /
+         daemonErrorLogPath, quickstart-lib.ts). The old ~/.config/cortex/logs/
+         root made the gate structurally inert on macOS — it polled a file
+         launchd never wrote. Keep all three in lockstep. -->
     <key>StandardOutPath</key>
-    <string>__HOME__/.config/cortex/logs/cortex-__STACK_SLUG__.log</string>
+    <string>__HOME__/.local/state/metafactory/cortex/logs/cortex-__STACK_SLUG__.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.config/cortex/logs/cortex-__STACK_SLUG__.error.log</string>
+    <string>__HOME__/.local/state/metafactory/cortex/logs/cortex-__STACK_SLUG__.error.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>HOME</key>


### PR DESCRIPTION
Closes #2282 (epic #2281, wave 1 A-lane).

The healthy-boot gate was structurally inert on macOS: launchd plists wrote daemon logs to the legacy config-root while the gate polls the canonical state tree. This PR unifies them: stack + relay plists now write to `~/.local/state/metafactory/cortex/logs/` (renderer is in-repo — `plist-render.sh` via postinstall/postupgrade — so the change propagates on `arc upgrade cortex`).

**Adversarial review (mandatory for this lane) BLOCKed round 1 with two real findings, both fixed:**
1. *Upgrade path never created the new dir* — postinstall §1b is deliberately inert on upgrade boxes, and launchd doesn't create Std\*Path parents → every existing macOS install would restart logging nowhere (the exact bug class being fixed). Fixed: `postupgrade.sh` mkdirs the state logs dir before the Darwin reloads; false "§1b covers this" comments corrected in systemd-render.sh + the e2e guard test.
2. *Darwin truncate without a restart* could wipe the only failure evidence → false-GREEN gate over a bus-dead daemon. Fixed: darwin truncate removed from this branch — it lands paired with restart-on-re-run in #2283 (truncate → restart → gate, matching Linux). A negative-space tripwire asserts darwin does NOT truncate.

Linux behavior byte-identical (ordering tripwire + all #2264 tests green). Tests: quickstart 51/51, xdg e2e 18 pass/1 todo, tsc + lint clean, `bash -n` clean.

Accepted residual until #2283: a macOS re-run after a failed prior boot can fast-fail on the stale error-log line — conservative-honest vs. the false-GREEN alternative; documented in the gate comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH