### PR TITLE
fix(quickstart): macOS parity — reach a running daemon on a fresh host (#2322)

### DIFF
--- a/docs/runbook-bootstrap-luna.md
+++ b/docs/runbook-bootstrap-luna.md
@@ -407,19 +407,37 @@ software-factory capability delta added.
 
 The known edges, front-loaded so you recognize them before they bite.
 
-### F2 — macOS: a fresh host needs an explicit `cortex start`
+### F2 — macOS: a fresh host reaches a running daemon automatically (cortex#2322)
 
-`cortex quickstart`'s Step 7 on macOS only *restarts* a launchd stack service
-that arc has already **loaded** (load/unload stays arc-owned); on a fresh Mac
-it prints a skip instead. Symptom: quickstart's gate can't find a running daemon,
-or `@luna` never comes online. Fix — start the daemon directly (idempotent):
+`cortex quickstart`'s Step 7 on macOS has two paths, split on whether arc has
+already **loaded** the launchd stack service (load/unload stays arc-owned):
+
+- **arc-loaded service** → Step 7 restarts it (`launchctl kickstart -k`) so the
+  daemon picks up the configs Step 5 patched.
+- **fresh Mac (not loaded)** → Step 7 now **starts the daemon directly** via a
+  detached `cortex start --config <pointer>` backstop, so the healthy-boot gate
+  (Step 8) reaches a **running** daemon. No manual pre-load step is required.
+  A re-run is idempotent: if that backstop daemon is already running, Step 7
+  skips cleanly (no double-start).
+
+Symptom you should NO LONGER see: quickstart's gate can't find a running daemon
+on a fresh Mac. If you do (e.g. the `cortex` binary isn't on `PATH` at
+`~/.local/bin/cortex`), Step 7 fails with the reason — start the daemon by hand
+(idempotent):
 
 ```bash
 cortex start --config ~/.config/metafactory/cortex/<slug>/<slug>.yaml
 ```
 
-`arc upgrade cortex` (which loads the launchd plist) is the alternative. Then
-re-check with `cortex status --config <pointer>`.
+`arc upgrade cortex` (which loads the launchd plist, converting the deployment
+to the arc-loaded path above) is the alternative. Then re-check with
+`cortex status --config <pointer>`.
+
+> **Backstop config re-apply.** The fresh-Mac backstop does not restart an
+> already-running backstop daemon to pick up a *later* config edit (only the
+> arc-loaded launchd path does). To apply a config change on the backstop
+> daemon, `cortex stop && cortex start --config <pointer>` (see "Stopping /
+> restarting the stack" below).
 
 ### Missing / wrong token: the gate stops cleanly
 

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -189,6 +189,14 @@ interface FakeOverrides {
   isActive?: (unit: string) => boolean;
   launchdServiceLoaded?: (label: string) => boolean;
   launchdKickstart?: (label: string) => CommandResult;
+  // cortex#2322 — darwin fresh-host backstop seams. Defaults: no backstop
+  // daemon running (so the not-loaded path starts one), and the start succeeds.
+  daemonBackstopRunning?: (pointerConfigPath: string) => boolean;
+  startDaemonBackstop?: (opts: {
+    pointerConfigPath: string;
+    logPath: string;
+    errorLogPath: string;
+  }) => CommandResult;
   // cortex#2264/#2283 — records the per-file log truncations step 7 performs
   // before the (re)start: called TWICE, once for the main `.log` and once for
   // the `.error.log` (so a test can assert both ran, with what paths, and in
@@ -218,6 +226,9 @@ function fakePorts(overrides: FakeOverrides = {}): QuickstartPorts {
     isActive: overrides.isActive ?? (() => false),
     launchdServiceLoaded: overrides.launchdServiceLoaded ?? (() => false),
     launchdKickstart: overrides.launchdKickstart ?? (() => ({ exitCode: 0, stdout: "", stderr: "" })),
+    daemonBackstopRunning: overrides.daemonBackstopRunning ?? (() => false),
+    startDaemonBackstop:
+      overrides.startDaemonBackstop ?? (() => ({ exitCode: 0, stdout: "backstop started (pid 4242)", stderr: "" })),
   };
   const provision: ProvisionPort = {
     provisionSeed: overrides.provisionSeed ?? (() => ({ exitCode: 0, stdout: "  ⊘ NKey already exists — reusing\n", stderr: "" })),
@@ -686,16 +697,17 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
     expect(res.stdout).toContain("Healthy-boot gate ✓");
   });
 
-  // A1's (#2297) negative-space tripwire — "darwin NEVER truncates" — guarded
-  // the UNPAIRED state and is superseded by cortex#2283: darwin now truncates
-  // exactly when a restart follows (loaded → truncate + kickstart, covered in
-  // the #2283 block below). What survives of the invariant is its real core:
-  // NO restart → NO truncate. This test pins that on the not-loaded path.
-  test("cortex#2283: darwin, service NOT loaded — no truncate, no kickstart (unpaired truncate stays impossible)", async () => {
+  // cortex#2322 — the not-loaded path is no longer a printed skip. On a fresh
+  // Mac (launchd service NOT loaded AND no backstop daemon running) it STARTS
+  // the daemon directly via the `cortex start --config <pointer>` backstop,
+  // paired with the both-logs truncate (truncate → start → gate). It must NOT
+  // touch launchctl kickstart (that's the arc-loaded path only).
+  test("cortex#2322: darwin, NOT loaded + not running (fresh Mac) — truncate + cortex start backstop, no kickstart", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
     const truncateCalls: string[] = [];
     const kickstartCalls: string[] = [];
+    const backstopCalls: { pointerConfigPath: string; logPath: string; errorLogPath: string }[] = [];
     const res = await withPlatform("darwin", () =>
       withEnv(validCtxEnv(), () =>
         dispatchQuickstart(
@@ -703,7 +715,12 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
           () =>
             fakePorts({
               launchdServiceLoaded: () => false,
+              daemonBackstopRunning: () => false,
               truncateLog: (p: string) => truncateCalls.push(p),
+              startDaemonBackstop: (opts) => {
+                backstopCalls.push(opts);
+                return { exitCode: 0, stdout: "backstop started (pid 4242)", stderr: "" };
+              },
               launchdKickstart: (label: string) => {
                 kickstartCalls.push(label);
                 return { exitCode: 0, stdout: "", stderr: "" };
@@ -713,12 +730,82 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
       ),
     );
     expect(res.exitCode).toBe(0);
-    expect(truncateCalls).toEqual([]);
+    // Both logs truncated (paired with the start), and the backstop ran exactly
+    // once against the pointer config path + the gate-visible log files.
+    expect(truncateCalls.length).toBe(2);
+    expect(backstopCalls.length).toBe(1);
+    expect(backstopCalls[0]?.pointerConfigPath).toBe(join(configDir, "work", "work.yaml"));
+    expect(backstopCalls[0]?.logPath).toBe(daemonLogPath(process.env.HOME ?? "", "work"));
+    expect(backstopCalls[0]?.errorLogPath).toBe(daemonErrorLogPath(process.env.HOME ?? "", "work"));
+    // The arc-loaded kickstart path is NEVER taken on a fresh (unloaded) host.
     expect(kickstartCalls).toEqual([]);
+    expect(res.stdout).toContain("cleared prior-boot logs");
+    expect(res.stdout).toContain("detached backstop");
+    expect(res.stdout).toContain("started (fresh host — cortex start backstop)");
+  });
+
+  // cortex#2322 — idempotency: a RE-RUN where the backstop daemon is already
+  // running (launchd still not loaded, but the pointer's pidfile names a live
+  // pid) is a CLEAN no-op skip — no double-start, and no truncate (a truncate
+  // is only ever paired with an actual (re)start; the A1/#2297 "unpaired
+  // truncate impossible" core survives on this sub-case).
+  test("cortex#2322: darwin, NOT loaded + already running (re-run) — clean skip, no truncate, no start", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const truncateCalls: string[] = [];
+    let startCalls = 0;
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              launchdServiceLoaded: () => false,
+              daemonBackstopRunning: () => true,
+              truncateLog: (p: string) => truncateCalls.push(p),
+              startDaemonBackstop: () => {
+                startCalls++;
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(truncateCalls).toEqual([]);
+    expect(startCalls).toBe(0);
     expect(res.stdout).not.toContain("cleared prior-boot");
-    // Today's arc-owned skip survives, and names the action taken.
-    expect(res.stdout).toContain("launchd is handled by arc");
-    expect(res.stdout).toContain("skip (not loaded — arc owns launchd load)");
+    expect(res.stdout).toContain("cortex daemon already running");
+  });
+
+  // cortex#2322 — a failed backstop start FAILS the step (exit 1) so the gate
+  // never runs against a daemon we couldn't launch (the truncate already wiped
+  // prior-boot evidence — same honesty contract as the loaded-kickstart-failed
+  // path).
+  test("cortex#2322: darwin, backstop start fails → exit 1, surfaces the error, gate never runs", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("darwin", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(
+          ["--config-dir", configDir, "--nats-dir", natsDir],
+          () =>
+            fakePorts({
+              launchdServiceLoaded: () => false,
+              daemonBackstopRunning: () => false,
+              startDaemonBackstop: () => ({
+                exitCode: 127,
+                stdout: "",
+                stderr: "cortex binary not found",
+              }),
+            }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("backstop failed: cortex binary not found");
+    // Step 8's gate line never printed — the run stopped at step 7.
+    expect(res.stdout).not.toContain("healthy-boot gate:");
   });
 
   // Linux ordering survives the cortex#2282 helper extraction (+ the
@@ -1128,9 +1215,24 @@ describe("dispatchQuickstart — cortex#2283 restart-on-re-run", () => {
     expect(darwinLoaded.exitCode).toBe(0);
     expect(stepNote(darwinLoaded.stdout)).toBe("restarted (config re-applied)");
 
-    const darwinNotLoaded = await runJson("darwin", { launchdServiceLoaded: () => false });
-    expect(darwinNotLoaded.exitCode).toBe(0);
-    expect(stepNote(darwinNotLoaded.stdout)).toBe("skip (not loaded — arc owns launchd load)");
+    // cortex#2322 — not loaded + not running (fresh Mac): the note now records
+    // the backstop START, not a skip.
+    const darwinFresh = await runJson("darwin", {
+      launchdServiceLoaded: () => false,
+      daemonBackstopRunning: () => false,
+    });
+    expect(darwinFresh.exitCode).toBe(0);
+    expect(stepNote(darwinFresh.stdout)).toBe("started (fresh host — cortex start backstop)");
+
+    // cortex#2322 — not loaded + already running (re-run): clean skip note.
+    const darwinReRun = await runJson("darwin", {
+      launchdServiceLoaded: () => false,
+      daemonBackstopRunning: () => true,
+    });
+    expect(darwinReRun.exitCode).toBe(0);
+    expect(stepNote(darwinReRun.stdout)).toBe(
+      "skip (not loaded; cortex daemon already running — backstop)",
+    );
   });
 });
 

--- a/src/cli/cortex/commands/quickstart-adapters.ts
+++ b/src/cli/cortex/commands/quickstart-adapters.ts
@@ -14,10 +14,12 @@
  * failing is an ordinary, expected outcome for quickstart, not a bug.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { spawn } from "node:child_process";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 
+import { pidFileFor } from "../../../common/pidfile";
 import type {
   CommandResult,
   GatePort,
@@ -93,6 +95,19 @@ function launchdGuiTarget(label: string): string {
   return `gui/${String(uid)}/${label}`;
 }
 
+/** cortex#2322 — resolve the `cortex` binary for the fresh-host backstop start.
+ *  Prefers `~/.local/bin/cortex` — the EXACT binary the launchd stack plist
+ *  invokes (`__HOME__/.local/bin/cortex start …`, `ai.meta-factory.cortex.stack.plist`),
+ *  so the backstop daemon and a later arc-loaded launchd daemon are the same
+ *  binary — then falls back to whatever `cortex` resolves to on PATH.
+ *  `undefined` when neither is found (surfaced as a clean step failure, never a
+ *  spawn throw). */
+function resolveCortexBin(): string | undefined {
+  const canonical = join(homedir(), ".local", "bin", "cortex");
+  if (existsSync(canonical)) return canonical;
+  return Bun.which("cortex") ?? undefined;
+}
+
 export function buildServicePort(): ServicePort {
   return {
     unitFileExists(unitTemplate: string): boolean {
@@ -142,6 +157,83 @@ export function buildServicePort(): ServicePort {
       // cortex#2283 — `-k`: kill the running instance, then restart it, so a
       // re-run applies patched configs on macOS.
       return runSync(["launchctl", "kickstart", "-k", launchdGuiTarget(label)]);
+    },
+    daemonBackstopRunning(pointerConfigPath: string): boolean {
+      // cortex#2322 — read the pointer's pidfile (the SAME derivation
+      // `cortex start --config <pointer>` writes, so the two converge across
+      // path spellings) and liveness-probe the pid. A missing/stale/unparseable
+      // pidfile ⇒ not running (safe to start); EPERM (a live pid owned by
+      // another user) counts as alive — conservatively skip rather than
+      // double-start.
+      const pidPath = pidFileFor(pointerConfigPath);
+      if (!existsSync(pidPath)) return false;
+      let pid: number;
+      try {
+        pid = parseInt(readFileSync(pidPath, "utf-8").trim(), 10);
+      } catch (_err) {
+        // Unreadable pidfile (race / permissions) — treat as not running; the
+        // start below is idempotent at the daemon layer (checkSingleton).
+        return false;
+      }
+      if (Number.isNaN(pid)) return false;
+      try {
+        process.kill(pid, 0); // signal 0 = liveness probe, delivers nothing
+        return true;
+      } catch (err) {
+        return (err as NodeJS.ErrnoException).code === "EPERM";
+      }
+    },
+    startDaemonBackstop(opts: {
+      pointerConfigPath: string;
+      logPath: string;
+      errorLogPath: string;
+    }): CommandResult {
+      // cortex#2322 — the fresh-Mac backstop: `cortex start --config <pointer>`
+      // launched DETACHED, redirecting stdout/stderr to the SAME log files the
+      // launchd plist targets and Step 8's gate greps (cortex#2282). This does
+      // NOT load a launchd service (arc owns that lifecycle); it starts the
+      // daemon process directly, exactly as the luna-stack bundle / runbook §F2
+      // document — lifted here so every consumer reaches a running daemon.
+      const cortexBin = resolveCortexBin();
+      if (cortexBin === undefined) {
+        return {
+          exitCode: 127,
+          stdout: "",
+          stderr:
+            "cortex binary not found (~/.local/bin/cortex or on PATH) — cannot start the fresh-host daemon backstop",
+        };
+      }
+      try {
+        // Both files were just truncated by clearPriorBootLogs (paired
+        // truncate → start → gate); open append so the detached daemon writes
+        // this boot's output into the gate-visible files.
+        mkdirSync(dirname(opts.logPath), { recursive: true });
+        const outFd = openSync(opts.logPath, "a");
+        const errFd = openSync(opts.errorLogPath, "a");
+        // node:child_process `detached: true` → setsid (own session/pgid), so
+        // the daemon survives quickstart's exit + any controlling-terminal
+        // SIGHUP; `unref()` lets quickstart exit without waiting on it.
+        const child = spawn(cortexBin, ["start", "--config", opts.pointerConfigPath], {
+          detached: true,
+          stdio: ["ignore", outFd, errFd],
+        });
+        child.unref();
+        // The child dup'd both fds at spawn; close our copies so quickstart
+        // doesn't hold them open past this call.
+        closeSync(outFd);
+        closeSync(errFd);
+        return {
+          exitCode: 0,
+          stdout: `cortex daemon backstop started (pid ${child.pid !== undefined ? String(child.pid) : "?"})`,
+          stderr: "",
+        };
+      } catch (err) {
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: err instanceof Error ? err.message : String(err),
+        };
+      }
     },
   };
 }

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -139,6 +139,44 @@ export interface ServicePort {
    * callers pass the bare plist Label (`launchdStackLabel()`).
    */
   launchdKickstart(label: string): CommandResult;
+  /**
+   * cortex#2322 — darwin FRESH-HOST backstop probe: is a `cortex start`
+   * daemon for this pointer config already running? Reads the pointer's
+   * pidfile (`pidFileFor()`, the SAME derivation `cortex start` writes) and
+   * liveness-probes the pid (`process.kill(pid, 0)`; EPERM counts as alive).
+   *
+   * This is the idempotency guard for the not-loaded path: arc owns the
+   * launchd load/unload lifecycle, so on a fresh Mac the stack service is
+   * never loaded — {@link launchdServiceLoaded} is false and the pre-#2322
+   * code just SKIPPED, leaving the daemon down and Step 8's gate to time out.
+   * Now the not-loaded path starts the daemon directly via
+   * {@link startDaemonBackstop}; this probe lets a RE-RUN see the already-
+   * running backstop daemon and skip cleanly instead of double-starting.
+   */
+  daemonBackstopRunning(pointerConfigPath: string): boolean;
+  /**
+   * cortex#2322 — darwin FRESH-HOST backstop start: launch the stack daemon
+   * DETACHED via `cortex start --config <pointerConfigPath>`, redirecting the
+   * child's stdout → `logPath` and stderr → `errorLogPath` (the SAME two files
+   * the launchd plist's `Std{Out,Error}Path` target and Step 8's gate greps —
+   * `daemonLogPath()` / `daemonErrorLogPath()`), so the gate reads this boot's
+   * output on darwin exactly as it does under launchd (cortex#2282).
+   *
+   * Detached + `unref`'d: the daemon runs on past quickstart's own exit (it is
+   * a long-lived process, quickstart is a one-shot CLI). Returns a
+   * `CommandResult` whose `exitCode === 0` ⇔ the spawn LAUNCHED (the daemon's
+   * own health is then confirmed by Step 8's gate, not by this call). It does
+   * NOT touch the launchd load/unload lifecycle — that stays arc-owned; this
+   * is the exact `cortex start --config <pointer>` backstop the luna-stack
+   * bundle + runbook §F2 document, lifted into quickstart so every consumer
+   * benefits (cortex#2322). Paired with a preceding both-logs truncate
+   * (truncate → start → gate), same ordering contract as the loaded path.
+   */
+  startDaemonBackstop(opts: {
+    pointerConfigPath: string;
+    logPath: string;
+    errorLogPath: string;
+  }): CommandResult;
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -31,9 +31,14 @@
  *                          REQUIRED — declared as a hard dependency, not
  *                          re-implemented here); a re-run also try-restarts
  *                          running units so fixed configs are picked up
- *                          (cortex#2283). macOS: restart a LOADED stack
- *                          service via launchctl kickstart -k (load/unload
- *                          stays arc-owned); not loaded → skip.
+ *                          (cortex#2283). macOS: LOADED stack service →
+ *                          restart via launchctl kickstart -k (load/unload
+ *                          stays arc-owned, cortex#2283); NOT loaded (a fresh
+ *                          Mac) → start the daemon DIRECTLY via a detached
+ *                          `cortex start --config <pointer>` backstop so the
+ *                          gate reaches a RUNNING daemon, not a printed hint
+ *                          (cortex#2322) — idempotent (a re-run skips when the
+ *                          backstop daemon is already running).
  *   8. Gate              — the §5 healthy-boot grep table + nats /healthz,
  *                          bounded wait.
  *
@@ -699,7 +704,10 @@ function clearPriorBootLogs(ports: QuickstartPorts, slug: string): string {
   return `  ✓ cleared prior-boot logs (${logPath}, ${errorLogPath})`;
 }
 
-function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean }): StepReport {
+function runServices(
+  ports: QuickstartPorts,
+  opts: { slug: string; configDir: string; skip: boolean },
+): StepReport {
   if (opts.skip) {
     return step("7. Services", true, ["  ○ --skip-services passed — skipping"]);
   }
@@ -707,7 +715,10 @@ function runServices(ports: QuickstartPorts, opts: { slug: string; skip: boolean
     return runServicesLinux(ports, opts.slug);
   }
   if (process.platform === "darwin") {
-    return runServicesDarwin(ports, opts.slug);
+    // cortex#2322 — the darwin branch needs the pointer config path (for the
+    // fresh-host `cortex start --config <pointer>` backstop + its pidfile
+    // running-probe), not just the slug.
+    return runServicesDarwin(ports, opts.slug, pointerConfigPath(opts.configDir, opts.slug));
   }
   return step("7. Services", true, ["  ○ non-Linux host — launchd is handled by arc; skip"]);
 }
@@ -786,29 +797,83 @@ function runServicesLinux(ports: QuickstartPorts, slug: string): StepReport {
 }
 
 /**
- * cortex#2283 — darwin branch: RESTART-ONLY. arc owns the launchd load/
- * unload lifecycle; quickstart never takes that over. When the stack service
- * is loaded (`launchctl print gui/$UID/<label>` exit 0), a re-run restarts it
- * via `launchctl kickstart -k` so the daemon picks up the configs step 5
- * patched — with the both-logs truncate (`.log` + `.error.log`) paired
- * IMMEDIATELY before it (truncate → restart → gate, same ordering contract
- * as Linux). When it is not loaded, keep the pre-#2283 "handled by arc" skip:
- * no restart means no truncate (an unpaired truncate would wipe current-boot
- * failure evidence and false-GREEN the gate — A1/#2297 adversarial finding).
+ * darwin branch. arc owns the launchd load/unload lifecycle; quickstart never
+ * takes that over. Two paths, split on whether arc has ALREADY loaded the
+ * stack service (`launchctl print gui/$UID/<label>` exit 0):
+ *
+ *   - LOADED (cortex#2283) — an arc-managed install: `launchctl kickstart -k`
+ *     restarts it so the daemon picks up the configs step 5 patched, with the
+ *     both-logs truncate paired IMMEDIATELY before it (truncate → restart →
+ *     gate, same ordering contract as Linux).
+ *
+ *   - NOT LOADED (cortex#2322) — a FRESH Mac: the pre-#2322 code just SKIPPED
+ *     here ("handled by arc"), leaving the daemon down so Step 8's gate could
+ *     only ever time out — the backstop was a printed hint, never a tested
+ *     path. Now the not-loaded path STARTS the daemon directly via a detached
+ *     `cortex start --config <pointer>` backstop (the exact command the
+ *     luna-stack bundle + runbook §F2 document), so the gate reaches a RUNNING
+ *     daemon. Idempotent: a re-run probes the pointer's pidfile
+ *     (`daemonBackstopRunning`) and skips cleanly when the backstop daemon is
+ *     already up — no double-start, no truncate (a truncate is only ever
+ *     paired with an actual (re)start; an unpaired truncate would wipe
+ *     current-boot evidence and false-GREEN the gate — A1/#2297). The start is
+ *     paired with the both-logs truncate exactly as the loaded path is.
+ *
+ * NOTE (idempotency limit, documented): the not-loaded backstop path does NOT
+ * restart an already-running backstop daemon to re-apply a config edit (unlike
+ * the launchd kickstart path). Picking up a changed config on the backstop
+ * daemon needs an explicit `cortex stop && cortex start --config <pointer>`
+ * (runbook §"Stopping / restarting the stack"). The fresh-host FIRST run — the
+ * cortex#2322 release gate — reaches a running daemon; re-run safety is a clean
+ * no-op, never a crash or duplicate.
  */
-function runServicesDarwin(ports: QuickstartPorts, slug: string): StepReport {
+function runServicesDarwin(ports: QuickstartPorts, slug: string, pointerPath: string): StepReport {
   const label = launchdStackLabel(slug);
+
+  // --- NOT LOADED: fresh-Mac backstop (cortex#2322) --------------------------
   if (!ports.service.launchdServiceLoaded(label)) {
-    const action = "skip (not loaded — arc owns launchd load)";
-    return {
-      ...step("7. Services", true, [`  ○ launchd is handled by arc; ${action}`]),
-      note: action,
-    };
+    // Idempotency guard: a prior quickstart run's backstop daemon is not a
+    // launchd service (launchdServiceLoaded stays false for it), so gate on
+    // the pointer's pidfile instead. Already running → clean skip.
+    if (ports.service.daemonBackstopRunning(pointerPath)) {
+      const action = "skip (not loaded; cortex daemon already running — backstop)";
+      return {
+        ...step("7. Services", true, [
+          `  ○ launchd not loaded (arc owns load); cortex daemon already running — skip`,
+        ]),
+        note: action,
+      };
+    }
+
+    const lines: string[] = [];
+    // Paired atomically with the backstop start below (truncate → start →
+    // gate) — never reached on the already-running skip above.
+    lines.push(clearPriorBootLogs(ports, slug));
+
+    const home = process.env.HOME ?? "";
+    const started = ports.service.startDaemonBackstop({
+      pointerConfigPath: pointerPath,
+      logPath: daemonLogPath(home, slug),
+      errorLogPath: daemonErrorLogPath(home, slug),
+    });
+    if (started.exitCode !== 0) {
+      // Fail the step (exit 1, gate never runs): the truncate above already
+      // wiped any prior boot's logs, so letting the gate run against a daemon
+      // we FAILED to launch could only time out dishonestly. Failing here
+      // keeps the truncate → start → gate pairing honest.
+      lines.push(`  ✗ cortex start --config <pointer> backstop failed: ${started.stderr.trim()}`);
+      return step("7. Services", false, lines);
+    }
+    lines.push(`  ✓ cortex start --config ${pointerPath} (detached backstop)`);
+    const action = "started (fresh host — cortex start backstop)";
+    lines.push(`  ✓ ${action}`);
+    return { ...step("7. Services", true, lines), note: action };
   }
 
+  // --- LOADED: arc-managed install, restart to re-apply (cortex#2283) --------
   const lines: string[] = [];
   // Paired atomically with the kickstart below — never called on the
-  // not-loaded path above.
+  // not-loaded paths above.
   lines.push(clearPriorBootLogs(ports, slug));
 
   const restart = ports.service.launchdKickstart(label);
@@ -1034,7 +1099,7 @@ export async function dispatchQuickstart(
   reports.push(provisionReport);
 
   // --- 7. Services -------------------------------------------------------------
-  const servicesReport = runServices(ports, { slug: s.slug, skip: flags.skipServices });
+  const servicesReport = runServices(ports, { slug: s.slug, configDir, skip: flags.skipServices });
   reports.push(servicesReport);
   if (!servicesReport.ok) {
     return finish(reports, 1, flags.json);


### PR DESCRIPTION
macOS parity — quickstart reaches a running daemon on a fresh host.

Closes #2322. Release-gate slice of epic #2319.

## Problem
On macOS, quickstart's service step only *restarted an already-loaded* launchd service; a fresh Mac never reached a running daemon, so the healthy-boot gate could only time out. The `cortex start` backstop was a printed hint, never exercised.

## Fix
On darwin, if the launchd service is NOT loaded (fresh host), the service step now starts the daemon directly via a detached `cortex start --config <pointer>` backstop instead of skipping. Load/unload stays arc-owned (invariant preserved). Idempotent: a re-run probes the pointer's pidfile and skips if already running (no double-start). Truncate→start→gate ordering matches the loaded-kickstart path. **Linux/systemd path is byte-unchanged.**

## Tests
`bun test quickstart.test.ts quickstart-lib.test.ts` → 130 pass, 0 fail. Fresh-start / already-running / start-failed branches exercised via mocked ports. `tsc --noEmit` + eslint clean.

## Release gate — NOT closed by this merge
The live adapter (detached spawn + fd redirection + setsid) is not unit-tested (matches the existing adapter-file convention). Its real behavior on a fresh Mac — daemon survives quickstart exit, boots to a healthy @luna reply, full `arc install && quickstart` end-to-end — is **principal-verification-required**. Merging the code does not tag v0.1.0; the live fresh-mac run does.

Also updates runbook §F2 to document the automated path + the backstop config-reapply limit.

Generated with Claude Code
