### PR TITLE
fix(stack): code capability carries a repo-scoped bash allowlist (#2331 7a)

### DIFF
--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -39,6 +39,7 @@ import { join } from "path";
 
 import { dispatchQuickstart } from "../quickstart";
 import { daemonErrorLogPath, daemonLogPath, launchdStackLabel } from "../quickstart-lib";
+import { loadConfigWithAgents } from "../../../../common/config/loader";
 import type {
   CommandResult,
   GatePort,
@@ -116,6 +117,9 @@ const CTX_KEYS = [
   "CTX_WEB_PORT",
   "CTX_WEB_TOKEN",
   "CLAUDE_CODE_OAUTH_TOKEN",
+  // cortex#2331 (7a) — OPTIONAL code-stack repo grant (sandboxed so a stray
+  // value never leaks a code allowlist into an unrelated test).
+  "CTX_REPO",
 ] as const;
 
 function withEnv<T>(env: Partial<Record<(typeof CTX_KEYS)[number], string>>, fn: () => Promise<T>): Promise<T> {
@@ -684,6 +688,42 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
     );
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("Healthy-boot gate ✓");
+  });
+
+  // cortex#2331 (7a) — CTX_REPO scaffolds a software-factory ("code") stack with
+  // a repo-scoped bash allowlist; its absence leaves a chat-only stack (the
+  // read-only floor). The MVP coding-Luna path the finding was about.
+  test("cortex#2331 7a: CTX_REPO scaffolds a code stack with a repo-scoped bash allowlist", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv({ CTX_REPO: "the-metafactory/cortex" }), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    const loaded = loadConfigWithAgents(join(configDir, "work", "work.yaml"));
+    const al = loaded.config.claude.bashAllowlist;
+    expect(al).toBeDefined();
+    const gitRule = al?.rules.find((r) => r.pattern.startsWith("^git"));
+    for (const verb of ["checkout", "commit", "push"]) {
+      expect(gitRule?.pattern).toContain(verb);
+    }
+    const ghRule = al?.rules.find((r) => r.pattern.startsWith("^gh"));
+    expect(ghRule?.repos).toEqual(["the-metafactory/cortex"]);
+  });
+
+  test("cortex#2331 7a: NO CTX_REPO leaves a chat-only stack (no bash allowlist)", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv(), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () => fakePorts()),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    const loaded = loadConfigWithAgents(join(configDir, "work", "work.yaml"));
+    expect(loaded.config.claude.bashAllowlist).toBeUndefined();
   });
 
   // A1's (#2297) negative-space tripwire — "darwin NEVER truncates" — guarded

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -414,6 +414,91 @@ describe("create --apply", () => {
 });
 
 // =============================================================================
+// create --capability code (cortex#2331 7a)
+// =============================================================================
+
+describe("create --capability code", () => {
+  test("(c) code stack composes + loads via the real loader with the repo-scoped allowlist", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas",
+      "--capability", "code", "--repo", "the-metafactory/cortex",
+      "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+
+    // The real loader (compose + zod-validate) accepts the written config — this
+    // IS the "parses against the schema" assertion (the apply path itself also
+    // runs validateConfigLoads, so exit 0 already proves it; assert the shape).
+    const loaded = loadConfigWithAgents(join(cfg, "demo", "demo.yaml"));
+    const al = loaded.config.claude.bashAllowlist;
+    expect(al).toBeDefined();
+    const gitRule = al?.rules.find((r) => r.pattern.startsWith("^git"));
+    for (const verb of ["checkout", "commit", "push", "branch", "log"]) {
+      expect(gitRule?.pattern).toContain(verb);
+    }
+    const ghRule = al?.rules.find((r) => r.pattern.startsWith("^gh"));
+    expect(ghRule?.repos).toEqual(["the-metafactory/cortex"]);
+  });
+
+  test("(b) a chat-only stack (no --capability) writes NO bashAllowlist", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const loaded = loadConfigWithAgents(join(cfg, "demo", "demo.yaml"));
+    expect(loaded.config.claude.bashAllowlist).toBeUndefined();
+  });
+
+  test("code stack without --repo still loads; gh rule is unscoped", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--capability", "code",
+      "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const loaded = loadConfigWithAgents(join(cfg, "demo", "demo.yaml"));
+    const ghRule = loaded.config.claude.bashAllowlist?.rules.find((r) => r.pattern.startsWith("^gh"));
+    expect(ghRule).toBeDefined();
+    expect(ghRule?.repos ?? []).toEqual([]);
+  });
+
+  test("--repo without --capability code is a usage error (nothing to scope)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--repo", "the-metafactory/cortex",
+      "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("requires --capability code");
+    expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+
+  test("an unrecognised --capability is a usage error", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--capability", "root",
+      "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("not recognised");
+    expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+
+  test("a malformed --repo is a usage error", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--capability", "code",
+      "--repo", "not-a-full-name", "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("owner/repo");
+    expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+});
+
+// =============================================================================
 // create — refuse overwrite
 // =============================================================================
 

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -23,7 +23,9 @@ import {
   retiredSeedPath,
   codeCapabilityBashAllowlist,
   CODE_GIT_VERBS,
+  CODE_GIT_WRITE_VERBS,
   CODE_GH_PR_VERBS,
+  CODE_GH_ISSUE_VERBS,
   type ScaffoldInputs,
 } from "../stack-lib";
 
@@ -249,6 +251,69 @@ describe("renderScaffold", () => {
 // =============================================================================
 
 describe("codeCapabilityBashAllowlist", () => {
+  // ---------------------------------------------------------------------------
+  // cortex#2331 (7a) review F3 — VERB-SET LOCK. Pin the exact verb sets so a
+  // future edit that widens them (adds `merge`, `reset`, `gh api`, …) trips a
+  // failing test, not a silent authority expansion. Exact-equality on the
+  // approved lists + negative assertions against the dangerous verbs.
+  // ---------------------------------------------------------------------------
+  test("(F3) the gh pr verb set is EXACTLY [create, view, list, diff, checks]", () => {
+    expect([...CODE_GH_PR_VERBS]).toEqual(["create", "view", "list", "diff", "checks"]);
+  });
+
+  test("(F3) the git WRITE verb set is EXACTLY the approved eight", () => {
+    expect([...CODE_GIT_WRITE_VERBS]).toEqual([
+      "checkout",
+      "switch",
+      "add",
+      "commit",
+      "push",
+      "pull",
+      "restore",
+      "stash",
+    ]);
+  });
+
+  test("(F3) the gh issue verb set is EXACTLY [view, list, comment, create]", () => {
+    expect([...CODE_GH_ISSUE_VERBS]).toEqual(["view", "list", "comment", "create"]);
+  });
+
+  test("(F3 negative) the git rule pattern contains NO reset/rebase/merge", () => {
+    const al = codeCapabilityBashAllowlist(["the-metafactory/cortex"]);
+    const gitRule = al.rules.find((r) => r.pattern.startsWith("^git"));
+    expect(gitRule).toBeDefined();
+    for (const forbidden of ["reset", "rebase", "merge"]) {
+      expect(gitRule?.pattern).not.toContain(forbidden);
+    }
+  });
+
+  test("(F3 negative) no gh rule pattern contains 'merge' or 'api'", () => {
+    const al = codeCapabilityBashAllowlist(["the-metafactory/cortex"]);
+    const ghRules = al.rules.filter((r) => r.pattern.startsWith("^gh"));
+    expect(ghRules.length).toBeGreaterThan(0);
+    for (const ghRule of ghRules) {
+      expect(ghRule.pattern).not.toContain("merge");
+      expect(ghRule.pattern).not.toContain("api");
+    }
+  });
+
+  test("(F2) the gh issue rule is present and pinned to the granted repo", () => {
+    const al = codeCapabilityBashAllowlist(["the-metafactory/cortex"]);
+    const issueRule = al.rules.find((r) => r.pattern.startsWith("^gh\\s+issue"));
+    expect(issueRule).toBeDefined();
+    for (const verb of CODE_GH_ISSUE_VERBS) {
+      expect(issueRule?.pattern).toContain(verb);
+    }
+    expect(issueRule?.repos).toEqual(["the-metafactory/cortex"]);
+  });
+
+  test("(F2) the gh pr comment rule is present and pinned to the granted repo", () => {
+    const al = codeCapabilityBashAllowlist(["the-metafactory/cortex"]);
+    const prCommentRule = al.rules.find((r) => r.pattern === "^gh\\s+pr\\s+comment\\b");
+    expect(prCommentRule).toBeDefined();
+    expect(prCommentRule?.repos).toEqual(["the-metafactory/cortex"]);
+  });
+
   test("git rule carries the exact read + write verb set, unscoped (repo scoping is cwd)", () => {
     const al = codeCapabilityBashAllowlist(["the-metafactory/cortex"]);
     const gitRule = al.rules.find((r) => r.pattern.startsWith("^git"));

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -21,6 +21,9 @@ import {
   readJoinedNetworkIds,
   parseLeafIncludeFiles,
   retiredSeedPath,
+  codeCapabilityBashAllowlist,
+  CODE_GIT_VERBS,
+  CODE_GH_PR_VERBS,
   type ScaffoldInputs,
 } from "../stack-lib";
 
@@ -238,6 +241,113 @@ describe("renderScaffold", () => {
     // Commented, not active — `stack create` never forces the key into the
     // parsed config; the daemon resolves the same default at runtime absent it.
     expect(system?.contents).not.toMatch(/^\s*workspaceDir:/m);
+  });
+});
+
+// =============================================================================
+// cortex#2331 (7a) — the code-capability bash allowlist
+// =============================================================================
+
+describe("codeCapabilityBashAllowlist", () => {
+  test("git rule carries the exact read + write verb set, unscoped (repo scoping is cwd)", () => {
+    const al = codeCapabilityBashAllowlist(["the-metafactory/cortex"]);
+    const gitRule = al.rules.find((r) => r.pattern.startsWith("^git"));
+    expect(gitRule).toBeDefined();
+    // Every declared git verb appears in the alternation…
+    for (const verb of CODE_GIT_VERBS) {
+      expect(gitRule?.pattern).toContain(verb);
+    }
+    // …the write verbs the coding loop needs are present…
+    for (const verb of ["checkout", "switch", "add", "commit", "push", "pull", "restore", "stash"]) {
+      expect(gitRule?.pattern).toContain(verb);
+    }
+    // …and git rules are NEVER repo-scoped (that field governs gh only).
+    expect(gitRule?.repos).toBeUndefined();
+  });
+
+  test("gh rule carries the exact pr verbs, pinned to the granted repo", () => {
+    const al = codeCapabilityBashAllowlist(["the-metafactory/cortex"]);
+    const ghRule = al.rules.find((r) => r.pattern.startsWith("^gh"));
+    expect(ghRule).toBeDefined();
+    for (const verb of CODE_GH_PR_VERBS) {
+      expect(ghRule?.pattern).toContain(verb);
+    }
+    expect(ghRule?.repos).toEqual(["the-metafactory/cortex"]);
+  });
+
+  test("with no granted repo the gh rule ships UNSCOPED (falls back to github.repos)", () => {
+    const al = codeCapabilityBashAllowlist([]);
+    const ghRule = al.rules.find((r) => r.pattern.startsWith("^gh"));
+    expect(ghRule?.repos).toBeUndefined();
+  });
+
+  test("retains the read-only utility floor (bashAllowlist REPLACES DEFAULT_CONFIG)", () => {
+    const al = codeCapabilityBashAllowlist([]);
+    const patterns = al.rules.map((r) => r.pattern);
+    // A code agent must not lose ls/cat/pwd when its allowlist replaces the floor.
+    expect(patterns).toContain("^ls\\b");
+    expect(patterns).toContain("^cat\\b");
+    expect(patterns).toContain("^pwd$");
+  });
+});
+
+describe("renderScaffold — code capability (cortex#2331 7a)", () => {
+  const base: ScaffoldInputs = {
+    slug: "demo",
+    principal: "andreas",
+    stackId: "andreas/demo",
+    agentId: "luna",
+    displayName: "Luna",
+    seedPath: "~/.config/nats/cortex-demo.nk",
+  };
+
+  test("(b) chat-only scaffold writes NO bashAllowlist (unchanged floor)", () => {
+    const files = renderScaffold(base);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    expect(system?.contents).not.toContain("bashAllowlist");
+    const parsed = parseYaml(system?.contents ?? "") as { claude?: { bashAllowlist?: unknown } };
+    expect(parsed.claude?.bashAllowlist).toBeUndefined();
+    // And the agent stays chat-only in the stack catalog + runtime.
+    const stack = files.find((f) => f.relPath === "stacks/demo.yaml");
+    expect(stack?.contents).not.toContain("id: code");
+  });
+
+  test("(a) code scaffold writes the allowlist with the exact verb set + repo pinning", () => {
+    const files = renderScaffold({ ...base, capabilities: ["chat", "code"], grantedRepos: ["the-metafactory/cortex"] });
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    const parsed = parseYaml(system?.contents ?? "") as {
+      claude?: { bashAllowlist?: { rules: { pattern: string; repos?: string[] }[]; repos: string[] } };
+    };
+    const al = parsed.claude?.bashAllowlist;
+    expect(al).toBeDefined();
+    const gitRule = al?.rules.find((r) => r.pattern.startsWith("^git"));
+    for (const verb of ["checkout", "switch", "add", "commit", "push", "pull", "restore", "stash", "log", "status"]) {
+      expect(gitRule?.pattern).toContain(verb);
+    }
+    const ghRule = al?.rules.find((r) => r.pattern.startsWith("^gh"));
+    expect(ghRule?.pattern).toContain("create");
+    expect(ghRule?.repos).toEqual(["the-metafactory/cortex"]);
+
+    // The agent declares chat + code in BOTH the catalog and its runtime.
+    const stack = files.find((f) => f.relPath === "stacks/demo.yaml");
+    expect(stack?.contents).toContain("id: code");
+    const parsedStack = parseYaml(stack?.contents ?? "") as {
+      agents?: { runtime?: { capabilities?: string[] } }[];
+      capabilities?: { id: string }[];
+    };
+    expect(parsedStack.agents?.[0]?.runtime?.capabilities).toEqual(["chat", "code"]);
+    expect((parsedStack.capabilities ?? []).map((c) => c.id).sort()).toEqual(["chat", "code"]);
+  });
+
+  test("code scaffold WITHOUT a granted repo writes the allowlist but leaves gh unscoped", () => {
+    const files = renderScaffold({ ...base, capabilities: ["chat", "code"], grantedRepos: [] });
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    const parsed = parseYaml(system?.contents ?? "") as {
+      claude?: { bashAllowlist?: { rules: { pattern: string; repos?: string[] }[] } };
+    };
+    const ghRule = parsed.claude?.bashAllowlist?.rules.find((r) => r.pattern.startsWith("^gh"));
+    expect(ghRule).toBeDefined();
+    expect(ghRule?.repos).toBeUndefined();
   });
 });
 

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -438,12 +438,20 @@ async function runScaffold(opts: {
   slug: string;
   principal: string;
   configDir: string;
+  /** cortex#2331 (7a) — when set (from CTX_REPO), scaffold a software-factory
+   *  ("code") stack scoped to this `owner/repo`: the stack's agent declares the
+   *  `code` capability and gets the git-write + gh-pr bash allowlist, repo-
+   *  scoped. Absent ⇒ a chat-only stack (unchanged). */
+  grantedRepo?: string;
 }): Promise<StepReport> {
   const create = await dispatchStack([
     "create",
     opts.slug,
     "--principal",
     opts.principal,
+    ...(opts.grantedRepo !== undefined
+      ? ["--capability", "code", "--repo", opts.grantedRepo]
+      : []),
     "--apply",
     "--config-dir",
     opts.configDir,
@@ -985,7 +993,19 @@ export async function dispatchQuickstart(
   }
 
   // --- 4. Scaffold ---------------------------------------------------------
-  const scaffoldReport = await runScaffold({ slug: s.slug, principal: s.principal, configDir });
+  // cortex#2331 (7a) — OPTIONAL: naming one repo via CTX_REPO scaffolds a
+  // software-factory ("code") stack — the agent declares the `code` capability
+  // and gets a repo-scoped git-write + gh-pr bash allowlist (least-privilege,
+  // one repo). This is the luna-stack MVP path ("read+write access scoped to
+  // one repo you name"). Absent ⇒ a chat-only stack (unchanged). A malformed
+  // value is rejected by `cortex stack create --repo` (surfaced as a step fail).
+  const ctxRepo = (process.env.CTX_REPO ?? "").trim();
+  const scaffoldReport = await runScaffold({
+    slug: s.slug,
+    principal: s.principal,
+    configDir,
+    ...(ctxRepo.length > 0 ? { grantedRepo: ctxRepo } : {}),
+  });
   reports.push(scaffoldReport);
   if (!scaffoldReport.ok) {
     return finish(reports, 1, flags.json);

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -384,12 +384,9 @@ export interface ScaffoldFile {
 // self-complete: the read-only utility floor + git READ verbs are re-declared
 // alongside the write delta.
 
-/** git verbs the code allowlist permits: the read-only floor (mirrors the hook's
- *  DEFAULT_CONFIG git rule) PLUS the write verbs the coding loop needs. Repo
- *  scoping for git is via the session cwd/allowedDirs, NOT a per-rule `repos`
- *  field — that field governs only `gh` commands (bash-guard.hook.ts). */
-export const CODE_GIT_VERBS = [
-  // read-only floor (kept in sync with DEFAULT_CONFIG's git rule)
+/** git READ verbs the code allowlist permits — the read-only floor, mirrors the
+ *  hook's DEFAULT_CONFIG git rule. */
+export const CODE_GIT_READ_VERBS = [
   "log",
   "diff",
   "show",
@@ -398,7 +395,13 @@ export const CODE_GIT_VERBS = [
   "fetch",
   "remote",
   "rev-parse",
-  // write delta — the software-factory loop (branch/commit/push, cortex#2331 7a)
+] as const;
+
+/** git WRITE verbs the code allowlist permits — the software-factory loop
+ *  (branch/commit/push, cortex#2331 7a). Locked to exactly these eight: it must
+ *  NEVER include history-rewriters (reset/rebase/merge) — those are the verbs
+ *  the 7a review flags as out-of-scope for an unattended code agent. */
+export const CODE_GIT_WRITE_VERBS = [
   "checkout",
   "switch",
   "add",
@@ -409,8 +412,25 @@ export const CODE_GIT_VERBS = [
   "stash",
 ] as const;
 
-/** `gh pr` verbs the code allowlist permits — repo-scoped to the granted repo. */
+/** git verbs the code allowlist permits: the read-only floor PLUS the write
+ *  verbs the coding loop needs. Repo scoping for git is via the session
+ *  cwd/allowedDirs, NOT a per-rule `repos` field — that field governs only `gh`
+ *  commands (bash-guard.hook.ts). */
+export const CODE_GIT_VERBS = [
+  ...CODE_GIT_READ_VERBS,
+  ...CODE_GIT_WRITE_VERBS,
+] as const;
+
+/** `gh pr` verbs the code allowlist permits — repo-scoped to the granted repo.
+ *  Locked to exactly these five: NEVER `merge` (a merge belongs to pilot/the
+ *  reviewer, not an unattended code agent) and NEVER a catch-all that could
+ *  reach `gh api`. */
 export const CODE_GH_PR_VERBS = ["create", "view", "list", "diff", "checks"] as const;
+
+/** `gh issue` verbs the code allowlist permits — repo-scoped to the granted
+ *  repo. Restores the CLAUDE.md issue-tracking workflow (comment on start,
+ *  create/view/list) for code agents (cortex#2331 7a review F2). */
+export const CODE_GH_ISSUE_VERBS = ["view", "list", "comment", "create"] as const;
 
 /** Read-only shell utilities carried into the code allowlist. The hook's
  *  DEFAULT_CONFIG floor, re-declared because a stack `bashAllowlist` REPLACES
@@ -448,17 +468,28 @@ export interface BashAllowlist {
  */
 export function codeCapabilityBashAllowlist(grantedRepos: string[]): BashAllowlist {
   const gitPattern = `^git\\s+(${CODE_GIT_VERBS.join("|")})\\b`;
-  const ghPattern = `^gh\\s+pr\\s+(${CODE_GH_PR_VERBS.join("|")})\\b`;
-  // Pin the gh rule to the granted repo(s) when known; else ship it unscoped so
+  const ghPrPattern = `^gh\\s+pr\\s+(${CODE_GH_PR_VERBS.join("|")})\\b`;
+  const ghIssuePattern = `^gh\\s+issue\\s+(${CODE_GH_ISSUE_VERBS.join("|")})\\b`;
+  const ghPrCommentPattern = `^gh\\s+pr\\s+comment\\b`;
+  // Pin every gh rule to the granted repo(s) when known; else ship unscoped so
   // `gh` falls back to the stack's own `github.repos` (empty on a fresh
   // scaffold). git rules carry NO `repos` — git scoping is cwd/allowedDirs.
-  const ghRule: BashAllowRule =
-    grantedRepos.length > 0 ? { pattern: ghPattern, repos: grantedRepos } : { pattern: ghPattern };
+  //
+  // NOTE: with the bash-guard's F1 fail-closed change, a pinned gh rule now
+  // REQUIRES the agent to pass `--repo owner/name` (a cwd-inferred gh call is
+  // denied). That is intended — it matches the security-preamble's "Always pass
+  // --repo" instruction. We deliberately DO NOT add `gh api` / `gh repo` /
+  // `gh run` here: `gh api` can reach arbitrary REST endpoints (including
+  // PR-merge) and must stay off the code allowlist.
+  const pin = (pattern: string): BashAllowRule =>
+    grantedRepos.length > 0 ? { pattern, repos: grantedRepos } : { pattern };
   return {
     rules: [
       ...CODE_READONLY_UTIL_PATTERNS.map((pattern) => ({ pattern })),
       { pattern: gitPattern },
-      ghRule,
+      pin(ghPrPattern),
+      pin(ghIssuePattern),
+      pin(ghPrCommentPattern),
     ],
     repos: [],
   };

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -339,12 +339,158 @@ export interface ScaffoldInputs {
   /** Conventional seed path (`~/.config/nats/cortex-<slug>.nk`). NOT generated
    *  here — `arc upgrade cortex` auto-provisions the seed on first install. */
   seedPath: string;
+  /**
+   * cortex#2331 (7a) — the agent's declared runtime capabilities. `chat` is
+   * always implied (the floor); when this list includes `code`, the agent is a
+   * software-factory tier assistant and the scaffold ALSO writes a
+   * `claude.bashAllowlist` carrying the git write verbs (branch/commit/push) +
+   * `gh pr` verbs on top of the read-only floor. Absent/omitting `code` ⇒ a
+   * chat-only stack with NO allowlist (unchanged behaviour — the bash guard's
+   * read-only DEFAULT_CONFIG floor applies). Default: `["chat"]`.
+   */
+  capabilities?: string[];
+  /**
+   * cortex#2331 (7a) — the repo(s) the code capability is scoped to, in
+   * `owner/repo` (full) form. Pins the code allowlist's `gh pr` rules via their
+   * `repos:` field. When empty and `code` is declared, the gh rules ship
+   * unscoped (the caller had no granted repo — `gh` then falls back to the
+   * stack's own `github.repos`, empty on a fresh scaffold). Ignored when `code`
+   * is not among `capabilities`. Default: `[]`.
+   */
+  grantedRepos?: string[];
 }
 
 /** A scaffold file to write, relative to the new stack's dir. */
 export interface ScaffoldFile {
   relPath: string;
   contents: string;
+}
+
+// =============================================================================
+// cortex#2331 (7a) — the code-capability bash allowlist
+// =============================================================================
+//
+// Finding 7a: a fresh quickstart/luna-stack scaffold shipped NO
+// `claude.bashAllowlist`, so its dispatched sessions fell back to
+// bash-guard.hook.ts's read-only DEFAULT_CONFIG — git log/diff/status but NO
+// checkout/commit/push. A software-factory ("code") agent could not run its
+// core loop. The approved fix (issue #2331, 7a-CONFIRMED) does NOT widen the
+// global guard defaults (they stay the correct floor for chat agents); instead
+// the `code` CAPABILITY carries its allowlist — a stack whose agent declares
+// `code` gets this block written into its scaffolded config.
+//
+// A stack config's `bashAllowlist` REPLACES the hook's DEFAULT_CONFIG (it is
+// not merged — see loadConfig() in bash-guard.hook.ts), so this set must be
+// self-complete: the read-only utility floor + git READ verbs are re-declared
+// alongside the write delta.
+
+/** git verbs the code allowlist permits: the read-only floor (mirrors the hook's
+ *  DEFAULT_CONFIG git rule) PLUS the write verbs the coding loop needs. Repo
+ *  scoping for git is via the session cwd/allowedDirs, NOT a per-rule `repos`
+ *  field — that field governs only `gh` commands (bash-guard.hook.ts). */
+export const CODE_GIT_VERBS = [
+  // read-only floor (kept in sync with DEFAULT_CONFIG's git rule)
+  "log",
+  "diff",
+  "show",
+  "status",
+  "branch",
+  "fetch",
+  "remote",
+  "rev-parse",
+  // write delta — the software-factory loop (branch/commit/push, cortex#2331 7a)
+  "checkout",
+  "switch",
+  "add",
+  "commit",
+  "push",
+  "pull",
+  "restore",
+  "stash",
+] as const;
+
+/** `gh pr` verbs the code allowlist permits — repo-scoped to the granted repo. */
+export const CODE_GH_PR_VERBS = ["create", "view", "list", "diff", "checks"] as const;
+
+/** Read-only shell utilities carried into the code allowlist. The hook's
+ *  DEFAULT_CONFIG floor, re-declared because a stack `bashAllowlist` REPLACES
+ *  (not extends) the default — a code agent must not lose `ls`/`cat`/`pwd`. */
+const CODE_READONLY_UTIL_PATTERNS = [
+  "^ls\\b",
+  "^pwd$",
+  "^echo\\b",
+  "^cat\\b",
+  "^head\\b",
+  "^tail\\b",
+  "^wc\\b",
+  "^which\\b",
+  "^file\\b",
+] as const;
+
+/** One allowlist rule (mirrors the `bashAllowlist.rules[]` schema — a regex
+ *  pattern + an optional gh repo whitelist). */
+export interface BashAllowRule {
+  pattern: string;
+  repos?: string[];
+}
+
+/** The `claude.bashAllowlist` shape (mirrors config.ts's schema). */
+export interface BashAllowlist {
+  rules: BashAllowRule[];
+  repos: string[];
+}
+
+/**
+ * Build the code-capability bash allowlist for a stack scoped to `grantedRepos`
+ * (`owner/repo` full form). The single source of truth for the verb set — the
+ * scaffold renderer and its tests both read it, so the "exact verb set"
+ * assertion can never drift from what ships (cortex#2331 7a).
+ */
+export function codeCapabilityBashAllowlist(grantedRepos: string[]): BashAllowlist {
+  const gitPattern = `^git\\s+(${CODE_GIT_VERBS.join("|")})\\b`;
+  const ghPattern = `^gh\\s+pr\\s+(${CODE_GH_PR_VERBS.join("|")})\\b`;
+  // Pin the gh rule to the granted repo(s) when known; else ship it unscoped so
+  // `gh` falls back to the stack's own `github.repos` (empty on a fresh
+  // scaffold). git rules carry NO `repos` — git scoping is cwd/allowedDirs.
+  const ghRule: BashAllowRule =
+    grantedRepos.length > 0 ? { pattern: ghPattern, repos: grantedRepos } : { pattern: ghPattern };
+  return {
+    rules: [
+      ...CODE_READONLY_UTIL_PATTERNS.map((pattern) => ({ pattern })),
+      { pattern: gitPattern },
+      ghRule,
+    ],
+    repos: [],
+  };
+}
+
+/**
+ * Render a `claude.bashAllowlist` block as YAML indented to sit INSIDE the
+ * `claude:` mapping (2-space base indent). Patterns/repos are emitted via
+ * `JSON.stringify` — a JSON-quoted scalar is a valid YAML double-quoted scalar,
+ * so backslashes in the regexes survive intact and can never inject YAML.
+ * Returns the empty string for a chat-only stack (no `code` capability) so the
+ * template omits the block entirely.
+ */
+function renderBashAllowlistYaml(allowlist: BashAllowlist): string {
+  const lines: string[] = [];
+  lines.push("  # cortex#2331 7a — code-capability bash allowlist. This stack's agent declares");
+  lines.push("  # the `code` runtime capability (software-factory tier), so its bash guard adds");
+  lines.push("  # the git write verbs (branch/commit/push) + `gh pr` verbs on top of the read-");
+  lines.push("  # only floor. A stack bashAllowlist REPLACES the guard's DEFAULT_CONFIG, so the");
+  lines.push("  # read-only utilities + git-read verbs are re-declared here. `gh` rules are repo-");
+  lines.push("  # scoped via `repos:`; git repo-scoping is the session cwd/allowedDirs, not a");
+  lines.push("  # per-rule field (bash-guard.hook.ts). Chat-only stacks omit this block.");
+  lines.push("  bashAllowlist:");
+  lines.push("    rules:");
+  for (const rule of allowlist.rules) {
+    lines.push(`      - pattern: ${JSON.stringify(rule.pattern)}`);
+    if (rule.repos !== undefined) {
+      lines.push(`        repos: ${JSON.stringify(rule.repos)}`);
+    }
+  }
+  lines.push(`    repos: ${JSON.stringify(allowlist.repos)}`);
+  return lines.join("\n");
 }
 
 /**
@@ -359,16 +505,25 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   const { slug, principal, stackId, agentId, displayName, seedPath } = inputs;
   const Display = displayName;
 
+  // cortex#2331 (7a) — `chat` is the always-present floor; `code` opts the stack
+  // into the software-factory bash allowlist. Dedupe + keep chat first.
+  const declared = inputs.capabilities ?? ["chat"];
+  const hasCode = declared.includes("code");
+  const grantedRepos = inputs.grantedRepos ?? [];
+  const bashAllowlistBlock = hasCode
+    ? renderBashAllowlistYaml(codeCapabilityBashAllowlist(grantedRepos))
+    : "";
+
   return [
-    { relPath: "system/system.yaml", contents: systemYaml(slug, seedPath) },
+    { relPath: "system/system.yaml", contents: systemYaml(slug, seedPath, bashAllowlistBlock) },
     { relPath: "surfaces/surfaces.yaml", contents: surfacesYaml(agentId, stackId) },
-    { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath) },
+    { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath, hasCode) },
     { relPath: `${slug}.yaml`, contents: pointerYaml(slug) },
     { relPath: `personas/${agentId}.md`, contents: personaStub(agentId, Display, stackId) },
   ];
 }
 
-function systemYaml(slug: string, seedPath: string): string {
+function systemYaml(slug: string, seedPath: string, bashAllowlistBlock: string): string {
   // The cross-cutting substrate layer — substituted from
   // docs/config-layout/system/system.yaml. NO active `identity:` block: the
   // authoritative, auto-provisioned signing identity is per-stack and lives in
@@ -391,7 +546,7 @@ claude:
   allowedTools: []
   disallowedTools:
     - Write
-  # workspaceDir — the dispatched CC session's cwd when no allowedDirs/
+${bashAllowlistBlock === "" ? "" : bashAllowlistBlock + "\n"}  # workspaceDir — the dispatched CC session's cwd when no allowedDirs/
   # dirRestrictions resolve one (a bare stack — cortex#2097). Scoped to this
   # stack so its dispatched sessions never inherit the daemon's own cwd
   # ($HOME / the cortex install repo). \`cortex stack create\` already
@@ -528,7 +683,22 @@ function stackYaml(
   agentId: string,
   displayName: string,
   seedPath: string,
+  hasCode: boolean,
 ): string {
+  // cortex#2331 (7a) — a `code` agent declares chat + code in its stack catalog
+  // AND its runtime.capabilities; the paired bash allowlist lives in the
+  // system.yaml `claude` block (where `claude` is owned in the config-split
+  // layout). A chat-only stack keeps just `chat`.
+  const codeCatalogEntry = hasCode
+    ? `  - id: code
+    description: Software-factory dispatch (branch/commit/push + gh pr) — cortex#2331 7a
+    provided_by: [${agentId}]
+`
+    : "";
+  const agentRuntimeCapabilities = hasCode
+    ? `        - chat
+        - code`
+    : `        - chat`;
   // The per-deployment stack layer — substituted from
   // docs/config-layout/stacks/research.yaml. principal-only policy pattern.
   return `# =============================================================================
@@ -569,7 +739,7 @@ capabilities:
   - id: chat
     description: Conversational dispatch (no-prefix synchronous chat)
     provided_by: [${agentId}]
-
+${codeCatalogEntry}
 # -----------------------------------------------------------------------------
 # policy — PRINCIPAL-ONLY pattern (CRITICAL for any guild others can join)
 # -----------------------------------------------------------------------------
@@ -621,7 +791,7 @@ agents:
       substrate: claude-code
       mode: in-process
       capabilities:
-        - chat
+${agentRuntimeCapabilities}
     # EMPTY — the Discord binding folds in from surfaces/surfaces.yaml.
     presence: {}
 

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -102,6 +102,14 @@ const SPEC: SubcommandSpec<StackSubcommand> = {
         "--principal": "value",
         "--display-name": "value",
         "--agent": "value",
+        // cortex#2331 (7a) — declare an extra runtime capability beyond the
+        // implied `chat` floor. `code` opts the stack into the software-factory
+        // bash allowlist (git write verbs + gh pr). Repeatable; only `code` is
+        // recognised today.
+        "--capability": "value-list",
+        // cortex#2331 (7a) — the repo the `code` grant is scoped to
+        // (`owner/repo`). Pins the allowlist's gh rules. Repeatable.
+        "--repo": "value-list",
         "--config-dir": "value",
         "--apply": "bool",
         "--dry-run": "bool",
@@ -157,6 +165,20 @@ function optionalValueFlag(
   const v = flags[name];
   return typeof v === "string" ? v : undefined;
 }
+
+/** Read a repeatable `value-list` flag as a string[] (empty when absent). */
+function listValueFlag(flags: FlagMap, name: string): string[] {
+  const v = flags[name];
+  return Array.isArray(v) ? v : [];
+}
+
+/** cortex#2331 (7a) — extra runtime capabilities the scaffolder knows how to
+ *  wire beyond the implied `chat` floor. Only `code` is recognised today (it
+ *  carries the software-factory bash allowlist). */
+const KNOWN_EXTRA_CAPABILITIES = new Set(["code"]);
+
+/** `owner/repo` shape for `--repo` (GitHub full-name grammar, permissive). */
+const REPO_FULLNAME_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 
 /**
  * `create` writes to disk; the DEFAULT is dry-run (safe). `--apply` opts into
@@ -276,6 +298,46 @@ function runCreate(
     );
   }
 
+  // --- capabilities + granted repos (cortex#2331 7a) -----------------------
+  // `chat` is the always-present floor; `--capability code` opts the stack into
+  // the software-factory bash allowlist. Reject any capability the scaffolder
+  // doesn't know how to wire (a typo must not silently produce a dead catalog
+  // entry). `--repo owner/repo` pins the code allowlist's gh rules.
+  const extraCapabilities: string[] = [];
+  for (const cap of listValueFlag(flags, "--capability")) {
+    if (cap === "chat") continue; // the implied floor — accepted, deduped
+    if (!KNOWN_EXTRA_CAPABILITIES.has(cap)) {
+      return usageError(
+        "create",
+        `--capability "${cap}" is not recognised (known: ${[...KNOWN_EXTRA_CAPABILITIES].join(", ")})`,
+        json,
+      );
+    }
+    if (!extraCapabilities.includes(cap)) extraCapabilities.push(cap);
+  }
+  const capabilities = ["chat", ...extraCapabilities];
+
+  const grantedRepos: string[] = [];
+  for (const repo of listValueFlag(flags, "--repo")) {
+    if (!REPO_FULLNAME_RE.test(repo)) {
+      return usageError(
+        "create",
+        `--repo "${repo}" must be an "owner/repo" GitHub full name`,
+        json,
+      );
+    }
+    if (!grantedRepos.includes(repo)) grantedRepos.push(repo);
+  }
+  // A --repo without the `code` capability has nothing to scope — reject rather
+  // than silently drop it (the principal likely forgot `--capability code`).
+  if (grantedRepos.length > 0 && !extraCapabilities.includes("code")) {
+    return usageError(
+      "create",
+      `--repo requires --capability code (there is nothing to repo-scope without the code capability)`,
+      json,
+    );
+  }
+
   // --- derive the born-aligned stack id ------------------------------------
   const stackId = `${principal}/${slug}`;
   const seedPath = `~/.config/nats/cortex-${slug}.nk`;
@@ -328,11 +390,11 @@ function runCreate(
   }
 
   // --- render --------------------------------------------------------------
-  const files = renderScaffold({ slug, principal, stackId, agentId, displayName, seedPath });
+  const files = renderScaffold({ slug, principal, stackId, agentId, displayName, seedPath, capabilities, grantedRepos });
 
   // --- dry-run (DEFAULT): print the file set, touch NOTHING ----------------
   if (!applyRes.apply) {
-    return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, false, json, workspaceDir);
+    return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, false, json, workspaceDir, capabilities, grantedRepos);
   }
 
   // --- apply: write the file set -------------------------------------------
@@ -402,7 +464,7 @@ function runCreate(
     );
   }
 
-  return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, true, json, workspaceDir);
+  return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, true, json, workspaceDir, capabilities, grantedRepos);
 }
 
 function renderPlan(
@@ -416,7 +478,10 @@ function renderPlan(
   applied: boolean,
   json: boolean,
   workspaceDir: string,
+  capabilities: string[],
+  grantedRepos: string[],
 ): ExitResult {
+  const hasCode = capabilities.includes("code");
   if (json) {
     return ok(
       renderJson(
@@ -433,6 +498,9 @@ function renderPlan(
             workspace_dir: workspaceDir,
             aligned: "true",
             applied: applied ? "true" : "false",
+            // cortex#2331 (7a) — capability set + (for code) the repo scoping.
+            capabilities: capabilities.join(","),
+            ...(hasCode && { code_allowlist: "true", granted_repos: grantedRepos.join(",") }),
           },
         ),
       ),
@@ -446,6 +514,11 @@ function renderPlan(
   lines.push(`  principal:  ${principal}`);
   lines.push(`  stack.id:   ${stackId}   (born aligned: dir == slug == trailing segment)`);
   lines.push(`  agent:      ${agentId}`);
+  lines.push(`  caps:       ${capabilities.join(", ")}`);
+  if (hasCode) {
+    const scope = grantedRepos.length > 0 ? grantedRepos.join(", ") : "(unscoped — falls back to github.repos)";
+    lines.push(`  code grant: bash allowlist written (git write verbs + gh pr) — gh repo scope: ${scope}`);
+  }
   lines.push(`  seed path:  ${seedPath}   (auto-provisioned by 'arc upgrade cortex' — NOT generated here)`);
   lines.push(`  workspace:  ${workspaceDir}   (${applied ? "created" : "would create"}, 0700 — the dispatch cwd fallback dir, cortex#2097)`);
   lines.push("");
@@ -929,6 +1002,12 @@ Flags (create):
                         zero or 2+ principals are present, it is REQUIRED.
   --display-name <name> The agent's display name (default: capitalized agent id).
   --agent <id>          The agent id on the scaffolded stack (default: assistant).
+  --capability <cap>    Declare an extra runtime capability beyond the implied
+                        chat floor (repeatable). \`code\` opts the stack into the
+                        software-factory bash allowlist (git write verbs + gh pr,
+                        cortex#2331 7a). Only \`code\` is recognised today.
+  --repo <owner/repo>   Repo the \`code\` grant is scoped to (repeatable); pins the
+                        allowlist's gh rules. Requires --capability code.
   --config-dir <path>   Config dir to create the stack under (default:
                         ~/.config/cortex). The stack lands at <config-dir>/<slug>/.
   --apply               Write the files (default: dry-run).

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -546,6 +546,78 @@ describe("bash-guard.hook — structured deny output", () => {
   });
 });
 
+// =============================================================================
+// cortex#2331 (7a) review F1 — the gh repo-pin bypass close.
+//
+// extractGhRepo previously matched only the WHITESPACE flag form
+// (`--repo owner/name` / `-R owner/name`). gh ALSO accepts the `=` form
+// (`--repo=owner/name` / `-R=owner/name`), so an agent on a repo-pinned rule
+// could reach any repo via `gh pr view --repo=other/repo`. And a pinned rule
+// with NO repo flag at all (cwd-inferred) fell through to a grant — the pin was
+// silently skippable. Both are now closed: the `=` form is extracted, and a
+// pinned rule with no extractable repo FAILS CLOSED (deny). Rules WITHOUT a
+// `repos` restriction are unchanged (the read-only floor keeps its behaviour).
+// =============================================================================
+describe("bash-guard.hook — gh repo-pin bypass close (F1)", () => {
+  // A repo-pinned gh rule: only the-metafactory/cortex is reachable.
+  const pinnedConfig = JSON.stringify({
+    rules: [{ pattern: "^gh\\s+(pr|issue)\\s", repos: ["the-metafactory/cortex"] }],
+  });
+  // An UNRESTRICTED gh rule (no repos on the rule, no top-level repos) — the
+  // floor behaviour that must stay unchanged by the fail-closed direction.
+  const floorConfig = JSON.stringify({
+    rules: [{ pattern: "^gh\\s+(pr|issue)\\s" }],
+  });
+
+  function runPinned(cmd: string) {
+    return runHook(cmd, {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: pinnedConfig,
+    });
+  }
+
+  test("`--repo=evil/other` (= form) on a pinned rule is DENIED (bypass closed)", () => {
+    const r = runPinned("gh pr view --repo=the-metafactory/some-other-repo 1");
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain(
+      "the-metafactory/some-other-repo",
+    );
+  });
+
+  test("`--repo=granted/repo` (= form) on a pinned rule is GRANTED", () => {
+    const r = runPinned("gh pr view --repo=the-metafactory/cortex 1");
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("`-R=granted/repo` (short = form) on a pinned rule is GRANTED", () => {
+    const r = runPinned("gh pr view -R=the-metafactory/cortex 1");
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("pinned rule with NO repo flag FAILS CLOSED (deny, pass --repo reason)", () => {
+    const r = runPinned("gh pr create --title x --body y");
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("--repo owner/name");
+  });
+
+  test("unrestricted floor rule with NO repo flag is still ALLOWED (unchanged)", () => {
+    const r = runHook("gh pr list", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: floorConfig,
+    });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+});
+
 describe("bash-guard.hook — block telemetry", () => {
   let homeDir: string;
 

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -140,11 +140,19 @@ function loadConfig(): GuardConfig | null {
 }
 
 /**
- * Extract repo from gh CLI command (--repo owner/name or -R owner/name).
- * Also handles: gh api repos/owner/name/...
+ * Extract repo from a gh CLI command. Matches BOTH the whitespace form
+ * (`--repo owner/name`, `-R owner/name`) AND the `=` form (`--repo=owner/name`,
+ * `-R=owner/name`) — gh accepts either, and matching only whitespace left the
+ * `=` form as a repo-pin bypass (cortex#2331 7a review F1). Also handles the
+ * `gh api repos/owner/name/...` path form.
+ *
+ * Returns null when no repo can be determined from the command. Callers that
+ * carry a `repos` restriction treat null as FAIL-CLOSED (deny) — a pin you can
+ * silently skip is not a pin.
  */
 function extractGhRepo(command: string): string | null {
-  const repoFlag = /(?:--repo|-R)\s+([^\s]+)/.exec(command);
+  // `(?:\s+|=)` accepts the space form and the `=` form for both flag spellings.
+  const repoFlag = /(?:--repo|-R)(?:\s+|=)([^\s]+)/.exec(command);
   if (repoFlag) return repoFlag[1] ?? null;
 
   const apiPath = /gh\s+api\s+repos\/([^/]+\/[^/\s]+)/.exec(command);
@@ -484,7 +492,24 @@ async function main(): Promise<void> {
             const repos = rule.repos ?? config.repos ?? [];
             if (repos.length > 0) {
               const repo = extractGhRepo(trimmed);
-              if (repo && !repos.includes(repo)) {
+              // FAIL-CLOSED (cortex#2331 7a review F1): a rule pinned to a repo
+              // set but no repo could be extracted (e.g. `gh pr create` with no
+              // --repo, cwd-inferred) must DENY — a pin you can silently skip by
+              // omitting the flag is not a pin. Rules WITHOUT a `repos`
+              // restriction are unaffected (repos.length === 0 skips this block).
+              if (!repo) {
+                const reason =
+                  `[Cortex Bash Guard] Blocked "${trimmed.slice(0, 80)}": ` +
+                  `this gh rule is pinned to repo(s) [${repos.join(", ")}] but no ` +
+                  `repo could be determined from the command. Pass ` +
+                  `--repo owner/name explicitly.`;
+                // Write the security decision FIRST — telemetry I/O
+                // (a filesystem appendFileSync) must never delay a deny.
+                deny(reason);
+                await emitBlockEvent(sessionId, reason, command);
+                return;
+              }
+              if (!repos.includes(repo)) {
                 const reason =
                   `[Cortex Bash Guard] Blocked "${trimmed.slice(0, 80)}": ` +
                   `repo "${repo}" is not in the allowed repo list ` +

--- a/src/runner/hooks/mcp-guard.hook.ts
+++ b/src/runner/hooks/mcp-guard.hook.ts
@@ -19,6 +19,16 @@
  * a blocking hook beats allow-by-default), it denies every `mcp__*` invocation
  * that is not covered by the session's grant list.
  *
+ * ## Where this hook is wired (it is NOT in cortex-hooks.json)
+ *
+ * This hook is registered DYNAMICALLY, per session, by cc-session
+ * (`src/runner/cc-session.ts:97-111`) into the curated `--settings` file it
+ * writes for each dispatched CC session — the same dynamic pattern skill-guard
+ * uses, gated on `mcpGrants` being defined. It is deliberately ABSENT from
+ * `src/settings/cortex-hooks.json` (that file wires the cc-events tap, not the
+ * per-session policy guards). A tester inspecting the hooks dir or that JSON
+ * won't see it wired — it isn't unwired, it's session-scoped. See cc-session.ts.
+ *
  * ## Grant grammar
  *
  * The grant list reaches this hook via the `CORTEX_MCP_GRANTS` env var (a


### PR DESCRIPTION
The `code` capability now carries a repo-scoped bash allowlist — the fix for the first field test's core-loop blocker (#2331 finding 7a).

## Problem
bash-guard's defaults permit only read-only git verbs, and a fresh scaffold ships no `claude.bashAllowlist` override — so the shipped software-factory tier could not branch/commit/push at all (confirmed on #2331).

## Design (as approved)
Global defaults stay the read-only floor for chat agents. A stack scaffolded with the `code` capability gets a `claude.bashAllowlist` written into its **system.yaml** `claude` block: git read+write verbs (no `repos` field — git scoping stays session cwd/allowedDirs, per existing guard semantics), `gh pr create/view/list/diff/checks` pinned to the granted repo, and the read-only utility floor re-declared (a stack allowlist REPLACES the hook defaults, so the floor must travel).

## Seam
`cortex stack create` (`stack.ts` + `stack-lib.ts`) — where the agent's declared capability is known; quickstart delegates scaffolding there, so both paths are covered from one place. New: `--capability code` + `--repo owner/repo` (usage-errors write nothing); quickstart honors optional `CTX_REPO` (absent ⇒ chat-only, byte-unchanged).

## Riders
- `mcp-guard.hook.ts` → 755 (matches siblings) + header comment naming its DYNAMIC registration via cc-session's curated settings (testers keep reading it as unwired — #2331 finding 3).

## Tests
stack-lib + stack-cli 72 pass · quickstart 63 pass · mcp-guard 30 pass · bash-guard suite in a 222-pass run · `tsc --noEmit` + eslint clean. Chat-only scaffolds proven to write NO allowlist.

## Known residual (follow-up, not this PR)
Scaffolded system.yaml still ships `disallowedTools: [Write]` — a code agent can Edit existing files but not create new ones via the Write tool. Filed as a follow-up on #2331.

Part of #2331 (finding 7a).

Generated with Claude Code
