### PR TITLE
fix(quickstart): re-run restarts a running daemon so fixed configs are picked up (#2283)

### DIFF
--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -38,7 +38,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { dispatchQuickstart } from "../quickstart";
-import { daemonErrorLogPath, daemonLogPath } from "../quickstart-lib";
+import { daemonErrorLogPath, daemonLogPath, launchdStackLabel } from "../quickstart-lib";
 import type {
   CommandResult,
   GatePort,
@@ -182,9 +182,18 @@ interface FakeOverrides {
   unitFileExists?: (unit: string) => boolean;
   daemonReload?: () => CommandResult;
   enableNow?: (units: string[]) => CommandResult;
-  // cortex#2264 — records the error-log truncation step 7 performs before the
-  // (re)start (so a test can assert it ran, with what path, and in what order).
-  truncateErrorLog?: (errorLogPath: string) => void;
+  // cortex#2283 — restart-on-re-run seams. Defaults: try-restart/kickstart
+  // succeed; isActive false (fresh boot); launchd NOT loaded (so darwin tests
+  // that don't opt in keep the pre-#2283 "handled by arc" skip path).
+  tryRestart?: (units: string[]) => CommandResult;
+  isActive?: (unit: string) => boolean;
+  launchdServiceLoaded?: (label: string) => boolean;
+  launchdKickstart?: (label: string) => CommandResult;
+  // cortex#2264/#2283 — records the per-file log truncations step 7 performs
+  // before the (re)start: called TWICE, once for the main `.log` and once for
+  // the `.error.log` (so a test can assert both ran, with what paths, and in
+  // what order relative to the restart).
+  truncateLog?: (logPath: string) => void;
   provisionSeed?: () => CommandResult;
   // cortex#2264 — takes the polled path so a test can return DIFFERENT content
   // for the main `.log` vs the `.error.log` sibling. Existing zero-arg lambdas
@@ -203,8 +212,12 @@ function fakePorts(overrides: FakeOverrides = {}): QuickstartPorts {
   const service: ServicePort = {
     unitFileExists: overrides.unitFileExists ?? (() => true),
     daemonReload: overrides.daemonReload ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
-    truncateErrorLog: overrides.truncateErrorLog ?? (() => {}),
+    truncateLog: overrides.truncateLog ?? (() => {}),
     enableNow: overrides.enableNow ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
+    tryRestart: overrides.tryRestart ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
+    isActive: overrides.isActive ?? (() => false),
+    launchdServiceLoaded: overrides.launchdServiceLoaded ?? (() => false),
+    launchdKickstart: overrides.launchdKickstart ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
   };
   const provision: ProvisionPort = {
     provisionSeed: overrides.provisionSeed ?? (() => ({ exitCode: 0, stdout: "  ⊘ NKey already exists — reusing\n", stderr: "" })),
@@ -567,7 +580,7 @@ describe("dispatchQuickstart — step 8 gate", () => {
           () =>
             fakePorts({
               // Step 7 (Linux) truncates the append-mode error log before restart.
-              truncateErrorLog: () => {
+              truncateLog: () => {
                 errorLogContent = "";
               },
               readLog: (p: string) => {
@@ -589,9 +602,12 @@ describe("dispatchQuickstart — step 8 gate", () => {
     expect(res.stdout).toContain("Healthy-boot gate ✓");
   });
 
-  // cortex#2264 — step 7 truncates the daemon's append-mode .error.log at the
-  // EXACT daemonErrorLogPath, BEFORE it (re)starts the daemon (enable --now).
-  test("cortex#2264: step 7 truncates the .error.log (correct path) before enable --now", async () => {
+  // cortex#2264/#2283 — step 7 pair-truncates BOTH append-mode daemon logs at
+  // the EXACT daemonLogPath + daemonErrorLogPath, BEFORE it (re)starts the
+  // daemon (enable --now). Both directions matter: a stale .error.log failure
+  // false-FAILS the gate (#2264); stale healthy .log lines false-PASS it over
+  // a daemon that dies on relaunch (#2283 review F1).
+  test("cortex#2264/#2283: step 7 truncates BOTH daemon logs (correct paths) before enable --now", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
     const calls: string[] = [];
@@ -601,7 +617,7 @@ describe("dispatchQuickstart — step 8 gate", () => {
           ["--config-dir", configDir, "--nats-dir", natsDir],
           () =>
             fakePorts({
-              truncateErrorLog: (p: string) => calls.push(`truncate:${p}`),
+              truncateLog: (p: string) => calls.push(`truncate:${p}`),
               enableNow: (u: string[]) => {
                 calls.push(`enable:${u.join(",")}`);
                 return { exitCode: 0, stdout: "", stderr: "" };
@@ -611,14 +627,15 @@ describe("dispatchQuickstart — step 8 gate", () => {
       ),
     );
     expect(res.exitCode).toBe(0);
-    const expectedPath = daemonErrorLogPath(process.env.HOME ?? "", "work");
-    // Truncation happened, targeting the exact daemonErrorLogPath…
-    expect(calls).toContain(`truncate:${expectedPath}`);
-    // …and it happened BEFORE the (re)start.
-    const truncIdx = calls.findIndex((c) => c.startsWith("truncate:"));
+    const home = process.env.HOME ?? "";
+    // BOTH truncations happened, targeting the exact gate-polled paths…
+    expect(calls).toContain(`truncate:${daemonLogPath(home, "work")}`);
+    expect(calls).toContain(`truncate:${daemonErrorLogPath(home, "work")}`);
+    // …and BOTH happened BEFORE the (re)start.
+    const lastTruncIdx = calls.map((c, i) => (c.startsWith("truncate:") ? i : -1)).reduce((a, b) => Math.max(a, b), -1);
     const enableIdx = calls.findIndex((c) => c.startsWith("enable:"));
-    expect(truncIdx).toBeGreaterThanOrEqual(0);
-    expect(enableIdx).toBeGreaterThan(truncIdx);
+    expect(lastTruncIdx).toBeGreaterThanOrEqual(0);
+    expect(enableIdx).toBeGreaterThan(lastTruncIdx);
   });
 });
 
@@ -669,40 +686,47 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
     expect(res.stdout).toContain("Healthy-boot gate ✓");
   });
 
-  // NEGATIVE SPACE (deliberate deferral, adversarial-review round 1): darwin
-  // must NOT truncate the .error.log on this branch. quickstart never restarts
-  // the daemon on macOS, and a truncate WITHOUT a paired restart destroys
-  // current-boot failure evidence — a bus-dead daemon's one-shot `failed to
-  // connect` line would be wiped while stale healthy `.log` lines persist
-  // (append mode), turning the gate false-GREEN. The paired
-  // truncate → restart → gate lands with A2 (cortex#2283). This test moves
-  // there, inverted, when it does.
-  test("cortex#2282: darwin — .error.log is NOT truncated (deferred to A2/#2283 with restart-on-re-run)", async () => {
+  // A1's (#2297) negative-space tripwire — "darwin NEVER truncates" — guarded
+  // the UNPAIRED state and is superseded by cortex#2283: darwin now truncates
+  // exactly when a restart follows (loaded → truncate + kickstart, covered in
+  // the #2283 block below). What survives of the invariant is its real core:
+  // NO restart → NO truncate. This test pins that on the not-loaded path.
+  test("cortex#2283: darwin, service NOT loaded — no truncate, no kickstart (unpaired truncate stays impossible)", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
     const truncateCalls: string[] = [];
+    const kickstartCalls: string[] = [];
     const res = await withPlatform("darwin", () =>
       withEnv(validCtxEnv(), () =>
         dispatchQuickstart(
           ["--config-dir", configDir, "--nats-dir", natsDir],
           () =>
             fakePorts({
-              truncateErrorLog: (p: string) => truncateCalls.push(p),
+              launchdServiceLoaded: () => false,
+              truncateLog: (p: string) => truncateCalls.push(p),
+              launchdKickstart: (label: string) => {
+                kickstartCalls.push(label);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
             }),
         ),
       ),
     );
     expect(res.exitCode).toBe(0);
     expect(truncateCalls).toEqual([]);
-    expect(res.stdout).not.toContain("cleared prior-boot error log");
-    expect(res.stdout).toContain("non-Linux host");
+    expect(kickstartCalls).toEqual([]);
+    expect(res.stdout).not.toContain("cleared prior-boot");
+    // Today's arc-owned skip survives, and names the action taken.
+    expect(res.stdout).toContain("launchd is handled by arc");
+    expect(res.stdout).toContain("skip (not loaded — arc owns launchd load)");
   });
 
-  // Linux ordering is byte-identical after the cortex#2282 helper extraction:
-  // the truncate still happens between daemon-reload and enable --now (covered
-  // in depth by the cortex#2264 tests above — this is the regression tripwire
-  // for the step-7 output line surviving the shared-helper refactor).
-  test("cortex#2282: linux — step 7 still emits the cleared-error-log line before enable --now", async () => {
+  // Linux ordering survives the cortex#2282 helper extraction (+ the
+  // cortex#2283 both-logs widening): the truncate still happens between
+  // daemon-reload and enable --now (covered in depth by the cortex#2264 tests
+  // above — this is the regression tripwire for the step-7 output line
+  // surviving the shared-helper refactors).
+  test("cortex#2282: linux — step 7 still emits the cleared-logs line before enable --now", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
     const res = await withPlatform("linux", () =>
@@ -711,8 +735,402 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
       ),
     );
     expect(res.exitCode).toBe(0);
-    expect(res.stdout).toContain("cleared prior-boot error log");
+    expect(res.stdout).toContain("cleared prior-boot logs");
     expect(res.stdout).toContain("enable --now");
+  });
+});
+
+// =============================================================================
+// cortex#2283 — A2: quickstart re-run restarts a running daemon
+// =============================================================================
+
+describe("dispatchQuickstart — cortex#2283 restart-on-re-run", () => {
+  // The label authority pin: the helper step 7 kickstarts with must equal the
+  // Label the plist template actually declares (after the renderer's
+  // __STACK_SLUG__ substitution) — mirrors the cortex#2282 log-path pin.
+  test("cortex#2283: launchdStackLabel matches the stack plist template Label after token substitution", () => {
+    const template = readFileSync(
+      join(import.meta.dir, "..", "..", "..", "..", "services", "ai.meta-factory.cortex.stack.plist"),
+      "utf-8",
+    );
+    const slug = "work";
+    const rendered = template.split("__STACK_SLUG__").join(slug);
+    const label = /<key>Label<\/key>\s*<string>([^<]+)<\/string>/.exec(rendered)?.[1];
+    expect(label).toBe(launchdStackLabel(slug));
+  });
+
+  // Linux recovery re-run (the issue's #1 newcomer trap): daemon RUNNING with
+  // a broken-then-fixed config. `enable --now` is a silent no-op on active
+  // units, so the try-restart of the probed-active units is what re-applies
+  // the config. Full ordering contract asserted:
+  // truncate(both logs) → enable --now → try-restart → gate.
+  test("cortex#2283: linux, daemon running — active units try-restarted, ordering truncate(×2) → enable → try-restart → gate", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const calls: string[] = [];
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              isActive: (u: string) => {
+                calls.push(`isActive:${u}`);
+                return true; // daemon (and nats) running — the recovery re-run case
+              },
+              truncateLog: (p: string) => calls.push(`truncate:${p}`),
+              enableNow: (u: string[]) => {
+                calls.push(`enable:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              tryRestart: (u: string[]) => {
+                calls.push(`try-restart:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              readLog: (p: string) => {
+                calls.push("gate:readLog");
+                return p.endsWith(".error.log") ? "" : FULL_HEALTHY_LOG;
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    // The exact restart invocation: BOTH units probed active → both restarted.
+    expect(calls).toContain("try-restart:nats@work,cortex@work");
+    // BOTH logs truncated (F1: stale healthy .log lines must not survive into
+    // the gate any more than stale .error.log failures may).
+    const home = process.env.HOME ?? "";
+    expect(calls).toContain(`truncate:${daemonLogPath(home, "work")}`);
+    expect(calls).toContain(`truncate:${daemonErrorLogPath(home, "work")}`);
+    // Ordering: BOTH truncates strictly before the (re)start pair, gate after.
+    const lastTruncIdx = calls.map((c, i) => (c.startsWith("truncate:") ? i : -1)).reduce((a, b) => Math.max(a, b), -1);
+    const enableIdx = calls.findIndex((c) => c.startsWith("enable:"));
+    const restartIdx = calls.findIndex((c) => c.startsWith("try-restart:"));
+    const gateIdx = calls.findIndex((c) => c === "gate:readLog");
+    expect(lastTruncIdx).toBeGreaterThanOrEqual(0);
+    expect(enableIdx).toBeGreaterThan(lastTruncIdx);
+    expect(restartIdx).toBeGreaterThan(enableIdx);
+    expect(gateIdx).toBeGreaterThan(restartIdx);
+    // Output honesty: the action taken is named, per unit.
+    expect(res.stdout).toContain("systemctl --user try-restart nats@work cortex@work");
+    expect(res.stdout).toContain("restarted (config re-applied): nats@work cortex@work");
+    expect(res.stdout).not.toContain("started (first boot)");
+  });
+
+  // Fresh boot: nothing active. enable --now does the starting (`--now` =
+  // `start` — it STARTS stopped units) and NO try-restart is issued: the
+  // probed-inactive units were just started by enable --now, and restarting
+  // them mid-bus-connect would land a one-shot `failed to connect` marker in
+  // the freshly-truncated .error.log → gate fast-fail on a healthy system
+  // (adversarial review F2; the earlier "no-op on stopped units" framing was
+  // a false model — try-restart of a just-STARTED unit is a real kill).
+  test("cortex#2283: linux, fresh boot — started via enable --now; NO try-restart issued", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const calls: string[] = [];
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              isActive: () => false,
+              enableNow: (u: string[]) => {
+                calls.push(`enable:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              tryRestart: (u: string[]) => {
+                calls.push(`try-restart:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    // enable --now started everything; try-restart NEVER ran.
+    expect(calls).toEqual(["enable:nats@work,cortex@work"]);
+    expect(res.stdout).toContain("started (first boot): nats@work cortex@work");
+    expect(res.stdout).not.toContain("restarted (config re-applied)");
+    expect(res.stdout).not.toContain("try-restart");
+  });
+
+  // Stopped-after-failure (boot failed → daemon exited → fix config → re-run):
+  // same call sequence as fresh boot — enable --now starts the stopped units,
+  // NO try-restart — and the stale prior-boot .error.log is truncated so the
+  // gate passes on the now-healthy boot instead of fast-failing stale.
+  test("cortex#2283: linux, stopped-after-failure — started (no try-restart), stale .error.log truncated, gate passes", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const calls: string[] = [];
+    let errorLogContent = "myelin-runtime: failed to connect — continuing without NATS: (the failed prior boot)";
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              isActive: () => false, // daemon exited after the failed boot
+              truncateLog: (p: string) => {
+                calls.push("truncate");
+                if (p.endsWith(".error.log")) errorLogContent = "";
+              },
+              enableNow: (u: string[]) => {
+                calls.push(`enable:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              tryRestart: (u: string[]) => {
+                calls.push(`try-restart:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              readLog: (p: string) => (p.endsWith(".error.log") ? errorLogContent : FULL_HEALTHY_LOG),
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    // Both logs truncated, then started — never a try-restart of cold units.
+    expect(calls).toEqual(["truncate", "truncate", "enable:nats@work,cortex@work"]);
+    expect(res.stdout).toContain("started (first boot)");
+    expect(res.stdout).not.toContain("bus connect FAILED");
+    expect(res.stdout).toContain("Healthy-boot gate ✓");
+  });
+
+  // Mixed state (nats survived the failed boot, cortex died): try-restart is
+  // scoped to EXACTLY the probed-active unit; the cold one is only started by
+  // enable --now. Per-unit output honesty reports both actions accurately.
+  test("cortex#2283: linux, mixed active/inactive — try-restart ONLY the active unit; per-unit honesty lines", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const calls: string[] = [];
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              isActive: (u: string) => u === "nats@work", // cortex@work is down
+              enableNow: (u: string[]) => {
+                calls.push(`enable:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              tryRestart: (u: string[]) => {
+                calls.push(`try-restart:${u.join(",")}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    // enable --now still targets both (enablement is idempotent; it also
+    // STARTS the cold cortex@work) — then try-restart hits ONLY nats@work.
+    expect(calls).toEqual(["enable:nats@work,cortex@work", "try-restart:nats@work"]);
+    // Per-unit honesty: each unit reported under the action actually taken.
+    expect(res.stdout).toContain("restarted (config re-applied): nats@work");
+    expect(res.stdout).toContain("started (first boot): cortex@work");
+  });
+
+  test("cortex#2283: linux — try-restart failure surfaces systemctl's stderr and exits 1 (gate never runs)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    let readLogCalls = 0;
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              isActive: () => true, // running units — the try-restart path
+              tryRestart: () => ({ exitCode: 1, stdout: "", stderr: "Job for cortex@work.service failed." }),
+              readLog: () => {
+                readLogCalls++;
+                return FULL_HEALTHY_LOG;
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("try-restart");
+    expect(res.stdout).toContain("Job for cortex@work.service failed.");
+    expect(readLogCalls).toBe(0);
+  });
+
+  // macOS recovery re-run: service LOADED → kickstart -k, with the truncate
+  // A1 (#2297) deliberately deferred now landing PAIRED with it. Full darwin
+  // ordering contract asserted: truncate → kickstart → gate.
+  test("cortex#2283: darwin, service loaded — truncate PAIRED with launchctl kickstart -k, ordering truncate → restart → gate", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const calls: string[] = [];
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              launchdServiceLoaded: (label: string) => {
+                calls.push(`loaded?:${label}`);
+                return true;
+              },
+              truncateLog: (p: string) => calls.push(`truncate:${p}`),
+              launchdKickstart: (label: string) => {
+                calls.push(`kickstart:${label}`);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+              readLog: (p: string) => {
+                calls.push("gate:readLog");
+                return p.endsWith(".error.log") ? "" : FULL_HEALTHY_LOG;
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    // The guard probed, then kickstart hit the EXACT plist Label.
+    expect(calls).toContain(`loaded?:${launchdStackLabel("work")}`);
+    expect(calls).toContain(`kickstart:${launchdStackLabel("work")}`);
+    // BOTH truncates targeted the exact gate-polled paths (F1)…
+    const home = process.env.HOME ?? "";
+    expect(calls).toContain(`truncate:${daemonLogPath(home, "work")}`);
+    expect(calls).toContain(`truncate:${daemonErrorLogPath(home, "work")}`);
+    // …and the pairing/ordering holds: truncate(×2) → kickstart → gate.
+    const lastTruncIdx = calls.map((c, i) => (c.startsWith("truncate:") ? i : -1)).reduce((a, b) => Math.max(a, b), -1);
+    const kickIdx = calls.findIndex((c) => c.startsWith("kickstart:"));
+    const gateIdx = calls.findIndex((c) => c === "gate:readLog");
+    expect(lastTruncIdx).toBeGreaterThanOrEqual(0);
+    expect(kickIdx).toBeGreaterThan(lastTruncIdx);
+    expect(gateIdx).toBeGreaterThan(kickIdx);
+    // Output honesty.
+    expect(res.stdout).toContain("launchctl kickstart -k");
+    expect(res.stdout).toContain("restarted (config re-applied)");
+  });
+
+  test("cortex#2283: darwin — kickstart failure surfaces launchctl's stderr and exits 1 (gate never runs on a stale daemon)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    let readLogCalls = 0;
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              launchdServiceLoaded: () => true,
+              launchdKickstart: () => ({ exitCode: 150, stdout: "", stderr: "Could not find service in domain" }),
+              readLog: () => {
+                readLogCalls++;
+                return FULL_HEALTHY_LOG;
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("launchctl kickstart -k");
+    expect(res.stdout).toContain("Could not find service in domain");
+    // The gate never ran: after the truncate wiped prior-boot evidence, gating
+    // a daemon we failed to restart could false-GREEN on stale healthy lines.
+    expect(readLogCalls).toBe(0);
+  });
+
+  // --skip-services regression (byte-identical bypass): NO service-port method
+  // is invoked at all — no probe, no truncate, no start, no restart — on
+  // either platform's branch.
+  test("cortex#2283: --skip-services still bypasses step 7 entirely — zero service-port calls (linux + darwin)", async () => {
+    for (const platform of ["linux", "darwin"] as const) {
+      const configDir = freshDir();
+      const natsDir = freshDir();
+      const calls: string[] = [];
+      const res = await withPlatform(platform, () =>
+        withEnv(validCtxEnv(), () =>
+          dispatchQuickstart(
+            ["--config-dir", configDir, "--nats-dir", natsDir, "--skip-services"],
+            () =>
+              fakePorts({
+                unitFileExists: () => {
+                  calls.push("unitFileExists");
+                  return true;
+                },
+                daemonReload: () => {
+                  calls.push("daemonReload");
+                  return { exitCode: 0, stdout: "", stderr: "" };
+                },
+                isActive: () => {
+                  calls.push("isActive");
+                  return false;
+                },
+                truncateLog: () => calls.push("truncate"),
+                enableNow: () => {
+                  calls.push("enable");
+                  return { exitCode: 0, stdout: "", stderr: "" };
+                },
+                tryRestart: () => {
+                  calls.push("try-restart");
+                  return { exitCode: 0, stdout: "", stderr: "" };
+                },
+                launchdServiceLoaded: () => {
+                  calls.push("loaded?");
+                  return true;
+                },
+                launchdKickstart: () => {
+                  calls.push("kickstart");
+                  return { exitCode: 0, stdout: "", stderr: "" };
+                },
+              }),
+          ),
+        ),
+      );
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain("--skip-services passed — skipping");
+      expect(calls).toEqual([]);
+    }
+  });
+
+  // Output honesty in --json: the step-7 item names the action taken, per
+  // unit on Linux (mixed states report both actions accurately).
+  test("cortex#2283: --json step-7 item carries the per-unit action note (linux running/fresh/mixed, darwin restarted/skip)", async () => {
+    interface Parsed {
+      status: string;
+      items?: { step: string; ok: string; note?: string }[];
+    }
+    const stepNote = (out: string): string | undefined =>
+      (JSON.parse(out) as Parsed).items?.find((i) => i.step === "7. Services")?.note;
+
+    const runJson = (platform: NodeJS.Platform, overrides: FakeOverrides) => {
+      const configDir = freshDir();
+      const natsDir = freshDir();
+      return withPlatform(platform, () =>
+        withEnv(validCtxEnv(), () =>
+          dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--json"], () => fakePorts(overrides)),
+        ),
+      );
+    };
+
+    const linuxRunning = await runJson("linux", { isActive: () => true });
+    expect(linuxRunning.exitCode).toBe(0);
+    expect(stepNote(linuxRunning.stdout)).toBe("restarted (config re-applied): nats@work cortex@work");
+
+    const linuxFresh = await runJson("linux", { isActive: () => false });
+    expect(linuxFresh.exitCode).toBe(0);
+    expect(stepNote(linuxFresh.stdout)).toBe("started (first boot): nats@work cortex@work");
+
+    // Mixed state: per-unit honesty in the combined note.
+    const linuxMixed = await runJson("linux", { isActive: (u: string) => u === "nats@work" });
+    expect(linuxMixed.exitCode).toBe(0);
+    expect(stepNote(linuxMixed.stdout)).toBe(
+      "restarted (config re-applied): nats@work; started (first boot): cortex@work",
+    );
+
+    const darwinLoaded = await runJson("darwin", { launchdServiceLoaded: () => true });
+    expect(darwinLoaded.exitCode).toBe(0);
+    expect(stepNote(darwinLoaded.stdout)).toBe("restarted (config re-applied)");
+
+    const darwinNotLoaded = await runJson("darwin", { launchdServiceLoaded: () => false });
+    expect(darwinNotLoaded.exitCode).toBe(0);
+    expect(stepNote(darwinNotLoaded.stdout)).toBe("skip (not loaded — arc owns launchd load)");
   });
 });
 

--- a/src/cli/cortex/commands/quickstart-adapters.ts
+++ b/src/cli/cortex/commands/quickstart-adapters.ts
@@ -75,13 +75,22 @@ export function buildPreflightPorts(): PreflightPorts {
 }
 
 // =============================================================================
-// Service (systemd user units, Linux only)
+// Service (systemd user units on Linux; launchd restart-only on darwin)
 // =============================================================================
 
 /** Where L1 (cortex#2071) renders the two template units. Mirrors the path
  *  Appendix A (README-AGENTS.md) documents. */
 function systemdUserUnitDir(): string {
   return join(homedir(), ".config", "systemd", "user");
+}
+
+/** cortex#2283 — launchd domain target for the current user's GUI domain:
+ *  `gui/<uid>/<label>`. `process.getuid` exists on every POSIX platform
+ *  (darwin included); the 0 fallback is unreachable in practice — these
+ *  methods are only invoked on darwin. */
+function launchdGuiTarget(label: string): string {
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  return `gui/${String(uid)}/${label}`;
 }
 
 export function buildServicePort(): ServicePort {
@@ -92,15 +101,17 @@ export function buildServicePort(): ServicePort {
     daemonReload(): CommandResult {
       return runSync(["systemctl", "--user", "daemon-reload"]);
     },
-    truncateErrorLog(errorLogPath: string): void {
-      // cortex#2264 — clear the append-mode `.error.log` before the (re)start so
-      // the gate reads only CURRENT-boot content. Best-effort: a failure here
-      // must NOT block the restart — the gate simply degrades to its timeout
-      // path (never a false-fail). mkdir -p first so a first-install run (log
-      // dir not yet created by the daemon) still lands an empty file.
+    truncateLog(logPath: string): void {
+      // cortex#2264 / cortex#2283 — clear ONE append-mode daemon log before
+      // the (re)start so the gate reads only CURRENT-boot content (step 7
+      // pair-truncates both the `.log` and the `.error.log`). Best-effort: a
+      // failure here must NOT block the restart — the gate simply degrades to
+      // its timeout path (never a false-fail). mkdir -p first so a
+      // first-install run (log dir not yet created by the daemon) still lands
+      // an empty file.
       try {
-        mkdirSync(dirname(errorLogPath), { recursive: true });
-        writeFileSync(errorLogPath, "");
+        mkdirSync(dirname(logPath), { recursive: true });
+        writeFileSync(logPath, "");
       } catch (_err) {
         // Swallow — see above; the gate never depends on this succeeding. Safe
         // to ignore.
@@ -108,6 +119,29 @@ export function buildServicePort(): ServicePort {
     },
     enableNow(units: string[]): CommandResult {
       return runSync(["systemctl", "--user", "enable", "--now", ...units]);
+    },
+    tryRestart(units: string[]): CommandResult {
+      // cortex#2283 — restart the probed-active units so the recovery re-run
+      // picks up patched configs; the orchestrator passes ONLY units the
+      // isActive pre-probe found running (a blanket try-restart would kill
+      // units enable --now just started, mid-bus-connect — review F2).
+      return runSync(["systemctl", "--user", "try-restart", ...units]);
+    },
+    isActive(unit: string): boolean {
+      // Read-only pre-start probe (cortex#2283) — exit 0 ⇔ active. Selects
+      // the tryRestart set + names the per-unit action in step 7's output.
+      // `--quiet` suppresses the state word; we only need the code.
+      return runSync(["systemctl", "--user", "is-active", "--quiet", unit]).exitCode === 0;
+    },
+    launchdServiceLoaded(label: string): boolean {
+      // cortex#2283 — exit 0 ⇔ loaded in the user's GUI domain. Quickstart
+      // never loads/unloads (arc owns that); this only gates the kickstart.
+      return runSync(["launchctl", "print", launchdGuiTarget(label)]).exitCode === 0;
+    },
+    launchdKickstart(label: string): CommandResult {
+      // cortex#2283 — `-k`: kill the running instance, then restart it, so a
+      // re-run applies patched configs on macOS.
+      return runSync(["launchctl", "kickstart", "-k", launchdGuiTarget(label)]);
     },
   };
 }

--- a/src/cli/cortex/commands/quickstart-lib.ts
+++ b/src/cli/cortex/commands/quickstart-lib.ts
@@ -747,6 +747,20 @@ export function daemonErrorLogPath(home: string, slug: string): string {
 }
 
 /**
+ * The launchd `Label` of the per-slug stack service — the plist template
+ * (`src/services/ai.meta-factory.cortex.stack.plist`) declares
+ * `ai.meta-factory.cortex.__STACK_SLUG__`, and the renderer
+ * (`scripts/lib/plist-render.sh`) substitutes `__STACK_SLUG__` with the slug.
+ * cortex#2283 — step 7's darwin restart targets `gui/$UID/<this label>` via
+ * `launchctl kickstart -k` (the gui target itself is built in the live
+ * adapter, where the real UID lives). A test pins this helper against the
+ * actual plist template so the two authorities cannot diverge silently.
+ */
+export function launchdStackLabel(slug: string): string {
+  return `ai.meta-factory.cortex.${slug}`;
+}
+
+/**
  * The marker the myelin runtime logs (to stderr → the `.error.log`) when the
  * PRIMARY bus connect fails and the runtime degrades to disabled
  * (`runtime.ts:834`: `myelin-runtime: failed to connect — continuing without
@@ -770,10 +784,12 @@ export const BUS_CONNECT_FAILURE_MARKER = "failed to connect — continuing with
  * continue posture is intentionally UNCHANGED — that fail-closed decision is
  * deferred).
  *
- * SAFE to fast-fail on the FIRST match because step 7 TRUNCATES this
- * append-mode `.error.log` immediately before it (re)starts the daemon
- * (`truncateErrorLog`), so anything present here is CURRENT-boot content — a
- * stale prior-boot failure line can no longer linger and cause a false-fail.
+ * SAFE to fast-fail on the FIRST match because step 7 pair-truncates BOTH
+ * append-mode daemon logs (`.log` + `.error.log`, `truncateLog` via
+ * `clearPriorBootLogs`) immediately before it (re)starts the daemon, so
+ * anything present here is CURRENT-boot content — a stale prior-boot failure
+ * line can no longer linger and cause a false-fail (and, symmetrically, stale
+ * prior-boot healthy `.log` lines can no longer cause a false-pass).
  */
 export function detectBusConnectFailure(errorLogText: string | undefined): string | undefined {
   if (errorLogText === undefined) return undefined;

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -57,13 +57,16 @@ export interface PreflightPorts {
 // =============================================================================
 
 /**
- * The injectable systemd seam. NEVER exercised on macOS in production
- * (quickstart's orchestrator skips the whole step off `process.platform`;
- * `truncateErrorLog` — pure fs — joins the darwin path only with A2 /
- * cortex#2283, paired with the restart it needs). This interface exists so a
- * test can inject a fake systemctl and assert the exact invocations
- * quickstart makes, without a real systemd on the test host (arc's L2
- * pattern, referenced in cortex#2094's acceptance criteria).
+ * The injectable host-service seam. The orchestrator branches off
+ * `process.platform`: Linux drives the systemd methods
+ * (`unitFileExists`/`daemonReload`/`enableNow`/`tryRestart`/`isActive`),
+ * darwin drives the launchd methods (`launchdServiceLoaded`/
+ * `launchdKickstart`) — restart-only; arc owns the launchd load/unload
+ * lifecycle (cortex#2283). `truncateLog` — pure fs — is shared by both
+ * branches, always paired with the (re)start that follows it. This interface
+ * exists so a test can inject a fake systemctl/launchctl and assert the exact
+ * invocations quickstart makes, without a real systemd/launchd on the test
+ * host (arc's L2 pattern, referenced in cortex#2094's acceptance criteria).
  */
 export interface ServicePort {
   /** Absolute path a systemd user unit named `unit` would be rendered at —
@@ -75,24 +78,67 @@ export interface ServicePort {
   /** `systemctl --user daemon-reload`. */
   daemonReload(): CommandResult;
   /**
-   * cortex#2264 — truncate the daemon's append-mode `.error.log` to EMPTY,
-   * immediately before the (re)start below, so step 8's gate only ever reads
-   * CURRENT-boot content. The `cortex@.service` unit routes `StandardError` with
-   * `append:` (never truncates), so a failure line from a PRIOR boot would
-   * otherwise persist and make the gate fast-fail on a stale line before the
-   * fresh boot has even connected. Called ONLY in the Linux branch that
-   * actually (re)starts the daemon — a truncate is only safe paired with a
-   * restart (truncate → restart → gate), else it destroys current-boot
-   * failure evidence. launchd's `StandardErrorPath` appends too (cortex#2282
-   * unified the paths), so the darwin call arrives with A2 (cortex#2283)
-   * alongside restart-on-re-run.
+   * cortex#2264 / cortex#2283 — truncate ONE append-mode daemon log file to
+   * EMPTY, immediately before the (re)start below, so step 8's gate only ever
+   * reads CURRENT-boot content. Called once per log file — step 7
+   * pair-truncates BOTH the `.error.log` (a stale prior-boot failure line
+   * would make the gate fast-fail before the fresh boot connects,
+   * cortex#2264) AND the main `.log` (stale prior-boot HEALTHY lines would
+   * otherwise satisfy the gate's positive signal even when the relaunched
+   * daemon dies on a still-broken config — a sub-second false-GREEN over a
+   * dead daemon; cortex#2283 adversarial review F1). Both systemd (`append:`)
+   * and launchd (`Std{Out,Error}Path`, cortex#2282-unified) append and never
+   * truncate on their own. Called ONLY in branches that actually (re)start
+   * the daemon — a truncate is only safe paired with a restart
+   * (truncate → restart → gate), else it destroys current-boot evidence; the
+   * darwin branch calls it immediately before its `launchctl kickstart -k`,
+   * and ONLY when the service is loaded (i.e. only when a restart follows).
    * Best-effort: never throws — a failure here degrades the gate to its honest
-   * timeout path, never a false-fail. `errorLogPath` is the exact path
-   * `daemonErrorLogPath()` computes.
+   * timeout path, never a false-fail. `logPath` is an exact path computed by
+   * `daemonLogPath()` / `daemonErrorLogPath()`.
    */
-  truncateErrorLog(errorLogPath: string): void;
-  /** `systemctl --user enable --now <units...>`. */
+  truncateLog(logPath: string): void;
+  /** `systemctl --user enable --now <units...>` — enables (idempotent) and
+   *  STARTS any stopped unit (`--now` = `start`); a silent no-op only for
+   *  units already active. */
   enableNow(units: string[]): CommandResult;
+  /**
+   * cortex#2283 — `systemctl --user try-restart <units...>`: restart the
+   * given units (restart-if-running; stopped units are untouched). Issued for
+   * exactly the units the `isActive` pre-probe found RUNNING — those are the
+   * ones `enableNow` silently no-ops on, so this is what re-applies fixed
+   * configs on a recovery re-run. NEVER issued for units the probe found
+   * stopped: `enable --now` just STARTED those, and a blanket try-restart
+   * would kill the fresh instance mid-bus-connect, landing its one-shot
+   * `failed to connect` marker in the just-truncated `.error.log` and
+   * fast-failing the gate on a healthy system (cortex#2283 adversarial
+   * review F2 — the unconditional sequence in the original issue spec was
+   * wrong). Restart of RUNNING units remains unconditional — this is
+   * run-state selection, not the out-of-scope config-changed detection.
+   */
+  tryRestart(units: string[]): CommandResult;
+  /**
+   * cortex#2283 — `systemctl --user is-active --quiet <unit>` (exit 0 →
+   * active). READ-ONLY pre-start probe with two consumers: it selects which
+   * units get `tryRestart` (probed-active only — see tryRestart above), and
+   * it names the per-unit action taken in step 7's output ("restarted
+   * (config re-applied)" vs "started (first boot)"). It never gates WHETHER
+   * a running unit is restarted — that stays unconditional.
+   */
+  isActive(unit: string): boolean;
+  /**
+   * cortex#2283 — darwin guard: `launchctl print gui/$UID/<label>` exit 0 ⇔
+   * the service is loaded in the user's GUI domain. Quickstart restarts ONLY
+   * a loaded service; load/unload stays arc-owned (out of scope).
+   */
+  launchdServiceLoaded(label: string): boolean;
+  /**
+   * cortex#2283 — `launchctl kickstart -k gui/$UID/<label>`: kill + restart
+   * the loaded service, so a re-run picks up patched configs on macOS. The
+   * `gui/$UID/` domain target is built inside the live adapter (real UID);
+   * callers pass the bare plist Label (`launchdStackLabel()`).
+   */
+  launchdKickstart(label: string): CommandResult;
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -29,8 +29,11 @@
  *   6. Seed provisioning — the SAME entry postupgrade.sh uses.
  *   7. Services          — Linux: systemd user units (L1, cortex#2071
  *                          REQUIRED — declared as a hard dependency, not
- *                          re-implemented here). macOS: arc handles launchd;
- *                          skip.
+ *                          re-implemented here); a re-run also try-restarts
+ *                          running units so fixed configs are picked up
+ *                          (cortex#2283). macOS: restart a LOADED stack
+ *                          service via launchctl kickstart -k (load/unload
+ *                          stays arc-owned); not loaded → skip.
  *   8. Gate              — the §5 healthy-boot grep table + nats /healthz,
  *                          bounded wait.
  *
@@ -76,6 +79,7 @@ import {
   detectBusConnectFailure,
   evaluateHealthyBootGate,
   gatePassed,
+  launchdStackLabel,
   natsConfPath,
   nkeyBasenameForSlug,
   patchStackYaml,
@@ -245,7 +249,10 @@ interface StepReport {
    *  Surfaced in the --json items as `skipped: "true"` so an operator sees an
    *  explicit deferral, never a green check for work that didn't run. */
   skipped?: boolean;
-  /** Short machine-readable reason accompanying `skipped` (--json `note`). */
+  /** Short machine-readable annotation (--json `note`): the reason
+   *  accompanying `skipped` (cortex#2275), and — cortex#2283 — step 7's
+   *  action-taken line ("restarted (config re-applied)" / "started (first
+   *  boot)" / "skip (not loaded — arc owns launchd load)"). */
   note?: string;
 }
 
@@ -658,40 +665,56 @@ function runSeedProvisioning(ports: QuickstartPorts, opts: { slug: string; confi
 }
 
 // =============================================================================
-// Step 7 — services (Linux only)
+// Step 7 — services (Linux: systemd; darwin: launchd restart-only)
 // =============================================================================
 
 /**
- * cortex#2264 / cortex#2282 — clear the daemon's append-mode `.error.log` so
- * step 8's gate only ever sees CURRENT-boot content. Without this, a
- * bus-connect failure line from a PRIOR boot would linger (both systemd
- * `StandardError=append:` and launchd `StandardErrorPath` append, never
- * truncate) and make the gate fast-fail on stale content before the fresh
- * daemon connects — breaking the "fix creds and re-run" recovery. Best-effort
- * (the port swallows fs errors). Extracted (cortex#2282) so it is callable
- * host-independently, but a truncate is ONLY safe paired atomically with a
- * (re)start — truncate → restart → gate — otherwise it destroys the
- * current-boot failure evidence the gate's fast-fail depends on. So today
- * ONLY the Linux branch calls it, immediately before its `enable --now`;
- * the darwin call arrives with A2 (cortex#2283), paired with the
- * restart-on-re-run it needs. Returns the human-readable step line.
+ * cortex#2264 / cortex#2282 / cortex#2283 — clear BOTH of the daemon's
+ * append-mode log files (`.log` + `.error.log`) so step 8's gate only ever
+ * sees CURRENT-boot content in EITHER file. Both stale directions poison the
+ * gate (systemd `append:` and launchd `Std{Out,Error}Path` never truncate):
+ *   - a stale `.error.log` failure line from a PRIOR boot fast-fails the gate
+ *     before the fresh daemon connects — breaking "fix creds and re-run"
+ *     recovery (cortex#2264);
+ *   - stale HEALTHY lines in the prior boot's `.log` satisfy the gate's
+ *     POSITIVE signal — try-restart/kickstart succeed at fork time regardless
+ *     of whether the relaunched daemon survives, so a daemon that dies on a
+ *     still-broken config would leave the old 5 healthy lines standing and
+ *     turn the gate green over a dead daemon (cortex#2283 adversarial review
+ *     F1).
+ * Best-effort (the port swallows fs errors). A truncate is ONLY safe paired
+ * atomically with a (re)start — truncate → restart → gate — otherwise it
+ * destroys the current-boot evidence the gate depends on. Both callers honor
+ * that pairing: the Linux branch calls it immediately before its
+ * `enable --now` + per-unit `try-restart`, and the darwin branch immediately
+ * before its `launchctl kickstart -k` — and ONLY when the service is loaded
+ * (no restart → no truncate). Returns the human-readable step line.
  */
-function clearPriorBootErrorLog(ports: QuickstartPorts, slug: string): string {
-  const errorLogPath = daemonErrorLogPath(process.env.HOME ?? "", slug);
-  ports.service.truncateErrorLog(errorLogPath);
-  return `  ✓ cleared prior-boot error log (${errorLogPath})`;
+function clearPriorBootLogs(ports: QuickstartPorts, slug: string): string {
+  const home = process.env.HOME ?? "";
+  const logPath = daemonLogPath(home, slug);
+  const errorLogPath = daemonErrorLogPath(home, slug);
+  ports.service.truncateLog(logPath);
+  ports.service.truncateLog(errorLogPath);
+  return `  ✓ cleared prior-boot logs (${logPath}, ${errorLogPath})`;
 }
 
 function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean }): StepReport {
   if (opts.skip) {
     return step("7. Services", true, ["  ○ --skip-services passed — skipping"]);
   }
-  if (process.platform !== "linux") {
-    return step("7. Services", true, ["  ○ non-Linux host — launchd is handled by arc; skip"]);
+  if (process.platform === "linux") {
+    return runServicesLinux(ports, opts.slug);
   }
+  if (process.platform === "darwin") {
+    return runServicesDarwin(ports, opts.slug);
+  }
+  return step("7. Services", true, ["  ○ non-Linux host — launchd is handled by arc; skip"]);
+}
 
+function runServicesLinux(ports: QuickstartPorts, slug: string): StepReport {
   const lines: string[] = [];
-  let ok = true;
+  const units = [`nats@${slug}`, `cortex@${slug}`];
 
   // L1 (cortex#2071) REQUIRED, not re-implemented here — an install without
   // it has no template units to enable an instance of.
@@ -716,20 +739,93 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
   }
   lines.push("  ✓ systemctl --user daemon-reload");
 
-  // cortex#2264 — clear the daemon's append-mode `.error.log` IMMEDIATELY
-  // before the (re)start (see clearPriorBootErrorLog above), so step 8's gate
-  // only ever sees CURRENT-boot content.
-  lines.push(clearPriorBootErrorLog(ports, opts.slug));
+  // cortex#2283 — per-unit PRE-start run-state probe. It selects which units
+  // get try-restart below AND names the per-unit action taken. This is
+  // run-state selection, NOT the out-of-scope config-changed detection: every
+  // probed-active unit is restarted unconditionally on every re-run.
+  const activeUnits = units.filter((u) => ports.service.isActive(u));
+  const inactiveUnits = units.filter((u) => !activeUnits.includes(u));
 
-  const enable = ports.service.enableNow([`nats@${opts.slug}`, `cortex@${opts.slug}`]);
+  // cortex#2264 / cortex#2283 — pair-truncate BOTH append-mode daemon logs
+  // IMMEDIATELY before the (re)start (see clearPriorBootLogs above), so step
+  // 8's gate only ever sees CURRENT-boot content in either file.
+  lines.push(clearPriorBootLogs(ports, slug));
+
+  const enable = ports.service.enableNow(units);
   if (enable.exitCode !== 0) {
-    lines.push(`  ✗ systemctl --user enable --now nats@${opts.slug} cortex@${opts.slug} failed: ${enable.stderr.trim()}`);
-    ok = false;
-  } else {
-    lines.push(`  ✓ systemctl --user enable --now nats@${opts.slug} cortex@${opts.slug}`);
+    lines.push(`  ✗ systemctl --user enable --now ${units.join(" ")} failed: ${enable.stderr.trim()}`);
+    return step("7. Services", false, lines);
+  }
+  lines.push(`  ✓ systemctl --user enable --now ${units.join(" ")}`);
+
+  // cortex#2283 — `enable --now` STARTS stopped units but is a silent no-op
+  // on ACTIVE ones (`--now` = `start`), so a recovery re-run never picked up
+  // fixed configs. try-restart the PROBED-ACTIVE units only: they are exactly
+  // the ones enable --now skipped. Never the probed-inactive ones —
+  // enable --now just started those, and restarting the fresh instance
+  // mid-bus-connect would land its one-shot `failed to connect` marker in the
+  // just-truncated `.error.log` and fast-fail the gate on a healthy system
+  // (adversarial review F2 — the issue spec's unconditional try-restart was
+  // wrong on this point).
+  if (activeUnits.length > 0) {
+    const restart = ports.service.tryRestart(activeUnits);
+    if (restart.exitCode !== 0) {
+      lines.push(`  ✗ systemctl --user try-restart ${activeUnits.join(" ")} failed: ${restart.stderr.trim()}`);
+      return step("7. Services", false, lines);
+    }
+    lines.push(`  ✓ systemctl --user try-restart ${activeUnits.join(" ")}`);
   }
 
-  return step("7. Services", ok, lines);
+  // Output honesty (per unit): only units that were actually running are
+  // reported restarted; cold ones were started by enable --now.
+  const actions: string[] = [];
+  if (activeUnits.length > 0) actions.push(`restarted (config re-applied): ${activeUnits.join(" ")}`);
+  if (inactiveUnits.length > 0) actions.push(`started (first boot): ${inactiveUnits.join(" ")}`);
+  for (const a of actions) lines.push(`  ✓ ${a}`);
+  return { ...step("7. Services", true, lines), note: actions.join("; ") };
+}
+
+/**
+ * cortex#2283 — darwin branch: RESTART-ONLY. arc owns the launchd load/
+ * unload lifecycle; quickstart never takes that over. When the stack service
+ * is loaded (`launchctl print gui/$UID/<label>` exit 0), a re-run restarts it
+ * via `launchctl kickstart -k` so the daemon picks up the configs step 5
+ * patched — with the both-logs truncate (`.log` + `.error.log`) paired
+ * IMMEDIATELY before it (truncate → restart → gate, same ordering contract
+ * as Linux). When it is not loaded, keep the pre-#2283 "handled by arc" skip:
+ * no restart means no truncate (an unpaired truncate would wipe current-boot
+ * failure evidence and false-GREEN the gate — A1/#2297 adversarial finding).
+ */
+function runServicesDarwin(ports: QuickstartPorts, slug: string): StepReport {
+  const label = launchdStackLabel(slug);
+  if (!ports.service.launchdServiceLoaded(label)) {
+    const action = "skip (not loaded — arc owns launchd load)";
+    return {
+      ...step("7. Services", true, [`  ○ launchd is handled by arc; ${action}`]),
+      note: action,
+    };
+  }
+
+  const lines: string[] = [];
+  // Paired atomically with the kickstart below — never called on the
+  // not-loaded path above.
+  lines.push(clearPriorBootLogs(ports, slug));
+
+  const restart = ports.service.launchdKickstart(label);
+  if (restart.exitCode !== 0) {
+    // Fail the step (exit 1, gate never runs): the truncate above already
+    // wiped the prior boot's logs, so letting the gate run against a daemon
+    // we FAILED to restart could only ever time out dishonestly — the daemon
+    // that IS running was never re-pointed at the fixed config. Failing here
+    // keeps the truncate → restart → gate pairing honest.
+    lines.push(`  ✗ launchctl kickstart -k gui/$UID/${label} failed: ${restart.stderr.trim()}`);
+    return step("7. Services", false, lines);
+  }
+  lines.push(`  ✓ launchctl kickstart -k gui/$UID/${label}`);
+
+  const action = "restarted (config re-applied)";
+  lines.push(`  ✓ ${action}`);
+  return { ...step("7. Services", true, lines), note: action };
 }
 
 // =============================================================================
@@ -786,16 +882,21 @@ async function runGate(
     }
     // cortex#2264 — a surfaced bus-connect failure is TERMINAL for this boot:
     // fail fast with the actual error line rather than burning the full
-    // timeout. On LINUX this is safe on the FIRST poll (before success is
-    // logged) because step 7 truncated this append-mode `.error.log` AND
-    // (re)started the daemon right before the gate — so any line here is from
-    // THIS boot, never a stale prior-boot failure. On darwin neither happens
-    // yet: quickstart does not restart the daemon, so a stale prior-boot line
-    // can fast-fail a re-run here — the paired truncate → restart → gate
-    // arrives with A2 (cortex#2283; a lone truncate would instead destroy
-    // current-boot failure evidence and false-GREEN the gate). SCOPE: surface
-    // + fast-fail only — the daemon still degrades and continues (its
-    // fail-closed-abort posture is a separate, deferred call).
+    // timeout. This is safe on the FIRST poll (before success is logged)
+    // because step 7 pair-truncated BOTH append-mode logs (`.log` +
+    // `.error.log`) AND (re)started the daemon right before the gate — Linux
+    // via enable --now + per-unit try-restart, darwin via launchctl
+    // kickstart -k when the service is loaded (cortex#2283) — so any line in
+    // EITHER file is from THIS boot: no stale prior-boot failure can
+    // fast-fail here, and no stale prior-boot HEALTHY lines can satisfy the
+    // positive gate over a daemon that died on relaunch (review F1).
+    // Residual: on darwin with the service NOT loaded
+    // (arc owns the load; quickstart neither restarts nor truncates), a stale
+    // prior-boot line can still fast-fail here — conservative-honest: with no
+    // loaded daemon the gate could never turn green anyway, and the stale
+    // line names the last real failure. SCOPE: surface + fast-fail only — the
+    // daemon still degrades and continues (its fail-closed-abort posture is a
+    // separate, deferred call).
     const busFailure = detectBusConnectFailure(ports.gate.readLog(errorLogPath));
     if (busFailure !== undefined) {
       return step("8. Healthy-boot gate", false, [


### PR DESCRIPTION
Closes #2283 (epic #2281, A-lane — completes the recovery story started in #2282).

The documented recovery flow (boot fails → fix config → re-run quickstart) was a silent no-op: `enable --now` never restarts an active unit and nothing else did. Now a re-run restarts running daemons on both hosts, with the truncate→restart→gate pairing the #2282 review mandated:

- **Linux:** per-unit — probed-active units get `try-restart` (after `enable --now` for enablement); probed-inactive units are started by `enable --now` alone, never try-restarted.
- **macOS:** `launchctl print` guard → loaded: truncate + `launchctl kickstart -k` (label pinned against the real plist template by test); not loaded: unchanged honest skip (arc owns launchd load).
- **Both:** `clearPriorBootLogs` truncates BOTH `.log` and `.error.log` before the restart, so every gate signal — positive and fast-fail — is current-boot-only.

**Adversarial review BLOCKed round 1 with two real finds, both fixed:** (F1) truncating only `.error.log` left the gate's *positive* signal stale-poisoned — restart-command success + prior boot's healthy lines = false GREEN over a crashed daemon; (F2) the unconditional try-restart after `enable --now` (a flaw inherited from the issue spec itself, per the commit message) double-started fresh boots and could poison the just-truncated error log mid-bus-connect. Review also spawned #2299 (relay restart follow-up).

Output honesty: per-unit "restarted (config re-applied)" / "started (first boot)" / "skip (not loaded — arc owns launchd load)", human + `--json`.

Tests: quickstart 61/61 (+ mixed-state case), quickstart-lib 67/67, tsc + lint clean. `--skip-services` pinned to zero service calls on both platforms; container path untouched.

Residual (documented): darwin not-loaded path unchanged; real-host recovery verification lands in D2's rehearsals (#2289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH