### PR TITLE
docs(bootstrap): zero→Luna spec + agent-bundle blueprint gallery

### DIFF
--- a/docs/bundle-blueprints.md
+++ b/docs/bundle-blueprints.md
@@ -1,0 +1,148 @@
+# Agent Bundle Blueprints
+
+**What this is.** Three shipped/real agent bundles, presented as **blueprints** —
+annotated, clone-me reference shapes for building your own cortex agent. Pick the
+one closest to what you want, copy its skeleton, change the persona + name.
+
+> **Terminology (this ecosystem overloads "blueprint" — keep them apart):**
+> - **agent bundle blueprint** *(this doc)* — a reference *template* for an arc
+>   `type: agent` bundle. A pattern to clone.
+> - **`blueprint.yaml`** — the feature dependency-graph (`blueprint` CLI). Unrelated.
+> - **`state: { blueprint: AgentState }`** — a per-agent durable-**memory** bundle. Unrelated.
+>
+> When we say "blueprint" below we always mean the first.
+
+Every one is the **same arc shape**: an in-process cortex agent = `arc-manifest.yaml`
+(`type: agent`, `targets: [cortex]`, `provides.files`, `capabilities`, `lifecycle`)
++ a `personas/<id>.md` (the character) + an `agents.d/<id>.yaml` fragment (id,
+capabilities, `presence`). They differ only in **behavior, surface, and privilege**.
+
+> **These aren't hypothetical — the gallery is already published.** The ecosystem
+> ships teaching-sample agent bundles under the `metafactory-cortex-agent-<name>`
+> naming class, all public and `arc install`-able:
+> `metafactory-cortex-agent-escort` (the canonical concierge sample) and
+> `metafactory-cortex-agent-example-{deterministic,hybrid,non-deterministic}` (the
+> three brain-class teaching samples). **Luna-Light joins them** as
+> `metafactory-cortex-agent-luna-light` — the simplest one, the assistant floor.
+> A newcomer can `arc install` any of these and read the source as a template.
+
+---
+
+## Blueprint 1 — **Luna-Light** · the assistant (the floor)
+
+*Clone this when you want: a plain, capable assistant on your own stack.*
+
+The simplest possible agent — a chat assistant, surface-neutral, zero privilege.
+The "hello world" of agent bundles, and the front door for a new user.
+
+| Facet | Shape |
+|---|---|
+| **Purpose** | General chat assistant (`@luna-light`) |
+| **Capabilities** | `chat`, `async` |
+| **Surface** | **neutral** — `presence: {}` (binds nothing; you bind it in `surfaces.yaml`, or dispatch over the bus) |
+| **Privilege** | minimal — reads its own config; **no** write/network/bash/secrets |
+| **Identity** | shares the stack's bus identity; mints nothing |
+| **Teaches** | the irreducible minimum: manifest + persona + fragment, and that `presence: {}` is the valid "no surface" form |
+
+```yaml
+# arc-manifest.yaml (essence)
+type: agent
+targets: [cortex]
+provides: { files: [{source: personas/luna-light.md, target: ~/.config/cortex/personas/luna-light.md},
+                    {source: agents.d/luna-light.yaml, target: ~/.config/cortex/agents.d/luna-light.yaml}] }
+capabilities: { filesystem: {read: [~/.config/cortex], write: []}, network: [], bash: {allowed: false}, secrets: [] }
+lifecycle: { preinstall: [scripts/check-cortex-version.sh], postinstall: [scripts/signal-cortex-reload.sh] }
+```
+
+Repo: `the-metafactory/metafactory-cortex-agent-luna-light` (grammar class
+`metafactory-cortex-agent-<name>`, alongside escort + the examples). Install (once
+public + published): `arc install luna-light` — or from URL today.
+
+---
+
+## Blueprint 2 — **Pier** · the concierge (guide, don't grant)
+
+*Clone this when you want: an agent that greets people and drives a workflow it
+must never complete itself.*
+
+The shipped community onboarding concierge. It greets newcomers on a public
+channel, walks them through a two-tier flow, and **surfaces admission requests to
+the principal — it issues nothing**. The load-bearing pattern: an agent that
+*guides* a privileged action without *holding* the privilege.
+
+| Facet | Shape |
+|---|---|
+| **Purpose** | Onboarding concierge (`@pier`) — greet + guide + surface |
+| **Capabilities** | `onboarding`, `chat` |
+| **Surface** | **hard-wired** to the community Discord guild (`presence.discord` with resolve-at-install `__PIER_*__` ids) |
+| **Privilege** | **airgapped** — `openOnboardingAllowedTools: [Read]`; issues no creds, runs no privileged CLI |
+| **Identity** | in-process, shares the stack identity; `trust: [luna]` |
+| **Teaches** | the **surfaces-not-issues** boundary (a principal — never the agent — runs the grant), resolve-at-install secret placeholders, and `openOnboarding: true` (a stranger can reach it before holding any role) |
+
+```yaml
+# the distinguishing bits vs Luna-Light
+identity: { id: pier }
+runtime: { capabilities: [onboarding, chat] }
+presence: { discord: { enabled: true, guildId: __PIER_GUILD_ID__, agentChannelId: __PIER_AGENT_CHANNEL_ID__, ... } }
+openOnboarding: true
+openOnboardingAllowedTools: [Read]   # the airgap
+```
+
+Reference: `arc-manifest-pier.yaml`, `personas/pier.md`, `agents.d/pier.yaml` (in cortex).
+
+---
+
+## Blueprint 3 — **Escort** · the quest concierge (stateful, verified onboarding)
+
+*Clone this when you want: onboarding as a guided, per-person, verifiable journey
+— not a linear doc.*
+
+The gamified successor to Pier (guildhall's quest-engine concierge). It opens a
+**private thread per arrival**, verifies identity (e.g. a GitHub handle), and runs
+onboarding as a **stateful quest** with per-step checks. Where Pier is a public
+greeter, Escort is a personal guide with memory of *where you are* in the flow.
+
+| Facet | Shape |
+|---|---|
+| **Purpose** | Per-arrival quest concierge — thread-per-newcomer, verified, resumable |
+| **Capabilities** | `onboarding`, `chat` (+ quest/verification behaviors) |
+| **Surface** | Discord, but **thread-scoped** — drives the `create_private_thread` brain effect (one thread per arrival) |
+| **Privilege** | still surfaces-not-issues (Pier's boundary), + verification (GitHub handle) |
+| **State** | **stateful** — tracks each newcomer's quest progress (the case for `state: {blueprint: AgentState}`) |
+| **Teaches** | how a concierge scales: private per-person threads + step-checks + resumable progress turn a runbook into a quest |
+
+> Status: **PUBLISHED** — `the-metafactory/metafactory-cortex-agent-escort`
+> (public), described in-repo as *"canonical sample of a cortex agent bundle —
+> deterministic onboarding greeter"*. Its gamified/quest extensions (per-arrival
+> threads, verification) are the roadmap; the agent-bundle shape is shipped.
+
+---
+
+## How the three inform `#bootstrap`
+
+```
+         guides                    delivers               is the script
+   ┌────────────────┐         ┌──────────────┐        ┌──────────────┐
+   │  Pier → Escort │  ──────▶│  Luna-Light  │◀───────│  the runbook │
+   │  (concierge)   │  hand   │  (the bundle)│  reads  │  (the spec)  │
+   └────────────────┘  over   └──────────────┘        └──────────────┘
+```
+
+- **Pier** is the front-door **now**: it can walk a newcomer through the runbook and
+  hand them `arc install luna-light`.
+- **Luna-Light** is the **payload**: the one-command assistant they end up with.
+- **Escort** is where the concierge **grows**: each runbook step becomes a quest step
+  with a check (✅ stack created · ✅ bus connected · ✅ `@luna` responds), per person,
+  resumable.
+
+The blueprints make the pattern **legible**: a newcomer can see the range (assistant
+→ concierge → quest concierge), understand that all three are the *same arc shape*,
+and clone the one they need.
+
+## References
+
+Bundle shape: `arc/docs/skill-repo-migration-spec.md`, ADR-0017. Pier:
+`arc-manifest-pier.yaml` + `personas/pier.md` + `agents.d/pier.yaml`. Escort:
+guildhall quests + `src/brain/protocol.ts` (`create_private_thread`, ADR cortex#2206).
+Luna-Light: `the-metafactory/metafactory-bundle-luna-light`. Companion spec:
+`design-bootstrap-luna.md`.

--- a/docs/bundle-blueprints.md
+++ b/docs/bundle-blueprints.md
@@ -22,13 +22,13 @@ capabilities, `presence`). They differ only in **behavior, surface, and privileg
 > naming class, all public and `arc install`-able:
 > `metafactory-cortex-agent-escort` (the canonical concierge sample) and
 > `metafactory-cortex-agent-example-{deterministic,hybrid,non-deterministic}` (the
-> three brain-class teaching samples). **Luna-Light joins them** as
-> `metafactory-cortex-agent-luna-light` — the simplest one, the assistant floor.
+> three brain-class teaching samples). **Luna-Lite joins them** as
+> `metafactory-cortex-agent-luna-lite` — the simplest one, the assistant floor.
 > A newcomer can `arc install` any of these and read the source as a template.
 
 ---
 
-## Blueprint 1 — **Luna-Light** · the assistant (the floor)
+## Blueprint 1 — **Luna-Lite** · the assistant (the floor)
 
 *Clone this when you want: a plain, capable assistant on your own stack.*
 
@@ -37,7 +37,7 @@ The "hello world" of agent bundles, and the front door for a new user.
 
 | Facet | Shape |
 |---|---|
-| **Purpose** | General chat assistant (`@luna-light`) |
+| **Purpose** | General chat assistant (`@luna-lite`) |
 | **Capabilities** | `chat`, `async` |
 | **Surface** | **neutral** — `presence: {}` (binds nothing; you bind it in `surfaces.yaml`, or dispatch over the bus) |
 | **Privilege** | minimal — reads its own config; **no** write/network/bash/secrets |
@@ -48,15 +48,15 @@ The "hello world" of agent bundles, and the front door for a new user.
 # arc-manifest.yaml (essence)
 type: agent
 targets: [cortex]
-provides: { files: [{source: personas/luna-light.md, target: ~/.config/cortex/personas/luna-light.md},
-                    {source: agents.d/luna-light.yaml, target: ~/.config/cortex/agents.d/luna-light.yaml}] }
+provides: { files: [{source: personas/luna-lite.md, target: ~/.config/cortex/personas/luna-lite.md},
+                    {source: agents.d/luna-lite.yaml, target: ~/.config/cortex/agents.d/luna-lite.yaml}] }
 capabilities: { filesystem: {read: [~/.config/cortex], write: []}, network: [], bash: {allowed: false}, secrets: [] }
 lifecycle: { preinstall: [scripts/check-cortex-version.sh], postinstall: [scripts/signal-cortex-reload.sh] }
 ```
 
-Repo: `the-metafactory/metafactory-cortex-agent-luna-light` (grammar class
+Repo: `the-metafactory/metafactory-cortex-agent-luna-lite` (grammar class
 `metafactory-cortex-agent-<name>`, alongside escort + the examples). Install (once
-public + published): `arc install luna-light` — or from URL today.
+public + published): `arc install luna-lite` — or from URL today.
 
 ---
 
@@ -80,7 +80,7 @@ the principal — it issues nothing**. The load-bearing pattern: an agent that
 | **Teaches** | the **surfaces-not-issues** boundary (a principal — never the agent — runs the grant), resolve-at-install secret placeholders, and `openOnboarding: true` (a stranger can reach it before holding any role) |
 
 ```yaml
-# the distinguishing bits vs Luna-Light
+# the distinguishing bits vs Luna-Lite
 identity: { id: pier }
 runtime: { capabilities: [onboarding, chat] }
 presence: { discord: { enabled: true, guildId: __PIER_GUILD_ID__, agentChannelId: __PIER_AGENT_CHANNEL_ID__, ... } }
@@ -123,14 +123,14 @@ greeter, Escort is a personal guide with memory of *where you are* in the flow.
 ```
          guides                    delivers               is the script
    ┌────────────────┐         ┌──────────────┐        ┌──────────────┐
-   │  Pier → Escort │  ──────▶│  Luna-Light  │◀───────│  the runbook │
+   │  Pier → Escort │  ──────▶│  Luna-Lite  │◀───────│  the runbook │
    │  (concierge)   │  hand   │  (the bundle)│  reads  │  (the spec)  │
    └────────────────┘  over   └──────────────┘        └──────────────┘
 ```
 
 - **Pier** is the front-door **now**: it can walk a newcomer through the runbook and
-  hand them `arc install luna-light`.
-- **Luna-Light** is the **payload**: the one-command assistant they end up with.
+  hand them `arc install luna-lite`.
+- **Luna-Lite** is the **payload**: the one-command assistant they end up with.
 - **Escort** is where the concierge **grows**: each runbook step becomes a quest step
   with a check (✅ stack created · ✅ bus connected · ✅ `@luna` responds), per person,
   resumable.
@@ -144,5 +144,5 @@ and clone the one they need.
 Bundle shape: `arc/docs/skill-repo-migration-spec.md`, ADR-0017. Pier:
 `arc-manifest-pier.yaml` + `personas/pier.md` + `agents.d/pier.yaml`. Escort:
 guildhall quests + `src/brain/protocol.ts` (`create_private_thread`, ADR cortex#2206).
-Luna-Light: `the-metafactory/metafactory-bundle-luna-light`. Companion spec:
+Luna-Lite: `the-metafactory/metafactory-bundle-luna-lite`. Companion spec:
 `design-bootstrap-luna.md`.

--- a/docs/bundle-blueprints.md
+++ b/docs/bundle-blueprints.md
@@ -144,5 +144,5 @@ and clone the one they need.
 Bundle shape: `arc/docs/skill-repo-migration-spec.md`, ADR-0017. Pier:
 `arc-manifest-pier.yaml` + `personas/pier.md` + `agents.d/pier.yaml`. Escort:
 guildhall quests + `src/brain/protocol.ts` (`create_private_thread`, ADR cortex#2206).
-Luna-Lite: `the-metafactory/metafactory-bundle-luna-lite`. Companion spec:
+Luna-Lite: `the-metafactory/metafactory-cortex-agent-luna-lite`. Companion spec:
 `design-bootstrap-luna.md`.

--- a/docs/design-bootstrap-luna.md
+++ b/docs/design-bootstrap-luna.md
@@ -34,9 +34,9 @@ common denominator of how this community actually runs):
 | **Cloud repo** | **GitHub** |
 
 **This tiers cleanly onto what we've built:**
-- **Luna-Light** is the *floor* — chat + async, zero tools. It is NOT the MVP; it's
+- **Luna-Lite** is the *floor* — chat + async, zero tools. It is NOT the MVP; it's
   the front door and the persona base.
-- **The MVP = Luna-Light + software-factory capability**: Claude-Code coding with
+- **The MVP = Luna-Lite + software-factory capability**: Claude-Code coding with
   the tool surface a dev assistant needs (bash, `gh`/GitHub, access to
   checked-out repos), bound to Discord, on a local stack, across the three OS
   targets. These are the "extensions to Luna" — each an explicit capability grant

--- a/docs/design-bootstrap-luna.md
+++ b/docs/design-bootstrap-luna.md
@@ -1,0 +1,146 @@
+# Design Spec — Bootstrap Your Own Luna (zero → working assistant stack)
+
+**Status:** draft
+**Owner:** principal (Andreas)
+**Audience:** a **new user** standing up their first metafactory assistant stack, and the maintainers building the path they follow.
+**Lineage (design-process SOP):** Research (`docs/design-onboarding-tooling-audit.md`) → this Design Spec → `blueprint.yaml` features → issues. Grounds on: `docs/sop-stack-onboarding.md`, `README-AGENTS.md` §3, `docs/config-layout/`, `arc-manifest-pier.yaml` (the bundle exemplar), ADR-0017 (surface tooling as arc bundles).
+**Discussion:** community `#bootstrap` (playbook + process for new users).
+
+---
+
+## 1. Problem
+
+Standing up a working assistant stack (a "Luna") today is a **~15-step recipe spread across 6 SOPs** (`design-onboarding-tooling-audit.md` §rank-1..5). The principal has done it five-plus times by hand; nobody else can. Two things are missing:
+
+1. **A single end-to-end path** — one document a newcomer follows from a clean machine to a responding `@luna`, instead of stitching `sop-stack-onboarding` + `sop-stack-identity` + `sop-network-join` + `README-AGENTS §3` + the config-layout template themselves.
+2. **A packaged shortcut** — an `arc install`-able bundle that scripts the automatable ~80% (persona + agent fragment + the `stack create → provision → make-live` chain), so the newcomer only does the irreducibly-manual edges.
+
+Both are wanted. They are **not alternatives** — the runbook is the specification the bundle automates.
+
+## 2. Goal (Definition of Done — a demonstrable walkthrough)
+
+A new user on a clean machine can reach a **working, bus-routable `@luna`** that responds on their chosen surface, by following ONE path. Concretely, a reviewer can watch:
+
+1. Prereqs installed (bun, NATS, Claude auth) and — *only if choosing Discord* — a bot app created + token in hand.
+2. `arc install cortex` (+ one surface adapter bundle) → cortex present.
+3. `cortex stack create luna --agent luna --apply` → a config-split stack scaffolded, born-aligned (`stack.id = <you>/luna`).
+4. Bus identity + connection stood up — **either** the full account-tree chain (`arc upgrade cortex` → `network provision --apply` → `network make-live --apply`) **or** the simple-bus mode (§6.3) for a solo/local Luna.
+5. `cortex start --config <pointer>` → daemon boots, connects to its bus, subscribes.
+6. A message to the surface reaches `@luna` and she replies.
+7. *(Better Luna, optional)* her persona/skills/memory come from a **soma projection** rather than the scaffold stub.
+
+**Phase 2 target:** steps 3–4 collapse into `arc install luna-stack` + a short prompt, leaving only steps 1 (prereqs/Discord app) and 6 (say hi).
+
+## 3. Grounding — what already exists (reuse, don't rebuild)
+
+| Building block | What it is | Reuse in this spec |
+|---|---|---|
+| **`cortex stack create <slug>`** (#808) | Scaffolds the config-split layout (`system/`, `surfaces/`, `stacks/<slug>.yaml`, pointer, `personas/<agent>.md`, 0700 workspace) born-aligned; **dry-run by default**, `--apply` writes. Does NOT mint the signing seed. | The runbook's Step 3; the bundle's postinstall core. |
+| **The lifecycle chain** | `stack create --apply` → `arc upgrade cortex` (seed) → `network provision --apply` (account tree) → `network make-live --apply` (bus creds + nats restart) → `cortex start` → optional `network join`. `stack create` prints it as "Next steps". | The canonical order the runbook and bundle both follow. |
+| **`pier`** | A **shipped in-process onboarding-concierge agent**, packaged as an arc `type: agent` bundle (`arc-manifest-pier.yaml`: `provides.files` persona+fragment, `lifecycle` hooks, `__ENV__` secret placeholders, `depends_on: cortex`). | The **exemplar bundle shape** to clone. AND Pier is the guided front-door: she greets newcomers in `#onboard-your-fleet` and walks them through this very runbook. |
+| **`vega`** | An in-process dev-loop orchestrator agent shipped as a **template** (copied into a stack's `agents.d/`, not `arc install`ed). | Proof that a stack is a *fleet of fragments*, not one persona — the model for shipping the `luna` fragment. |
+| **`quickstart`** (L3, `src/cli/cortex/commands/quickstart.ts`) | Env-contract-driven one-command provision. | The bundle's non-interactive install spine — but see §6.2 (Discord-hard-wired). |
+| **L4 compose** (`deploy/compose/`) | `docker compose up -d` container path (v6.10.0). | A second delivery target for users who want Luna in a container, not on a host. |
+| **soma projection** | soma owns Luna's *content* (Purpose/Memory/skills) and **projects** it into the substrate config the runtime reads. | The "better Luna" — real identity/memory instead of the scaffold stub. Bundle `depends_on` or a documented follow-on. |
+| **AgentState blueprint** (`state: {blueprint: AgentState}`) | Per-agent durable state (`~/.config/cortex/agents/luna/`). | Optional: gives Luna memory across sessions. |
+
+**What a stack "having Luna" means:** a `luna` agent fragment (`agents.d/luna.yaml`) + `personas/luna.md`, `@luna` as the routed assistant name (`did:mf:luna`), optionally an AgentState blueprint (memory) and a soma projection (content). `stack create` writes a *generic `assistant` placeholder* (#1338); `--agent luna` (or an installed Luna persona) is what makes it Luna.
+
+## 4. The one irreducible truth (scope boundary)
+
+Two edges **cannot** be fully automated — the runbook documents them, the bundle flags them, neither hides them:
+
+- **Discord app creation** — `quickstart.ts` confirms the Developer Portal has no API; creating the bot app + inviting it is manual, principal-only. *(A web/gateway surface avoids this entirely — see §6.2.)*
+- **Federation trust-handoff + hub topology** — the two-party cred handoff and account-topology (`onboarding-audit` rank 1–3) are irreducibly two-party. **A solo Luna doesn't need them** (§6.3); they are opt-in when the user later federates.
+
+Everything between these edges is scriptable.
+
+## 5. Decision — deliver in two phases (runbook first, then bundle)
+
+**DD-1. Ship the runbook first.** A single `docs/runbook-bootstrap-luna.md` (or a `#bootstrap`-pinned playbook) that collapses the 6 SOPs into one zero→Luna path, using today's tooling. It is shippable now, validates the flow end-to-end, and is exactly what `#bootstrap` asked for. It also becomes the executable specification for Phase 2.
+
+**DD-2. Then codify the automatable core into an arc bundle** — `metafactory-bundle-luna-stack` — modeled on `arc-manifest-pier.yaml`. Building the bundle *before* a proven runbook risks automating a flow we haven't nailed; building it *after* means the bundle's postinstall is a mechanical transcription of a validated recipe.
+
+**DD-3. Name things precisely (avoid the "blueprint" trap).** The stack-standup is an **arc bundle** (not a "blueprint"). Its *work* is tracked as a **`blueprint.yaml` feature** (Sense A). Luna's *memory* attaches via **`state: {blueprint: AgentState}`** (Sense B). These are three different "blueprints"; the spec keeps them apart.
+
+**DD-4. Default to the simplest working Luna.** The primary target is a **solo, local, simple-bus Luna** (no federation, no Discord app if the user picks the web surface). Federation and Discord are opt-in upgrades, not prerequisites. This is the lowest-friction "it works" a newcomer can reach.
+
+## 6. Design detail
+
+### 6.1 The bundle (`metafactory-bundle-luna-stack`)
+
+Modeled on `arc-manifest-pier.yaml`:
+
+```yaml
+schema: arc/v1
+name: luna-stack           # identity is manifest.name, not the repo name
+version: 0.1.0
+type: agent                # (candidate: a new `process` type if postinstall grows)
+tier: community
+targets: [cortex]
+provides:
+  files:
+    - personas/luna.md            → ~/.config/metafactory/cortex/personas/
+    - agents.d/luna.yaml          → ~/.config/metafactory/cortex/agents.d/
+depends_on:
+  packages:
+    - { name: cortex, repo: the-metafactory/cortex }
+    - { name: <surface-adapter>, repo: the-metafactory/metafactory-cortex-adapter-<web|discord> }
+    # optional: soma projection, agent-state blueprint
+lifecycle:
+  preinstall:  scripts/check-cortex-version.sh      # (pier's pattern)
+  postinstall: scripts/bootstrap-luna.sh            # runs the §6.4 chain, non-interactive
+```
+
+The bundle **provides** persona + fragment and **runs** the `stack create → provision → make-live` chain in postinstall. It **cannot** mint bus creds itself (that stays a cortex/arc CLI step invoked by the hook) nor cross the §4 edges. Secrets ride as `__ENV__` placeholders resolved at install (pier's pattern), never baked.
+
+### 6.2 Surface choice — web-first for the solo path
+
+`quickstart` is currently Discord-hard-wired (#2153); a `--surface web` mode is in flight (#2153). For the **lowest-friction solo Luna**, the spec prefers the **web/gateway surface** as the default — it removes the manual Discord-app edge (§4) entirely. Discord remains a first-class opt-in for users who want a Discord-facing assistant. The runbook documents both; the bundle takes a `--surface` choice.
+
+### 6.3 Bus tier — simple-bus for solo, account-tree for federation
+
+A solo Luna needs a bus but not the federation account-tree. Per **#2182**, the L4/simple-bus model is: `stack create` + `provision-stack generate` (signing seed only), then connect **anonymously** to a local unauthenticated bus (clear `system.yaml`'s `credsPath`). This is the default for a solo/local/container Luna. The full `network provision → make-live` account-tree chain is the **federation** path, opt-in. **This spec depends on #2182** landing a first-class `--simple-bus` scaffold mode; until then the runbook documents the manual `credsPath`-clear workaround.
+
+### 6.4 The scripted chain (what postinstall / the runbook Step 3–5 runs)
+
+```
+cortex stack create luna --agent luna --apply          # config-split scaffold, born-aligned
+# solo/simple-bus:
+#   provision-stack generate (seed) ; clear system.yaml credsPath ; cortex start   (#2182)
+# federated:
+#   arc upgrade cortex (seed) ; cortex network provision luna --apply ;
+#   cortex network make-live luna --apply ; cortex start ; (later) cortex network join <net>
+```
+
+### 6.5 Pier as the front-door
+
+The community "process for new users" is: a newcomer lands in `#onboard-your-fleet`, **Pier** greets them (she already does this, airgapped/Read-only), and walks them through the runbook — or, in Phase 2, hands them the one-line `arc install luna-stack`. Pier issues nothing; she guides + surfaces admission requests. No new agent needed for the front-door — it exists.
+
+## 7. Open decisions (need a principal call)
+
+1. **Bundle `type`** — `agent` (reuse pier's schema) vs a new `process`/`pipeline` type for a postinstall that orchestrates a multi-step chain. *(Recommend: start `agent`; propose `process` to arc if postinstall outgrows it.)*
+2. **soma projection** — bundle-in (Luna's content ships in the bundle) vs `depends_on` soma vs "connect soma later" as a documented follow-on. *(Recommend: `depends_on` optional; the scaffold stub works without it, soma makes her *your* Luna.)*
+3. **Default surface** — commit web-first for solo (§6.2), or keep Discord the documented default and web the opt-in? *(Recommend: web-first for the solo runbook; both documented.)*
+4. **Naming** — do we ship her as `luna` (the reference assistant) or make the bundle prompt for the user's own assistant name (their Luna, their name)? The `assistant` placeholder (#1338) exists precisely so we don't hard-name. *(Recommend: bundle prompts for a name, defaults to a neutral suggestion — "your own version of Luna".)*
+5. **Dependency on #2182 / #2153** — this spec's solo path assumes the simple-bus mode and web surface land. Sequence those as prerequisites, or ship the runbook against the manual workarounds now?
+
+## 8. Acceptance criteria (binary)
+
+- [ ] `docs/runbook-bootstrap-luna.md` exists: a single path from clean machine → responding `@luna`, no cross-references required to complete it, with the §4 manual edges called out explicitly.
+- [ ] A test user (not the principal) follows the runbook and reaches a responding assistant on the web surface **without touching a Discord Developer Portal**.
+- [ ] The runbook's federated path is a clearly-marked *opt-in upgrade*, not on the solo critical path.
+- [ ] *(Phase 2)* `arc install luna-stack` scaffolds persona + fragment and runs the §6.4 chain in postinstall, leaving only §4 edges + "say hi" to the user.
+- [ ] *(Phase 2)* the bundle refuses/fails-loud on a missing prereq (cortex version, bus, Claude auth) — pier's `check-cortex-version.sh` pattern.
+- [ ] "blueprint" is used in exactly one sense per occurrence (DD-3); no doc conflates the three.
+
+## 9. Rough edges this spec must not paper over
+
+- Discord app creation is manual (§4) — the runbook says so up front.
+- Federation is two-party and out of scope for solo (§4, §6.3) — opt-in.
+- The multi-surface deploy (bot + dashboard + MC worker + registry) has no single orchestrator (`onboarding-audit` rank-5 / G4 `cortex release`) — out of scope here; Luna-solo needs only the daemon + one surface.
+- `nkey_pub` write-back is in 3 sites with silent-fail risk (audit G3) — the chain in §6.4 relies on `arc upgrade cortex` handling it; the runbook verifies signing works before declaring done.
+
+## 10. Provenance
+
+Research: `docs/design-onboarding-tooling-audit.md` (Luna, cortex#1139). Exemplar: `arc-manifest-pier.yaml`, `personas/pier.md`, `agents.d/pier.yaml`. Lifecycle: `src/cli/cortex/commands/stack.ts`, `provision-stack.ts`, `network*.ts`. Bundle grammar: `arc/docs/skill-repo-migration-spec.md`, ADR-0017. Blueprint senses: `blueprint/blueprint.yaml`, `cortex-config.ts:992-1013`. Surface/bus edges: `#2153` (web surface), `#2182` (simple-bus). Community track: `#bootstrap`, `#onboard-your-fleet`.

--- a/docs/design-bootstrap-luna.md
+++ b/docs/design-bootstrap-luna.md
@@ -63,7 +63,9 @@ Everything between these edges is scriptable.
 
 **DD-3. Name things precisely (avoid the "blueprint" trap).** The stack-standup is an **arc bundle** (not a "blueprint"). Its *work* is tracked as a **`blueprint.yaml` feature** (Sense A). Luna's *memory* attaches via **`state: {blueprint: AgentState}`** (Sense B). These are three different "blueprints"; the spec keeps them apart.
 
-**DD-4. Default to the simplest working Luna.** The primary target is a **solo, local, simple-bus Luna** (no federation, no Discord app if the user picks the web surface). Federation and Discord are opt-in upgrades, not prerequisites. This is the lowest-friction "it works" a newcomer can reach.
+**DD-4. Default to the simplest working Luna — solo, local, simple-bus.** The primary target is a **solo, local, simple-bus Luna** (no federation). Federation is an opt-in upgrade, not a prerequisite.
+
+**DD-5. Discord-first surface (principal decision, 2026-07).** The default surface a newcomer binds Luna to is **Discord**, not web. Rationale: the entire fleet UX is Discord-native — `pier`/`escort` greet newcomers in Discord, releases + admissions flow through Discord, and the community *is* on Discord; landing a newcomer's Luna where the community already lives beats an isolated web endpoint. **Consequence, stated plainly:** this puts the one irreducible manual edge — creating a Discord bot app + inviting it (§4) — **on the critical path** of the default flow. The runbook must therefore front-load the Discord-app step and make it the clearest part of the walkthrough. The web surface stays a documented, first-class *alternative* (it's the right pick for a headless/gateway Luna and the one that avoids the manual edge), but it is no longer the recommended default.
 
 ## 6. Design detail
 
@@ -94,9 +96,23 @@ lifecycle:
 
 The bundle **provides** persona + fragment and **runs** the `stack create → provision → make-live` chain in postinstall. It **cannot** mint bus creds itself (that stays a cortex/arc CLI step invoked by the hook) nor cross the §4 edges. Secrets ride as `__ENV__` placeholders resolved at install (pier's pattern), never baked.
 
-### 6.2 Surface choice — web-first for the solo path
+### 6.2 Surface choice — Discord-first (DD-5)
 
-`quickstart` is currently Discord-hard-wired (#2153); a `--surface web` mode is in flight (#2153). For the **lowest-friction solo Luna**, the spec prefers the **web/gateway surface** as the default — it removes the manual Discord-app edge (§4) entirely. Discord remains a first-class opt-in for users who want a Discord-facing assistant. The runbook documents both; the bundle takes a `--surface` choice.
+The default surface is **Discord** (DD-5): it lands the newcomer's Luna where the
+fleet UX and the community already live (`pier`/`escort` greet there, releases +
+admissions flow there). `quickstart` is already Discord-oriented, which fits.
+
+The cost this accepts, stated plainly: creating the Discord bot app + inviting it
+is the one irreducible manual edge (§4), and Discord-first puts it **on the
+critical path**. So the runbook front-loads it — the Discord-app step is the first
+and most carefully-documented part of the walkthrough, with the Developer-Portal
+click-path spelled out (quickstart only *validates* the token; it can't create the
+app).
+
+The **web/gateway surface stays first-class** — it's the right default for a
+headless/gateway Luna and the one path that avoids the manual edge, so the runbook
+documents it as the explicit alternative. The bundle takes a `--surface
+<discord|web>` choice (defaulting to `discord`).
 
 ### 6.3 Bus tier — simple-bus for solo, account-tree for federation
 
@@ -121,7 +137,7 @@ The community "process for new users" is: a newcomer lands in `#onboard-your-fle
 
 1. **Bundle `type`** — `agent` (reuse pier's schema) vs a new `process`/`pipeline` type for a postinstall that orchestrates a multi-step chain. *(Recommend: start `agent`; propose `process` to arc if postinstall outgrows it.)*
 2. **soma projection** — bundle-in (Luna's content ships in the bundle) vs `depends_on` soma vs "connect soma later" as a documented follow-on. *(Recommend: `depends_on` optional; the scaffold stub works without it, soma makes her *your* Luna.)*
-3. **Default surface** — commit web-first for solo (§6.2), or keep Discord the documented default and web the opt-in? *(Recommend: web-first for the solo runbook; both documented.)*
+3. ~~**Default surface**~~ — **RESOLVED (DD-5): Discord-first.** The runbook front-loads the Discord-app step; web is the documented alternative.
 4. **Naming** — do we ship her as `luna` (the reference assistant) or make the bundle prompt for the user's own assistant name (their Luna, their name)? The `assistant` placeholder (#1338) exists precisely so we don't hard-name. *(Recommend: bundle prompts for a name, defaults to a neutral suggestion — "your own version of Luna".)*
 5. **Dependency on #2182 / #2153** — this spec's solo path assumes the simple-bus mode and web surface land. Sequence those as prerequisites, or ship the runbook against the manual workarounds now?
 

--- a/docs/design-bootstrap-luna.md
+++ b/docs/design-bootstrap-luna.md
@@ -17,6 +17,39 @@ Standing up a working assistant stack (a "Luna") today is a **~15-step recipe sp
 
 Both are wanted. They are **not alternatives** — the runbook is the specification the bundle automates.
 
+## 1.5 What "MVP" means (per Vincent + `#bootstrap`, 2026-07)
+
+`#bootstrap` defines the target as *"fresh cortex install → a **minimum viable
+product (MVP) software factory assistant**"* — not a chat toy, an assistant that
+can do the software-factory work. The MVP is pinned by these constraints (the
+common denominator of how this community actually runs):
+
+| Axis | MVP constraint |
+|---|---|
+| **OS targets** | macOS · Debian-based Linux · WSL2 |
+| **Install path** | cortex **native** install (not container — L4 compose is a parallel option, not the MVP path) |
+| **Stack** | **local** (not federated) |
+| **Coding agent** | **Claude Code** (already cortex's substrate) |
+| **Communication** | **Discord** (aligns with DD-5) |
+| **Cloud repo** | **GitHub** |
+
+**This tiers cleanly onto what we've built:**
+- **Luna-Light** is the *floor* — chat + async, zero tools. It is NOT the MVP; it's
+  the front door and the persona base.
+- **The MVP = Luna-Light + software-factory capability**: Claude-Code coding with
+  the tool surface a dev assistant needs (bash, `gh`/GitHub, access to
+  checked-out repos), bound to Discord, on a local stack, across the three OS
+  targets. These are the "extensions to Luna" — each an explicit capability grant
+  on the fragment, not baked into the light floor.
+- **Full Luna** (memory via AgentState, soma-projected identity/skills, federation)
+  is the ceiling — beyond MVP.
+
+So the bootstrap journey's real deliverable is **the MVP tier**: the runbook and the
+Phase-2 bundle must stand up not just a chat Luna but a *working software-factory
+assistant* under the constraints above. The OS matrix (mac/Debian/WSL2) and the
+capability set (Claude-Code + bash + `gh` + repo access) become first-class
+acceptance criteria, not afterthoughts.
+
 ## 2. Goal (Definition of Done — a demonstrable walkthrough)
 
 A new user on a clean machine can reach a **working, bus-routable `@luna`** that responds on their chosen surface, by following ONE path. Concretely, a reviewer can watch:

--- a/docs/design-luna-stack-bundle.md
+++ b/docs/design-luna-stack-bundle.md
@@ -1,0 +1,276 @@
+# Design Spec — the Luna-Stack bundle (Phase 2: stand up a whole Luna stack)
+
+**Status:** draft + validated prototype
+**Owner:** principal (Andreas)
+**Audience:** maintainers building the Phase-2 one-install stack stand-up, and reviewers of the prototype bundle.
+**Lineage (design-process SOP):** `design-bootstrap-luna.md` (DD-1 runbook-first, DD-2 then-bundle, DD-4 solo/local/simple-bus, DD-5 Discord-first) → this spec → the validated prototype at `~/Developer/metafactory-bundle-luna-stack-proto/`.
+**Grounds on (verified, not asserted):** `metafactory-bundle-luna-light/` (the Phase-1 exemplar), `cortex/arc-manifest-pier.yaml` + `agents.d/pier.yaml` (the surface-bound agent exemplar), `cortex/src/cli/cortex/commands/{stack,provision-stack,quickstart,quickstart-lib}.ts` (the actual CLI surface), `arc/src/lib/{validate-manifest,repo-name}.ts` + `arc/src/types.ts` (the validator), `arc/docs/skill-repo-migration-spec.md` (naming grammar + manifest contract).
+
+---
+
+## 1. What the bundle is
+
+Luna-Stack is **luna-light's bigger sibling.** Where luna-light ships a persona +
+agent fragment onto a stack you *already run*, Luna-Stack's install **stands up
+the whole stack**: it scaffolds a config-split cortex stack, provisions the
+signing seed, binds the Discord surface, and boots the daemon — so one
+`arc install` plus a bot token plus a slug gives you a responding `@luna` on
+Discord. It is the Phase-2 target of `design-bootstrap-luna.md` §2: steps 3–5 of
+the bootstrap walkthrough collapse into one install, leaving the operator only
+the §4 manual edge (creating the Discord app) and "say hi".
+
+It keeps luna-light's shape — an in-process cortex agent (persona + `agents.d`
+fragment) that shares the stack's bus identity and mints no credentials of its
+own — and adds one thing: an install-time **bootstrap hook** that drives the
+cortex CLI.
+
+### Name + class (recommendation, with justification)
+
+**Recommended: `metafactory-cortex-agent-luna-stack`, manifest `type: agent`.**
+
+The choice is between `metafactory-bundle-luna-stack` and
+`metafactory-cortex-agent-luna-stack`. The class-choice rule
+(`skill-repo-migration-spec.md` §3.1) is mechanical:
+
+- `metafactory-bundle-<name>` is for **CLI-led or multi-skill *cross-app*
+  collections** (e.g. `metafactory-bundle-discord`, which ships a `discord` CLI
+  used across apps). Luna-Stack is neither: it targets **only cortex**, and its
+  **lead artifact is the persona + fragment** — the postinstall orchestration is
+  lifecycle glue, not a separately-installable CLI. So `bundle` does **not** fit
+  by the rule.
+- `metafactory-cortex-agent-<name>` is the **app-coupled agent class** — a
+  bundle inseparable from cortex's runtime and CLI. That is exactly Luna-Stack
+  (it drives `cortex stack create` / `cortex quickstart`). It also keeps it
+  sorting adjacent to its documented siblings — the shipped `metafactory-cortex-
+  agent-escort` and `metafactory-cortex-agent-luna-light` (per
+  `bundle-blueprints.md`).
+
+On the **manifest `type`**: keep `type: agent` for v0.1.0. It reuses the proven
+pier/luna-light schema (arc validates it today), and the orchestration is a
+`lifecycle` hook — the same way luna-light runs a reload hook while declaring
+`bash.allowed: false` for the agent. `process` is the candidate **upgrade** (it
+exists in arc's `ArtifactType`) if the orchestration ever outgrows the agent
+shape, but arc's `process` type carries extra pulse-process requirements this
+bundle does not need — so it is deferred, not adopted (matches
+`design-bootstrap-luna.md` open Q1: "start `agent`; propose `process` if
+postinstall outgrows it").
+
+> **Prototype-dir caveat.** The validated skeleton lives in a dir named
+> `metafactory-bundle-luna-stack-proto` (per the task), so its manifest `name`
+> is `luna-stack-proto` to satisfy arc's §4.2 name-derivation *in that dir*. The
+> shipping repo is `metafactory-cortex-agent-luna-stack` / `name: luna-stack`.
+> See §7 finding (F4): arc's `toStrictName` does not know the
+> `metafactory-cortex-agent-` prefix, so on the real repo the derivation guard
+> does not fire and `name: luna-stack` passes anyway.
+
+## 2. The manifest shape
+
+Verified against `arc validate` (passes). Full source:
+`~/Developer/metafactory-bundle-luna-stack-proto/arc-manifest.yaml`.
+
+| Field | Value | Why |
+|---|---|---|
+| `schema` | `arc/v1` | required literal |
+| `type` | `agent` | reuse the proven schema; `process` deferred (§1) |
+| `targets` | `[cortex]` | single-target install into cortex HostAdapter |
+| `identity.id` | `luna` | routes as `@luna` (the reference assistant) |
+| `provides.files` | **LIST** of `{source, target}` | drops `personas/luna.md` + `agents.d/luna.yaml` (arc `types.ts:420` — a list, never a map; pier's map form is legacy) |
+| `dependencies` | `cortex >=6.10.0`, `metafactory-cortex-adapter-discord >=0.1.0` | read **by name** for the first-party load exemption (cortex's own loader lane) |
+| `depends_on.packages` | `{name, repo}` for the discord adapter | the arc **auto-install** contract (cortex#2028) — arc clones + installs it on `arc install luna-stack` |
+| `capabilities` | fs read `~/.config/cortex`, `network: []`, `bash.allowed: false`, `secrets: []` | describes the **agent** (Luna reads her own config, rides the stack bus identity). The install-time chain is a *lifecycle hook*, a separate axis — same modeling as luna-light |
+| `lifecycle.preinstall` | `scripts/preinstall-gate.sh` | cortex-version + `LUNA_BOT_TOKEN` gate |
+| `lifecycle.postinstall` | `scripts/postinstall-bootstrap.sh` | the stand-up orchestration |
+
+Discord binding lives in `agents.d/luna.yaml`'s `presence.discord` (pier-style,
+DD-5), with every id a resolve-at-install `__LUNA_*__` placeholder — no live
+token or snowflake is ever committed (compass#84 / L2). An unset value fails
+SOFT (surface disabled, stack still boots), matching pier.
+
+## 3. The postinstall orchestration (the exact chain)
+
+**Strategy: prefer `cortex quickstart`; hand-stitched chain as documented
+fallback.** The key grounding discovery: `cortex quickstart`
+(`src/cli/cortex/commands/quickstart.ts`, cortex#2094) already **is** the
+scripted stand-up chain — one idempotent, env-contract-driven command that does
+preflight → validate env → write nats conf → `cortex stack create` → patch the
+surfaces/stack/system configs (the Discord binding) → provision the signing seed
+→ (re)start services → healthy-boot gate. It is Discord-first via
+`--surface discord` (default; cortex#2164), and re-runnable without damage. This
+is what `design-bootstrap-luna.md` §3 anticipated as "the bundle's non-
+interactive install spine." So the bundle **rides quickstart** rather than
+re-implementing a fragile chain.
+
+**Path A (preferred) — map `LUNA_*` → quickstart's `CTX_*` contract and exec:**
+
+```bash
+export CTX_PRINCIPAL=$LUNA_PRINCIPAL   CTX_SLUG=$LUNA_SLUG
+export CTX_NATS_PORT=$LUNA_NATS_PORT   CTX_NATS_MON=$LUNA_NATS_MON
+export CTX_GUILD_ID=$LUNA_GUILD_ID     CTX_CHANNEL_ID=$LUNA_CHANNEL_ID
+export CTX_LOG_CHANNEL_ID=${LUNA_LOG_CHANNEL_ID:-$LUNA_CHANNEL_ID}
+export CTX_MY_DISCORD_ID=$LUNA_MY_DISCORD_ID
+export CTX_DISCORD_TOKEN=$LUNA_BOT_TOKEN     # gates success; never echoed
+cortex quickstart --surface discord
+```
+
+The `CTX_*` required contract is verified from `quickstart-lib.ts`:
+`CTX_PRINCIPAL, CTX_SLUG, CTX_NATS_PORT, CTX_NATS_MON, CTX_GUILD_ID,
+CTX_CHANNEL_ID, CTX_LOG_CHANNEL_ID, CTX_MY_DISCORD_ID` + secret
+`CTX_DISCORD_TOKEN` (gates) + optional `CLAUDE_CODE_OAUTH_TOKEN`.
+
+**Path B (fallback / reference) — the discrete chain quickstart wraps**, verified
+against `stack.ts` + `provision-stack.ts` (these are the real command
+signatures):
+
+```bash
+# 1. Scaffold, born-aligned, --agent luna (not the generic `assistant` default)
+cortex stack create $LUNA_SLUG --principal $LUNA_PRINCIPAL --agent luna --apply
+# 2. Provision the signing seed (solo needs only the seed, not the account tree)
+arc upgrade cortex        # OR: cortex provision-stack generate $LUNA_PRINCIPAL \
+                          #        --seed-path ~/.config/nats/$LUNA_SLUG.nk \
+                          #        --stack-id $LUNA_PRINCIPAL/$LUNA_SLUG
+# 2b. SIMPLE-BUS (#2182 gap): clear nats.credsPath in system.yaml for anonymous
+#     local-bus connect. NO --simple-bus flag exists yet (see F1). quickstart's
+#     local-nats path avoids this edit — another reason Path A is preferred.
+#     FEDERATED instead: cortex network provision $SLUG --apply
+#                        cortex network make-live $SLUG --apply
+# 3. Boot + reload
+cortex start --config ~/.config/metafactory/cortex/$LUNA_SLUG/$LUNA_SLUG.yaml
+cortex agents reload
+```
+
+**Discord-first, front-loaded manual edge.** Per DD-5, the Discord-app creation
+(§4) is on the critical path. The bundle handles it as the **preinstall gate**
+(§below), not the postinstall — the install refuses to even start until
+`LUNA_BOT_TOKEN` is present, so the operator hits the clearest possible stop
+*before* anything is scaffolded.
+
+### The preinstall gate
+
+`scripts/preinstall-gate.sh` (mirrors luna-light's `check-cortex-version.sh` +
+pier's `PIER_BOT_TOKEN` gate). It fails loud, before any file is written, on:
+
+1. `cortex` not on PATH → tells you to `arc install cortex`.
+2. cortex `< 6.10.0` → tells you to `arc upgrade cortex` (quickstart is the spine).
+3. **`LUNA_BOT_TOKEN` unset** → prints the full Discord Developer-Portal
+   click-path (create app → Bot → Reset Token → Message Content Intent → OAuth2
+   invite → Copy IDs). This is the DD-5 manual edge, made the loudest thing.
+4. `LUNA_GUILD_ID` / `LUNA_CHANNEL_ID` unset → **WARN only** (fail SOFT: the
+   stack still stands up; the Discord surface is disabled until they're set),
+   matching pier's soft-warn discipline.
+
+## 4. What it can't do (the irreducible edges) — and how it degrades honestly
+
+- **Creating the Discord bot app is manual** (`design-bootstrap-luna.md` §4;
+  quickstart's own doc-comment confirms "the Developer Portal has no API").
+  Degrade: the preinstall gate **refuses** with the exact click-path, before
+  scaffolding. It never pretends to have done it.
+- **Federation is out of scope for solo** (§4, DD-4). The bundle stands up a
+  **solo/local/simple-bus** Luna; `cortex network provision/make-live/join` are
+  the opt-in upgrade, never on this path. Degrade: not attempted, documented as
+  the next step.
+- **`cortex quickstart` is Linux/systemd-first.** Its service step renders
+  systemd user units on Linux; on **macOS** it only restarts an *already-loaded*
+  launchd service (load/unload stays arc-owned). On a fresh macOS host the
+  daemon may need an explicit `cortex start --config <pointer>` / `arc upgrade
+  cortex` to register the plist. Degrade: the postinstall prints this caveat and
+  the exact command; Path B's `cortex start` covers it. (This matters — the
+  primary principal is on macOS. See F2.)
+- **soma content is not bundled.** Luna ships the scaffold persona, not the
+  principal's projected identity/memory. Degrade: honest in the persona ("no
+  private memory yet"); soma projection is the documented upgrade.
+
+## 5. Acceptance criteria (binary)
+
+- [ ] `arc install luna-stack` with `LUNA_BOT_TOKEN` + `LUNA_SLUG` (+ guild/channel
+      ids) set → a booted stack with `@luna` bound to a Discord channel and
+      responding, **OR** a clear stop at the one manual edge (missing token →
+      the preinstall gate's Developer-Portal instructions).
+- [ ] With `LUNA_BOT_TOKEN` **unset**, the install aborts in preinstall with the
+      click-path and writes **nothing** (no partial stack).
+- [ ] The postinstall is **idempotent** — a re-run after fixing one env var does
+      not clobber an already-stood-up stack (inherited from quickstart's
+      idempotence; Path B guards each step).
+- [ ] The stood-up stack is **solo/simple-bus** — no `network provision` /
+      `make-live` runs; federation stays opt-in.
+- [ ] **Content-safe**: no live token or snowflake in any shipped file; every id
+      is a `__LUNA_*__` / `<REPLACE_ME>` placeholder.
+- [ ] `arc validate` passes on the bundle. *(Met by the prototype.)*
+
+## 6. Prototype status
+
+Validated skeleton at `~/Developer/metafactory-bundle-luna-stack-proto/`:
+`arc-manifest.yaml` (passes `arc validate`), `personas/luna.md` (public-safe,
+adapted from luna-light), `agents.d/luna.yaml` (Discord presence, `__LUNA_*__`
+placeholders), `scripts/preinstall-gate.sh` + `scripts/postinstall-bootstrap.sh`
+(executable, `bash -n` clean). No git remote, not published, never installed on
+a live stack — authored for review.
+
+## 7. CLI-surface findings (real gaps to file)
+
+- **F1 — No first-class simple-bus scaffold mode (`cortex#2182` not landed).**
+  Neither `stack create` nor `provision-stack` has a `--simple-bus` flag or any
+  `credsPath`-clearing step (grep of both command files: empty). The solo/
+  anonymous-bus model the spec's DD-4 default depends on is today a **manual
+  `system.yaml` edit** (blank `nats.credsPath`). *Mitigation in place:*
+  `cortex quickstart`'s local-nats path is functionally the solo bus (local
+  nats conf + seed only, no account tree), so the bundle reaches a solo Luna via
+  Path A without the manual edit — but a discrete `--simple-bus` scaffold flag
+  would let Path B stand alone. **File against cortex#2182.**
+- **F2 — `cortex quickstart` is Linux/systemd-first; macOS service step is
+  partial.** Step 7 renders systemd units on Linux (hard-requires cortex#2071)
+  but on macOS only restarts an already-loaded launchd service. For a Mac-first
+  principal, a fresh-host install may not register the daemon plist via
+  quickstart alone. **File: a macOS-parity path for quickstart's service step
+  (or document the `cortex start` follow-up as a first-class branch).**
+- **F3 — `stack create` default agent is `assistant`, and the Discord binding
+  lives in two possible places.** The scaffold writes a generic `assistant`
+  fragment (#1338); the bundle instead drops its own `agents.d/luna.yaml`
+  (id `luna`) via `provides.files`. But quickstart patches the Discord binding
+  into `surfaces/surfaces.yaml`, while the bundle's fragment carries
+  `presence.discord` (pier-style). **Open reconciliation:** does Luna bind
+  Discord via the agent fragment's `presence` or via `surfaces.yaml`? Both exist;
+  the bundle should pick one so the two don't double-bind. Needs a design call
+  (see open questions).
+- **F4 — arc's §4.2 name-derivation (`toStrictName`) doesn't know the
+  `metafactory-cortex-agent-` / `-adapter-` / `-renderer-` classes.** It only
+  strips `metafactory-skill-`, `metafactory-bundle-`, and
+  `metafactory-<app>-skill-`. So for the shipped cortex agent bundles (escort,
+  luna-light, this one) the derivation guard **returns null and silently does
+  not apply** — `name` is unchecked against the dir. Not blocking (permissive,
+  not wrong), but the validator's §4.2 enforcement has a blind spot for the
+  exact classes cortex ships. **File against arc** (extend `toStrictName` to the
+  `-agent-`/`-adapter-`/`-renderer-` app classes).
+
+## 8. Open questions for the principal
+
+1. **Fragment `presence` vs `surfaces.yaml` for the Discord binding (F3).** The
+   pier exemplar puts `presence.discord` on the agent fragment; quickstart
+   patches `surfaces.yaml`. Which is canonical for a bundle-shipped agent? (Recommend:
+   fragment `presence` for a single-surface agent like Luna, since it travels
+   with the bundle; reserve `surfaces.yaml` for shared cross-agent gateway
+   bindings.)
+2. **`luna` vs a prompted name.** Ship her as the reference `@luna`, or prompt
+   for the operator's own assistant name (their Luna, their name)? The
+   `assistant` placeholder (#1338) exists so we needn't hard-name. (Recommend:
+   default `luna`, allow `LUNA_AGENT_ID` override — matches
+   `design-bootstrap-luna.md` open Q4.)
+3. **`type: agent` now vs push arc for `type: process`.** Adopt the deferred
+   `process` type now (needs arc's pulse-process requirements clarified), or stay
+   `agent` until the orchestration demonstrably outgrows it? (Recommend: stay
+   `agent`; revisit if the postinstall grows a second orchestration concern.)
+4. **Sequence vs #2182 / F1.** Ship the bundle now against quickstart's local-
+   nats solo path (works today), or block on a first-class `--simple-bus`
+   scaffold flag so Path B is self-sufficient? (Recommend: ship against
+   quickstart now; F1 is a nice-to-have, not a blocker.)
+5. **macOS parity (F2).** Is a Linux-first stand-up acceptable for v0.1.0 (with
+   the documented macOS `cortex start` follow-up), or is macOS parity a release
+   gate given the primary principal runs macOS?
+
+## 9. Provenance
+
+Exemplars: `metafactory-bundle-luna-light/` (Phase-1), `cortex/arc-manifest-pier.yaml`
++ `agents.d/pier.yaml` + `scripts/pier/`. CLI surface (verified):
+`cortex/src/cli/cortex/commands/{stack,provision-stack,quickstart,quickstart-lib,agents}.ts`.
+Validator: `arc/src/lib/{validate-manifest,repo-name}.ts`, `arc/src/types.ts`,
+`arc/src/cli.ts`. Naming + manifest contract: `arc/docs/skill-repo-migration-spec.md`.
+Design lineage: `design-bootstrap-luna.md` (DD-1/2/4/5), `bundle-blueprints.md`.

--- a/docs/design-luna-stack-bundle.md
+++ b/docs/design-luna-stack-bundle.md
@@ -10,19 +10,53 @@
 
 ## 1. What the bundle is
 
-Luna-Stack is **luna-light's bigger sibling.** Where luna-light ships a persona +
-agent fragment onto a stack you *already run*, Luna-Stack's install **stands up
-the whole stack**: it scaffolds a config-split cortex stack, provisions the
-signing seed, binds the Discord surface, and boots the daemon — so one
-`arc install` plus a bot token plus a slug gives you a responding `@luna` on
-Discord. It is the Phase-2 target of `design-bootstrap-luna.md` §2: steps 3–5 of
-the bootstrap walkthrough collapse into one install, leaving the operator only
-the §4 manual edge (creating the Discord app) and "say hi".
+Luna-Stack is **luna-lite's bigger sibling, standing up the MVP tier.** Where
+luna-lite ships a persona + agent fragment onto a stack you *already run*,
+Luna-Stack's install **stands up the whole stack**: it scaffolds a config-split
+cortex stack, provisions the signing seed, binds the Discord surface, and boots
+the daemon — so one `arc install` plus a bot token plus a slug gives you a
+responding `@luna` on Discord. It is the Phase-2 target of
+`design-bootstrap-luna.md` §2, delivering the **MVP tier** its §1.5 defines: not
+a chat toy but a *working software-factory assistant*.
 
-It keeps luna-light's shape — an in-process cortex agent (persona + `agents.d`
+It keeps luna-lite's shape — an in-process cortex agent (persona + `agents.d`
 fragment) that shares the stack's bus identity and mints no credentials of its
-own — and adds one thing: an install-time **bootstrap hook** that drives the
-cortex CLI.
+own — and adds two things: (1) an install-time **bootstrap hook** that drives the
+cortex CLI, and (2) the **software-factory capability delta** (§1.5) that makes
+Luna a coding assistant, not just a chat one.
+
+## 1.5 MVP constraints + the software-factory capability delta
+
+Per `#bootstrap` (and `design-bootstrap-luna.md` §1.5), the target is a **minimum
+viable software-factory assistant** — pinned to this common denominator:
+
+| Axis | MVP constraint | How this bundle meets it |
+|---|---|---|
+| **OS targets** | macOS · Debian Linux · WSL2 | portable POSIX-bash scripts; OS detection + per-host service path (§4 matrix) |
+| **Install path** | cortex **native** (not container) | drives `cortex quickstart` / native CLI; L4 compose out of scope |
+| **Stack** | **local**, not federated | LOCAL/simple-bus only; no `network provision/make-live` (DD-4) |
+| **Coding agent** | **Claude Code** | cortex's own substrate (`runtime.substrate: claude-code`) |
+| **Communication** | **Discord** | DD-5 Discord-first; the fragment carries `presence.discord` |
+| **Cloud repo** | **GitHub** | `gh`/`git` tool deps + `github.com` network grant |
+
+**The software-factory delta over the luna-lite floor.** Luna-lite is the *floor*
+(chat + async, read-only, zero tools). The MVP is luna-lite **plus** a coding
+surface. Each grant is explicit in the bundle and is a deliberate widening of
+luna-lite's zero-tool posture:
+
+| Grant | luna-lite floor | luna-stack MVP (the delta) | Where declared |
+|---|---|---|---|
+| **shell** | `bash.allowed: false` | `bash.allowed: true` | manifest `capabilities.bash` |
+| **filesystem** | read `~/.config/cortex`, no write | read+write **one** repo (`LUNA_REPO`) — least-privilege, not a broad `~/Developer` write | manifest `capabilities.filesystem` |
+| **network** | `[]` | `github.com` + `api.github.com` (git/gh over HTTPS) | manifest `capabilities.network` |
+| **tools** | none | `gh` (GitHub CLI) + `git` on PATH | manifest `depends_on.tools` + preinstall gate |
+| **agent tools** | `[Read]`-class | `[Read, Edit, Write, Bash, Grep, Glob]` | persona `allowedTools` |
+| **capability label** | `chat`, `async` | `+ code` | fragment `runtime.capabilities` |
+
+`gh` holds its own auth (`gh auth login`) — **no secret is baked into the bundle**
+(`capabilities.secrets: []`); the preinstall gate checks `gh auth status`
+(WARN-only). That is the honest privilege boundary: the bundle grants the
+*ability* to reach GitHub; the principal's own `gh` credentials authorize it.
 
 ### Name + class (recommendation, with justification)
 
@@ -42,12 +76,12 @@ The choice is between `metafactory-bundle-luna-stack` and
   bundle inseparable from cortex's runtime and CLI. That is exactly Luna-Stack
   (it drives `cortex stack create` / `cortex quickstart`). It also keeps it
   sorting adjacent to its documented siblings — the shipped `metafactory-cortex-
-  agent-escort` and `metafactory-cortex-agent-luna-light` (per
-  `bundle-blueprints.md`).
+  agent-escort` and `metafactory-cortex-agent-luna-lite` (per
+  `bundle-blueprints.md`; the floor bundle was renamed luna-light → luna-lite).
 
 On the **manifest `type`**: keep `type: agent` for v0.1.0. It reuses the proven
-pier/luna-light schema (arc validates it today), and the orchestration is a
-`lifecycle` hook — the same way luna-light runs a reload hook while declaring
+pier/luna-lite schema (arc validates it today), and the orchestration is a
+`lifecycle` hook — the same way luna-lite runs a reload hook while declaring
 `bash.allowed: false` for the agent. `process` is the candidate **upgrade** (it
 exists in arc's `ArtifactType`) if the orchestration ever outgrows the agent
 shape, but arc's `process` type carries extra pulse-process requirements this
@@ -77,7 +111,8 @@ Verified against `arc validate` (passes). Full source:
 | `provides.files` | **LIST** of `{source, target}` | drops `personas/luna.md` + `agents.d/luna.yaml` (arc `types.ts:420` — a list, never a map; pier's map form is legacy) |
 | `dependencies` | `cortex >=6.10.0`, `metafactory-cortex-adapter-discord >=0.1.0` | read **by name** for the first-party load exemption (cortex's own loader lane) |
 | `depends_on.packages` | `{name, repo}` for the discord adapter | the arc **auto-install** contract (cortex#2028) — arc clones + installs it on `arc install luna-stack` |
-| `capabilities` | fs read `~/.config/cortex`, `network: []`, `bash.allowed: false`, `secrets: []` | describes the **agent** (Luna reads her own config, rides the stack bus identity). The install-time chain is a *lifecycle hook*, a separate axis — same modeling as luna-light |
+| `depends_on.tools` | `gh`, `git` | software-factory host prereqs; the preinstall gate verifies both |
+| `capabilities` | fs read+write **one** repo (`LUNA_REPO`, least-privilege), network `github.com`/`api.github.com`, `bash.allowed: true`, `secrets: []` | the **software-factory delta** (§1.5) — a coding agent, not luna-lite's read-only floor. The install-time chain stays a separate *lifecycle hook* |
 | `lifecycle.preinstall` | `scripts/preinstall-gate.sh` | cortex-version + `LUNA_BOT_TOKEN` gate |
 | `lifecycle.postinstall` | `scripts/postinstall-bootstrap.sh` | the stand-up orchestration |
 
@@ -141,22 +176,32 @@ cortex agents reload
 **Discord-first, front-loaded manual edge.** Per DD-5, the Discord-app creation
 (§4) is on the critical path. The bundle handles it as the **preinstall gate**
 (§below), not the postinstall — the install refuses to even start until
-`LUNA_BOT_TOKEN` is present, so the operator hits the clearest possible stop
+`LUNA_BOT_TOKEN` is present, so the principal hits the clearest possible stop
 *before* anything is scaffolded.
 
 ### The preinstall gate
 
-`scripts/preinstall-gate.sh` (mirrors luna-light's `check-cortex-version.sh` +
-pier's `PIER_BOT_TOKEN` gate). It fails loud, before any file is written, on:
+`scripts/preinstall-gate.sh` (mirrors luna-lite's `check-cortex-version.sh` +
+pier's `PIER_BOT_TOKEN` gate, extended for the software-factory + OS-matrix
+prereqs). It **detects the host** (macOS / Debian / WSL2) and prints the service
+path first, then gates. **HARD (abort, nothing written):**
 
-1. `cortex` not on PATH → tells you to `arc install cortex`.
-2. cortex `< 6.10.0` → tells you to `arc upgrade cortex` (quickstart is the spine).
-3. **`LUNA_BOT_TOKEN` unset** → prints the full Discord Developer-Portal
-   click-path (create app → Bot → Reset Token → Message Content Intent → OAuth2
-   invite → Copy IDs). This is the DD-5 manual edge, made the loudest thing.
-4. `LUNA_GUILD_ID` / `LUNA_CHANNEL_ID` unset → **WARN only** (fail SOFT: the
-   stack still stands up; the Discord surface is disabled until they're set),
-   matching pier's soft-warn discipline.
+1. `cortex` not on PATH → `arc install cortex`.
+2. cortex `< 6.10.0` → `arc upgrade cortex` (quickstart is the spine).
+3. `git` not on PATH → software-factory prereq, with the per-OS install hint.
+4. `gh` not on PATH → software-factory prereq (MVP cloud repo is GitHub).
+5. **`LUNA_BOT_TOKEN` unset** → the full Discord Developer-Portal click-path
+   (create app → Bot → Reset Token → Message Content Intent → OAuth2 invite →
+   Copy IDs). The DD-5 manual edge, made the loudest thing.
+
+**SOFT (WARN, install continues — pier's fail-soft discipline):**
+
+6. `LUNA_GUILD_ID` / `LUNA_CHANNEL_ID` unset → Discord surface disabled at load.
+7. `gh auth status` not authenticated → Luna codes locally but can't push /
+   open PRs until `gh auth login`.
+8. `claude` (Claude Code) not on PATH → cortex's substrate; usually present.
+9. WSL2 without systemd → warns to enable it or rely on the `cortex start`
+   backstop (see §4 matrix).
 
 ## 4. What it can't do (the irreducible edges) — and how it degrades honestly
 
@@ -164,17 +209,24 @@ pier's `PIER_BOT_TOKEN` gate). It fails loud, before any file is written, on:
   quickstart's own doc-comment confirms "the Developer Portal has no API").
   Degrade: the preinstall gate **refuses** with the exact click-path, before
   scaffolding. It never pretends to have done it.
-- **Federation is out of scope for solo** (§4, DD-4). The bundle stands up a
-  **solo/local/simple-bus** Luna; `cortex network provision/make-live/join` are
-  the opt-in upgrade, never on this path. Degrade: not attempted, documented as
-  the next step.
-- **`cortex quickstart` is Linux/systemd-first.** Its service step renders
-  systemd user units on Linux; on **macOS** it only restarts an *already-loaded*
-  launchd service (load/unload stays arc-owned). On a fresh macOS host the
-  daemon may need an explicit `cortex start --config <pointer>` / `arc upgrade
-  cortex` to register the plist. Degrade: the postinstall prints this caveat and
-  the exact command; Path B's `cortex start` covers it. (This matters — the
-  primary principal is on macOS. See F2.)
+- **Federation is out of scope for the MVP** (DD-4). The bundle stands up a
+  **local/simple-bus** Luna; `cortex network provision/make-live/join` are the
+  opt-in upgrade, never on this path. Degrade: not attempted, documented as the
+  next step.
+- **The service step is not uniform across the OS matrix.** `cortex quickstart`
+  handles systemd on Linux and a launchctl-restart on macOS, but neither covers
+  every fresh host. The bundle's postinstall detects the host and backstops with
+  an explicit `cortex start --config <pointer>` (idempotent) so all three OS
+  targets reach a running daemon:
+
+  | Host | quickstart service step | Bundle handling |
+  |---|---|---|
+  | **macOS** | restarts an *already-loaded* launchd service only (load/unload stays arc-owned) | `cortex start` backstop registers/starts the daemon on a fresh host |
+  | **Debian Linux** | renders + starts systemd user units (native path; hard-requires cortex#2071) | works directly; `cortex start` is a no-op backstop |
+  | **WSL2** | systemd path **only if** WSL2 systemd is enabled (`/etc/wsl.conf [boot] systemd=true`) | preinstall WARNs; `cortex start` backstop covers a systemd-less WSL2 |
+
+  Degrade: the postinstall prints the exact `cortex start` line for the detected
+  host; Path B uses the same backstop. See F2 (macOS) + F5 (WSL2 systemd).
 - **soma content is not bundled.** Luna ships the scaffold persona, not the
   principal's projected identity/memory. Degrade: honest in the persona ("no
   private memory yet"); soma projection is the documented upgrade.
@@ -190,8 +242,15 @@ pier's `PIER_BOT_TOKEN` gate). It fails loud, before any file is written, on:
 - [ ] The postinstall is **idempotent** — a re-run after fixing one env var does
       not clobber an already-stood-up stack (inherited from quickstart's
       idempotence; Path B guards each step).
-- [ ] The stood-up stack is **solo/simple-bus** — no `network provision` /
+- [ ] The stood-up stack is **local/simple-bus** — no `network provision` /
       `make-live` runs; federation stays opt-in.
+- [ ] **Software-factory surface present**: the installed Luna has `bash.allowed:
+      true`, `github.com` network, read+write on the single `LUNA_REPO`, and `gh`+`git`
+      on PATH — i.e. she can clone, branch, run tests, and open a PR, not just
+      chat. *(Met by the prototype's manifest + persona + gate.)*
+- [ ] **OS matrix**: the preinstall gate + postinstall run on macOS, Debian, and
+      WSL2, detecting the host and reaching a running daemon on each (via
+      quickstart's service step or the `cortex start` backstop).
 - [ ] **Content-safe**: no live token or snowflake in any shipped file; every id
       is a `__LUNA_*__` / `<REPLACE_ME>` placeholder.
 - [ ] `arc validate` passes on the bundle. *(Met by the prototype.)*
@@ -199,11 +258,13 @@ pier's `PIER_BOT_TOKEN` gate). It fails loud, before any file is written, on:
 ## 6. Prototype status
 
 Validated skeleton at `~/Developer/metafactory-bundle-luna-stack-proto/`:
-`arc-manifest.yaml` (passes `arc validate`), `personas/luna.md` (public-safe,
-adapted from luna-light), `agents.d/luna.yaml` (Discord presence, `__LUNA_*__`
-placeholders), `scripts/preinstall-gate.sh` + `scripts/postinstall-bootstrap.sh`
-(executable, `bash -n` clean). No git remote, not published, never installed on
-a live stack — authored for review.
+`arc-manifest.yaml` (passes `arc validate`; software-factory `capabilities` +
+`depends_on.tools`), `personas/luna.md` (public-safe software-factory persona
+with `allowedTools`), `agents.d/luna.yaml` (Discord presence + `code` capability,
+`__LUNA_*__` placeholders), `scripts/preinstall-gate.sh` (cortex+git+gh+token
+gate, OS detection) + `scripts/postinstall-bootstrap.sh` (quickstart-preferred,
+OS-matrix daemon backstop) — both executable, `bash -n` clean. No git remote, not
+published, never installed on a live stack — authored for review.
 
 ## 7. CLI-surface findings (real gaps to file)
 
@@ -235,11 +296,18 @@ a live stack — authored for review.
   `metafactory-cortex-agent-` / `-adapter-` / `-renderer-` classes.** It only
   strips `metafactory-skill-`, `metafactory-bundle-`, and
   `metafactory-<app>-skill-`. So for the shipped cortex agent bundles (escort,
-  luna-light, this one) the derivation guard **returns null and silently does
+  luna-lite, this one) the derivation guard **returns null and silently does
   not apply** — `name` is unchecked against the dir. Not blocking (permissive,
   not wrong), but the validator's §4.2 enforcement has a blind spot for the
   exact classes cortex ships. **File against arc** (extend `toStrictName` to the
   `-agent-`/`-adapter-`/`-renderer-` app classes).
+- **F5 — WSL2 systemd is not guaranteed.** quickstart's Linux service step
+  assumes systemd user units, but WSL2 only runs systemd when the distro opts in
+  (`/etc/wsl.conf [boot] systemd=true`, newer WSL). On a systemd-less WSL2 the
+  service step can't complete. *Mitigation in place:* the preinstall gate detects
+  WSL2 and WARNs; the postinstall backstops with `cortex start`. **File: make
+  quickstart's service step degrade explicitly on a systemd-less host** (detect +
+  fall back to a foreground/`cortex start` path) rather than assuming systemd.
 
 ## 8. Open questions for the principal
 
@@ -250,7 +318,7 @@ a live stack — authored for review.
    with the bundle; reserve `surfaces.yaml` for shared cross-agent gateway
    bindings.)
 2. **`luna` vs a prompted name.** Ship her as the reference `@luna`, or prompt
-   for the operator's own assistant name (their Luna, their name)? The
+   for the principal's own assistant name (their Luna, their name)? The
    `assistant` placeholder (#1338) exists so we needn't hard-name. (Recommend:
    default `luna`, allow `LUNA_AGENT_ID` override — matches
    `design-bootstrap-luna.md` open Q4.)
@@ -262,9 +330,16 @@ a live stack — authored for review.
    nats solo path (works today), or block on a first-class `--simple-bus`
    scaffold flag so Path B is self-sufficient? (Recommend: ship against
    quickstart now; F1 is a nice-to-have, not a blocker.)
-5. **macOS parity (F2).** Is a Linux-first stand-up acceptable for v0.1.0 (with
-   the documented macOS `cortex start` follow-up), or is macOS parity a release
-   gate given the primary principal runs macOS?
+5. **macOS parity (F2) + WSL2 systemd (F5).** Is a Linux-first stand-up
+   acceptable for v0.1.0 (with the documented macOS/WSL2 `cortex start`
+   backstop), or is full three-OS parity a release gate? The MVP names all three
+   as targets, which argues for the backstop being a *tested* path, not just a
+   printed hint.
+6. **Repo scope default.** ✅ **RESOLVED (epic #2319):** it's a sample bundle, so
+   it ships least-privilege by construction — the coding grant is a **single
+   repo the principal names** (`LUNA_REPO`), NOT a broad `~/Developer` write.
+   Widen only via an explicit reviewed allowlist edit to `capabilities.filesystem`.
+   The shipped bundle and the runbook both reflect this single-repo scope.
 
 ## 9. Provenance
 

--- a/scripts/xdg-audit-allow.yaml
+++ b/scripts/xdg-audit-allow.yaml
@@ -410,6 +410,16 @@ allow:
     match: ~/\.config/cortex/agents
     reason: agent instance-state path — future agent-instance-state wave (live in arc)
     owner: agent-instance-state
+  - pattern: config-tree
+    path: docs/bundle-blueprints.md
+    match: ~/\.config/cortex
+    reason: documents the real arc `provides.files` install targets for the agent-bundle blueprints (personas/ + agents.d/) — same config-tree the shipped manifests are carved for
+    owner: bootstrap-luna
+  - pattern: config-tree
+    path: docs/design-bootstrap-luna.md
+    match: ~/\.config/cortex
+    reason: documents the AgentState durable-state install path (~/.config/cortex/agents/) in the bootstrap design spec
+    owner: bootstrap-luna
   - pattern: bin-home
     path: CLAUDE.md
     match: ~/bin/discord


### PR DESCRIPTION
Seeds the `#bootstrap` journey with two grounded design docs.

- **`docs/design-bootstrap-luna.md`** — the strategy for standing up a new user's own assistant: runbook-first (validate the flow) → arc bundle (codify it). Grounded in `design-onboarding-tooling-audit.md` + the real `stack create → provision → make-live` lifecycle. Names the irreducible manual edges (Discord app, federation) and the known rough edges (#2182 simple-bus, #2153 web surface).
- **`docs/bundle-blueprints.md`** — `luna-light` / `pier` / `escort` presented as annotated **clone-me reference bundles**, explicitly distinct from `blueprint.yaml` (feature graph) and AgentState `state:{blueprint}` (memory). Cites the already-published `metafactory-cortex-agent-*` gallery (escort = "canonical sample"; the three brain-class examples).

Companion to the built bundle **`metafactory-cortex-agent-luna-light`** (a working, `arc install`-from-URL agent bundle, validated on a live stack — coexists with production `@luna`).

Gates: vocab (carve-outs + wire-vocab) PASS, XDG PASS locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)