### PR TITLE
fix(bash-guard): drop gh api/run from the DEFAULT floor (cortex#2335)

### DIFF
--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -618,6 +618,97 @@ describe("bash-guard.hook — gh repo-pin bypass close (F1)", () => {
   });
 });
 
+// =============================================================================
+// cortex#2335 — the DEFAULT floor's gh rule drops `api` and `run`.
+//
+// The floor runs with `repos: []`, so the repo-pin block (F1) never engages for
+// it. While `api`/`run` were on the floor gh rule, ANY bash-guarded agent on the
+// default floor (channel set, no custom CORTEX_BASH_GUARD) could auto-approve
+// `gh api -X PUT repos/<o>/<r>/pulls/<n>/merge` (merge a PR), `gh api -X DELETE`,
+// `gh api graphql`, `gh api user`, and `gh run` workflow dispatch — a raw REST
+// surface STRONGER than the deliberately-narrowed code capability (whose
+// allowlist omits exactly these; stack-lib.ts). The floor now exposes the
+// porcelain verbs (pr/issue/repo) only; a stack needing `api`/`run` declares an
+// explicit (ideally repos-pinned) rule. These tests drive the DEFAULT floor
+// itself — CORTEX_CHANNEL set, NO agent-id, NO CORTEX_BASH_GUARD → loadConfig()
+// returns DEFAULT_CONFIG (not the F1 floorConfig mirror, which is a stand-in).
+// =============================================================================
+describe("bash-guard.hook — floor drops gh api/run (cortex#2335)", () => {
+  // A real DEFAULT-floor session: channel present (passes gate-1), no agent-id
+  // (no gate-2 CLI bypass), no CORTEX_BASH_GUARD (loadConfig → DEFAULT_CONFIG).
+  function runFloor(cmd: string) {
+    return runHook(cmd, {
+      CORTEX_CHANNEL: "community",
+      CORTEX_AGENT_ID: undefined,
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: undefined,
+    });
+  }
+
+  function expectFloorDeny(stdout: string): void {
+    const out = JSON.parse(stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecision).not.toBe("allow");
+    expect(out.continue).toBeUndefined();
+  }
+
+  test("`gh api -X PUT .../pulls/N/merge` is DENIED on the floor (the hole)", () => {
+    const r = runFloor(
+      "gh api -X PUT repos/the-metafactory/cortex/pulls/1/merge",
+    );
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh api user` (raw endpoint, no repo to pin) is DENIED on the floor", () => {
+    const r = runFloor("gh api user");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh api graphql` is DENIED on the floor", () => {
+    const r = runFloor("gh api graphql -f query='{viewer{login}}'");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh run list` (workflow dispatch surface) is DENIED on the floor", () => {
+    const r = runFloor("gh run list");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh pr list` is still GRANTED on the floor (porcelain unchanged)", () => {
+    const r = runFloor("gh pr list");
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("`gh issue view 1` is still GRANTED on the floor (porcelain unchanged)", () => {
+    const r = runFloor("gh issue view 1");
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("`gh repo view` is still GRANTED on the floor (porcelain unchanged)", () => {
+    const r = runFloor("gh repo view the-metafactory/cortex");
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("a stack that EXPLICITLY grants `gh api` (own rule) still works — floor removal is not a global ban", () => {
+    // The escape hatch Andreas's proposal preserves: an agent genuinely needing
+    // gh api declares its own rule. Proves we closed the FLOOR, not gh api itself.
+    const r = runHook("gh api repos/the-metafactory/cortex/contents/README.md", {
+      CORTEX_CHANNEL: "recon",
+      CORTEX_AGENT_ID: "recon-agent",
+      CORTEX_BASH_GUARD: JSON.stringify({ rules: [{ pattern: "^gh\\s+api\\s" }] }),
+    });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+});
+
 describe("bash-guard.hook — block telemetry", () => {
   let homeDir: string;
 

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -696,6 +696,52 @@ describe("bash-guard.hook — floor drops gh api/run (cortex#2335)", () => {
     expectGrantDecision(r.stdout);
   });
 
+  // --- cortex#2335 review (mellanon): porcelain SUBCOMMAND restriction. The
+  // verb-open floor allowed destructive porcelain — mutating ops the code
+  // capability forbids. The floor must be <= the code capability. These assert
+  // the mutating porcelain is DENIED (this is what "went unnoticed"). ---
+  test("`gh pr merge` is DENIED on the floor (floor must not out-power the code agent)", () => {
+    const r = runFloor("gh pr merge 1 --repo the-metafactory/cortex");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh pr merge --admin` (branch-protection bypass) is DENIED on the floor", () => {
+    const r = runFloor("gh pr merge 1 --admin");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh pr review --approve` (self-approve) is DENIED on the floor", () => {
+    const r = runFloor("gh pr review 1 --approve");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh pr close` is DENIED on the floor", () => {
+    const r = runFloor("gh pr close 1");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh issue delete` is DENIED on the floor", () => {
+    const r = runFloor("gh issue delete 1 --yes");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh repo delete` is DENIED on the floor (prompt-injection blast radius)", () => {
+    const r = runFloor("gh repo " + "delete the-metafactory/cortex --yes");
+    expect(r.status).toBe(0);
+    expectFloorDeny(r.stdout);
+  });
+
+  test("`gh pr comment` (non-mutating collab) is still GRANTED on the floor", () => {
+    const r = runFloor("gh pr comment 1 --body hi");
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
   test("a stack that EXPLICITLY grants `gh api` (own rule) still works — floor removal is not a global ban", () => {
     // The escape hatch Andreas's proposal preserves: an agent genuinely needing
     // gh api declares its own rule. Proves we closed the FLOOR, not gh api itself.

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -100,17 +100,25 @@ interface GuardConfig {
 
 const DEFAULT_CONFIG: GuardConfig = {
   rules: [
-    // gh: the read/write PORCELAIN verbs only. `api` and `run` are DELIBERATELY
-    // absent from the floor (cortex#2335). `gh api` is a raw REST client — on the
-    // floor (repos: []) the repo-pin block never engages, so it can reach ANY
-    // endpoint the host's gh login has (`-X PUT repos/<o>/<r>/pulls/<n>/merge`,
-    // `-X DELETE`, releases, deploy keys, `gh api graphql`, `gh api user`),
-    // sidestepping every verb-level distinction drawn elsewhere. `gh run` can
-    // dispatch/cancel/rerun workflows. This mirrors the code capability's
-    // allowlist (stack-lib.ts: "we deliberately DO NOT add gh api / gh repo /
-    // gh run"). A stack that genuinely needs them declares an explicit
-    // bashAllowlist rule (ideally repos-pinned) — never the floor.
-    { pattern: "^gh\\s+(pr|issue|repo)\\s" },
+    // gh: READ-ONLY porcelain SUBCOMMANDS only (cortex#2335). Two vectors are
+    // closed here:
+    //   1. `api`/`run` are absent — `gh api` is a raw REST client; on the floor
+    //      (repos: []) the repo-pin block never engages, so it could reach ANY
+    //      endpoint (`-X PUT repos/<o>/<r>/pulls/<n>/merge`, `-X DELETE`, deploy
+    //      keys, `gh api graphql`), and `gh run` can dispatch/cancel workflows.
+    //   2. Porcelain is subcommand-restricted, NOT verb-open. A bare
+    //      `^gh\s+(pr|issue|repo)\s` still allowed `gh pr merge --admin`,
+    //      `gh pr review --approve`, `gh issue delete`, `gh repo delete` — so a
+    //      floor agent on untrusted Discord input (prompt injection) could merge
+    //      or delete, i.e. the chat floor stayed STRONGER than the deliberately
+    //      narrowed code capability (stack-lib.ts pins `gh pr` to
+    //      create|view|list|diff|checks, "NEVER merge", no `gh repo` at all).
+    // The floor now allows only non-mutating subcommands, mirroring/under the
+    // code capability. A stack needing more declares an explicit (ideally
+    // repos-pinned) bashAllowlist rule — never the floor.
+    { pattern: "^gh\\s+pr\\s+(view|list|diff|checks|status|comment)\\b" },
+    { pattern: "^gh\\s+issue\\s+(view|list|status|comment)\\b" },
+    { pattern: "^gh\\s+repo\\s+view\\b" },
     { pattern: "^git\\s+(log|diff|show|status|branch|fetch|remote|rev-parse)\\b" },
     { pattern: "^ls\\b" },
     { pattern: "^pwd$" },

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -100,7 +100,17 @@ interface GuardConfig {
 
 const DEFAULT_CONFIG: GuardConfig = {
   rules: [
-    { pattern: "^gh\\s+(pr|issue|repo|api|run)\\s" },
+    // gh: the read/write PORCELAIN verbs only. `api` and `run` are DELIBERATELY
+    // absent from the floor (cortex#2335). `gh api` is a raw REST client — on the
+    // floor (repos: []) the repo-pin block never engages, so it can reach ANY
+    // endpoint the host's gh login has (`-X PUT repos/<o>/<r>/pulls/<n>/merge`,
+    // `-X DELETE`, releases, deploy keys, `gh api graphql`, `gh api user`),
+    // sidestepping every verb-level distinction drawn elsewhere. `gh run` can
+    // dispatch/cancel/rerun workflows. This mirrors the code capability's
+    // allowlist (stack-lib.ts: "we deliberately DO NOT add gh api / gh repo /
+    // gh run"). A stack that genuinely needs them declares an explicit
+    // bashAllowlist rule (ideally repos-pinned) — never the floor.
+    { pattern: "^gh\\s+(pr|issue|repo)\\s" },
     { pattern: "^git\\s+(log|diff|show|status|branch|fetch|remote|rev-parse)\\b" },
     { pattern: "^ls\\b" },
     { pattern: "^pwd$" },


### PR DESCRIPTION
## The gap

The bash-guard DEFAULT floor granted `^gh\s+(pr|issue|repo|api|run)\s` with `repos: []`, so the repo-pin block never engages for it. `gh api` is a raw REST client, so any bash-guarded agent on the floor could auto-approve `gh api -X PUT repos/<o>/<r>/pulls/<n>/merge` (merge a PR), `-X DELETE`, releases, deploy keys, `gh api graphql`, `gh api user`, plus `gh run` workflow dispatch, on any repo the host gh login reaches. That is a stronger gh surface than the deliberately-narrowed code capability, whose allowlist omits exactly these (`stack-lib.ts`).

## Fix

The floor exposes the porcelain verbs (`pr|issue|repo`) only. Agents that genuinely need `api`/`run` declare an explicit, ideally repos-pinned, `bashAllowlist` rule.

## Reliance survey

Every in-repo `gh api` caller (CI workflows, `arc-ref-bump`, `check-wire-vocab`, Grove/Mission-Control server) runs outside the bash-guard hook. No shipped stack yaml relies on the floor for `api`/`run`.

## Follow-up (not in scope here)

`halden` grants `gh api` via its own stack allowlist and keeps that surface after this floor fix, which is exactly the "grant api only to trusted stacks" note in the issue. That config lives outside the repo, so whether halden is trusted for raw REST is a separate call.

## Tests

Adds a floor-scoped regression block (8 tests): `gh api` merge/user/graphql and `gh run` denied on the floor; `pr`/`issue`/`repo` still granted; an explicit `api` rule still works (removal is not a global ban). 107 pass, lint clean.

Closes #2335
