### PR TITLE
fix(mc): roster panel + /api/networks survive version-skewed payloads (#2311)

### DIFF
--- a/src/surface/mc/__tests__/networks-api.test.ts
+++ b/src/surface/mc/__tests__/networks-api.test.ts
@@ -401,3 +401,85 @@ describe("handleListNetworks — per-principal acceptance (MC-A2, the second tru
     expect(otherAccepts).toEqual({ andreas: "self", zeta: "accepted-named" });
   });
 });
+
+// cortex#2311 — never-5xx hardening: every injected view seam is guarded, so a
+// throwing seam DEGRADES (logged to stderr) instead of taking the route to the
+// catch-all 500. Repro class: post-myelin-RFC mid-migration adapters whose
+// enumeration/resolvers throw on current shapes.
+describe("handleListNetworks — seam-throw degradation (cortex#2311, never 5xx)", () => {
+  it("a throwing view.networks() degrades to an empty list, never 5xx", async () => {
+    const v: NetworksView = {
+      localPrincipal: "andreas",
+      networks: () => {
+        throw new Error("mid-migration enumeration boom");
+      },
+      resolveAdmittedRoster: () =>
+        Promise.resolve({ ok: false, reason: "not_configured", detail: "n/a" }),
+    };
+    const res = await handleListNetworks(v, presenceView([rec({ agentId: "luna" })]));
+    expect(res.status).toBe(200);
+    expect(await body(res)).toEqual({ networks: [] });
+  });
+
+  it("a throwing presence snapshot degrades to no-presence (members absent), never 5xx", async () => {
+    const throwingPresence: AgentPresenceView = {
+      getAgents: () => {
+        throw new Error("presence snapshot boom");
+      },
+    };
+    const res = await handleListNetworks(
+      view({
+        "research-collab": {
+          ok: true,
+          roster: { admitted: ["jc"], pending: [], authoritative: true },
+        },
+      }),
+      throwingPresence,
+    );
+    expect(res.status).toBe(200);
+    const net = (await body(res)).networks[0]!;
+    // No presence observable → every member honestly absent, none present.
+    expect(net.members.every((m) => m.verdict !== "admitted-present")).toBe(true);
+    expect(net.members.map((m) => m.principal).sort()).toEqual(["andreas", "jc"]);
+  });
+
+  it("a throwing acceptsPeer degrades per-member to default-deny, never 5xx", async () => {
+    const v: NetworksView = {
+      localPrincipal: "andreas",
+      networks: () => [
+        { networkId: "research-collab", leafNode: "rc-leaf", confidentiality: CLEARTEXT },
+      ],
+      resolveAdmittedRoster: () =>
+        Promise.resolve({
+          ok: true,
+          roster: { admitted: ["jc"], pending: [], authoritative: true },
+        }),
+      acceptsPeer: () => {
+        throw new Error("acceptance resolver boom");
+      },
+    };
+    const res = await handleListNetworks(v, presenceView([rec({ agentId: "luna" })]));
+    expect(res.status).toBe(200);
+    const accepts = Object.fromEntries(
+      (await body(res)).networks[0]!.members.map((m) => [m.principal, m.accepts]),
+    );
+    // Default-deny honesty: self for the serving principal, not-accepted otherwise.
+    expect(accepts).toEqual({ andreas: "self", jc: "not-accepted" });
+  });
+
+  it("a view with no confidentiality posture omits the field (surface renders 'unknown'), never 5xx", async () => {
+    const v: NetworksView = {
+      localPrincipal: "andreas",
+      networks: () => [
+        // No `confidentiality` — an older/mid-migration posture-less adapter.
+        { networkId: "research-collab", leafNode: "rc-leaf" },
+      ],
+      resolveAdmittedRoster: () =>
+        Promise.resolve({ ok: false, reason: "not_configured", detail: "n/a" }),
+    };
+    const res = await handleListNetworks(v, null);
+    expect(res.status).toBe(200);
+    const net = (await body(res)).networks[0]!;
+    expect(net.confidentiality).toBeUndefined();
+  });
+});

--- a/src/surface/mc/api/networks.ts
+++ b/src/surface/mc/api/networks.ts
@@ -80,8 +80,11 @@ export interface JoinedNetworkInfo {
    * posture, derived from config (`encryption` mode + `payload_key` presence +
    * `payload_key_id`). `cortex.ts` supplies it via `confidentialityPosture(n)`;
    * tests supply a stub. The handler maps it to the snake_case wire DTO.
+   * OPTIONAL (cortex#2311): an older/mid-migration adapter that carries no
+   * posture omits it; the handler then omits the wire field and the surface
+   * renders "encryption: unknown" (never assumed encrypted, never a throw).
    */
-  confidentiality: NetworkConfidentialityPosture;
+  confidentiality?: NetworkConfidentialityPosture;
 }
 
 /**
@@ -224,10 +227,13 @@ export interface NetworkMembershipDTO {
   roster_scope: RosterScope | null;
   /**
    * MC-A3 (cortex#1277, ADR-0019/0018) — the network's read-only confidentiality
-   * posture. Always present; the surface badges it honestly (never fakes
-   * "encrypted" for a configured-but-keyless network).
+   * posture. The surface badges it honestly (never fakes "encrypted" for a
+   * configured-but-keyless network). OPTIONAL on the wire (cortex#2311): a view
+   * adapter that predates MC-A3 / carries no posture omits it, and the surface
+   * renders "encryption: unknown" (never assumed encrypted) rather than the
+   * handler throwing into a 500. The live `cortex.ts` view always supplies it.
    */
-  confidentiality: NetworkConfidentialityDTO;
+  confidentiality?: NetworkConfidentialityDTO;
   /** Admitted roster reconciled ⋈ presence into per-member verdicts. */
   members: MembershipMemberDTO[];
   /**
@@ -333,13 +339,37 @@ export async function handleListNetworks(
       return Response.json({ networks: [] } satisfies ListNetworksResponse);
     }
 
-    const records = presence ? presence.getAgents() : [];
+    // cortex#2311 — never-5xx is this route's stated contract, so the injected
+    // view seams are guarded STRUCTURALLY (mirroring the resolveAdmittedRoster
+    // guard below): a throwing presence snapshot degrades to "no presence
+    // observed" (members render absent, honestly) rather than a 500.
+    let records: ReturnType<NonNullable<typeof presence>["getAgents"]> = [];
+    if (presence) {
+      try {
+        records = presence.getAgents();
+      } catch (err) {
+        process.stderr.write(
+          `[api] GET /api/networks: presence snapshot threw (degrading to none): ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
     const presentStacksByPrincipal = derivePresentStacksByPrincipal(
       records,
       view.localPrincipal,
     );
 
-    const joined = view.networks();
+    // cortex#2311 — a throwing networks() enumeration degrades to an empty
+    // list (logged, never silent): "no networks renderable" beats a 500 that
+    // takes the whole Network view down.
+    let joined: JoinedNetworkInfo[];
+    try {
+      joined = view.networks();
+    } catch (err) {
+      process.stderr.write(
+        `[api] GET /api/networks: view.networks() threw (degrading to empty): ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return Response.json({ networks: [] } satisfies ListNetworksResponse);
+    }
 
     // Resolve every roster first so the anomaly candidates can be computed
     // against the union of admitted principals across all AUTHORITATIVE networks
@@ -422,6 +452,26 @@ export async function handleListNetworks(
         ...(everReceivedPresence !== undefined ? { everReceivedPresence } : {}),
       });
 
+      // MC-A2 — the SECOND trust layer (acceptance), orthogonal to the
+      // membership verdict. The view supplies the live resolver; when it's
+      // absent (older wiring / test stub) — or when it THROWS (cortex#2311:
+      // never-5xx; a mid-migration resolver must not take the route down) —
+      // we default-deny honestly (self for the serving principal,
+      // not-accepted otherwise).
+      const acceptsOf = (memberPrincipal: string): PeerAcceptance => {
+        const fallback: PeerAcceptance =
+          memberPrincipal === view.localPrincipal ? "self" : "not-accepted";
+        if (view.acceptsPeer === undefined) return fallback;
+        try {
+          return view.acceptsPeer(info.networkId, memberPrincipal);
+        } catch (err) {
+          process.stderr.write(
+            `[api] GET /api/networks: acceptsPeer("${info.networkId}", "${memberPrincipal}") threw (default-deny): ${err instanceof Error ? err.message : String(err)}\n`,
+          );
+          return fallback;
+        }
+      };
+
       return {
         network_id: info.networkId,
         leaf_node: info.leafNode,
@@ -429,26 +479,21 @@ export async function handleListNetworks(
         roster_scope: rosterScope,
         // MC-A3 — carry the config-derived confidentiality posture through to the
         // wire DTO (camelCase posture → snake_case DTO). Read-only; the surface
-        // badges it honestly. Independent of the roster read above.
-        confidentiality: {
-          mode: info.confidentiality.mode,
-          key_present: info.confidentiality.keyPresent,
-          key_id: info.confidentiality.keyId,
-        },
+        // badges it honestly. Independent of the roster read above. cortex#2311:
+        // a view that carries no posture omits the field — the surface renders
+        // "encryption: unknown" (never assumed encrypted, never a throw).
+        ...(info.confidentiality !== undefined && {
+          confidentiality: {
+            mode: info.confidentiality.mode,
+            key_present: info.confidentiality.keyPresent,
+            key_id: info.confidentiality.keyId,
+          },
+        }),
         members: members.map((m) => ({
           principal: m.principal,
           verdict: m.verdict,
           present_stacks: m.presentStacks,
-          // MC-A2 — the SECOND trust layer (acceptance), orthogonal to the
-          // membership verdict above. The view supplies the live resolver; when
-          // it's absent (older wiring / test stub) we default-deny honestly
-          // (self for the serving principal, not-accepted otherwise).
-          accepts:
-            view.acceptsPeer !== undefined
-              ? view.acceptsPeer(info.networkId, m.principal)
-              : m.principal === view.localPrincipal
-                ? "self"
-                : "not-accepted",
+          accepts: acceptsOf(m.principal),
         })),
         roster_states: rosterStates,
       };

--- a/src/surface/mc/dashboard-v2/__tests__/network-roster-panel-skew-2311.test.tsx
+++ b/src/surface/mc/dashboard-v2/__tests__/network-roster-panel-skew-2311.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * cortex#2311 — NetworkRosterPanel version-skew defense.
+ *
+ * The dashboard bundle is built at install time and can drift from the serving
+ * daemon across wire renames (e.g. FS-6's `admitted-absent` →
+ * `absent-offline`/`absent-unheard`, cortex#1821). Pre-#2311 the badge adapters
+ * were compile-time-total switches with NO runtime fallback: an out-of-union
+ * verdict/acceptance/status returned `undefined` and the panel threw on
+ * `.tone` inside `networks.map → members.map`, blanking the whole Network view.
+ *
+ * These tests feed the panel deliberately skewed payloads (cast past the
+ * compile-time types, exactly as JSON off the wire arrives) and assert it
+ * renders an honest fallback — never a throw, and one bad entry never blanks
+ * the panel.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { NetworkRosterPanel } from "../components/network-roster-panel";
+import type { NetworkMembershipDTO } from "../hooks/use-networks";
+import {
+  acceptanceBadge,
+  rosterStatusBadge,
+  summarizeMembership,
+  verdictBadge,
+} from "../lib/network-membership-adapter";
+import type {
+  MembershipVerdict,
+  PeerAcceptance,
+  RosterStatus,
+} from "../../api/networks";
+
+/** Build a DTO from a RAW (possibly skewed) object — the wire's eye view. */
+function wire(raw: unknown): NetworkMembershipDTO {
+  return raw as NetworkMembershipDTO;
+}
+
+function render(networks: NetworkMembershipDTO[]): string {
+  return renderToStaticMarkup(
+    createElement(NetworkRosterPanel, { networks, localPrincipal: "andreas" }),
+  );
+}
+
+const BASE = {
+  network_id: "research",
+  leaf_node: "research-leaf",
+  roster_status: "ok",
+  roster_scope: "complete",
+  confidentiality: { mode: "off", key_present: false, key_id: null },
+} as const;
+
+describe("NetworkRosterPanel — version-skew defense (cortex#2311)", () => {
+  it("legacy pre-FS-6 'admitted-absent' verdict renders an honest absent badge, no throw", () => {
+    const html = render([
+      wire({
+        ...BASE,
+        members: [
+          { principal: "jc", verdict: "admitted-absent", present_stacks: [], accepts: "not-accepted" },
+        ],
+      }),
+    ]);
+    expect(html).toContain("jc");
+    expect(html).toContain(">absent<");
+    expect(html).toContain("tone-warn");
+  });
+
+  it("an unrecognized verdict renders the unknown fallback badge, no throw", () => {
+    const html = render([
+      wire({
+        ...BASE,
+        members: [
+          { principal: "jc", verdict: "some-future-verdict", present_stacks: [], accepts: "not-accepted" },
+        ],
+      }),
+    ]);
+    expect(html).toContain("verdict unknown");
+    expect(html).toContain("tone-warn");
+    // Honesty: never claim presence for an unknown verdict.
+    expect(html).not.toContain(">present<");
+  });
+
+  it("an unrecognized acceptance renders the unknown fallback chip, no throw", () => {
+    const html = render([
+      wire({
+        ...BASE,
+        members: [
+          { principal: "jc", verdict: "admitted-present", present_stacks: ["hub"], accepts: "accepted-did" },
+        ],
+      }),
+    ]);
+    expect(html).toContain('data-acceptance="unknown"');
+    expect(html).toContain("acceptance unknown");
+  });
+
+  it("an unrecognized roster_status renders the unknown status chip, no throw", () => {
+    const html = render([
+      wire({ ...BASE, roster_status: "forbidden", members: [] }),
+    ]);
+    expect(html).toContain("roster: unknown");
+  });
+
+  it("a missing members array renders the empty-roster state, no throw", () => {
+    const html = render([wire({ ...BASE, members: undefined })]);
+    expect(html).toContain("No admitted members resolved.");
+  });
+
+  it("a missing confidentiality posture renders 'unknown' (never assumed encrypted), no throw", () => {
+    const html = render([
+      wire({
+        ...BASE,
+        confidentiality: undefined,
+        members: [
+          { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
+        ],
+      }),
+    ]);
+    expect(html).toContain('data-posture="unknown"');
+    expect(html).not.toContain('data-posture="encrypted"');
+  });
+
+  it("one bad entry does not blank the panel — good rows still render", () => {
+    const html = render([
+      wire({
+        ...BASE,
+        members: [
+          null, // holey/corrupt entry
+          { verdict: "admitted-present" }, // no principal, no present_stacks, no accepts
+          { principal: "jc", verdict: "bogus", present_stacks: [], accepts: "bogus" },
+          { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
+        ],
+        roster_states: [null, { principal: "jc", admission_state: "SOME_NEW_STATE", sealed: false, hub_authorized_at: null, authorship: "unchecked" }],
+      }),
+    ]);
+    // The healthy row survives its corrupt siblings.
+    expect(html).toContain("andreas");
+    expect(html).toContain("(you)");
+    // The partially-shaped rows render with fallbacks instead of throwing.
+    expect(html).toContain("(unknown principal)");
+    expect(html).toContain("verdict unknown");
+  });
+});
+
+describe("network-membership-adapter — runtime totality (cortex#2311)", () => {
+  it("verdictBadge never returns undefined for out-of-union values", () => {
+    for (const v of ["admitted-absent", "whatever", "", undefined, null]) {
+      const badge = verdictBadge(v as unknown as MembershipVerdict);
+      expect(badge).toBeDefined();
+      expect(typeof badge.tone).toBe("string");
+    }
+  });
+
+  it("acceptanceBadge never returns undefined for out-of-union values", () => {
+    for (const a of ["accepted-did", "", undefined, null]) {
+      const badge = acceptanceBadge(a as unknown as PeerAcceptance);
+      expect(badge).toBeDefined();
+      expect(badge.token).toBe("unknown");
+    }
+  });
+
+  it("rosterStatusBadge never returns undefined for out-of-union values", () => {
+    for (const s of ["forbidden", "", undefined, null]) {
+      const badge = rosterStatusBadge(s as unknown as RosterStatus, null);
+      expect(badge).toBeDefined();
+      expect(badge.tone).toBe("warn");
+    }
+  });
+
+  it("summarizeMembership tolerates a missing/holey members array", () => {
+    expect(
+      summarizeMembership({ members: undefined as unknown as NetworkMembershipDTO["members"] }),
+    ).toEqual({ present: 0, absent: 0, unadmitted: 0, pending: 0, total: 0 });
+    const s = summarizeMembership({
+      members: [
+        null,
+        { principal: "jc", verdict: "bogus", present_stacks: [], accepts: "self" },
+        { principal: "andreas", verdict: "admitted-present", present_stacks: ["main"], accepts: "self" },
+      ] as unknown as NetworkMembershipDTO["members"],
+    });
+    // Unknown verdicts stay uncounted in the coarse header tallies but are in total.
+    expect(s.total).toBe(3);
+    expect(s.present).toBe(1);
+  });
+});

--- a/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
+++ b/src/surface/mc/dashboard-v2/components/network-roster-panel.tsx
@@ -65,6 +65,9 @@ export function NetworkRosterPanel({
           // revoked, kept visually distinct) rendered as a separate group.
           const { byPrincipal: stateByPrincipal, former: formerMembers } =
             partitionRosterStates(net.roster_states ?? []);
+          // cortex#2311 — defensive against a version-skewed/partial payload:
+          // a missing members array renders as an empty roster, never a throw.
+          const members = net.members ?? [];
           return (
             <li key={net.network_id} className="network-roster-group">
               <div className="network-roster-group-header">
@@ -100,30 +103,37 @@ export function NetworkRosterPanel({
                   roster (they are join/onboarding affordances, not roster
                   state). The roster stays a pure trust-group view: group header
                   + membership rows + former members. */}
-              {net.members.length === 0 ? (
+              {members.length === 0 ? (
                 <div className="dim network-roster-empty">
                   No admitted members resolved.
                 </div>
               ) : (
                 <ul className="network-roster-members">
-                  {net.members.map((m) => {
+                  {members.map((m, i) => {
+                    // cortex#2311 — one bad entry must not blank the panel: a
+                    // null/holey entry is skipped; badge derivation is total at
+                    // runtime (the adapter renders honest fallbacks for skewed
+                    // values), so no property read below can throw.
+                    if (m === null || m === undefined) return null;
+                    const principal = m.principal ?? "(unknown principal)";
                     const badge = verdictBadge(m.verdict);
                     const acceptance = acceptanceBadge(m.accepts);
-                    const isYou = localPrincipal !== null && m.principal === localPrincipal;
+                    const isYou = localPrincipal !== null && principal === localPrincipal;
                     // FLG-4 — the member's lifecycle state (seal / hub-authorize /
                     // authorship), when the read carries it. Absent ⇒ no extra
                     // badges (honest: pre-FLG-4 server or facet-less read).
-                    const st = stateByPrincipal.get(m.principal);
+                    const st = stateByPrincipal.get(principal);
                     const seal = st ? sealBadge(st.sealed) : null;
                     const hubAuth = st ? formatHubAuthorized(st.hub_authorized_at) : null;
                     const authorship = st ? authorshipBadge(st.authorship) : null;
+                    const presentStacks = m.present_stacks ?? [];
                     return (
                       <li
-                        key={m.principal}
+                        key={m.principal ?? `member-${i.toString()}`}
                         className="network-roster-member"
                       >
                         <span className="network-roster-principal">
-                          {m.principal}
+                          {principal}
                           {isYou ? (
                             <span className="dim network-roster-you"> (you)</span>
                           ) : null}
@@ -175,9 +185,9 @@ export function NetworkRosterPanel({
                             {authorship.label}
                           </span>
                         ) : null}
-                        {m.present_stacks.length > 0 ? (
+                        {presentStacks.length > 0 ? (
                           <span className="dim network-roster-stacks">
-                            {m.present_stacks.join(", ")}
+                            {presentStacks.join(", ")}
                           </span>
                         ) : null}
                       </li>

--- a/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
+++ b/src/surface/mc/dashboard-v2/lib/network-membership-adapter.ts
@@ -36,6 +36,13 @@ export interface VerdictBadge {
  * Map a membership verdict → badge. Deterministic + total over the union, so the
  * compiler enforces a case for every verdict (a new verdict won't silently fall
  * through).
+ *
+ * RUNTIME totality (cortex#2311): the dashboard bundle is built at install time
+ * and can skew against the serving daemon across wire renames (e.g. the
+ * pre-FS-6 `admitted-absent` → `absent-offline`/`absent-unheard` split,
+ * cortex#1821). An out-of-union verdict therefore CAN arrive at runtime; the
+ * `default` branch renders an honest fallback badge instead of returning
+ * `undefined` (which crashed the whole roster panel on `.tone`).
  */
 export function verdictBadge(verdict: MembershipVerdict): VerdictBadge {
   switch (verdict) {
@@ -72,6 +79,28 @@ export function verdictBadge(verdict: MembershipVerdict): VerdictBadge {
         tone: "pending",
         title: "Admission request pending — not yet admitted",
       };
+    default: {
+      // Exhaustiveness guard: a new MembershipVerdict must add a case above, or
+      // this assignment fails to compile. The runtime fallback below is for
+      // VERSION-SKEWED payloads only (bundle ≠ daemon).
+      const _exhaustive: never = verdict;
+      const raw = String(_exhaustive);
+      if (raw === "admitted-absent") {
+        // The pre-FS-6 collapsed absence (renamed in cortex#1821): the serving
+        // daemon predates the offline/unheard split. Absent, family unknown.
+        return {
+          label: "absent",
+          tone: "warn",
+          title:
+            "Admitted to the roster but not observed present (legacy 'admitted-absent' verdict — the serving daemon predates the FS-6 offline/unheard split).",
+        };
+      }
+      return {
+        label: "verdict unknown",
+        tone: "warn",
+        title: `Unrecognized membership verdict '${raw}' — likely dashboard/daemon version skew. Not assumed present.`,
+      };
+    }
   }
 }
 
@@ -116,7 +145,9 @@ export type AcceptanceToken =
   | "self"
   | "accepted-network"
   | "accepted-named"
-  | "not-accepted";
+  | "not-accepted"
+  /** cortex#2311 — runtime fallback for a version-skewed payload value. */
+  | "unknown";
 
 /** A render-ready acceptance badge. */
 export interface AcceptanceBadge {
@@ -168,6 +199,17 @@ export function acceptanceBadge(accepts: PeerAcceptance): AcceptanceBadge {
         title:
           "Admitted to the roster but NOT accepted by this principal — no federated offering admits it (default-deny). You dispatch it no federated work.",
       };
+    default: {
+      // cortex#2311 — runtime totality against version-skewed payloads (see
+      // verdictBadge). Compile-time totality is preserved by the `never` guard.
+      const _exhaustive: never = accepts;
+      return {
+        label: "acceptance unknown",
+        tone: "warn",
+        token: "unknown",
+        title: `Unrecognized acceptance '${String(_exhaustive)}' — likely dashboard/daemon version skew. Not assumed accepted.`,
+      };
+    }
   }
 }
 
@@ -216,6 +258,16 @@ export function rosterStatusBadge(
         title:
           "Live admission-rows read not wired (A1) — pending A2 + registry ADR-0018 Q3 roster fix",
       };
+    default: {
+      // cortex#2311 — runtime totality against version-skewed payloads (see
+      // verdictBadge). Compile-time totality is preserved by the `never` guard.
+      const _exhaustive: never = status;
+      return {
+        label: "roster: unknown",
+        tone: "warn",
+        title: `Unrecognized roster status '${String(_exhaustive)}' — likely dashboard/daemon version skew.`,
+      };
+    }
   }
 }
 
@@ -496,6 +548,8 @@ export function partitionRosterStates(states: readonly RosterMemberStateDTO[]): 
   const byPrincipal = new Map<string, RosterMemberStateDTO>();
   const former: RosterMemberStateDTO[] = [];
   for (const s of states) {
+    // cortex#2311 — skip null/holey entries from a skewed payload (defensive).
+    if (s === null || s === undefined) continue;
     if (isFormerMemberState(s.admission_state)) {
       former.push(s);
     } else {
@@ -520,15 +574,20 @@ export interface MembershipSummary {
 export function summarizeMembership(
   net: Pick<NetworkMembershipDTO, "members">,
 ): MembershipSummary {
+  // cortex#2311 — tolerate a version-skewed/partial payload: a missing members
+  // array tallies as empty rather than throwing. Unrecognized verdicts fall
+  // through the switch uncounted (they still appear as rows with an honest
+  // fallback badge; the header stays a coarse count of known states).
+  const members = net.members ?? [];
   const summary: MembershipSummary = {
     present: 0,
     absent: 0,
     unadmitted: 0,
     pending: 0,
-    total: net.members.length,
+    total: members.length,
   };
-  for (const m of net.members) {
-    switch (m.verdict) {
+  for (const m of members) {
+    switch (m?.verdict) {
       case "admitted-present":
         summary.present += 1;
         break;


### PR DESCRIPTION
Closes #2311. **Left open for review per current mode.**

**Crash root cause (exact):** three badge functions in `network-membership-adapter.ts` were compile-time-total switches with no runtime default. The FS-6 rename (`admitted-absent` → `absent-offline`/`absent-unheard`, PR #1835) + the dashboard bundle being **built at install time** = bundle↔daemon version skew delivers out-of-union values → the fns return undefined → `.tone` throws in `network-roster-panel.tsx:132/143` — matching the reported minified trace frame-for-frame.

**Fixes (MC-only, zero wire/protocol code touched):**
- Adapter: runtime `default:` branches on all three badge fns (exhaustiveness guard kept); legacy value → honest "absent" badge; unknown → warn-toned "unknown".
- Panel: null-safe against missing `members[]`/`present_stacks`/`principal`/`confidentiality` and holey entries — one bad entry renders a fallback row, never blanks the panel.
- `/api/networks`: honored its own documented never-5xx contract — per-seam degradation with stderr logging (empty-list 200 / no-presence / default-deny / optional confidentiality) instead of catch-all 500.

**The reported 500:** all 18 dashboard GET routes probed on a live fresh-DB boot — zero 500s on current main, so the live 500 is data-dependent; honestly not guess-fixed (network-tab capture requested on the issue if it recurs). The `/api/networks` contract-violation class it most plausibly was IS fixed.

**Tests:** 15 new (skew fixtures render without throwing; 4 seam-throw route tests). Scoped: 1269 pass / 0 fail; tsc clean; dashboard bundle builds.

**Follow-up worth filing:** the durable cure for skew is rebuilding the dashboard bundle in lockstep on `arc upgrade cortex` — defensive rendering is the safety net, not the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfTfScc3UjzTB2s17R15SH