### PR TITLE
feat(runner): EBH-1 — cortex-owned PreToolUse path guard (F1)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -157,7 +157,7 @@ provides:
       matcher: Bash
     - event: PreToolUse
       command: ${PAI_DIR}/hooks/CortexPathGuard.hook.ts
-      matcher: Read|Write|Edit|Glob|Grep
+      matcher: Read|Write|Edit|Glob|Grep|NotebookEdit
 
 # Capability declarations (cortex#2285 C1 honesty pass, house rule: an
 # undeclared capability is a security bug). First deliberate review of this

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -95,6 +95,12 @@ provides:
       target: ~/.claude/hooks/CortexEventLogger.hook.ts
     - source: src/runner/hooks/bash-guard.hook.ts
       target: ~/.claude/hooks/CortexBashGuard.hook.ts
+    # EBH-1 (cortex#2343) — cortex-owned PreToolUse path guard for the file
+    # tools (Read/Write/Edit/Glob/Grep). Registered GLOBALLY below (unlike
+    # the Skill/MCP guards) because — like CortexBashGuard — it gates every
+    # bot session's file access, not a per-session grant list.
+    - source: src/runner/hooks/path-guard.hook.ts
+      target: ~/.claude/hooks/CortexPathGuard.hook.ts
     # cortex#710 (C-701 Part B) — per-skill grant PreToolUse hook. Installed
     # as a symlink ONLY (no `hooks:` entry below) so it is NEVER registered in
     # the principal's GLOBAL settings.json — it would otherwise gate the
@@ -149,6 +155,9 @@ provides:
     - event: PreToolUse
       command: ${PAI_DIR}/hooks/CortexBashGuard.hook.ts
       matcher: Bash
+    - event: PreToolUse
+      command: ${PAI_DIR}/hooks/CortexPathGuard.hook.ts
+      matcher: Read|Write|Edit|Glob|Grep
 
 # Capability declarations (cortex#2285 C1 honesty pass, house rule: an
 # undeclared capability is a security bug). First deliberate review of this

--- a/src/common/path-containment.ts
+++ b/src/common/path-containment.ts
@@ -140,6 +140,18 @@ export interface RealpathResolution {
  * plain "create this new file" request isn't spuriously denied just because
  * the leaf doesn't exist yet.
  *
+ * cortex#2343 adversarial review round 6: ascending on ANY `realpathSync`
+ * failure was itself a fail-open pattern — a NUL-byte path (EINVAL),
+ * a permission-denied ancestor (EACCES), or a symlink loop (ELOOP) would
+ * ALSO ascend past the un-resolvable segment and re-append it, UN-
+ * REVALIDATED, onto whatever ancestor happened to resolve — silently
+ * granting on an error class that has nothing to do with "not created yet".
+ * Only `ENOENT`/`ENOTDIR` (the legitimate "this segment doesn't exist as a
+ * directory yet" case the Write-tool tolerance above exists for) may
+ * ascend; every OTHER errno is a genuine resolution failure and returns
+ * `ok: false` immediately, matching this module's own "any resolution
+ * error ⇒ ok:false" invariant instead of quietly special-casing it away.
+ *
  * Bounded to 1024 ascents so a pathological input (or a filesystem that
  * NEVER resolves, e.g. every ancestor including `/` throws) cannot spin
  * forever — that case reports `ok: false`, never a silent success.
@@ -156,6 +168,17 @@ export function resolveProspectiveRealpath(absPath: string): RealpathResolution 
         : real;
       return { ok: true, real: real2, reason: "" };
     } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") {
+        // A genuine resolution failure (NUL byte ⇒ EINVAL, permission
+        // denied ⇒ EACCES, symlink loop ⇒ ELOOP, or anything else) — do
+        // NOT ascend past it. FAIL CLOSED.
+        return {
+          ok: false,
+          real: "",
+          reason: `"${absPath}" does not resolve to a real path: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
       const parent = dirname(current);
       if (parent === current) {
         // Reached the filesystem root and even IT doesn't resolve — give up.

--- a/src/common/path-containment.ts
+++ b/src/common/path-containment.ts
@@ -18,7 +18,7 @@
 
 import { realpathSync } from "fs";
 import { homedir } from "os";
-import { basename, dirname, join, sep } from "path";
+import { basename, dirname, isAbsolute, join, sep } from "path";
 
 /**
  * Expand a single leading `~` to the invoking user's home directory. Mirrors
@@ -194,4 +194,225 @@ export function isContainedIn(baseDir: string, candidatePath: string): boolean {
   const realCandidateRes = resolveProspectiveRealpath(expandUserPath(candidatePath));
   if (!realCandidateRes.ok) return false;
   return isWithin(realBaseRes.real, realCandidateRes.real);
+}
+
+// =============================================================================
+// THE single token→real-path reducer (cortex#2343 adversarial review round 3).
+//
+// ROOT CAUSE of the R1 (~user) and the bash-brace-expansion bypasses: bash
+// command tokens and file-tool paths were being reduced to a real path by
+// DIVERGENT code in bash-guard.hook.ts and path-guard.hook.ts. Every fix
+// landed on ONE surface and left the other open (tilde-user handled in
+// path-guard's env expansion but not bash's; braces handled in path-guard's
+// Glob branch but never wired into bash-guard's command-path check at all).
+// `reduceTokenToRealPathOrReject` is now the ONE place a raw token becomes a
+// checkable real path (or an outright rejection) for BOTH hooks — a fix here
+// fixes both surfaces by construction, and a hook can no longer drift out of
+// sync with the other's protections.
+// =============================================================================
+
+/**
+ * Glob/shell metacharacters that mark the end of a token's LITERAL
+ * (containment-checkable) portion, EXCLUDING `{` — brace groups are handled
+ * separately by {@link expandBraceAlternatives} so their CONTENTS get
+ * inspected rather than treated as an opaque metachar boundary. `*`/`?`/`[`
+ * are genuine wildcards on BOTH surfaces this module serves: Glob's
+ * `pattern` argument uses them as glob syntax, and a live shell ALSO
+ * performs pathname expansion on them for a Bash argument (`cat /etc/pa*`
+ * really does undergo shell globbing) — so the same "derive the literal
+ * prefix before the first one" treatment is correct for both.
+ */
+const GLOB_METACHAR_RE = /[*?[]/;
+
+/**
+ * Derive the containment-checkable literal portion of a single path/pattern
+ * token (braces already resolved — see {@link expandBraceAlternatives}):
+ *
+ *   - No metachar in the token at all → the token IS the literal path,
+ *     returned UNCHANGED (nothing to trim; the caller resolves this
+ *     VERBATIM — e.g. a plain Bash argument naming one exact file, or a
+ *     Read/Write `file_path`).
+ *   - A metachar (`*`/`?`/`[`) IS present → returns the token's literal
+ *     directory prefix up to (not including) the metachar, trimmed back to
+ *     the last complete `/` segment (a partial trailing segment, e.g. the
+ *     `fo` in `fo*o`, is not a real directory boundary and is dropped
+ *     rather than mis-containment-checked). May be `""` when the token has
+ *     no directory component before the wildcard (e.g. `*.ts`) — that means
+ *     nothing is containment-checkable from the LITERAL portion alone; the
+ *     caller falls back to trusting its own already-scoped root (cwd / the
+ *     dispatch-configured working directory).
+ *
+ * Exported for unit tests.
+ */
+export function deriveLiteralPathPrefix(token: string): string {
+  const metaIdx = token.search(GLOB_METACHAR_RE);
+  if (metaIdx === -1) return token;
+  const prefix = token.slice(0, metaIdx);
+  const lastSlash = prefix.lastIndexOf("/");
+  if (lastSlash === -1) return "";
+  return prefix.slice(0, lastSlash + 1);
+}
+
+export type BraceExpansionResult =
+  | { kind: "none" } // no brace group at all — treat the token as the sole alternative
+  | { kind: "expanded"; alternatives: string[] } // one clean, ≥2-option brace group, resolved
+  | { kind: "ambiguous" }; // nested/unbalanced/multiple/single-option brace groups — FAIL CLOSED
+
+/**
+ * Expand ONE level of brace alternatives in a path/pattern token:
+ * `"{a,b,c}/x"` → `["a/x", "b/x", "c/x"]`. This is what makes
+ * `cat {/tmp/secret,x}/f` (a real bash brace expansion — bash genuinely
+ * runs the command once per alternative) and a Glob pattern's
+ * `{../secret,x}/*` both get their HIDDEN alternatives inspected instead of
+ * stopping at the opaque `{` boundary.
+ *
+ * FAILS CLOSED (`kind: "ambiguous"`) rather than guessing on anything this
+ * simple one-level parser can't confidently handle: a nested brace group, a
+ * second top-level brace group, an unbalanced `{`/`}`, or a brace group with
+ * FEWER THAN TWO comma-separated options (a real shell only performs brace
+ * expansion with ≥2 alternatives — `{solo}` with no comma is usually left
+ * LITERAL by bash, so "expanding" it would mean containment-checking a
+ * DIFFERENT string than the one bash actually reads; safer to refuse the
+ * whole token than guess at a non-standard single-option form). Legitimate
+ * patterns/commands never need any of these shapes, so denying them costs
+ * nothing real. Exported for unit tests.
+ */
+export function expandBraceAlternatives(token: string): BraceExpansionResult {
+  const firstOpen = token.indexOf("{");
+  if (firstOpen === -1) return { kind: "none" };
+
+  const firstClose = token.indexOf("}", firstOpen);
+  if (firstClose === -1) return { kind: "ambiguous" }; // unbalanced
+
+  const inner = token.slice(firstOpen + 1, firstClose);
+  if (inner.includes("{") || inner.includes("}")) return { kind: "ambiguous" }; // nested
+
+  const rest = token.slice(firstClose + 1);
+  if (rest.includes("{") || rest.includes("}")) return { kind: "ambiguous" }; // a second group
+
+  const prefix = token.slice(0, firstOpen);
+  const options = inner.split(",");
+  if (options.length < 2) return { kind: "ambiguous" }; // not a real alternation
+
+  const alternatives = options.map((opt) => prefix + opt + rest);
+  return { kind: "expanded", alternatives };
+}
+
+export interface ReducedToken {
+  ok: boolean;
+  /**
+   * Real (symlink-resolved) paths the caller must containment-check — ONE
+   * entry per token normally, but potentially several when the token
+   * contained a brace group (bash's brace expansion genuinely runs the
+   * command once per alternative, e.g. `cat {a,b}/f` reads BOTH `a/f` and
+   * `b/f` — so BOTH must pass containment, not just one). An EMPTY array is
+   * NOT a failure — it means nothing is containment-checkable from this
+   * token alone (a bare wildcard with no directory component, e.g.
+   * `*.ts`); the caller's own already-scoped root (cwd) covers it.
+   */
+  reals: string[];
+  /** Populated when `ok` is false — WHY the token was rejected. */
+  reason: string;
+}
+
+/**
+ * THE single source of truth for turning any raw path/pattern token (a Bash
+ * command argument, or a file-tool `file_path`/`path`/Glob `pattern`) into
+ * zero or more checkable real paths, or an outright fail-closed rejection.
+ * Both `bash-guard.hook.ts` and `path-guard.hook.ts` call this — see the
+ * module-section doc above for why unifying this one function is the
+ * actual fix, not another per-surface patch.
+ *
+ * Pipeline (each stage's rationale is documented on the function it calls):
+ *   1. `expandUserPath` — expand the known-safe `~`/`~/`/`$VAR`/`${VAR}` forms.
+ *   2. `isUnresolvedShellToken` — FAIL CLOSED if a `~user` form or a residual
+ *      `$` survived (R1) — never resolved-against-cwd.
+ *   3. Brace expansion (`expandBraceAlternatives`) if the token contains
+ *      `{` — FAIL CLOSED on ambiguous brace syntax.
+ *   4. For EACH alternative (exactly one, when there were no braces):
+ *      - When the token had ≥2 brace alternatives, OR this alternative
+ *        itself carries a genuine wildcard metachar (`*`/`?`/`[`): derive
+ *        its literal prefix (`deriveLiteralPathPrefix`) and REJECT THE
+ *        WHOLE TOKEN outright if that prefix is absolute or carries a `..`
+ *        segment — legit brace alternatives / glob patterns never need
+ *        either, so this is an unconditional veto, not a normal
+ *        containment check that a coincidental in-scope match could pass.
+ *        An EMPTY literal prefix (bare wildcard, no directory component)
+ *        means nothing is checkable from this alternative — skip it (not a
+ *        failure).
+ *      - Otherwise (the common case: one plain literal token, no braces, no
+ *        wildcard) resolve it NORMALLY (absolute as-is, else joined against
+ *        `cwd`) — an absolute path that happens to be INSIDE an allowed dir
+ *        stays ALLOWED here; the caller's ordinary containment check
+ *        (`isContainedIn`) is what decides that, same as it always has for
+ *        Read/Write `file_path`.
+ *   5. Every candidate that reaches this point is realpath-resolved via
+ *      `resolveProspectiveRealpath` (symlink-safe, tolerates a not-yet-
+ *      existing Write target) and collected into `reals`.
+ */
+export function reduceTokenToRealPathOrReject(rawToken: string, cwd: string): ReducedToken {
+  const expanded = expandUserPath(rawToken);
+
+  if (isUnresolvedShellToken(expanded)) {
+    return {
+      ok: false,
+      reals: [],
+      reason:
+        `token "${rawToken}" contains an unresolvable shell expansion (a ~user form or a ` +
+        `literal "$")`,
+    };
+  }
+
+  let alternatives: string[];
+  if (expanded.includes("{")) {
+    const braceResult = expandBraceAlternatives(expanded);
+    if (braceResult.kind === "ambiguous") {
+      return {
+        ok: false,
+        reals: [],
+        reason:
+          `token "${rawToken}" has brace syntax that cannot be confidently parsed (nested, ` +
+          `unbalanced, single-option, or multiple brace groups)`,
+      };
+    }
+    alternatives = braceResult.kind === "expanded" ? braceResult.alternatives : [expanded];
+  } else {
+    alternatives = [expanded];
+  }
+
+  const isMultiAlternative = alternatives.length > 1;
+  const reals: string[] = [];
+
+  for (const alt of alternatives) {
+    const literalPrefix = deriveLiteralPathPrefix(alt);
+    const hasWildcard = literalPrefix !== alt;
+    const strictVeto = isMultiAlternative || hasWildcard;
+
+    let candidate: string;
+    if (strictVeto) {
+      if (literalPrefix === "") continue; // nothing checkable from this alternative — not a failure
+      if (isAbsolute(literalPrefix) || literalPrefix.split("/").some((seg) => seg === "..")) {
+        return {
+          ok: false,
+          reals: [],
+          reason:
+            `token "${rawToken}" resolves to an absolute path or a ".." escape via ` +
+            `${isMultiAlternative ? "a brace alternative" : "a wildcard"} ("${alt}") — this is ` +
+            `refused unconditionally, regardless of whether it happens to land in scope`,
+        };
+      }
+      candidate = literalPrefix;
+    } else {
+      candidate = alt;
+    }
+
+    const absCandidate = isAbsolute(candidate) ? candidate : join(cwd, candidate);
+    const resolved = resolveProspectiveRealpath(absCandidate);
+    if (!resolved.ok) {
+      return { ok: false, reals: [], reason: `token "${rawToken}" ${resolved.reason}` };
+    }
+    reals.push(resolved.real);
+  }
+
+  return { ok: true, reals, reason: "" };
 }

--- a/src/common/path-containment.ts
+++ b/src/common/path-containment.ts
@@ -36,6 +36,52 @@ export function expandHome(path: string): string {
 }
 
 /**
+ * Expand shell-style `~`/`~/` and `$VAR`/`${VAR}` references in a raw path
+ * token to the values a real shell would substitute — BEFORE the token is
+ * ever classified as absolute/relative or joined with a cwd.
+ *
+ * Without this, a token like `~/.ssh/id_rsa` or `$HOME/.ssh/id_rsa` is NOT
+ * absolute (`path.isAbsolute` doesn't know shell syntax), so a naive
+ * `resolve(cwd, token)` treats it as a LITERAL relative path
+ * (`<cwd>/~/.ssh/id_rsa`) — which usually resolves harmlessly inside an
+ * allowed dir — while the real shell/tool expands it to the ACTUAL home
+ * directory, almost always OUTSIDE the sandbox. This is the "guard checks a
+ * different path than the shell runs" bypass (cortex#2343 adversarial
+ * review finding B1). Every raw path token extracted from a tool call or a
+ * Bash command MUST be passed through this BEFORE `isAbsolute`/`resolve`.
+ *
+ * Rules (the subset of POSIX shell expansion that matters for a path
+ * argument):
+ *   - A single leading `~` or `~/` expands to `process.env.HOME`.
+ *   - `$VAR` / `${VAR}` anywhere in the string expands to `process.env.VAR`
+ *     — an UNSET var expands to the EMPTY STRING, exactly like a real shell
+ *     (`echo $NOPE` prints nothing) — never left as a literal `$VAR`
+ *     substring that could dodge containment by resolving to a path that
+ *     doesn't match anything in particular.
+ *
+ * Deliberately NOT handled:
+ *   - Command substitution `$(...)` / backticks, glob expansion, `~otheruser`
+ *     forms, and full shell quote-removal/word-splitting semantics.
+ *     `rejectsChaining()` in bash-guard.hook.ts already refuses any command
+ *     containing `$(`/backticks BEFORE any path check runs, so a token
+ *     carrying one never reaches this function from that hook.
+ *   - path-guard.hook.ts's file-tool inputs aren't shell-evaluated at all;
+ *     `~`/`$VAR` expansion there is pure defense-in-depth (this hook has no
+ *     way to know whether the specific tool implementation would itself
+ *     expand them before touching the filesystem).
+ */
+export function expandUserPath(raw: string): string {
+  const homeExpanded = expandHome(raw);
+  return homeExpanded.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
+    (_match: string, braced: string | undefined, bare: string | undefined) => {
+      const name = braced ?? bare ?? "";
+      return process.env[name] ?? "";
+    },
+  );
+}
+
+/**
  * True when `realTarget` is `realBase` itself or a path underneath it.
  * Both arguments MUST already be realpath'd (symlinks resolved) — this
  * function does no I/O, it only compares strings. Exported so callers that
@@ -118,9 +164,9 @@ export function resolveProspectiveRealpath(absPath: string): RealpathResolution 
  * "contained".
  */
 export function isContainedIn(baseDir: string, candidatePath: string): boolean {
-  const realBaseRes = resolveProspectiveRealpath(expandHome(baseDir));
+  const realBaseRes = resolveProspectiveRealpath(expandUserPath(baseDir));
   if (!realBaseRes.ok) return false;
-  const realCandidateRes = resolveProspectiveRealpath(expandHome(candidatePath));
+  const realCandidateRes = resolveProspectiveRealpath(expandUserPath(candidatePath));
   if (!realCandidateRes.ok) return false;
   return isWithin(realBaseRes.real, realCandidateRes.real);
 }

--- a/src/common/path-containment.ts
+++ b/src/common/path-containment.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared realpath + subpath-containment discipline (EBH-1, cortex#2343).
+ *
+ * Extracted so `path-guard.hook.ts` (file-tool PreToolUse guard) and
+ * `bash-guard.hook.ts` (Bash read-command path checks) reuse EXACTLY the
+ * same symlink-resolution + containment logic `src/adapters/loader.ts`
+ * already applies to bundle install paths and manifest `entry` resolution
+ * (`resolveEntryWithinBundle` ~:709-730, the containment check at ~:246,
+ * :284-293) — "reuse, do not hand-roll" (issue #2343 step 2). `loader.ts`
+ * itself is left untouched: it is already hardened + tested, and this slice
+ * has no reason to touch it. This module is the generic primitive both the
+ * loader's discipline and this new guard now conceptually share.
+ *
+ * Every function here is written to FAIL CLOSED: any resolution error
+ * (ENOENT on every ancestor, a symlink loop, a permissions error) is
+ * reported as `ok: false`, never silently treated as "contained".
+ */
+
+import { realpathSync } from "fs";
+import { homedir } from "os";
+import { basename, dirname, join, sep } from "path";
+
+/**
+ * Expand a single leading `~` to the invoking user's home directory. Mirrors
+ * the `d.replace(/^~/, process.env.HOME ?? "~")` idiom already used at
+ * `dispatch-handler.ts` (effectiveCwd / workspaceFallbackDir) so `allowedDirs`
+ * / `readOnlyDirs` entries authored with a `~` prefix resolve the same way
+ * here as they do when cortex builds `--add-dir` / cwd from the same config.
+ */
+export function expandHome(path: string): string {
+  if (path === "~") return process.env.HOME ?? homedir();
+  if (path.startsWith("~/")) {
+    return (process.env.HOME ?? homedir()) + path.slice(1);
+  }
+  return path;
+}
+
+/**
+ * True when `realTarget` is `realBase` itself or a path underneath it.
+ * Both arguments MUST already be realpath'd (symlinks resolved) — this
+ * function does no I/O, it only compares strings. Exported so callers that
+ * already hold two realpath'd strings (e.g. an already-verified base) can
+ * reuse the exact comparison `loader.ts` uses, without re-deriving it.
+ */
+export function isWithin(realBase: string, realTarget: string): boolean {
+  return realTarget === realBase || realTarget.startsWith(realBase + sep);
+}
+
+export interface RealpathResolution {
+  ok: boolean;
+  /** The resolved real path (only meaningful when `ok` is true). */
+  real: string;
+  /** Human-readable failure reason (only meaningful when `ok` is false). */
+  reason: string;
+}
+
+/**
+ * Resolve `absPath` to its real (symlink-followed) form, tolerating a path
+ * that does not exist YET (the Write-tool case: the target file is about to
+ * be created, so `realpathSync` on the full path throws ENOENT even though
+ * the request is entirely legitimate).
+ *
+ * Strategy: walk up from the full path until an ancestor that DOES exist is
+ * found, realpath THAT ancestor (resolving any symlinks in the existing
+ * portion), then re-append the non-existent tail verbatim. This is the
+ * standard "realpath of a prospective path" technique — it still resolves
+ * every symlink that is actually resolvable, and a symlink planted in the
+ * EXISTING portion pointing outside the sandbox is still caught, while a
+ * plain "create this new file" request isn't spuriously denied just because
+ * the leaf doesn't exist yet.
+ *
+ * Bounded to 1024 ascents so a pathological input (or a filesystem that
+ * NEVER resolves, e.g. every ancestor including `/` throws) cannot spin
+ * forever — that case reports `ok: false`, never a silent success.
+ */
+export function resolveProspectiveRealpath(absPath: string): RealpathResolution {
+  let current = absPath;
+  const tailSegments: string[] = [];
+
+  for (let i = 0; i < 1024; i++) {
+    try {
+      const real = realpathSync(current);
+      const real2 = tailSegments.length > 0
+        ? join(real, ...tailSegments.reverse())
+        : real;
+      return { ok: true, real: real2, reason: "" };
+    } catch (err) {
+      const parent = dirname(current);
+      if (parent === current) {
+        // Reached the filesystem root and even IT doesn't resolve — give up.
+        return {
+          ok: false,
+          real: "",
+          reason: `"${absPath}" does not resolve to a real path: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      tailSegments.push(basename(current));
+      current = parent;
+    }
+  }
+  return {
+    ok: false,
+    real: "",
+    reason: `"${absPath}" did not resolve within the ascent bound — refusing`,
+  };
+}
+
+/**
+ * Resolve+containment-check `candidatePath` against one policy root
+ * (`baseDir`, e.g. one entry of `allowedDirs`/`readOnlyDirs`). Both sides are
+ * tilde-expanded and realpath'd (symlinks followed) before comparison — a
+ * symlink planted INSIDE an allowed dir that points OUTSIDE it resolves to
+ * its real target first, so it cannot escape the check (issue #2343
+ * acceptance bullet 4).
+ *
+ * Returns `ok: false` (never throws) when either side fails to resolve —
+ * FAIL CLOSED: an unresolvable base or candidate is never treated as
+ * "contained".
+ */
+export function isContainedIn(baseDir: string, candidatePath: string): boolean {
+  const realBaseRes = resolveProspectiveRealpath(expandHome(baseDir));
+  if (!realBaseRes.ok) return false;
+  const realCandidateRes = resolveProspectiveRealpath(expandHome(candidatePath));
+  if (!realCandidateRes.ok) return false;
+  return isWithin(realBaseRes.real, realCandidateRes.real);
+}

--- a/src/common/path-containment.ts
+++ b/src/common/path-containment.ts
@@ -82,6 +82,31 @@ export function expandUserPath(raw: string): string {
 }
 
 /**
+ * True when an ALREADY-`expandUserPath()`-processed string still carries a
+ * form we cannot confidently resolve (cortex#2343 adversarial-review round 2,
+ * finding R1). `expandUserPath` only handles the bare `~`/`~/` and `$VAR`/
+ * `${VAR}` forms; anything else it leaves untouched:
+ *
+ *   - `~user` / `~otheruser` (any `~` NOT followed immediately by `/` or
+ *     end-of-string) — the OTHER user's home directory. There is no
+ *     portable, dependency-free way to resolve an arbitrary system
+ *     account's home dir, and no legitimate cortex use ever needs one.
+ *     Left unexpanded, the string still starts with `~`.
+ *   - Any `$` that didn't match the `$VAR`/`${VAR}` regex (e.g. `$1`, `$(`,
+ *     a bare trailing `$`) — an expansion form we don't model.
+ *
+ * The FIX PHILOSOPHY (per the adversarial review): don't keep chasing
+ * individual shell-expansion variants one repro at a time — expand only the
+ * known-safe forms, and FAIL CLOSED on anything else. A result that still
+ * starts with `~` or still contains `$` after `expandUserPath` MUST be
+ * denied by the caller, never resolved-against-cwd (which is exactly the
+ * "guard checks a different path than the shell runs" bypass class).
+ */
+export function isUnresolvedShellToken(expanded: string): boolean {
+  return expanded.startsWith("~") || expanded.includes("$");
+}
+
+/**
  * True when `realTarget` is `realBase` itself or a path underneath it.
  * Both arguments MUST already be realpath'd (symlinks resolved) — this
  * function does no I/O, it only compares strings. Exported so callers that

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -41,6 +41,14 @@ export interface CCSessionOpts {
   allowedTools?: string[];
   disallowedTools?: string[];
   allowedDirs?: string[];
+  /**
+   * EBH-1 (cortex#2343) — directories the session may READ but not modify.
+   * Passed to path-guard.hook.ts / bash-guard.hook.ts's path checks via the
+   * `CORTEX_PATH_GUARD` env var (mirrors `allowedDirs`'s own role there).
+   * Distinct from `allowedDirs` so a write into one of these is DENIED
+   * (closes F6) while a read is permitted — see {@link resolvePathGuardEnv}.
+   */
+  readOnlyDirs?: string[];
   timeoutMs?: number;
   cwd?: string;
   additionalArgs?: string[];
@@ -262,6 +270,29 @@ export function resolveBashGuardEnv(
   return JSON.stringify({});
 }
 
+/**
+ * Resolve the AUTHORITATIVE `CORTEX_PATH_GUARD` value cortex writes onto
+ * every spawned session env (EBH-1, cortex#2343 step 5) — mirrors
+ * {@link resolveBashGuardEnv}'s "always a string, always written" contract
+ * so a stale/injected value can never survive and so path-guard.hook.ts /
+ * bash-guard.hook.ts's path checks always read the SAME policy this
+ * session's `--add-dir`/preamble were built from (design spec DD-1).
+ *
+ * Total — ALWAYS returns a JSON string:
+ *   - `{allowedDirs:[...], readOnlyDirs:[...]}` from the opts the caller
+ *     resolved (may legitimately both be `[]` — the hooks treat an empty
+ *     policy as "no restriction configured", matching the EXISTING
+ *     `security-preamble.ts` contract; see path-guard.hook.ts's module doc).
+ */
+export function resolvePathGuardEnv(
+  opts: Pick<CCSessionOpts, "allowedDirs" | "readOnlyDirs">,
+): string {
+  return JSON.stringify({
+    allowedDirs: opts.allowedDirs ?? [],
+    readOnlyDirs: opts.readOnlyDirs ?? [],
+  });
+}
+
 export class CCSession extends EventEmitter {
   private proc: ReturnType<typeof Bun.spawn> | null = null;
   private timeoutId: Timer | null = null;
@@ -449,6 +480,13 @@ export class CCSession extends EventEmitter {
     // even if a value reaches the base env by any other route. See
     // {@link resolveBashGuardEnv} for the value semantics.
     env.CORTEX_BASH_GUARD = resolveBashGuardEnv(this.opts);
+
+    // EBH-1 (cortex#2343 step 5) — pass allowedDirs/readOnlyDirs to
+    // path-guard.hook.ts / bash-guard.hook.ts's path checks. Written
+    // UNCONDITIONALLY for the same reason CORTEX_BASH_GUARD is: cortex is
+    // always the authoritative writer, so this OVERWRITES anything the
+    // layered base/agent env carried.
+    env.CORTEX_PATH_GUARD = resolvePathGuardEnv(this.opts);
 
     // Suppress ANTHROPIC_API_KEY when OAuth token is present
     if (env.CLAUDE_CODE_OAUTH_TOKEN) {

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -45,8 +45,12 @@ export interface CCSessionOpts {
    * EBH-1 (cortex#2343) — directories the session may READ but not modify.
    * Passed to path-guard.hook.ts / bash-guard.hook.ts's path checks via the
    * `CORTEX_PATH_GUARD` env var (mirrors `allowedDirs`'s own role there).
-   * Distinct from `allowedDirs` so a write into one of these is DENIED
-   * (closes F6) while a read is permitted — see {@link resolvePathGuardEnv}.
+   * Distinct from `allowedDirs` so a write into one of these is DENIED while
+   * a read is permitted — see {@link resolvePathGuardEnv}. NOTE: this field
+   * is wired and unit-tested but NOT YET populated by any live dispatch
+   * path (dispatch-handler.ts still flattens readOnlyDirs into the merged
+   * allowedDirs list it builds) — F6 closes in production once that
+   * threading lands (EBH-1b, a separate slice).
    */
   readOnlyDirs?: string[];
   timeoutMs?: number;

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -1854,3 +1854,105 @@ describe("bash-guard.hook — round 5: character whitelist matrix", () => {
     expectGrantDecision(r.stdout);
   });
 });
+
+// =============================================================================
+// Bypass #6 (cortex#2343 adversarial review round 6, FINAL L1 round) —
+// flag-value classification / arbitrary file-content exfil. A `-`-prefixed
+// token was unconditionally skipped as "just a flag" — never classified as
+// a path, so never whitelisted or containment-checked. `file -f<path>` /
+// `file --files-from=<path>` read the path GLUED to the flag and echo that
+// file's CONTENTS back on error (a real, live exfil primitive, confirmed
+// against the actual `file` binary below) — a different class from the
+// character-based bypasses rounds 1-5 closed.
+// =============================================================================
+describe("bash-guard.hook — round 6: flag-value classification matrix", () => {
+  let root: string;
+  let allowedDir: string;
+  let secretDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-r6-matrix-"));
+    allowedDir = join(root, "allowed");
+    secretDir = join(root, "secret");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(secretDir, { recursive: true });
+    writeFileSync(join(secretDir, "canary.txt"), "SECRET_CANARY_LINE\n");
+    writeFileSync(join(allowedDir, "file.txt"), "plain\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  test("file -f/x — path glued to a short flag ⇒ DENY (real `file` echoes the secret line on error)", () => {
+    const canaryPath = join(secretDir, "canary.txt");
+    // Ground truth: the real `file` binary reads canaryPath as a LIST of
+    // filenames-to-check (one per line) and, since "SECRET_CANARY_LINE" is
+    // not a real file, echoes it back verbatim in its error output — an
+    // exfil primitive, not a hypothetical.
+    const realFile = spawnSync("file", [`-f${canaryPath}`], { encoding: "utf-8" });
+    expect(realFile.stdout + realFile.stderr).toContain("SECRET_CANARY_LINE");
+
+    const r = runHook(`file -f${canaryPath}`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecisionReason).toContain("path-shaped value glued to a flag");
+  });
+
+  test("file --files-from=/x — path glued via = ⇒ DENY (real `file` echoes the secret line on error)", () => {
+    const canaryPath = join(secretDir, "canary.txt");
+    const realFile = spawnSync("file", [`--files-from=${canaryPath}`], { encoding: "utf-8" });
+    expect(realFile.stdout + realFile.stderr).toContain("SECRET_CANARY_LINE");
+
+    const r = runHook(`file --files-from=${canaryPath}`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("wc --files0-from=/x — path glued via = on a different path-checked command ⇒ DENY", () => {
+    const r = runHook(
+      `wc --files0-from=${join(secretDir, "canary.txt")}`,
+      policyEnv(),
+      "Bash",
+      "test-session",
+      allowedDir,
+    );
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("ls -l — boolean flag, no path-shaped content ⇒ ALLOW (no over-deny regression)", () => {
+    const r = runHook("ls -l", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("head -n 20 file.txt — value-taking flag with a NUMERIC (non-path) value ⇒ ALLOW", () => {
+    const r = runHook("head -n 20 file.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("file --color=auto file.txt — = flag with a non-path value ⇒ ALLOW", () => {
+    const r = runHook("file --color=auto file.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("file --mime-type file.txt — bare boolean-ish flag with no value at all ⇒ ALLOW", () => {
+    const r = runHook("file --mime-type file.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+});
+

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -75,6 +75,7 @@ function runHook(
   env: Record<string, string | undefined>,
   toolName = "Bash",
   sessionId = "test-session",
+  cwd?: string,
 ): RunResult {
   const input = JSON.stringify({
     session_id: sessionId,
@@ -95,6 +96,7 @@ function runHook(
     encoding: "utf-8",
     input,
     env: merged,
+    ...(cwd !== undefined && { cwd }),
   });
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
@@ -1266,5 +1268,77 @@ describe("bash-guard.hook — path containment for read commands (EBH-1, cortex#
     expect(r.status).toBe(0);
     const out = JSON.parse(r.stdout.trim());
     expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+});
+
+// =============================================================================
+// B1 (CRITICAL, cortex#2343 adversarial review) — `~`/`$VAR` must expand to
+// the REAL path before the containment check, or the guard checks a
+// DIFFERENT path than the shell actually runs (a token like
+// `~/.ssh/id_rsa` / `$HOME/.ssh/id_rsa` is not absolute, so a naive
+// resolve(cwd, token) treats it as a literal relative path under an
+// already-allowed cwd — silently ALLOWING an escape into the real home dir).
+// =============================================================================
+describe("bash-guard.hook — B1: ~/$VAR expansion before path containment", () => {
+  let root: string;
+  let allowedDir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-b1-"));
+    allowedDir = join(root, "allowed");
+    fakeHome = join(root, "fakehome");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(join(fakeHome, ".ssh"), { recursive: true });
+    writeFileSync(join(fakeHome, ".ssh", "id_rsa"), "fake-key\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+      HOME: fakeHome,
+    };
+  }
+
+  test("DENY 'cat $HOME/.ssh/id_rsa' when HOME is outside allowedDirs, cwd inside allowedDir", () => {
+    const r = runHook("cat $HOME/.ssh/id_rsa", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("DENY 'cat ~/.ssh/id_rsa' when HOME is outside allowedDirs, cwd inside allowedDir", () => {
+    const r = runHook("cat ~/.ssh/id_rsa", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("control: 'cat /etc/hosts' still denies (sanity — proves the policy IS active)", () => {
+    const r = runHook("cat /etc/hosts", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("legitimate 'cat ~/allowed/ok.txt' resolving INSIDE allowedDirs still grants", () => {
+    const r = runHook(
+      `cat ~/allowed/ok.txt`,
+      {
+        CORTEX_CHANNEL: "test-channel",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+        HOME: root, // ~/allowed resolves to <root>/allowed === allowedDir
+      },
+      "Bash",
+      "test-session",
+      allowedDir,
+    );
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
   });
 });

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -1503,3 +1503,170 @@ describe("bash-guard.hook — round 3: brace expansion + wildcard CLASS matrix",
     expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
   });
 });
+
+// =============================================================================
+// Bypass #4 (cortex#2343 adversarial review round 4) — bash quote-removal.
+// `extractCommandPaths` only stripped a quote pair that wraps a WHOLE
+// token; an EMBEDDED quote pair (including bash's `""`/`''`
+// empty-string-concatenation form, which real bash quote-REMOVES —
+// `/a/""/../b` reads as `/a/../b`) survived verbatim, so the guard resolved
+// a DIFFERENT string than the shell actually runs. Fixed by refusing to
+// predict shell quote-removal at all: any candidate path token that STILL
+// contains a `"`/`'` after the whole-token strip DENIES THE WHOLE COMMAND.
+// Each deny case below is verified against REAL bash (`bash -c`) to
+// confirmed it reads outside allowedDirs (or fails to parse at all) — the
+// guard's deny is not over-cautious, it is the ONLY safe answer.
+// =============================================================================
+describe("bash-guard.hook — round 4: bash quote-removal CLASS matrix", () => {
+  let root: string;
+  let allowedDir: string;
+  let secretDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-r4-matrix-"));
+    allowedDir = join(root, "allowed");
+    secretDir = join(root, "secret");
+    mkdirSync(join(allowedDir, "sub"), { recursive: true });
+    mkdirSync(secretDir, { recursive: true });
+    writeFileSync(join(secretDir, "canary.txt"), "canary\n");
+    writeFileSync(join(allowedDir, "sub", "b"), "inside\n");
+    writeFileSync(join(allowedDir, "my file.txt"), "spacefile\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  test('cat /a/""/../secret/x — embedded EMPTY double-quote segment ⇒ DENY (real bash reads OUTSIDE allowedDirs)', () => {
+    // Ground truth: `bash -c` on this exact command reads secretDir/canary.txt
+    // — the "" segment vanishes via bash quote-removal, so the ".." cancels
+    // "sub" instead of a phantom empty segment. Confirmed live.
+    const realBash = spawnSync("bash", ["-c", `cat ${allowedDir}/sub/""/../../secret/canary.txt`], {
+      encoding: "utf-8",
+    });
+    expect(realBash.stdout.trim()).toBe("canary");
+
+    const r = runHook(`cat ${allowedDir}/sub/""/../../secret/canary.txt`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat /a/''/../secret/x — embedded EMPTY single-quote segment ⇒ DENY (real bash reads OUTSIDE allowedDirs)", () => {
+    const realBash = spawnSync("bash", ["-c", `cat ${allowedDir}/sub/''/../../secret/canary.txt`], {
+      encoding: "utf-8",
+    });
+    expect(realBash.stdout.trim()).toBe("canary");
+
+    const r = runHook(`cat ${allowedDir}/sub/''/../../secret/canary.txt`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test('cat /a/"b"/c — embedded double-quote wrapping mid-token text ⇒ DENY', () => {
+    // Real bash resolves this to the SAME file (quote-removal of "sub" just
+    // unquotes it back to `sub`), so it stays inside allowedDirs — but the
+    // guard denies anyway per the fail-closed-on-ambiguity policy: it must
+    // not GUESS that an embedded quote is harmless just because it happens
+    // to resolve safely in one case. Confirmed real bash still reads it
+    // (proving the command IS a live, parseable bash invocation, not a
+    // syntax error the guard could safely ignore).
+    const realBash = spawnSync("bash", ["-c", `cat ${allowedDir}/"sub"/b`], { encoding: "utf-8" });
+    expect(realBash.stdout.trim()).toBe("inside");
+
+    const r = runHook(`cat ${allowedDir}/"sub"/b`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat /a/'b'c — embedded single-quote NOT wrapping the whole token ⇒ DENY", () => {
+    const realBash = spawnSync("bash", ["-c", `cat ${allowedDir}/sub/'b'`], { encoding: "utf-8" });
+    expect(realBash.stdout.trim()).toBe("inside");
+
+    const r = runHook(`cat ${allowedDir}/sub/'b'`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test('cat "my file.txt" — WHOLE-TOKEN quoted (legit space-in-path) inside allowedDirs ⇒ ALLOW', () => {
+    const realBash = spawnSync("bash", ["-c", `cd ${allowedDir} && cat "my file.txt"`], { encoding: "utf-8" });
+    expect(realBash.stdout.trim()).toBe("spacefile");
+
+    const r = runHook('cat "my file.txt"', policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test('cat "/abs/outside" — WHOLE-TOKEN quoted, outside allowedDirs ⇒ DENY (by normal containment, not quote-ambiguity)', () => {
+    const realBash = spawnSync("bash", ["-c", `cat "${join(secretDir, "canary.txt")}"`], { encoding: "utf-8" });
+    expect(realBash.stdout.trim()).toBe("canary");
+
+    const r = runHook(`cat "${join(secretDir, "canary.txt")}"`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    // Distinguish from the quote-ambiguity deny reason — this one denies via
+    // ordinary containment (the reducer produced a clean real path, and it
+    // just wasn't inside allowedDirs).
+    expect(out.hookSpecificOutput?.permissionDecisionReason).toContain(
+      "resolves outside every configured allowedDirs",
+    );
+  });
+
+  test('cat "/a/b (dangling/unbalanced quote) ⇒ DENY (real bash fails to even PARSE the command)', () => {
+    const realBash = spawnSync("bash", ["-c", `cat "${join(allowedDir, "sub", "b")}`], { encoding: "utf-8" });
+    expect(realBash.status).not.toBe(0); // bash: unexpected EOF while looking for matching `"'
+
+    const r = runHook(`cat "${join(allowedDir, "sub", "b")}`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+});
+
+describe("bash-guard.hook — round 4: malformed CORTEX_BASH_GUARD fails closed", () => {
+  test("present-but-unparseable CORTEX_BASH_GUARD ⇒ DENY (was DEFAULT_CONFIG fallback — fail OPEN — before this fix)", () => {
+    const r = runHook("ls", {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_BASH_GUARD: "{not valid json",
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("present-but-non-object CORTEX_BASH_GUARD (a JSON array) ⇒ DENY", () => {
+    const r = runHook("ls", {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_BASH_GUARD: "[1,2,3]",
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("absent CORTEX_BASH_GUARD still behaves as DEFAULT_CONFIG (unaffected by this fix)", () => {
+    const r = runHook("ls", { CORTEX_CHANNEL: "test-channel", CORTEX_BASH_GUARD: undefined });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test('{"disabled":true} still passes through (unaffected by this fix — a well-formed instruction, not malformed)', () => {
+    const r = runHook("rm -rf /tmp/x", {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_BASH_GUARD: JSON.stringify({ disabled: true }),
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+});

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -1411,3 +1411,95 @@ describe("bash-guard.hook — R1: shell-expansion CLASS matrix", () => {
     expectGrantDecision(r.stdout);
   });
 });
+
+// =============================================================================
+// "Still-open bypass" (cortex#2343 adversarial review round 3) — bash brace
+// expansion. `rejectsChaining` does not (and should not) block `{` — brace
+// expansion is not a chaining primitive — but the R2 brace-awareness fix
+// only ever landed in path-guard's Glob branch, never in bash-guard's own
+// command-path check, so `cat {/tmp/secret,x}/f` (a REAL bash brace
+// expansion — bash genuinely reads BOTH `/tmp/secret/f` and `x/f`) sailed
+// through unrecognised. Root-caused + fixed by routing BOTH hooks through
+// the ONE shared `reduceTokenToRealPathOrReject` (path-containment.ts) —
+// this matrix proves bash-guard now shares the exact same brace/wildcard
+// treatment path-guard's Glob branch does.
+// =============================================================================
+describe("bash-guard.hook — round 3: brace expansion + wildcard CLASS matrix", () => {
+  let root: string;
+  let allowedDir: string;
+  let secretDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-r3-matrix-"));
+    allowedDir = join(root, "allowed");
+    secretDir = join(root, "secret");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(secretDir, { recursive: true });
+    writeFileSync(join(secretDir, "canary.txt"), "canary\n");
+    writeFileSync(join(allowedDir, "ok.log"), "fine\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  test("cat {/abs,x}/f — absolute alternative HIDDEN inside a brace ⇒ DENY", () => {
+    const r = runHook(`cat {${secretDir},x}/canary.txt`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat {../rel,x}/f — .. traversal alternative HIDDEN inside a brace ⇒ DENY", () => {
+    const r = runHook("cat {../secret,x}/canary.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("control: cat /tmp/.../secret/canary.txt (plain absolute, no braces) still denies", () => {
+    // Proves the two brace repros above are specifically about braces, not
+    // about the absolute path being denied for some unrelated reason.
+    const r = runHook(`cat ${join(secretDir, "canary.txt")}`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat *.log — bare cwd-relative wildcard with no directory component ⇒ ALLOW", () => {
+    const r = runHook("cat *.log", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat /etc/pa* — absolute pathname glob (shell pathname expansion) ⇒ DENY", () => {
+    const r = runHook("cat /etc/pa*", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat {a,b}/ok.log — two SAFE relative brace alternatives, both resolving inside allowedDir ⇒ ALLOW", () => {
+    mkdirSync(join(allowedDir, "a"), { recursive: true });
+    mkdirSync(join(allowedDir, "b"), { recursive: true });
+    writeFileSync(join(allowedDir, "a", "ok.log"), "a\n");
+    writeFileSync(join(allowedDir, "b", "ok.log"), "b\n");
+    const r = runHook("cat {a,b}/ok.log", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat {a,../secret}/ok.log — ONE safe + ONE escaping alternative ⇒ DENY (any risky alternative vetoes the whole token)", () => {
+    const r = runHook("cat {a,../secret}/canary.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+});

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -31,7 +31,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { spawnSync } from "child_process";
 import { join } from "path";
-import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync } from "fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, existsSync, readFileSync, readdirSync } from "fs";
 import { tmpdir } from "os";
 
 const HOOK_PATH = join(import.meta.dir, "..", "bash-guard.hook.ts");
@@ -1149,5 +1149,122 @@ describe("bash-guard.hook — read-only aws (integration via hook + halden confi
 
   test("DENY describe piped into a destructive command (no-bypass)", () => {
     expectDeny("aws ec2 describe-instances | aws ec2 terminate-instances");
+  });
+});
+
+// =============================================================================
+// EBH-1 (cortex#2343 step 3) — path containment for the read-command rules
+// (cat/head/tail/ls/wc/file). Command-shape allow alone is no longer
+// sufficient: these tests prove the SAME CORTEX_PATH_GUARD policy
+// path-guard.hook.ts enforces for the file tools also gates these Bash
+// read commands' path argument(s).
+// =============================================================================
+describe("bash-guard.hook — path containment for read commands (EBH-1, cortex#2343)", () => {
+  let root: string;
+  let allowedDir: string;
+  let readOnlyDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-path-"));
+    allowedDir = join(root, "allowed");
+    readOnlyDir = join(root, "readonly");
+    outsideDir = join(root, "outside");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(readOnlyDir, { recursive: true });
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(allowedDir, "ok.txt"), "fine\n");
+    writeFileSync(join(readOnlyDir, "system.yaml"), "secret: true\n");
+    writeFileSync(join(outsideDir, "secret.txt"), "nope\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [readOnlyDir] }),
+    };
+  }
+
+  for (const cmd of ["cat", "head", "tail", "ls", "wc", "file"]) {
+    test(`DENY "${cmd} <path outside allowedDirs/readOnlyDirs>"`, () => {
+      const r = runHook(`${cmd} ${join(outsideDir, "secret.txt")}`, policyEnv());
+      expect(r.status).toBe(0);
+      const out = JSON.parse(r.stdout.trim());
+      expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+      expect(out.hookSpecificOutput?.permissionDecisionReason).toContain("EBH-1");
+    });
+
+    test(`ALLOW "${cmd} <path inside allowedDirs>"`, () => {
+      const target = cmd === "ls" || cmd === "wc" ? join(allowedDir, "ok.txt") : join(allowedDir, "ok.txt");
+      const r = runHook(`${cmd} ${target}`, policyEnv());
+      expect(r.status).toBe(0);
+      expectGrantDecision(r.stdout);
+    });
+
+    test(`ALLOW "${cmd} <path inside readOnlyDir>" (read command, read-only dir is fine)`, () => {
+      const r = runHook(`${cmd} ${join(readOnlyDir, "system.yaml")}`, policyEnv());
+      expect(r.status).toBe(0);
+      expectGrantDecision(r.stdout);
+    });
+  }
+
+  test("DENY cat of the cortex-config-shaped path outside allowedDirs (repro from issue #2343)", () => {
+    const configLikeDir = join(root, "config-like", "metafactory", "cortex", "system");
+    mkdirSync(configLikeDir, { recursive: true });
+    writeFileSync(join(configLikeDir, "system.yaml"), "token: abc\n");
+    const r = runHook(`cat ${join(configLikeDir, "system.yaml")}`, policyEnv());
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("DENY via a symlink inside allowedDir pointing outside it (realpath'd before check)", () => {
+    const linkPath = join(allowedDir, "escape-link");
+    symlinkSync(outsideDir, linkPath);
+    const r = runHook(`cat ${join(linkPath, "secret.txt")}`, policyEnv());
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("no CORTEX_PATH_GUARD configured (no restriction) ⇒ command-shape allow alone still GRANTS", () => {
+    // Preserves EXISTING behaviour for sessions that haven't configured
+    // allowedDirs — matches security-preamble.ts's "no dirs ⇒ no restriction"
+    // contract. Uses `ls` (no args) which is always allowlisted.
+    const r = runHook("ls", { CORTEX_CHANNEL: "test-channel", CORTEX_PATH_GUARD: undefined });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("malformed CORTEX_PATH_GUARD ⇒ DENY even for an otherwise-allowlisted read command", () => {
+    const r = runHook("ls", { CORTEX_CHANNEL: "test-channel", CORTEX_PATH_GUARD: "{not json" });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("path check does not apply to non-path-checked commands (gh/git unaffected)", () => {
+    // `gh pr view` isn't in PATH_CHECKED_COMMANDS — the containment check
+    // must not fire for it even under an active, narrow allowedDirs policy.
+    const r = runHook("gh pr view 1 --repo the-metafactory/cortex", {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("existing #2337 gh-floor rules are untouched: gh pr merge still DENIES", () => {
+    const r = runHook("gh pr merge 1 --admin", {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
   });
 });

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -1342,3 +1342,72 @@ describe("bash-guard.hook — B1: ~/$VAR expansion before path containment", () 
     expectGrantDecision(r.stdout);
   });
 });
+
+// =============================================================================
+// R1 (cortex#2343 adversarial review ROUND 2) — table-driven matrix covering
+// the CLASS of shell-expansion tokens for the Bash read-command path, not
+// just the two repros the review gave.
+// =============================================================================
+describe("bash-guard.hook — R1: shell-expansion CLASS matrix", () => {
+  let root: string;
+  let allowedDir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-r1-matrix-"));
+    allowedDir = join(root, "allowed");
+    fakeHome = join(root, "fakehome");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(fakeHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+      HOME: fakeHome, // outside allowedDir — any HOME-based resolution must deny
+    };
+  }
+
+  interface Row {
+    label: string;
+    arg: string;
+    expectDeny: boolean;
+  }
+
+  const rows: Row[] = [
+    { label: "~root/x (other user's home)", arg: "~root/x", expectDeny: true },
+    { label: "~someuser/x (other user's home)", arg: "~someuser/x", expectDeny: true },
+    { label: "~/x (HOME outside allowedDirs)", arg: "~/x", expectDeny: true },
+    { label: "~ bare (HOME outside allowedDirs)", arg: "~", expectDeny: true },
+    { label: "${HOME}/x (HOME outside allowedDirs)", arg: "${HOME}/x", expectDeny: true },
+    { label: "$HOME/x (HOME outside allowedDirs)", arg: "$HOME/x", expectDeny: true },
+    { label: "$UNSET_EBH1_VAR/x (unset ⇒ empty string ⇒ /x ⇒ outside)", arg: "$UNSET_EBH1_VAR/x", expectDeny: true },
+    { label: "a/$5/mid-path ($5 unresolvable — not a valid var name)", arg: "a/$5/mid-path", expectDeny: true },
+    { label: "/etc/hosts (plain absolute, no shell syntax — sanity control)", arg: "/etc/hosts", expectDeny: true },
+  ];
+
+  for (const { label, arg, expectDeny } of rows) {
+    test(`cat ${label} → ${expectDeny ? "DENY" : "ALLOW"}`, () => {
+      delete process.env.UNSET_EBH1_VAR;
+      const r = runHook(`cat ${arg}`, policyEnv(), "Bash", "test-session", allowedDir);
+      expect(r.status).toBe(0);
+      const out = JSON.parse(r.stdout.trim());
+      if (expectDeny) {
+        expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+      } else {
+        expect(out.hookSpecificOutput?.permissionDecision).toBe("allow");
+      }
+    });
+  }
+
+  test("positive control: 'cat ok.txt' (plain relative, resolves inside allowedDir) allows", () => {
+    const r = runHook("cat ok.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+});

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -1598,11 +1598,30 @@ describe("bash-guard.hook — round 4: bash quote-removal CLASS matrix", () => {
     expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
   });
 
-  test('cat "my file.txt" — WHOLE-TOKEN quoted (legit space-in-path) inside allowedDirs ⇒ ALLOW', () => {
+  test('cat "my file.txt" — WHOLE-TOKEN quoted space-in-path ⇒ DENY (round 5 supersedes round 4 here)', () => {
+    // Round 4 allowed this (a cleanly whole-token-quoted path with a space
+    // is unambiguous — bash really does read exactly "my file.txt"). Round
+    // 5's character WHITELIST deliberately excludes whitespace (the
+    // adversarial review's own explicit character list + required-ALLOW
+    // list did NOT carve out an exception for it), so this is now denied —
+    // an intentional, documented over-denial of a legitimate-but-rare case
+    // via these six read-only bash commands, traded for closing the whole
+    // unenumerated char-trick class by construction. A space-containing
+    // path is still reachable through the Read tool (path-guard.hook.ts,
+    // which is NOT whitelisted — file_path is taken literally, no shell
+    // involved) or by widening allowedDirs.
     const realBash = spawnSync("bash", ["-c", `cd ${allowedDir} && cat "my file.txt"`], { encoding: "utf-8" });
-    expect(realBash.stdout.trim()).toBe("spacefile");
+    expect(realBash.stdout.trim()).toBe("spacefile"); // real bash CAN read it — the guard still refuses, deliberately
 
     const r = runHook('cat "my file.txt"', policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat ok.txt (no space, whitelisted chars only) inside allowedDirs ⇒ ALLOW — proves round 5 didn't break the common case", () => {
+    writeFileSync(join(allowedDir, "ok.txt"), "fine\n");
+    const r = runHook("cat ok.txt", policyEnv(), "Bash", "test-session", allowedDir);
     expect(r.status).toBe(0);
     expectGrantDecision(r.stdout);
   });
@@ -1668,5 +1687,170 @@ describe("bash-guard.hook — round 4: malformed CORTEX_BASH_GUARD fails closed"
     });
     expect(r.status).toBe(0);
     expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+});
+
+// =============================================================================
+// Bypass #5 (cortex#2343 adversarial review round 5) — bash backslash
+// escaping, the signal to stop blacklisting individual shell tricks and
+// flip to a character WHITELIST. `\.` → `.` under bash's escape removal,
+// so `cat /a/\../secret/x` reads `/a/../secret/x` — a DIFFERENT path than
+// the guard's literal-token resolution saw. Every DENY case below is
+// cross-checked against REAL bash (`bash -c`) to confirm the guard's
+// refusal matches what the shell would actually do (or, for the safe
+// ALLOW cases, that the whitelist does NOT over-deny ordinary paths).
+// =============================================================================
+describe("bash-guard.hook — round 5: character whitelist matrix", () => {
+  let root: string;
+  let allowedDir: string;
+  let secretDir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-r5-matrix-"));
+    allowedDir = join(root, "allowed");
+    secretDir = join(root, "secret");
+    fakeHome = join(root, "fakehome");
+    mkdirSync(join(allowedDir, "src"), { recursive: true });
+    mkdirSync(join(allowedDir, "sub", "dir"), { recursive: true });
+    mkdirSync(join(allowedDir, "repo"), { recursive: true });
+    mkdirSync(secretDir, { recursive: true });
+    mkdirSync(fakeHome, { recursive: true });
+    writeFileSync(join(secretDir, "canary.txt"), "canary\n");
+    writeFileSync(join(allowedDir, "src", "foo.ts"), "ts\n");
+    writeFileSync(join(allowedDir, "sub", "dir", "file.txt"), "nested\n");
+    writeFileSync(join(allowedDir, "repo", "file"), "repofile\n");
+    writeFileSync(join(allowedDir, "ok.log"), "log\n");
+    writeFileSync(join(allowedDir, "file-name_v2.txt"), "v2\n");
+    writeFileSync(join(allowedDir, "file.txt"), "plain\n");
+    writeFileSync(join(allowedDir, "b.c@1"), "at1\n");
+    writeFileSync(join(allowedDir, "x y"), "spacefile\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  function denyEnv(): Record<string, string> {
+    // HOME deliberately OUTSIDE allowedDirs — matches round 1/2's fixture
+    // convention so a `~`-based escape denies via containment as expected.
+    return { ...policyEnv(), HOME: fakeHome };
+  }
+
+  // ---- DENY: backslash + unenumerated character tricks ----
+
+  test("cat /a/\\../secret/x — backslash-escaped dot-dot ⇒ DENY (real bash reads OUTSIDE allowedDirs)", () => {
+    const realBash = spawnSync("bash", ["-c", `cat ${allowedDir}/\\../secret/canary.txt`], { encoding: "utf-8" });
+    // The backslash is a no-op escape (`\.` → `.`), so bash resolves this
+    // relative to allowedDir's PARENT — it escapes allowedDir entirely.
+    expect(realBash.stdout.trim()).toBe("canary");
+
+    const r = runHook(`cat ${allowedDir}/\\../secret/canary.txt`, denyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat /a/\\secret/x — backslash before a plain char (no-op escape) ⇒ DENY (real bash reads the secret)", () => {
+    const realBash = spawnSync("bash", ["-c", `cat ${root}/\\secret/canary.txt`], { encoding: "utf-8" });
+    expect(realBash.stdout.trim()).toBe("canary");
+
+    const r = runHook(`cat ${root}/\\secret/canary.txt`, denyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat /a/x\\ y — backslash-escaped space ⇒ DENY (real bash reads the space-named file inside allowedDirs; denied anyway — backslash is never whitelisted)", () => {
+    const realBash = spawnSync("bash", ["-c", `cat ${allowedDir}/x\\ y`], { encoding: "utf-8" });
+    expect(realBash.stdout.trim()).toBe("spacefile");
+
+    const r = runHook(`cat ${allowedDir}/x\\ y`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat /a/$(echo x) — command substitution ⇒ DENY (already via rejectsChaining — round 5 keeps this intact)", () => {
+    const r = runHook(`cat ${allowedDir}/$(echo x)`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat /a/foo^bar — caret (bash quick-substitution char) ⇒ DENY", () => {
+    const r = runHook(`cat ${allowedDir}/foo^bar`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("cat /a/foo!bar — bang (bash history-expansion char) ⇒ DENY", () => {
+    const r = runHook(`cat ${allowedDir}/foo!bar`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  // ---- ALLOW: ordinary paths must not be over-denied ----
+
+  test("cat /src/foo.ts (absolute, whitelisted chars, inside allowedDirs) ⇒ ALLOW", () => {
+    const r = runHook(`cat ${allowedDir}/src/foo.ts`, policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat ~/repo/file (tilde, HOME resolves INSIDE allowedDirs) ⇒ ALLOW", () => {
+    // HOME points AT allowedDir itself so `~/repo/file` resolves inside
+    // scope — proves the whitelist lets `~` through to the reducer rather
+    // than blocking it itself (unlike round 1/2's fixtures, which
+    // deliberately point HOME OUTSIDE to prove the opposite: a DENY).
+    const r = runHook("cat ~/repo/file", { ...policyEnv(), HOME: allowedDir }, "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat sub/dir/file.txt (relative, nested, whitelisted chars) ⇒ ALLOW", () => {
+    const r = runHook("cat sub/dir/file.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat *.log (bare wildcard, no directory component) ⇒ ALLOW", () => {
+    const r = runHook("cat *.log", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat file-name_v2.txt (hyphen + underscore + digit, all whitelisted) ⇒ ALLOW", () => {
+    const r = runHook("cat file-name_v2.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("head -n 20 file.txt (flag + numeric value + plain filename) ⇒ ALLOW", () => {
+    const r = runHook("head -n 20 file.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat a/b.c@1 (@ is whitelisted) ⇒ ALLOW", () => {
+    const r = runHook("cat b.c@1", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("cat $HOME/x style (reducer-expanded $VAR, resolves INSIDE allowedDirs) ⇒ ALLOW", () => {
+    writeFileSync(join(allowedDir, "x"), "homefile\n");
+    const r = runHook("cat $HOME/x", { ...policyEnv(), HOME: allowedDir }, "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
   });
 });

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -32,16 +32,20 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { spawnSync } from "child_process";
 import { join } from "path";
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync, existsSync, readFileSync, readdirSync, writeFileSync } from "fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, existsSync, readFileSync, readdirSync, writeFileSync, realpathSync } from "fs";
 import { tmpdir, homedir } from "os";
 import {
   parsePathGuardConfig,
   extractCandidatePaths,
   decidePath,
-  expandBraceAlternatives,
-  isRiskyGlobPatternRoot,
 } from "../path-guard.hook";
-import { expandUserPath, isUnresolvedShellToken } from "../../../common/path-containment";
+import {
+  expandUserPath,
+  isUnresolvedShellToken,
+  expandBraceAlternatives,
+  deriveLiteralPathPrefix,
+  reduceTokenToRealPathOrReject,
+} from "../../../common/path-containment";
 
 const HOOK_PATH = join(import.meta.dir, "..", "path-guard.hook.ts");
 
@@ -164,30 +168,63 @@ describe("parsePathGuardConfig", () => {
 });
 
 describe("extractCandidatePaths", () => {
+  const CWD = "/cwd";
+
   test("Read/Write/Edit require file_path", () => {
-    expect(extractCandidatePaths("Read", { file_path: "/a/b.ts" })).toEqual({ paths: ["/a/b.ts"] });
-    expect(extractCandidatePaths("Write", { file_path: "/a/b.ts" })).toEqual({ paths: ["/a/b.ts"] });
-    expect(extractCandidatePaths("Edit", { file_path: "/a/b.ts" })).toEqual({ paths: ["/a/b.ts"] });
+    expect(extractCandidatePaths("Read", { file_path: "/a/b.ts" }, CWD)).toEqual({
+      tokens: [{ raw: "/a/b.ts", base: CWD }],
+    });
+    expect(extractCandidatePaths("Write", { file_path: "/a/b.ts" }, CWD)).toEqual({
+      tokens: [{ raw: "/a/b.ts", base: CWD }],
+    });
+    expect(extractCandidatePaths("Edit", { file_path: "/a/b.ts" }, CWD)).toEqual({
+      tokens: [{ raw: "/a/b.ts", base: CWD }],
+    });
   });
 
-  test("Read with no file_path ⇒ malformed (null)", () => {
-    expect(extractCandidatePaths("Read", {})).toEqual({ paths: null });
+  test("Read with no file_path ⇒ malformed (null, with a reason)", () => {
+    const r = extractCandidatePaths("Read", {}, CWD);
+    expect(r.tokens).toBeNull();
+    expect(typeof r.reason).toBe("string");
   });
 
-  test("Glob/Grep with explicit path ⇒ that path", () => {
-    expect(extractCandidatePaths("Glob", { pattern: "**/*.ts", path: "/a" })).toEqual({ paths: ["/a"] });
-    expect(extractCandidatePaths("Grep", { pattern: "foo", path: "/a" })).toEqual({ paths: ["/a"] });
+  test("NotebookEdit requires notebook_path", () => {
+    expect(extractCandidatePaths("NotebookEdit", { notebook_path: "/a/b.ipynb" }, CWD)).toEqual({
+      tokens: [{ raw: "/a/b.ipynb", base: CWD }],
+    });
+    const r = extractCandidatePaths("NotebookEdit", {}, CWD);
+    expect(r.tokens).toBeNull();
   });
 
-  test("Glob/Grep with no path ⇒ [] (nothing to check, not malformed)", () => {
-    expect(extractCandidatePaths("Glob", { pattern: "**/*.ts" })).toEqual({ paths: [] });
-    expect(extractCandidatePaths("Grep", { pattern: "foo" })).toEqual({ paths: [] });
+  test("Glob with explicit path ⇒ BOTH path (base=cwd) and pattern (base=path) become tokens", () => {
+    expect(extractCandidatePaths("Glob", { pattern: "**/*.ts", path: "/a" }, CWD)).toEqual({
+      tokens: [
+        { raw: "/a", base: CWD },
+        { raw: "**/*.ts", base: "/a" },
+      ],
+    });
+  });
+
+  test("Grep with explicit path ⇒ that path only (pattern never becomes a token)", () => {
+    expect(extractCandidatePaths("Grep", { pattern: "foo", path: "/a" }, CWD)).toEqual({
+      tokens: [{ raw: "/a", base: CWD }],
+    });
+  });
+
+  test("Glob with no path ⇒ pattern token alone, base=cwd", () => {
+    expect(extractCandidatePaths("Glob", { pattern: "**/*.ts" }, CWD)).toEqual({
+      tokens: [{ raw: "**/*.ts", base: CWD }],
+    });
+  });
+
+  test("Grep with no path ⇒ [] (nothing to check, not malformed)", () => {
+    expect(extractCandidatePaths("Grep", { pattern: "foo" }, CWD)).toEqual({ tokens: [] });
   });
 
   test("Grep's `pattern` (content regex) is NEVER treated as a path", () => {
     // A pattern that LOOKS like a path must not leak into the containment check.
-    const r = extractCandidatePaths("Grep", { pattern: "/etc/passwd" });
-    expect(r.paths).toEqual([]);
+    const r = extractCandidatePaths("Grep", { pattern: "/etc/passwd" }, CWD);
+    expect(r.tokens).toEqual([]);
   });
 });
 
@@ -820,23 +857,85 @@ describe("expandBraceAlternatives (R2 fix)", () => {
   test("two top-level brace groups ⇒ ambiguous", () => {
     expect(expandBraceAlternatives("{a,b}/{c,d}").kind).toBe("ambiguous");
   });
+
+  test("single-option brace (no comma) ⇒ ambiguous (not a real bash alternation)", () => {
+    // A real shell only performs brace expansion with ≥2 alternatives —
+    // `{solo}` with no comma is usually left LITERAL by bash. Expanding it
+    // anyway would containment-check a DIFFERENT string than the one bash
+    // actually reads, so this is refused rather than guessed at.
+    expect(expandBraceAlternatives("{solo}/x").kind).toBe("ambiguous");
+  });
 });
 
-describe("isRiskyGlobPatternRoot (R2 fix)", () => {
-  test("empty root ⇒ not risky", () => {
-    expect(isRiskyGlobPatternRoot("")).toBe(false);
+describe("deriveLiteralPathPrefix (round 2/3 fix)", () => {
+  test("no metachar at all ⇒ the token is returned UNCHANGED (fully literal)", () => {
+    expect(deriveLiteralPathPrefix("/etc/passwd")).toBe("/etc/passwd");
+    expect(deriveLiteralPathPrefix("relative/file.ts")).toBe("relative/file.ts");
   });
 
-  test("absolute root ⇒ risky", () => {
-    expect(isRiskyGlobPatternRoot("/etc/")).toBe(true);
+  test("wildcard with a directory prefix ⇒ trimmed to the last complete segment", () => {
+    expect(deriveLiteralPathPrefix("/etc/pa*")).toBe("/etc/");
+    expect(deriveLiteralPathPrefix("../secret/*")).toBe("../secret/");
+    expect(deriveLiteralPathPrefix("src/**")).toBe("src/");
   });
 
-  test("relative root with a .. segment ⇒ risky", () => {
-    expect(isRiskyGlobPatternRoot("../secret/")).toBe(true);
+  test("wildcard with NO directory prefix ⇒ empty", () => {
+    expect(deriveLiteralPathPrefix("*.ts")).toBe("");
+    expect(deriveLiteralPathPrefix("**/x")).toBe("");
+  });
+});
+
+describe("reduceTokenToRealPathOrReject — unifies both hooks' token reduction (round 3 fix)", () => {
+  let root: string;
+  let allowedDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    // realpathSync the mkdtemp root up front (macOS symlinks /tmp →
+    // /private/tmp) so every path this suite asserts on already matches
+    // what resolveProspectiveRealpath() itself returns.
+    root = realpathSync(mkdtempSync(join(tmpdir(), "reducer-unit-")));
+    allowedDir = join(root, "allowed");
+    outsideDir = join(root, "outside");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(outsideDir, { recursive: true });
   });
 
-  test("relative root with no .. segment ⇒ not risky", () => {
-    expect(isRiskyGlobPatternRoot("src/")).toBe(false);
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("plain literal absolute path resolves to exactly one real path (normal containment applies)", () => {
+    const r = reduceTokenToRealPathOrReject(join(outsideDir, "f.txt"), allowedDir);
+    expect(r.ok).toBe(true);
+    expect(r.reals).toEqual([join(outsideDir, "f.txt")]);
+  });
+
+  test("~user form ⇒ rejected outright (R1)", () => {
+    const r = reduceTokenToRealPathOrReject("~root/.ssh/id_rsa", allowedDir);
+    expect(r.ok).toBe(false);
+  });
+
+  test("brace alternative with an absolute option ⇒ rejected outright, regardless of scope (R2/R3)", () => {
+    const r = reduceTokenToRealPathOrReject(`{${outsideDir},x}/f.txt`, allowedDir);
+    expect(r.ok).toBe(false);
+  });
+
+  test("brace alternative with a .. option ⇒ rejected outright (R2/R3)", () => {
+    const r = reduceTokenToRealPathOrReject("{../outside,x}/f.txt", allowedDir);
+    expect(r.ok).toBe(false);
+  });
+
+  test("brace with 2 safe relative alternatives ⇒ BOTH become real paths to containment-check", () => {
+    const r = reduceTokenToRealPathOrReject("{a,b}/f.txt", allowedDir);
+    expect(r.ok).toBe(true);
+    expect(r.reals.sort()).toEqual([join(allowedDir, "a", "f.txt"), join(allowedDir, "b", "f.txt")].sort());
+  });
+
+  test("bare wildcard with no directory prefix ⇒ empty reals (nothing to check, not a failure)", () => {
+    const r = reduceTokenToRealPathOrReject("*.ts", allowedDir);
+    expect(r.ok).toBe(true);
+    expect(r.reals).toEqual([]);
   });
 });
 

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Tests for the Cortex Path Guard PreToolUse hook (EBH-1, cortex#2343).
+ *
+ * Covers every acceptance-criterion bullet from issue #2343:
+ *   - Read/Write/Edit/Glob/Grep of a path outside `allowedDirs` → deny.
+ *   - Write/Edit targeting a `readOnlyDir` → deny (F6); Read → allow.
+ *   - A symlink INSIDE an allowed dir pointing OUTSIDE it → deny (realpath'd
+ *     before the containment check).
+ *   - Non-cortex session (no CORTEX_CHANNEL) → pass through, no behavior change.
+ *   - Fail-closed on malformed CORTEX_PATH_GUARD / unreadable stdin.
+ *   - Pure-function unit coverage for parsePathGuardConfig / extractCandidatePaths
+ *     / decidePath, mirroring bash-guard.hook.test.ts's style.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, existsSync, readFileSync, readdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import {
+  parsePathGuardConfig,
+  extractCandidatePaths,
+  decidePath,
+} from "../path-guard.hook";
+
+const HOOK_PATH = join(import.meta.dir, "..", "path-guard.hook.ts");
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+// Mirrors bash-guard.hook.test.ts's env-stripping helper: the test process
+// itself may run inside a cortex agent session, so start from a clean slate
+// and only apply what each test explicitly sets.
+const SURFACE_ENV_KEYS = [
+  "CORTEX_CHANNEL",
+  "CORTEX_AGENT_ID",
+  "CORTEX_AGENT_NAME",
+  "CORTEX_NETWORK",
+  "CORTEX_PROJECT",
+  "CORTEX_ENTITY",
+  "CORTEX_PRINCIPAL",
+  "CORTEX_PATH_GUARD",
+  "GROVE_CHANNEL",
+  "GROVE_AGENT_ID",
+  "GROVE_AGENT_NAME",
+  "GROVE_NETWORK",
+  "GROVE_PROJECT",
+  "GROVE_ENTITY",
+  "GROVE_OPERATOR",
+];
+
+function runHook(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  env: Record<string, string | undefined>,
+  sessionId = "test-session",
+): RunResult {
+  const input = JSON.stringify({
+    session_id: sessionId,
+    tool_name: toolName,
+    tool_input: toolInput,
+  });
+  const overrides = new Set(SURFACE_ENV_KEYS);
+  const merged: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && !overrides.has(k)) merged[k] = v;
+  }
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) merged[k] = v;
+  }
+  const result = spawnSync("bun", [HOOK_PATH], {
+    encoding: "utf-8",
+    input,
+    env: merged,
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+function expectGrantDecision(stdout: string): void {
+  const out = JSON.parse(stdout.trim());
+  expect(out.hookSpecificOutput).toBeDefined();
+  expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+  expect(out.hookSpecificOutput.permissionDecision).toBe("allow");
+  expect(out.continue).toBeUndefined();
+}
+
+function expectDenyDecision(stdout: string): void {
+  const out = JSON.parse(stdout.trim());
+  expect(out.hookSpecificOutput).toBeDefined();
+  expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+  expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+  expect(typeof out.hookSpecificOutput.permissionDecisionReason).toBe("string");
+}
+
+// =============================================================================
+// Pure-function unit tests
+// =============================================================================
+
+describe("parsePathGuardConfig", () => {
+  test("undefined ⇒ legitimate empty policy (ok, no restriction)", () => {
+    const r = parsePathGuardConfig(undefined);
+    expect(r.ok).toBe(true);
+    expect(r.policy).toEqual({ allowedDirs: [], readOnlyDirs: [] });
+  });
+
+  test("empty string ⇒ legitimate empty policy", () => {
+    const r = parsePathGuardConfig("");
+    expect(r.ok).toBe(true);
+    expect(r.policy).toEqual({ allowedDirs: [], readOnlyDirs: [] });
+  });
+
+  test("{} ⇒ legitimate empty policy", () => {
+    const r = parsePathGuardConfig("{}");
+    expect(r.ok).toBe(true);
+    expect(r.policy).toEqual({ allowedDirs: [], readOnlyDirs: [] });
+  });
+
+  test("valid policy round-trips", () => {
+    const r = parsePathGuardConfig(JSON.stringify({ allowedDirs: ["/a"], readOnlyDirs: ["/b"] }));
+    expect(r.ok).toBe(true);
+    expect(r.policy).toEqual({ allowedDirs: ["/a"], readOnlyDirs: ["/b"] });
+  });
+
+  test("malformed JSON ⇒ ok:false (fail closed, NOT empty policy)", () => {
+    const r = parsePathGuardConfig("{not json");
+    expect(r.ok).toBe(false);
+  });
+
+  test("non-object JSON (array) ⇒ ok:false", () => {
+    const r = parsePathGuardConfig("[1,2,3]");
+    expect(r.ok).toBe(false);
+  });
+
+  test("non-array allowedDirs value is coerced to [] (tolerant, still ok)", () => {
+    const r = parsePathGuardConfig(JSON.stringify({ allowedDirs: "not-an-array" }));
+    expect(r.ok).toBe(true);
+    expect(r.policy.allowedDirs).toEqual([]);
+  });
+});
+
+describe("extractCandidatePaths", () => {
+  test("Read/Write/Edit require file_path", () => {
+    expect(extractCandidatePaths("Read", { file_path: "/a/b.ts" })).toEqual({ paths: ["/a/b.ts"] });
+    expect(extractCandidatePaths("Write", { file_path: "/a/b.ts" })).toEqual({ paths: ["/a/b.ts"] });
+    expect(extractCandidatePaths("Edit", { file_path: "/a/b.ts" })).toEqual({ paths: ["/a/b.ts"] });
+  });
+
+  test("Read with no file_path ⇒ malformed (null)", () => {
+    expect(extractCandidatePaths("Read", {})).toEqual({ paths: null });
+  });
+
+  test("Glob/Grep with explicit path ⇒ that path", () => {
+    expect(extractCandidatePaths("Glob", { pattern: "**/*.ts", path: "/a" })).toEqual({ paths: ["/a"] });
+    expect(extractCandidatePaths("Grep", { pattern: "foo", path: "/a" })).toEqual({ paths: ["/a"] });
+  });
+
+  test("Glob/Grep with no path ⇒ [] (nothing to check, not malformed)", () => {
+    expect(extractCandidatePaths("Glob", { pattern: "**/*.ts" })).toEqual({ paths: [] });
+    expect(extractCandidatePaths("Grep", { pattern: "foo" })).toEqual({ paths: [] });
+  });
+
+  test("Grep's `pattern` (content regex) is NEVER treated as a path", () => {
+    // A pattern that LOOKS like a path must not leak into the containment check.
+    const r = extractCandidatePaths("Grep", { pattern: "/etc/passwd" });
+    expect(r.paths).toEqual([]);
+  });
+});
+
+// =============================================================================
+// decidePath — needs a real temp-dir fixture (containment does realpath I/O).
+// =============================================================================
+
+describe("decidePath", () => {
+  let root: string;
+  let allowedDir: string;
+  let readOnlyDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-decide-"));
+    allowedDir = join(root, "allowed");
+    readOnlyDir = join(root, "readonly");
+    outsideDir = join(root, "outside");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(readOnlyDir, { recursive: true });
+    mkdirSync(outsideDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("Read inside allowedDir ⇒ allow", () => {
+    const d = decidePath("Read", join(allowedDir, "f.txt"), { allowedDirs: [allowedDir], readOnlyDirs: [] });
+    expect(d.allow).toBe(true);
+  });
+
+  test("Write outside every policy dir ⇒ deny", () => {
+    const d = decidePath("Write", join(outsideDir, "f.txt"), { allowedDirs: [allowedDir], readOnlyDirs: [] });
+    expect(d.allow).toBe(false);
+  });
+
+  test("Read inside readOnlyDir ⇒ allow", () => {
+    const d = decidePath("Read", join(readOnlyDir, "f.txt"), { allowedDirs: [], readOnlyDirs: [readOnlyDir] });
+    expect(d.allow).toBe(true);
+  });
+
+  test("Write inside readOnlyDir ⇒ deny (F6)", () => {
+    const d = decidePath("Write", join(readOnlyDir, "f.txt"), { allowedDirs: [], readOnlyDirs: [readOnlyDir] });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("READ-ONLY");
+  });
+
+  test("Edit inside readOnlyDir ⇒ deny (F6)", () => {
+    const d = decidePath("Edit", join(readOnlyDir, "f.txt"), { allowedDirs: [], readOnlyDirs: [readOnlyDir] });
+    expect(d.allow).toBe(false);
+  });
+
+  test("a dir listed in BOTH allowedDirs and readOnlyDirs ⇒ write allowed (allow wins)", () => {
+    const d = decidePath("Write", join(allowedDir, "f.txt"), {
+      allowedDirs: [allowedDir],
+      readOnlyDirs: [allowedDir],
+    });
+    expect(d.allow).toBe(true);
+  });
+});
+
+// =============================================================================
+// Full-process (spawned hook) tests
+// =============================================================================
+
+describe("path-guard.hook — pass-through behaviour", () => {
+  test("no CORTEX_CHANNEL ⇒ pass through unchanged", () => {
+    const r = runHook("Read", { file_path: "/etc/passwd" }, { CORTEX_CHANNEL: undefined, GROVE_CHANNEL: undefined });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("non-governed tool name ⇒ pass through", () => {
+    const r = runHook("Bash", { command: "ls" }, { CORTEX_CHANNEL: "test" });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("CORTEX_CHANNEL set but no CORTEX_PATH_GUARD (no restriction configured) ⇒ pass through", () => {
+    const r = runHook("Read", { file_path: "/etc/passwd" }, { CORTEX_CHANNEL: "test", CORTEX_PATH_GUARD: undefined });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("CORTEX_PATH_GUARD={} (explicit empty policy) ⇒ pass through", () => {
+    const r = runHook("Write", { file_path: "/etc/passwd" }, { CORTEX_CHANNEL: "test", CORTEX_PATH_GUARD: "{}" });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+});
+
+describe("path-guard.hook — fail-closed behaviour", () => {
+  test("malformed CORTEX_PATH_GUARD ⇒ deny (not pass-through)", () => {
+    const r = runHook(
+      "Read",
+      { file_path: "/anything" },
+      { CORTEX_CHANNEL: "test", CORTEX_PATH_GUARD: "{not valid json" },
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("Read with no file_path (malformed call) under an active policy ⇒ deny", () => {
+    const r = runHook(
+      "Read",
+      {},
+      { CORTEX_CHANNEL: "test", CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: ["/tmp"], readOnlyDirs: [] }) },
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+});
+
+describe("path-guard.hook — containment enforcement (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+  let readOnlyDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-spawn-"));
+    allowedDir = join(root, "allowed");
+    readOnlyDir = join(root, "readonly");
+    outsideDir = join(root, "outside");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(readOnlyDir, { recursive: true });
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(readOnlyDir, "secret.yaml"), "token: abc\n");
+    writeFileSync(join(outsideDir, "escape.txt"), "nope\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [readOnlyDir] }),
+    };
+  }
+
+  for (const toolName of ["Read", "Write", "Edit", "Glob", "Grep"]) {
+    test(`${toolName} of a path outside allowedDirs/readOnlyDirs ⇒ deny`, () => {
+      const toolInput =
+        toolName === "Glob"
+          ? { pattern: "**/*", path: outsideDir }
+          : toolName === "Grep"
+            ? { pattern: "secret", path: outsideDir }
+            : { file_path: join(outsideDir, "escape.txt") };
+      const r = runHook(toolName, toolInput, policyEnv());
+      expect(r.status).toBe(0);
+      expectDenyDecision(r.stdout);
+    });
+  }
+
+  test("Write into readOnlyDir ⇒ deny (closes F6)", () => {
+    const r = runHook("Write", { file_path: join(readOnlyDir, "secret.yaml") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("READ-ONLY");
+  });
+
+  test("Edit into readOnlyDir ⇒ deny (closes F6)", () => {
+    const r = runHook(
+      "Edit",
+      { file_path: join(readOnlyDir, "secret.yaml"), old_string: "a", new_string: "b" },
+      policyEnv(),
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("Read of readOnlyDir ⇒ allow", () => {
+    const r = runHook("Read", { file_path: join(readOnlyDir, "secret.yaml") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("Glob rooted in readOnlyDir ⇒ allow (read-only tool)", () => {
+    const r = runHook("Glob", { pattern: "*.yaml", path: readOnlyDir }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("Write into allowedDir ⇒ allow", () => {
+    const r = runHook("Write", { file_path: join(allowedDir, "new-file.txt") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("Write into a NEW file that does not exist yet, inside allowedDir ⇒ allow", () => {
+    // Proves resolveProspectiveRealpath's "walk to nearest existing ancestor"
+    // handling — the Write tool's whole point is creating a file that does
+    // NOT exist yet, so a naive realpathSync(candidate) would ENOENT.
+    const r = runHook("Write", { file_path: join(allowedDir, "brand-new", "deep", "file.ts") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("Glob with no explicit path argument ⇒ allow (relies on session cwd scope)", () => {
+    const r = runHook("Glob", { pattern: "**/*.ts" }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("symlink INSIDE allowedDir pointing OUTSIDE it ⇒ deny (realpath'd before check)", () => {
+    const linkPath = join(allowedDir, "escape-link");
+    symlinkSync(outsideDir, linkPath);
+    const r = runHook("Read", { file_path: join(linkPath, "escape.txt") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("symlink INSIDE allowedDir pointing OUTSIDE it ⇒ Write also denied", () => {
+    const linkPath = join(allowedDir, "escape-link-write");
+    symlinkSync(outsideDir, linkPath);
+    const r = runHook("Write", { file_path: join(linkPath, "new-escape.txt") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("cortex config dir style path (outside allowedDirs) ⇒ deny", () => {
+    // Mirrors the CONFIG IMMUTABILITY prose rule — proves the guard denies a
+    // read of an out-of-scope config-shaped path exactly like any other
+    // out-of-scope path (this hook has no config-dir special case; the deny
+    // comes purely from containment).
+    const configLikeDir = join(root, "config-like", "metafactory", "cortex");
+    mkdirSync(configLikeDir, { recursive: true });
+    writeFileSync(join(configLikeDir, "system.yaml"), "secret: true\n");
+    const r = runHook("Read", { file_path: join(configLikeDir, "system.yaml") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+});
+
+// =============================================================================
+// Telemetry — mirrors bash-guard.hook.test.ts's block-telemetry coverage.
+// =============================================================================
+
+describe("path-guard.hook — block telemetry", () => {
+  let homeDir: string;
+  let root: string;
+  let allowedDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "path-guard-telemetry-home-"));
+    root = mkdtempSync(join(tmpdir(), "path-guard-telemetry-root-"));
+    allowedDir = join(root, "allowed");
+    outsideDir = join(root, "outside");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(outsideDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("a block writes a tool.path.blocked event to the JSONL fallback", () => {
+    const sessionId = "path-telemetry-session";
+    const r = runHook(
+      "Read",
+      { file_path: join(outsideDir, "secret.txt") },
+      {
+        CORTEX_CHANNEL: "test-channel",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+        HOME: homeDir,
+      },
+      sessionId,
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+
+    const rawDir = join(homeDir, ".claude", "events", "raw");
+    expect(existsSync(rawDir)).toBe(true);
+    const files = readdirSync(rawDir);
+    expect(files).toContain(`${sessionId}.jsonl`);
+
+    const lines = readFileSync(join(rawDir, `${sessionId}.jsonl`), "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const event = JSON.parse(lines[0] ?? "{}");
+    expect(event.event_type).toBe("tool.path.blocked");
+    expect(event.session_id).toBe(sessionId);
+    expect(event.source.hook).toBe("PreToolUse");
+    expect(event.source.tool_name).toBe("Read");
+  });
+
+  test("an allowed call writes no telemetry", () => {
+    const sessionId = "path-no-telemetry-session";
+    const r = runHook(
+      "Read",
+      { file_path: join(allowedDir, "ok.txt") },
+      {
+        CORTEX_CHANNEL: "test-channel",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+        HOME: homeDir,
+      },
+      sessionId,
+    );
+    expect(r.status).toBe(0);
+    const rawFile = join(homeDir, ".claude", "events", "raw", `${sessionId}.jsonl`);
+    expect(existsSync(rawFile)).toBe(false);
+  });
+});

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -1051,3 +1051,40 @@ describe("path-guard.hook — B4: NotebookEdit coverage (spawned)", () => {
     expectDenyDecision(r.stdout);
   });
 });
+
+// =============================================================================
+// cortex#2343 adversarial review round 6 — resolveProspectiveRealpath
+// (path-containment.ts) must FAIL CLOSED on any realpathSync error OTHER
+// than ENOENT/ENOTDIR, not silently ascend past it. A NUL-byte file_path is
+// the concrete repro (Bun/Node's realpathSync throws ERR_INVALID_ARG_VALUE
+// for it, NOT ENOENT) — this is path-guard.hook.ts's file_path specifically
+// BECAUSE it carries NO character whitelist (round 5 deliberately left this
+// hook un-whitelisted: file_path is taken literally by Claude Code, no
+// shell involved), so this is the one surface where the reducer's own
+// resolution discipline is the ENTIRE defense against a malformed path.
+// =============================================================================
+describe("path-guard.hook — round 6: NUL-byte file_path fails closed (reducer, not the whitelist)", () => {
+  let root: string;
+  let allowedDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-r6-nul-"));
+    allowedDir = join(root, "allowed");
+    mkdirSync(allowedDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("Read file_path with an embedded NUL byte ⇒ deny", () => {
+    const nulPath = join(allowedDir, "a") + String.fromCharCode(0) + "b";
+    const r = runHook(
+      "Read",
+      { file_path: nulPath },
+      { CORTEX_CHANNEL: "test", CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }) },
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+});

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -38,8 +38,10 @@ import {
   parsePathGuardConfig,
   extractCandidatePaths,
   decidePath,
+  expandBraceAlternatives,
+  isRiskyGlobPatternRoot,
 } from "../path-guard.hook";
-import { expandUserPath } from "../../../common/path-containment";
+import { expandUserPath, isUnresolvedShellToken } from "../../../common/path-containment";
 
 const HOOK_PATH = join(import.meta.dir, "..", "path-guard.hook.ts");
 
@@ -543,6 +545,50 @@ describe("expandUserPath (B1 fix)", () => {
   });
 });
 
+// =============================================================================
+// R1 (cortex#2343 adversarial review ROUND 2) — table-driven matrix covering
+// the CLASS of shell-expansion tokens, not just the two repros the review
+// gave. Every row exercises expandUserPath() + isUnresolvedShellToken()
+// together — this is the exact pair both hooks call before isAbsolute/resolve.
+// =============================================================================
+describe("expandUserPath + isUnresolvedShellToken — R1 class matrix", () => {
+  const FAKE_HOME = "/tmp/ebh1-r1-matrix-fakehome";
+
+  interface Row {
+    label: string;
+    token: string;
+    expectAmbiguous: boolean; // true ⇒ the hook must fail-closed DENY
+  }
+
+  const rows: Row[] = [
+    { label: "~root/x (other user's home)", token: "~root/x", expectAmbiguous: true },
+    { label: "~someuser/x (other user's home)", token: "~someuser/x", expectAmbiguous: true },
+    { label: "~/x (bare-slash form — resolves via HOME, not ambiguous)", token: "~/x", expectAmbiguous: false },
+    { label: "~ (bare tilde alone — resolves via HOME, not ambiguous)", token: "~", expectAmbiguous: false },
+    { label: "${HOME}/x (braced var — resolves, not ambiguous)", token: "${HOME}/x", expectAmbiguous: false },
+    { label: "$HOME/x (bare var — resolves, not ambiguous)", token: "$HOME/x", expectAmbiguous: false },
+    { label: "$UNSET_EBH1_VAR/x (unset var ⇒ empty string, not ambiguous)", token: "$UNSET_EBH1_VAR/x", expectAmbiguous: false },
+    { label: "a/$5/mid-path (unresolvable — $5 isn't a valid var name)", token: "a/$5/mid-path", expectAmbiguous: true },
+    { label: "plain/relative/path.txt (no shell syntax at all)", token: "plain/relative/path.txt", expectAmbiguous: false },
+    { label: "/already/absolute/path.txt (no shell syntax at all)", token: "/already/absolute/path.txt", expectAmbiguous: false },
+  ];
+
+  for (const { label, token, expectAmbiguous } of rows) {
+    test(`${label} → ${expectAmbiguous ? "AMBIGUOUS (must deny)" : "resolves cleanly"}`, () => {
+      const prevHome = process.env.HOME;
+      process.env.HOME = FAKE_HOME;
+      delete process.env.UNSET_EBH1_VAR;
+      try {
+        const expanded = expandUserPath(token);
+        expect(isUnresolvedShellToken(expanded)).toBe(expectAmbiguous);
+      } finally {
+        if (prevHome === undefined) delete process.env.HOME;
+        else process.env.HOME = prevHome;
+      }
+    });
+  }
+});
+
 describe("path-guard.hook — B1: ~/$VAR expansion before containment (spawned)", () => {
   let root: string;
   let allowedDir: string;
@@ -611,6 +657,69 @@ describe("path-guard.hook — B1: ~/$VAR expansion before containment (spawned)"
   });
 });
 
+describe("path-guard.hook — R1: shell-expansion CLASS matrix (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-r1-matrix-"));
+    allowedDir = join(root, "allowed");
+    fakeHome = join(root, "fakehome");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(fakeHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+      HOME: fakeHome, // outside allowedDir — any HOME-based resolution must deny
+    };
+  }
+
+  interface Row {
+    label: string;
+    file_path: string;
+    expectDeny: boolean;
+  }
+
+  const rows: Row[] = [
+    { label: "~root/x (other user's home)", file_path: "~root/x", expectDeny: true },
+    { label: "~someuser/x (other user's home)", file_path: "~someuser/x", expectDeny: true },
+    { label: "~/x (HOME outside allowedDirs)", file_path: "~/x", expectDeny: true },
+    { label: "~ bare (HOME outside allowedDirs)", file_path: "~", expectDeny: true },
+    { label: "${HOME}/x (HOME outside allowedDirs)", file_path: "${HOME}/x", expectDeny: true },
+    { label: "$HOME/x (HOME outside allowedDirs)", file_path: "$HOME/x", expectDeny: true },
+    { label: "$UNSET_EBH1_VAR/x (unset ⇒ empty string ⇒ /x ⇒ outside)", file_path: "$UNSET_EBH1_VAR/x", expectDeny: true },
+    { label: "a/$5/mid-path ($5 unresolvable — not a valid var name)", file_path: "a/$5/mid-path", expectDeny: true },
+    { label: "/etc/hosts (plain absolute, no shell syntax — sanity control)", file_path: "/etc/hosts", expectDeny: true },
+  ];
+
+  for (const { label, file_path, expectDeny } of rows) {
+    test(`${label} → ${expectDeny ? "DENY" : "ALLOW"}`, () => {
+      delete process.env.UNSET_EBH1_VAR;
+      const r = runHook("Read", { file_path }, policyEnv(), "test-session", allowedDir);
+      expect(r.status).toBe(0);
+      if (expectDeny) {
+        expectDenyDecision(r.stdout);
+      } else {
+        expectGrantDecision(r.stdout);
+      }
+    });
+  }
+
+  test("positive control: a plain relative path resolving INSIDE allowedDirs allows", () => {
+    const r = runHook("Read", { file_path: "ok.txt" }, policyEnv(), "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+});
+
 // =============================================================================
 // B2 — Glob's `pattern` argument is itself a path (unlike Grep's).
 // =============================================================================
@@ -672,6 +781,113 @@ describe("path-guard.hook — B2: Glob pattern path-traversal (spawned)", () => 
     // (relies on session cwd scope, unaffected by the B2 Glob-only fix).
     expectGrantDecision(r.stdout);
   });
+});
+
+// =============================================================================
+// R2 (cortex#2343 adversarial review ROUND 2) — pure-function unit coverage
+// for the brace-expansion + risky-root primitives, plus a table-driven
+// SPAWNED matrix covering the CLASS of Glob pattern shapes, not just the
+// one repro the review gave.
+// =============================================================================
+
+describe("expandBraceAlternatives (R2 fix)", () => {
+  test("no braces at all ⇒ kind:none", () => {
+    expect(expandBraceAlternatives("src/**/*.ts")).toEqual({ kind: "none" });
+  });
+
+  test("one clean brace group ⇒ expanded alternatives", () => {
+    expect(expandBraceAlternatives("{../secret,x}/*")).toEqual({
+      kind: "expanded",
+      alternatives: ["../secret/*", "x/*"],
+    });
+  });
+
+  test("brace group with 3 alternatives", () => {
+    expect(expandBraceAlternatives("{/etc,x,../y}/passwd")).toEqual({
+      kind: "expanded",
+      alternatives: ["/etc/passwd", "x/passwd", "../y/passwd"],
+    });
+  });
+
+  test("unbalanced brace ⇒ ambiguous", () => {
+    expect(expandBraceAlternatives("{a,b/*").kind).toBe("ambiguous");
+  });
+
+  test("nested brace ⇒ ambiguous", () => {
+    expect(expandBraceAlternatives("{a,{b,c}}/*").kind).toBe("ambiguous");
+  });
+
+  test("two top-level brace groups ⇒ ambiguous", () => {
+    expect(expandBraceAlternatives("{a,b}/{c,d}").kind).toBe("ambiguous");
+  });
+});
+
+describe("isRiskyGlobPatternRoot (R2 fix)", () => {
+  test("empty root ⇒ not risky", () => {
+    expect(isRiskyGlobPatternRoot("")).toBe(false);
+  });
+
+  test("absolute root ⇒ risky", () => {
+    expect(isRiskyGlobPatternRoot("/etc/")).toBe(true);
+  });
+
+  test("relative root with a .. segment ⇒ risky", () => {
+    expect(isRiskyGlobPatternRoot("../secret/")).toBe(true);
+  });
+
+  test("relative root with no .. segment ⇒ not risky", () => {
+    expect(isRiskyGlobPatternRoot("src/")).toBe(false);
+  });
+});
+
+describe("path-guard.hook — R2: Glob pattern CLASS matrix (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-r2-matrix-"));
+    allowedDir = join(root, "allowed");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(join(allowedDir, "src"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  interface Row {
+    label: string;
+    pattern: string;
+    expectDeny: boolean;
+  }
+
+  const rows: Row[] = [
+    { label: "../x (plain traversal, no brace)", pattern: "../x", expectDeny: true },
+    { label: "{../x,y}/* (traversal HIDDEN inside a brace alternative)", pattern: "{../x,y}/*", expectDeny: true },
+    { label: "{/etc,x}/passwd (absolute HIDDEN inside a brace alternative)", pattern: "{/etc,x}/passwd", expectDeny: true },
+    { label: "**/x (legit — no directory prefix at all)", pattern: "**/x", expectDeny: false },
+    { label: "*.ts (legit — no directory prefix at all)", pattern: "*.ts", expectDeny: false },
+    { label: "src/** (legit — relative prefix resolving inside allowedDirs)", pattern: "src/**", expectDeny: false },
+  ];
+
+  for (const { label, pattern, expectDeny } of rows) {
+    test(`${label} → ${expectDeny ? "DENY" : "ALLOW"}`, () => {
+      const r = runHook("Glob", { path: allowedDir, pattern }, policyEnv());
+      expect(r.status).toBe(0);
+      if (expectDeny) {
+        expectDenyDecision(r.stdout);
+      } else {
+        expectGrantDecision(r.stdout);
+      }
+    });
+  }
 });
 
 // =============================================================================

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -3,25 +3,43 @@
  *
  * Covers every acceptance-criterion bullet from issue #2343:
  *   - Read/Write/Edit/Glob/Grep of a path outside `allowedDirs` → deny.
- *   - Write/Edit targeting a `readOnlyDir` → deny (F6); Read → allow.
+ *   - Write/Edit/NotebookEdit targeting a `readOnlyDir` → deny (the
+ *     read-only-write MECHANISM this hook enforces; F6 goes fully live once
+ *     dispatch-handler.ts threads a distinct readOnlyDirs through to
+ *     CORTEX_PATH_GUARD on live sessions — EBH-1b, a separate slice); Read →
+ *     allow.
  *   - A symlink INSIDE an allowed dir pointing OUTSIDE it → deny (realpath'd
  *     before the containment check).
  *   - Non-cortex session (no CORTEX_CHANNEL) → pass through, no behavior change.
  *   - Fail-closed on malformed CORTEX_PATH_GUARD / unreadable stdin.
  *   - Pure-function unit coverage for parsePathGuardConfig / extractCandidatePaths
  *     / decidePath, mirroring bash-guard.hook.test.ts's style.
+ *
+ * Plus the cortex#2343 adversarial-review fixes (B1/B2/B4):
+ *   - B1: `~`/`$VAR` in a file_path/path token must expand to the REAL path
+ *     before containment (a naive isAbsolute/resolve on the raw token treats
+ *     `~/.ssh/id_rsa` as a literal relative path under cwd — the "guard
+ *     checks a different path than the shell runs" bypass).
+ *   - B2: Glob's `pattern` argument is itself a path (unlike Grep's, which
+ *     is a content regex) — its literal directory prefix must be
+ *     containment-checked too, closing an unchecked absolute-pattern /
+ *     `../` traversal-via-pattern hole.
+ *   - B4: `NotebookEdit` is a grantable, mutating file tool
+ *     (tool-inventory.ts) that the matcher/GOVERNED_TOOLS previously
+ *     omitted entirely — any stack granting it got unchecked file access.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { spawnSync } from "child_process";
 import { join } from "path";
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, existsSync, readFileSync, readdirSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { tmpdir, homedir } from "os";
 import {
   parsePathGuardConfig,
   extractCandidatePaths,
   decidePath,
 } from "../path-guard.hook";
+import { expandUserPath } from "../../../common/path-containment";
 
 const HOOK_PATH = join(import.meta.dir, "..", "path-guard.hook.ts");
 
@@ -57,6 +75,7 @@ function runHook(
   toolInput: Record<string, unknown>,
   env: Record<string, string | undefined>,
   sessionId = "test-session",
+  cwd?: string,
 ): RunResult {
   const input = JSON.stringify({
     session_id: sessionId,
@@ -75,6 +94,7 @@ function runHook(
     encoding: "utf-8",
     input,
     env: merged,
+    ...(cwd !== undefined && { cwd }),
   });
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
@@ -208,13 +228,13 @@ describe("decidePath", () => {
     expect(d.allow).toBe(true);
   });
 
-  test("Write inside readOnlyDir ⇒ deny (F6)", () => {
+  test("Write inside readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
     const d = decidePath("Write", join(readOnlyDir, "f.txt"), { allowedDirs: [], readOnlyDirs: [readOnlyDir] });
     expect(d.allow).toBe(false);
     expect(d.reason).toContain("READ-ONLY");
   });
 
-  test("Edit inside readOnlyDir ⇒ deny (F6)", () => {
+  test("Edit inside readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
     const d = decidePath("Edit", join(readOnlyDir, "f.txt"), { allowedDirs: [], readOnlyDirs: [readOnlyDir] });
     expect(d.allow).toBe(false);
   });
@@ -323,7 +343,7 @@ describe("path-guard.hook — containment enforcement (spawned)", () => {
     });
   }
 
-  test("Write into readOnlyDir ⇒ deny (closes F6)", () => {
+  test("Write into readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
     const r = runHook("Write", { file_path: join(readOnlyDir, "secret.yaml") }, policyEnv());
     expect(r.status).toBe(0);
     expectDenyDecision(r.stdout);
@@ -331,7 +351,7 @@ describe("path-guard.hook — containment enforcement (spawned)", () => {
     expect(out.hookSpecificOutput.permissionDecisionReason).toContain("READ-ONLY");
   });
 
-  test("Edit into readOnlyDir ⇒ deny (closes F6)", () => {
+  test("Edit into readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
     const r = runHook(
       "Edit",
       { file_path: join(readOnlyDir, "secret.yaml"), old_string: "a", new_string: "b" },
@@ -475,5 +495,244 @@ describe("path-guard.hook — block telemetry", () => {
     expect(r.status).toBe(0);
     const rawFile = join(homeDir, ".claude", "events", "raw", `${sessionId}.jsonl`);
     expect(existsSync(rawFile)).toBe(false);
+  });
+});
+
+// =============================================================================
+// B1 (CRITICAL) — `~`/`$VAR` must expand to the REAL path before containment.
+// =============================================================================
+
+describe("expandUserPath (B1 fix)", () => {
+  test("bare ~ expands to HOME", () => {
+    expect(expandUserPath("~")).toBe(process.env.HOME ?? homedir());
+  });
+
+  test("~/ prefix expands to HOME", () => {
+    expect(expandUserPath("~/.ssh/id_rsa")).toBe((process.env.HOME ?? homedir()) + "/.ssh/id_rsa");
+  });
+
+  test("$HOME expands via process.env", () => {
+    const prev = process.env.HOME;
+    process.env.HOME = "/fake/home";
+    try {
+      expect(expandUserPath("$HOME/.ssh/id_rsa")).toBe("/fake/home/.ssh/id_rsa");
+    } finally {
+      process.env.HOME = prev;
+    }
+  });
+
+  test("${VAR} braced form expands", () => {
+    const prev = process.env.EBH1_TEST_VAR;
+    process.env.EBH1_TEST_VAR = "/somewhere";
+    try {
+      expect(expandUserPath("${EBH1_TEST_VAR}/leak")).toBe("/somewhere/leak");
+    } finally {
+      if (prev === undefined) delete process.env.EBH1_TEST_VAR;
+      else process.env.EBH1_TEST_VAR = prev;
+    }
+  });
+
+  test("unset $VAR expands to empty string (matches real shell)", () => {
+    delete process.env.EBH1_DEFINITELY_UNSET;
+    expect(expandUserPath("$EBH1_DEFINITELY_UNSET/leak")).toBe("/leak");
+  });
+
+  test("a plain path with no ~ or $ is unchanged", () => {
+    expect(expandUserPath("/a/b/c.txt")).toBe("/a/b/c.txt");
+    expect(expandUserPath("relative/file.ts")).toBe("relative/file.ts");
+  });
+});
+
+describe("path-guard.hook — B1: ~/$VAR expansion before containment (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+  let fakeHome: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-b1-"));
+    allowedDir = join(root, "allowed");
+    fakeHome = join(root, "fakehome");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(join(fakeHome, ".ssh"), { recursive: true });
+    writeFileSync(join(fakeHome, ".ssh", "id_rsa"), "fake-key\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+      HOME: fakeHome,
+    };
+  }
+
+  test("Read with file_path '~/.ssh/id_rsa' (HOME outside allowedDirs) ⇒ deny, cwd inside allowedDir", () => {
+    const r = runHook("Read", { file_path: "~/.ssh/id_rsa" }, policyEnv(), "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("Read with file_path '$HOME/.ssh/id_rsa' (HOME outside allowedDirs) ⇒ deny, cwd inside allowedDir", () => {
+    const r = runHook("Read", { file_path: "$HOME/.ssh/id_rsa" }, policyEnv(), "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("control: Read with file_path '/etc/hosts' still denies (sanity)", () => {
+    const r = runHook("Read", { file_path: "/etc/hosts" }, policyEnv(), "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("legitimate '~/...' path that DOES resolve inside allowedDirs still allows", () => {
+    // allowedDirs itself is configured as an absolute path here (not under
+    // HOME), so exercise the positive case with HOME pointed AT allowedDir's
+    // parent so `~/allowed/...` resolves into policy scope.
+    const homeAsRoot = root; // HOME = root, allowedDir = root/allowed
+    const r = runHook(
+      "Read",
+      { file_path: "~/allowed/ok.txt" },
+      {
+        CORTEX_CHANNEL: "test",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+        HOME: homeAsRoot,
+      },
+      "test-session",
+      allowedDir,
+    );
+    // File doesn't need to exist for Read to be judged in-policy by the
+    // guard (existence is the tool's concern, not the guard's) — only
+    // containment matters here.
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+});
+
+// =============================================================================
+// B2 — Glob's `pattern` argument is itself a path (unlike Grep's).
+// =============================================================================
+
+describe("path-guard.hook — B2: Glob pattern path-traversal (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+  let secretDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-b2-"));
+    allowedDir = join(root, "allowed");
+    secretDir = join(root, "secret");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(secretDir, { recursive: true });
+    writeFileSync(join(secretDir, "leak.txt"), "nope\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  test("Glob with an ABSOLUTE pattern outside allowedDirs (no `path` field) ⇒ deny", () => {
+    const r = runHook("Glob", { pattern: `${secretDir}/*` }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("Glob with path=allowedDir and a `../` traversal pattern ⇒ deny", () => {
+    const r = runHook("Glob", { path: allowedDir, pattern: "../secret/*" }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("Glob with a harmless relative pattern (no path prefix) still allows", () => {
+    const r = runHook("Glob", { pattern: "*.ts" }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("Glob with a relative directory-prefixed pattern resolving INSIDE allowedDirs allows", () => {
+    mkdirSync(join(allowedDir, "src"), { recursive: true });
+    const r = runHook("Glob", { path: allowedDir, pattern: "src/**/*.ts" }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("Grep's `pattern` (content regex) is still NEVER treated as a path even after the B2 fix", () => {
+    const r = runHook("Grep", { pattern: secretDir }, policyEnv());
+    expect(r.status).toBe(0);
+    // No `path` field given ⇒ nothing to containment-check for Grep ⇒ allow
+    // (relies on session cwd scope, unaffected by the B2 Glob-only fix).
+    expectGrantDecision(r.stdout);
+  });
+});
+
+// =============================================================================
+// B4 — NotebookEdit must be governed (was a complete bypass before the fix).
+// =============================================================================
+
+describe("path-guard.hook — B4: NotebookEdit coverage (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-b4-"));
+    allowedDir = join(root, "allowed");
+    outsideDir = join(root, "outside");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, "secret.ipynb"), "{}\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  test("NotebookEdit outside allowedDirs ⇒ deny (was pass-through before the fix)", () => {
+    const r = runHook("NotebookEdit", { notebook_path: join(outsideDir, "secret.ipynb") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("NotebookEdit inside allowedDirs ⇒ allow", () => {
+    const r = runHook("NotebookEdit", { notebook_path: join(allowedDir, "nb.ipynb") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("NotebookEdit into a readOnlyDir ⇒ deny (mutating tool, same as Write/Edit)", () => {
+    const readOnlyDir = join(root, "readonly");
+    mkdirSync(readOnlyDir, { recursive: true });
+    const r = runHook(
+      "NotebookEdit",
+      { notebook_path: join(readOnlyDir, "nb.ipynb") },
+      {
+        CORTEX_CHANNEL: "test",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [], readOnlyDirs: [readOnlyDir] }),
+      },
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("NotebookEdit with no notebook_path (malformed) under an active policy ⇒ deny", () => {
+    const r = runHook("NotebookEdit", {}, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
   });
 });

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -31,7 +31,7 @@ import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
 import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
-import { isContainedIn, expandUserPath } from "../../common/path-containment";
+import { isContainedIn, expandUserPath, isUnresolvedShellToken } from "../../common/path-containment";
 import { parsePathGuardConfig } from "./path-guard.hook";
 
 interface HookInput {
@@ -314,6 +314,23 @@ export function checkCommandPaths(trimmedCommand: string): { allow: boolean; rea
     // relative path, and resolves harmlessly inside the allowed dir while
     // the real shell reads the actual home directory outside it.
     const expandedPath = expandUserPath(rawPath);
+
+    // R1 fix (cortex#2343 adversarial review round 2): FAIL CLOSED on
+    // anything expandUserPath couldn't confidently resolve — a `~user` form
+    // (e.g. `~root/.ssh/id_rsa`) or a literal `$` left over from an
+    // expansion form we don't model. Resolving it against cwd instead (the
+    // R1 bug) treats it as a harmless literal relative path when the real
+    // shell would read a DIFFERENT, unresolvable-by-us location.
+    if (isUnresolvedShellToken(expandedPath)) {
+      return {
+        allow: false,
+        reason:
+          `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": path token ` +
+          `"${rawPath}" contains an unresolvable shell expansion (a ~user form or a ` +
+          `literal "$") — denying to stay fail-closed.`,
+      };
+    }
+
     const absPath = isAbsolute(expandedPath) ? expandedPath : resolvePath(process.cwd(), expandedPath);
     const contained =
       policy.allowedDirs.some((d) => isContainedIn(d, absPath)) ||

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -23,6 +23,43 @@
  *     pipeline (HTTP POST to the dashboard ingest endpoint, with a JSONL
  *     fallback) so blocks are observable. Best-effort — never blocks the
  *     deny decision.
+ *
+ * ## Known limitations (cortex#2343 adversarial review, 5 rounds — L1's last)
+ *
+ * This guard inspects the command STRING, not a real shell parse tree — it
+ * is a best-effort classifier against bash's word-evaluation rules and each
+ * path-checked command's own path-reading behavior, not a formal shell
+ * parser. Five adversarial rounds each found ONE way the guard's literal-
+ * token resolution diverged from what bash/the tool would actually read
+ * (tilde-user expansion, brace expansion, quote-removal, backslash-escaping,
+ * flag-glued path values) — the fix each time was to FAIL CLOSED on
+ * whatever couldn't be confidently classified/resolved, culminating in
+ * round 5's character whitelist (deny anything outside a closed safe set)
+ * and round 6's flag-value classification (deny anything `-`-prefixed that
+ * looks path-shaped). That posture — fail closed on ambiguity — is what
+ * makes this guard SAFE, but it is NOT airtight by construction the way a
+ * real parser + kernel boundary would be. The kernel sandbox (L2, EBH-2/
+ * EBH-3, `docs/design-session-sandbox.md`) is the actual boundary; this
+ * guard is Tier-0 defense-in-depth in front of it.
+ *
+ * Accepted residuals (deliberately not chased further — over-deny, not
+ * under-deny, direction):
+ *   - Bash special parameters (`$_`, `$0`, `$#`, `$@`, `$*`, `$-`, `$$`,
+ *     `$!`, `$?`) are NOT expanded by `expandUserPath`'s `$VAR`/`${VAR}`
+ *     regex (it only matches `[A-Za-z_][A-Za-z0-9_]*` identifiers) — a
+ *     token containing one still has a residual `$` after expansion and is
+ *     denied by `isUnresolvedShellToken`, even in the rare case a special
+ *     parameter would have expanded to something harmless. Over-deny, safe
+ *     direction.
+ *   - A future command added to `PATH_CHECKED_COMMANDS` with a not-yet-
+ *     modeled value-taking flag (some GNU option this review didn't
+ *     enumerate) is mitigated by round 6's path-shaped-flag-value deny —
+ *     any `-`-prefixed token containing `/`/`~`/a `.`-leading `=`-value
+ *     denies outright rather than being silently skipped — but a flag
+ *     whose value is path-shaped WITHOUT any of those characters (there is
+ *     no such known case among GNU coreutils/`file`) would not be caught by
+ *     construction. Any new addition to `PATH_CHECKED_COMMANDS` should be
+ *     reviewed against this class specifically.
  */
 
 import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
@@ -336,6 +373,31 @@ export interface ExtractedCommandPaths {
 const SAFE_PATH_CHAR_RE = /^[A-Za-z0-9/._~$@:+%,={}[\]*?-]*$/;
 
 /**
+ * cortex#2343 adversarial review round 6 — True when a `-`-prefixed token
+ * LOOKS like it carries a path glued to the flag, and must therefore be
+ * denied rather than blanket-skipped as "just a flag":
+ *
+ *   - the token contains a `/` anywhere (`-f/tmp/x`, `--files-from=/tmp/x`), or
+ *   - the token contains a `~` anywhere (`-f~/x`), or
+ *   - the token has a `--flag=value` form whose value starts with `.`
+ *     (`--files-from=.hidden`) — a relative/dotfile path with no `/`, which
+ *     the first two checks alone would miss.
+ *
+ * A boolean/non-path flag (`-l`, `-d`, `--mime-type`, `--color=auto`) hits
+ * none of these and is still skipped/allowed, unchanged. This function is
+ * used ONLY to decide "deny outright", never to decide "this is safe" — it
+ * has no false-negative cost in the safe direction (see the call site: a
+ * `false` result still just `continue`s past the token as before; it is
+ * NEVER treated as ok-to-resolve on its own).
+ */
+function isPathShapedFlagValue(tok: string): boolean {
+  if (tok.includes("/") || tok.includes("~")) return true;
+  const eqIdx = tok.indexOf("=");
+  if (eqIdx !== -1 && tok.slice(eqIdx + 1).startsWith(".")) return true;
+  return false;
+}
+
+/**
  * Extract candidate path arguments from a single, already env-stripped,
  * already-segment-split shell command string. Deliberately NOT a full shell
  * parser: `rejectsChaining()` (above, runs BEFORE this) already refuses
@@ -374,6 +436,20 @@ const SAFE_PATH_CHAR_RE = /^[A-Za-z0-9/._~$@:+%,={}[\]*?-]*$/;
  * never embed a quote character mid-path; whole-token-quoted paths (for
  * spaces) are unaffected, since those are fully stripped clean above.
  *
+ * cortex#2343 adversarial review round 6 (flag-value classification, the
+ * FINAL L1 round): a `-`-prefixed token was unconditionally skipped as "just
+ * a flag" — never classified as a path, so never whitelisted or reduced.
+ * `file`'s `-f`/`--files-from` and `wc`'s `--files0-from` read the PATH
+ * GLUED to the flag and can echo that file's contents back on error —
+ * `file -f/tmp/secret/x` / `file --files-from=/tmp/secret/x` exfiltrated
+ * arbitrary file content while the guard saw "just a flag" and allowed it.
+ * Fixed by {@link isPathShapedFlagValue}: any `-`-prefixed token that LOOKS
+ * like it carries a path is denied outright rather than being classified
+ * (deny-broadening only — a boolean/non-path flag like `-l`/`--mime-type`/
+ * `--color=auto` still contains none of `/`/`~`/a `.`-leading `=`-value, so
+ * it's still skipped, still allowed; this can never turn a previously-
+ * denied command into an allowed one).
+ *
  * Exported for unit tests.
  */
 export function extractCommandPaths(command: string): ExtractedCommandPaths {
@@ -381,7 +457,18 @@ export function extractCommandPaths(command: string): ExtractedCommandPaths {
   const paths: string[] = [];
   for (let i = 1; i < tokens.length; i++) {
     let tok = tokens[i];
-    if (tok === undefined || tok.startsWith("-")) continue;
+    if (tok === undefined) continue;
+    if (tok.startsWith("-")) {
+      if (isPathShapedFlagValue(tok)) {
+        return {
+          paths: null,
+          reason:
+            `path-shaped value glued to a flag ("${tok.slice(0, 80)}") — cannot safely ` +
+            `classify what this flag consumes, denying fail-closed`,
+        };
+      }
+      continue;
+    }
     if (
       (tok.startsWith('"') && tok.endsWith('"') && tok.length >= 2) ||
       (tok.startsWith("'") && tok.endsWith("'") && tok.length >= 2)

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -31,7 +31,7 @@ import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
 import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
-import { isContainedIn } from "../../common/path-containment";
+import { isContainedIn, expandUserPath } from "../../common/path-containment";
 import { parsePathGuardConfig } from "./path-guard.hook";
 
 interface HookInput {
@@ -308,7 +308,13 @@ export function checkCommandPaths(trimmedCommand: string): { allow: boolean; rea
 
   const candidatePaths = extractCommandPaths(trimmedCommand);
   for (const rawPath of candidatePaths) {
-    const absPath = isAbsolute(rawPath) ? rawPath : resolvePath(process.cwd(), rawPath);
+    // B1 fix (cortex#2343 adversarial review): expand `~`/`$VAR` BEFORE
+    // isAbsolute/resolve — otherwise `~/.ssh/id_rsa` or `$HOME/.ssh/id_rsa`
+    // isn't recognised as absolute, gets joined onto cwd as a LITERAL
+    // relative path, and resolves harmlessly inside the allowed dir while
+    // the real shell reads the actual home directory outside it.
+    const expandedPath = expandUserPath(rawPath);
+    const absPath = isAbsolute(expandedPath) ? expandedPath : resolvePath(process.cwd(), expandedPath);
     const contained =
       policy.allowedDirs.some((d) => isContainedIn(d, absPath)) ||
       policy.readOnlyDirs.some((d) => isContainedIn(d, absPath));

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -143,20 +143,63 @@ interface GuardConfigRaw {
   repos?: string[];
 }
 
-function loadConfig(): GuardConfig | null {
+/**
+ * Result of loading `CORTEX_BASH_GUARD`. Mirrors `path-guard.hook.ts`'s
+ * `parsePathGuardConfig` posture (cortex#2343 adversarial review round 4 —
+ * aligning a fail-OPEN the review flagged):
+ *
+ *   - `ok:true, config:GuardConfig` — a usable config (absent/empty env ⇒
+ *     `DEFAULT_CONFIG`; valid JSON, not disabled ⇒ the parsed config).
+ *   - `ok:true, config:null` — G-300: the principal DM explicitly disabled
+ *     the guard (`{"disabled":true}`). Distinct from `ok:false` — this is
+ *     an intentional, well-formed instruction, not a failure.
+ *   - `ok:false, config:null` — `CORTEX_BASH_GUARD` is PRESENT but
+ *     unparseable JSON, or parses to something other than an object. This
+ *     used to silently fall back to `DEFAULT_CONFIG` (fail OPEN — a
+ *     corrupted/tampered env var got the safe default instead of a deny).
+ *     Now the caller must DENY, matching `parsePathGuardConfig`'s posture:
+ *     absence/empty is a legitimate "no config" state, but a PRESENT,
+ *     malformed value is a genuine failure. `disabled`/`rules`/`repos`
+ *     fields with the WRONG type (e.g. `rules` not an array) are tolerated
+ *     (coerced via the existing `??` fallbacks) — only a JSON parse
+ *     failure or a non-object top level is treated as malformed.
+ */
+interface LoadConfigResult {
+  ok: boolean;
+  config: GuardConfig | null;
+  reason: string;
+}
+
+function loadConfig(): LoadConfigResult {
   const raw = process.env.CORTEX_BASH_GUARD;
-  if (raw) {
-    try {
-      const parsed = JSON.parse(raw) as GuardConfigRaw;
-      // G-300: Principal DM disables bash guard entirely
-      if (parsed.disabled) return null;
-      return {
-        rules: parsed.rules ?? DEFAULT_CONFIG.rules,
-        repos: parsed.repos ?? [],
-      };
-    } catch { /* fall through */ }
+  if (!raw) return { ok: true, config: DEFAULT_CONFIG, reason: "" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      config: null,
+      reason: `CORTEX_BASH_GUARD is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
-  return DEFAULT_CONFIG;
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, config: null, reason: "CORTEX_BASH_GUARD did not parse to a JSON object" };
+  }
+
+  const guardRaw = parsed as GuardConfigRaw;
+  // G-300: Principal DM disables bash guard entirely — a well-formed
+  // instruction, not a failure.
+  if (guardRaw.disabled) return { ok: true, config: null, reason: "" };
+  return {
+    ok: true,
+    config: {
+      rules: guardRaw.rules ?? DEFAULT_CONFIG.rules,
+      repos: guardRaw.repos ?? [],
+    },
+    reason: "",
+  };
 }
 
 /**
@@ -248,6 +291,18 @@ function rejectsChaining(command: string): boolean {
 /** Bash read commands whose path argument(s) get containment-checked. */
 const PATH_CHECKED_COMMANDS = new Set(["cat", "head", "tail", "ls", "wc", "file"]);
 
+export interface ExtractedCommandPaths {
+  /**
+   * null = the WHOLE COMMAND must be denied — a candidate path token still
+   * carries an embedded or unbalanced quote character after the whole-token
+   * strip below (cortex#2343 adversarial review round 4, finding: bash
+   * quote-removal). See {@link reason}.
+   */
+  paths: string[] | null;
+  /** Populated when `paths` is null — WHY the command must be denied. */
+  reason?: string;
+}
+
 /**
  * Extract candidate path arguments from a single, already env-stripped,
  * already-segment-split shell command string. Deliberately NOT a full shell
@@ -262,10 +317,34 @@ const PATH_CHECKED_COMMANDS = new Set(["cat", "head", "tail", "ls", "wc", "file"
  * it falls through and is conservatively treated as a candidate path — this
  * can under-deny (a numeric flag value resolves relative to the session's
  * already-allowed cwd, so it almost always still resolves inside policy
- * scope) but never OVER-denies a real flag as an escaping path. Exported for
- * unit tests.
+ * scope) but never OVER-denies a real flag as an escaping path.
+ *
+ * A token that is wrapped ENTIRELY in one matching pair of quotes (e.g. the
+ * whole `"my file.txt"` argument, used for a path containing a space) is
+ * unwrapped and kept — this is the one shell-quoting form we DO replicate,
+ * because it's unambiguous: the regex below only ever captures a `"…"`/`'…'`
+ * span as ONE token when it starts and ends the token, so a legitimate
+ * whole-token quote can only ever produce a clean strip.
+ *
+ * cortex#2343 adversarial review round 4 (bash quote-removal, the 4th
+ * bypass in this series): real bash performs quote-REMOVAL, including the
+ * `""`/`''` EMPTY-STRING-CONCATENATION form — `/a/""/../b` is read by bash
+ * as `/a/../b` (the empty quoted segment vanishes, so the `..` cancels the
+ * PREVIOUS segment instead of a phantom one), which silently changes which
+ * directory a `..` escapes from. We do NOT attempt to replicate this or any
+ * other embedded-quote form — tilde-user and brace-expansion were BOTH
+ * bypassed by trying to predict one more corner of shell parsing, so the
+ * line now is: don't predict, refuse. Any token that STILL contains a `"`
+ * or `'` after the whole-token strip above (an embedded quote mid-token, OR
+ * a dangling/unbalanced quote that the strip couldn't cleanly remove) DENIES
+ * THE WHOLE COMMAND — `paths: null` — rather than resolving a string that
+ * might not be the one the shell actually reads. Legitimate file reads
+ * never embed a quote character mid-path; whole-token-quoted paths (for
+ * spaces) are unaffected, since those are fully stripped clean above.
+ *
+ * Exported for unit tests.
  */
-export function extractCommandPaths(command: string): string[] {
+export function extractCommandPaths(command: string): ExtractedCommandPaths {
   const tokens = command.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
   const paths: string[] = [];
   for (let i = 1; i < tokens.length; i++) {
@@ -277,9 +356,18 @@ export function extractCommandPaths(command: string): string[] {
     ) {
       tok = tok.slice(1, -1);
     }
-    if (tok.length > 0) paths.push(tok);
+    if (tok.length === 0) continue;
+    if (tok.includes('"') || tok.includes("'")) {
+      return {
+        paths: null,
+        reason:
+          `embedded or unbalanced quote character in path argument "${tok.slice(0, 80)}" — ` +
+          `cannot safely resolve what the shell would actually run, denying fail-closed`,
+      };
+    }
+    paths.push(tok);
   }
-  return paths;
+  return { paths };
 }
 
 /**
@@ -314,7 +402,14 @@ export function checkCommandPaths(trimmedCommand: string): { allow: boolean; rea
     return { allow: true, reason: "" };
   }
 
-  const candidatePaths = extractCommandPaths(trimmedCommand);
+  const extracted = extractCommandPaths(trimmedCommand);
+  if (extracted.paths === null) {
+    return {
+      allow: false,
+      reason: `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": ${extracted.reason}.`,
+    };
+  }
+  const candidatePaths = extracted.paths;
   const cwd = process.cwd();
 
   for (const rawPath of candidatePaths) {
@@ -573,7 +668,22 @@ async function main(): Promise<void> {
   const sessionId =
     input.session_id ?? process.env.CLAUDE_SESSION_ID ?? "unknown";
 
-  const config = loadConfig();
+  const configResult = loadConfig();
+
+  // cortex#2343 adversarial review round 4 — a PRESENT but malformed
+  // CORTEX_BASH_GUARD used to silently fall back to DEFAULT_CONFIG (fail
+  // OPEN). Now it's a genuine failure: DENY, matching path-guard.hook.ts's
+  // parsePathGuardConfig posture. Absence/empty stays "no config" (handled
+  // inside loadConfig() as ok:true, config:DEFAULT_CONFIG) — only a
+  // present-but-unparseable value reaches this branch.
+  if (!configResult.ok) {
+    const reason = `[Cortex Bash Guard] Blocked: ${configResult.reason} — denying to stay fail-closed.`;
+    deny(reason);
+    await emitBlockEvent(sessionId, reason, command);
+    return;
+  }
+
+  const config = configResult.config;
 
   // G-300: Guard disabled (principal DM) — pass through, defer to the already-
   // permissive bypass session. Intentionally NOT a grant: this path is out of

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -26,12 +26,12 @@
  */
 
 import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
-import { isAbsolute, join, resolve as resolvePath } from "path";
+import { join } from "path";
 import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
 import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
-import { isContainedIn, expandUserPath, isUnresolvedShellToken } from "../../common/path-containment";
+import { isContainedIn, reduceTokenToRealPathOrReject } from "../../common/path-containment";
 import { parsePathGuardConfig } from "./path-guard.hook";
 
 interface HookInput {
@@ -287,7 +287,15 @@ export function extractCommandPaths(command: string): string[] {
  * `CORTEX_PATH_GUARD`. Mirrors path-guard.hook.ts's own policy semantics
  * exactly (same parser, same "empty policy = no restriction configured"
  * contract, same fail-closed-on-malformed-config posture) — see that file's
- * module doc for the full rationale. Exported for unit tests.
+ * module doc for the full rationale.
+ *
+ * cortex#2343 adversarial review round 3: every raw token reduces to zero
+ * or more real paths through {@link reduceTokenToRealPathOrReject} — the
+ * ONE shared reducer both this hook and path-guard.hook.ts call. This is
+ * what closed the root cause of the R1 (`~user`) and bash-brace-expansion
+ * bypasses: those fixes previously lived in divergent, hook-local code, so
+ * a fix landing on one surface (e.g. path-guard's Glob branch) left the
+ * other (bash-guard's command-path check) open. Exported for unit tests.
  */
 export function checkCommandPaths(trimmedCommand: string): { allow: boolean; reason: string } {
   const configResult = parsePathGuardConfig(process.env.CORTEX_PATH_GUARD);
@@ -307,43 +315,32 @@ export function checkCommandPaths(trimmedCommand: string): { allow: boolean; rea
   }
 
   const candidatePaths = extractCommandPaths(trimmedCommand);
-  for (const rawPath of candidatePaths) {
-    // B1 fix (cortex#2343 adversarial review): expand `~`/`$VAR` BEFORE
-    // isAbsolute/resolve — otherwise `~/.ssh/id_rsa` or `$HOME/.ssh/id_rsa`
-    // isn't recognised as absolute, gets joined onto cwd as a LITERAL
-    // relative path, and resolves harmlessly inside the allowed dir while
-    // the real shell reads the actual home directory outside it.
-    const expandedPath = expandUserPath(rawPath);
+  const cwd = process.cwd();
 
-    // R1 fix (cortex#2343 adversarial review round 2): FAIL CLOSED on
-    // anything expandUserPath couldn't confidently resolve — a `~user` form
-    // (e.g. `~root/.ssh/id_rsa`) or a literal `$` left over from an
-    // expansion form we don't model. Resolving it against cwd instead (the
-    // R1 bug) treats it as a harmless literal relative path when the real
-    // shell would read a DIFFERENT, unresolvable-by-us location.
-    if (isUnresolvedShellToken(expandedPath)) {
+  for (const rawPath of candidatePaths) {
+    const reduced = reduceTokenToRealPathOrReject(rawPath, cwd);
+    if (!reduced.ok) {
       return {
         allow: false,
         reason:
-          `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": path token ` +
-          `"${rawPath}" contains an unresolvable shell expansion (a ~user form or a ` +
-          `literal "$") — denying to stay fail-closed.`,
+          `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": ${reduced.reason} ` +
+          `— denying to stay fail-closed.`,
       };
     }
-
-    const absPath = isAbsolute(expandedPath) ? expandedPath : resolvePath(process.cwd(), expandedPath);
-    const contained =
-      policy.allowedDirs.some((d) => isContainedIn(d, absPath)) ||
-      policy.readOnlyDirs.some((d) => isContainedIn(d, absPath));
-    if (!contained) {
-      return {
-        allow: false,
-        reason:
-          `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": path "${absPath}" ` +
-          `resolves outside every configured allowedDirs/readOnlyDirs entry (EBH-1, ` +
-          `cortex#2343). Ask the principal to widen allowedDirs if this path is genuinely ` +
-          `needed.`,
-      };
+    for (const realPath of reduced.reals) {
+      const contained =
+        policy.allowedDirs.some((d) => isContainedIn(d, realPath)) ||
+        policy.readOnlyDirs.some((d) => isContainedIn(d, realPath));
+      if (!contained) {
+        return {
+          allow: false,
+          reason:
+            `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": path "${realPath}" ` +
+            `resolves outside every configured allowedDirs/readOnlyDirs entry (EBH-1, ` +
+            `cortex#2343). Ask the principal to widen allowedDirs if this path is genuinely ` +
+            `needed.`,
+        };
+      }
     }
   }
   return { allow: true, reason: "" };

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -294,14 +294,46 @@ const PATH_CHECKED_COMMANDS = new Set(["cat", "head", "tail", "ls", "wc", "file"
 export interface ExtractedCommandPaths {
   /**
    * null = the WHOLE COMMAND must be denied — a candidate path token still
-   * carries an embedded or unbalanced quote character after the whole-token
-   * strip below (cortex#2343 adversarial review round 4, finding: bash
-   * quote-removal). See {@link reason}.
+   * carries an embedded/unbalanced quote character after the whole-token
+   * strip (round 4: bash quote-removal), or a character outside the safe
+   * whitelist (round 5: bash backslash-escaping and the whole unenumerated
+   * class of char-based tricks). See {@link reason}.
    */
   paths: string[] | null;
   /** Populated when `paths` is null — WHY the command must be denied. */
   reason?: string;
 }
+
+/**
+ * cortex#2343 adversarial review round 5 — the WHITELIST that replaces
+ * blacklisting individual shell tricks. Rounds 1–4 each closed ONE
+ * predicted bypass (tilde-user, brace expansion, quote-removal) only for
+ * the review to find the NEXT unmodelled char trick — round 5 is backslash
+ * escaping: bash removes a backslash before the char it escapes
+ * (`\.` → `.`), so `cat /a/\../secret/x` reads `/a/../secret/x` while the
+ * guard's literal-token resolution saw an unescaped `\` byte and either
+ * mis-resolved it or (worse) let it through unchecked entirely.
+ *
+ * We stop predicting bash's word-evaluation rules and instead require every
+ * character in a path token to come from a closed, conservative safe set:
+ * letters, digits, and `/ . _ - ~ $ { } [ ] * ? @ : + % , =`. ANYTHING else
+ * — backslash, quotes (already denied separately, round 4), backticks,
+ * parens, `!`, `#`, `^`, whitespace, control characters, and any char-based
+ * trick not yet enumerated by an adversarial review — is OUTSIDE the set
+ * and DENIES the command. This is closed-by-construction against the whole
+ * class, not just the instances found so far, at the cost of over-denying
+ * some exotic-but-legit paths (a filename with a literal `!` or `#`, say).
+ * That is the correct trade for a security guard: the kernel sandbox (L2,
+ * EBH-2/EBH-3) is the real boundary behind this one, so an occasional
+ * legitimate command needing a wider character has an escape hatch (widen
+ * `allowedDirs`, or route through a tool other than these six bash
+ * commands) that a silently-bypassed guard does not.
+ *
+ * The reducer (`reduceTokenToRealPathOrReject`) still does all the actual
+ * `~`/`$VAR`/brace/glob interpretation — this whitelist runs BEFORE it and
+ * only ever narrows what reaches it; it never widens anything.
+ */
+const SAFE_PATH_CHAR_RE = /^[A-Za-z0-9/._~$@:+%,={}[\]*?-]*$/;
 
 /**
  * Extract candidate path arguments from a single, already env-stripped,
@@ -363,6 +395,18 @@ export function extractCommandPaths(command: string): ExtractedCommandPaths {
         reason:
           `embedded or unbalanced quote character in path argument "${tok.slice(0, 80)}" — ` +
           `cannot safely resolve what the shell would actually run, denying fail-closed`,
+      };
+    }
+    // Round 5 fix: character WHITELIST. Do not try to interpret whatever the
+    // offending character means to bash (backslash-escape, or anything
+    // else) — a token containing ANY character outside SAFE_PATH_CHAR_RE
+    // denies the whole command.
+    if (!SAFE_PATH_CHAR_RE.test(tok)) {
+      return {
+        paths: null,
+        reason:
+          `unsafe character in path argument "${tok.slice(0, 80)}" (outside the safe ` +
+          `character whitelist) — denying fail-closed`,
       };
     }
     paths.push(tok);

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -26,11 +26,13 @@
  */
 
 import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
-import { join } from "path";
+import { isAbsolute, join, resolve as resolvePath } from "path";
 import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
 import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
+import { isContainedIn } from "../../common/path-containment";
+import { parsePathGuardConfig } from "./path-guard.hook";
 
 interface HookInput {
   session_id?: string;
@@ -230,6 +232,98 @@ function rejectsChaining(command: string): boolean {
   // / job-control). Same collapse trick.
   if (command.replace(/&&/g, "").includes("&")) return true;
   return false;
+}
+
+// =============================================================================
+// Path containment for read-command rules (EBH-1, cortex#2343 step 3).
+//
+// Command-shape allow (the DEFAULT_CONFIG rules above) is necessary but no
+// longer sufficient: `^cat\b` matches `cat ~/.config/metafactory/cortex/
+// system/system.yaml` with no path check. These commands additionally
+// containment-check their path argument(s) against the SAME
+// `CORTEX_PATH_GUARD` policy `path-guard.hook.ts` enforces for the file
+// tools — one resolved policy, two enforcement points (design spec DD-1).
+// =============================================================================
+
+/** Bash read commands whose path argument(s) get containment-checked. */
+const PATH_CHECKED_COMMANDS = new Set(["cat", "head", "tail", "ls", "wc", "file"]);
+
+/**
+ * Extract candidate path arguments from a single, already env-stripped,
+ * already-segment-split shell command string. Deliberately NOT a full shell
+ * parser: `rejectsChaining()` (above, runs BEFORE this) already refuses
+ * every construct that could smuggle a hidden argument (pipes, command
+ * substitution, backticks, redirects, background `&`, newlines), so this
+ * only has to tokenize a single simple invocation (`cat foo.txt`,
+ * `ls -la /some/dir`, `head -n 20 bar.log`).
+ *
+ * Tokens starting with `-` are treated as flags and skipped. A flag's VALUE
+ * token (e.g. the `20` in `head -n 20 file`) is NOT itself `-`-prefixed, so
+ * it falls through and is conservatively treated as a candidate path — this
+ * can under-deny (a numeric flag value resolves relative to the session's
+ * already-allowed cwd, so it almost always still resolves inside policy
+ * scope) but never OVER-denies a real flag as an escaping path. Exported for
+ * unit tests.
+ */
+export function extractCommandPaths(command: string): string[] {
+  const tokens = command.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+  const paths: string[] = [];
+  for (let i = 1; i < tokens.length; i++) {
+    let tok = tokens[i];
+    if (tok === undefined || tok.startsWith("-")) continue;
+    if (
+      (tok.startsWith('"') && tok.endsWith('"') && tok.length >= 2) ||
+      (tok.startsWith("'") && tok.endsWith("'") && tok.length >= 2)
+    ) {
+      tok = tok.slice(1, -1);
+    }
+    if (tok.length > 0) paths.push(tok);
+  }
+  return paths;
+}
+
+/**
+ * Containment-check every path argument of a path-checked command against
+ * `CORTEX_PATH_GUARD`. Mirrors path-guard.hook.ts's own policy semantics
+ * exactly (same parser, same "empty policy = no restriction configured"
+ * contract, same fail-closed-on-malformed-config posture) — see that file's
+ * module doc for the full rationale. Exported for unit tests.
+ */
+export function checkCommandPaths(trimmedCommand: string): { allow: boolean; reason: string } {
+  const configResult = parsePathGuardConfig(process.env.CORTEX_PATH_GUARD);
+  if (!configResult.ok) {
+    return {
+      allow: false,
+      reason:
+        `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": ${configResult.reason} ` +
+        `— denying to stay fail-closed.`,
+    };
+  }
+  const { policy } = configResult;
+  if (policy.allowedDirs.length === 0 && policy.readOnlyDirs.length === 0) {
+    // No restriction configured for this session — matches the existing
+    // security-preamble.ts contract (allDirs.length === 0 ⇒ no restriction).
+    return { allow: true, reason: "" };
+  }
+
+  const candidatePaths = extractCommandPaths(trimmedCommand);
+  for (const rawPath of candidatePaths) {
+    const absPath = isAbsolute(rawPath) ? rawPath : resolvePath(process.cwd(), rawPath);
+    const contained =
+      policy.allowedDirs.some((d) => isContainedIn(d, absPath)) ||
+      policy.readOnlyDirs.some((d) => isContainedIn(d, absPath));
+    if (!contained) {
+      return {
+        allow: false,
+        reason:
+          `[Cortex Bash Guard] Blocked "${trimmedCommand.slice(0, 80)}": path "${absPath}" ` +
+          `resolves outside every configured allowedDirs/readOnlyDirs entry (EBH-1, ` +
+          `cortex#2343). Ask the principal to widen allowedDirs if this path is genuinely ` +
+          `needed.`,
+      };
+    }
+  }
+  return { allow: true, reason: "" };
 }
 
 // =============================================================================
@@ -556,6 +650,19 @@ async function main(): Promise<void> {
       deny(reason);
       await emitBlockEvent(sessionId, reason, command);
       return;
+    }
+
+    // EBH-1 (cortex#2343 step 3) — path-containment for the read-command
+    // rules. Runs AFTER the shape-allowlist match (matched === true), so it
+    // only tightens an already-allowed command, never widens one.
+    const headWord = /^([A-Za-z][A-Za-z0-9_]*)\b/.exec(trimmed)?.[1]?.toLowerCase();
+    if (headWord && PATH_CHECKED_COMMANDS.has(headWord)) {
+      const pathCheck = checkCommandPaths(trimmed);
+      if (!pathCheck.allow) {
+        deny(pathCheck.reason);
+        await emitBlockEvent(sessionId, pathCheck.reason, command);
+        return;
+      }
     }
   }
 

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -61,7 +61,7 @@ import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
 import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
-import { isContainedIn, expandUserPath } from "../../common/path-containment";
+import { isContainedIn, expandUserPath, isUnresolvedShellToken } from "../../common/path-containment";
 
 // =============================================================================
 // Hook I/O types
@@ -106,25 +106,24 @@ const WRITE_TOOLS = new Set(["Write", "Edit", "NotebookEdit"]);
 
 /**
  * Glob metacharacters that mark the end of a pattern's LITERAL directory
- * prefix. `minimatch`/glob syntax uses `*`, `?`, `[...]`, and `{...}` for
- * wildcarding — the first occurrence of any of these ends the literal
- * (containment-checkable) portion of the pattern.
+ * prefix, EXCLUDING `{` — brace groups are handled separately by
+ * {@link expandBraceAlternatives} so their CONTENTS get inspected rather
+ * than treated as an opaque metachar boundary (cortex#2343 adversarial
+ * review round 2, finding R2: `{../secret,x}/*` used to stop at `{` and
+ * never see the `../secret` traversal hiding inside it).
  */
-const GLOB_METACHAR_RE = /[*?[{]/;
+const GLOB_METACHAR_RE = /[*?[]/;
 
 /**
- * Derive the containment-checkable directory prefix from a Glob `pattern`
- * (cortex#2343 adversarial review finding B2 — Glob's `pattern`, unlike
- * Grep's, IS a filesystem path and can itself be absolute or carry `../`
- * traversal, e.g. `/etc/*` or `../secret/*`).
- *
- * Takes everything before the first glob metachar, then trims back to the
- * last `/` in that prefix — a partial trailing SEGMENT (e.g. the `fo` in
- * `fo*o`) is not a real directory boundary and is dropped rather than
- * mis-containment-checked. Returns `""` when the pattern has no directory
- * prefix worth checking (e.g. `*.ts`, `**\/*.ts`) — that case relies on the
- * `path` field (if given) or the session's already-scoped cwd, unaffected
- * by this fix. Exported for unit tests.
+ * Derive the containment-checkable directory prefix from a single Glob
+ * pattern ALTERNATIVE (braces already resolved — see
+ * {@link expandBraceAlternatives}). Takes everything before the first glob
+ * metachar, then trims back to the last `/` in that prefix — a partial
+ * trailing SEGMENT (e.g. the `fo` in `fo*o`) is not a real directory
+ * boundary and is dropped rather than mis-containment-checked. Returns `""`
+ * when the pattern has no directory prefix worth checking (e.g. `*.ts`,
+ * `**\/*.ts`) — that case relies on the `path` field (if given) or the
+ * session's already-scoped cwd. Exported for unit tests.
  */
 export function derivePatternGlobRoot(pattern: string): string {
   const metaIdx = pattern.search(GLOB_METACHAR_RE);
@@ -132,6 +131,62 @@ export function derivePatternGlobRoot(pattern: string): string {
   const lastSlash = prefix.lastIndexOf("/");
   if (lastSlash === -1) return "";
   return prefix.slice(0, lastSlash + 1);
+}
+
+export type BraceExpansionResult =
+  | { kind: "none" } // no brace group at all — treat `pattern` as the sole alternative
+  | { kind: "expanded"; alternatives: string[] } // one clean brace group, resolved
+  | { kind: "ambiguous" }; // nested/unbalanced/multiple brace groups — FAIL CLOSED
+
+/**
+ * Expand ONE level of brace alternatives in a Glob pattern:
+ * `"{a,b,c}/x"` → `["a/x", "b/x", "c/x"]` (cortex#2343 adversarial review
+ * round 2, finding R2 — `derivePatternGlobRoot` alone stops at the first
+ * metachar, so `{../secret,x}/*` never got its `../secret` alternative
+ * inspected at all).
+ *
+ * FAILS CLOSED (`kind: "ambiguous"`) rather than guessing on anything this
+ * simple one-level parser can't confidently handle: a nested brace group
+ * inside the first one, more than one top-level brace group, or an
+ * unbalanced `{`/`}`. The instruction from the adversarial review is
+ * explicit: "if brace parsing is at all uncertain, DENY the pattern" —
+ * legitimate Glob patterns never need nested/multiple brace groups, so
+ * denying that shape costs nothing real. Exported for unit tests.
+ */
+export function expandBraceAlternatives(pattern: string): BraceExpansionResult {
+  const firstOpen = pattern.indexOf("{");
+  if (firstOpen === -1) return { kind: "none" };
+
+  const firstClose = pattern.indexOf("}", firstOpen);
+  if (firstClose === -1) return { kind: "ambiguous" }; // unbalanced
+
+  const inner = pattern.slice(firstOpen + 1, firstClose);
+  if (inner.includes("{") || inner.includes("}")) return { kind: "ambiguous" }; // nested
+
+  const rest = pattern.slice(firstClose + 1);
+  if (rest.includes("{") || rest.includes("}")) return { kind: "ambiguous" }; // a second group
+
+  const prefix = pattern.slice(0, firstOpen);
+  const options = inner.split(",");
+  const alternatives = options.map((opt) => prefix + opt + rest);
+  return { kind: "expanded", alternatives };
+}
+
+/**
+ * True when `patternRoot` (a derived literal directory prefix — may be `""`
+ * when the pattern has none) is inherently unsafe for a Glob `pattern`
+ * argument: absolute, or carrying a `..` path segment. Per the adversarial
+ * review: "legit globs never need `..`, absolute, or escaping braces" — a
+ * risky alternative denies the WHOLE Glob call outright rather than being
+ * handed to the normal containment check (which could, in principle, still
+ * ALLOW an absolute pattern that happens to resolve inside scope — the
+ * review wants a strictly narrower, unconditional rule for Glob's pattern
+ * argument specifically). Exported for unit tests.
+ */
+export function isRiskyGlobPatternRoot(patternRoot: string): boolean {
+  if (patternRoot === "") return false;
+  if (isAbsolute(patternRoot)) return true;
+  return patternRoot.split("/").some((segment) => segment === "..");
 }
 
 // =============================================================================
@@ -199,8 +254,16 @@ export function parsePathGuardConfig(raw: string | undefined): PathGuardConfigRe
 // =============================================================================
 
 export interface ExtractedPaths {
-  /** null = the call is malformed for this tool (a required path is missing). */
+  /**
+   * null = the call must be DENIED for this tool — either a required path is
+   * missing (malformed call), or (Glob only) the `pattern` argument is
+   * itself unsafe/ambiguous (absolute, carries a `..` segment, or brace
+   * parsing was uncertain — cortex#2343 adversarial review round 2, R2).
+   */
   paths: string[] | null;
+  /** Populated when `paths` is null — WHY the call must be denied. Falls
+   *  back to a generic reason at the call site when absent. */
+  reason?: string;
 }
 
 /**
@@ -251,22 +314,55 @@ export function extractCandidatePaths(toolName: string, toolInput: HookInput["to
     const explicitPath = hasExplicitPath ? (pathField as string) : undefined;
 
     const patternField = (input as GlobGrepToolInput).pattern;
-    const patternRoot = typeof patternField === "string" ? derivePatternGlobRoot(patternField) : "";
-
     const paths: string[] = [];
     if (explicitPath !== undefined) paths.push(explicitPath);
-    if (patternRoot) {
-      // Absolute prefix (e.g. `/etc/*`) is checked as-is regardless of
-      // `path`. A relative prefix resolves against `path` when given
-      // (mirrors how Glob itself would search relative to `path`); with no
-      // `path`, it's pushed as-is and resolved against cwd downstream (same
-      // treatment as every other relative candidate).
-      paths.push(
-        isAbsolute(patternRoot) || explicitPath === undefined
-          ? patternRoot
-          : join(explicitPath, patternRoot),
-      );
+
+    if (typeof patternField === "string") {
+      // R2 fix (cortex#2343 adversarial review round 2): brace-aware
+      // traversal/absolute check. Expand ONE level of brace alternatives
+      // FIRST — `{../secret,x}/*` must have its `../secret` alternative
+      // inspected, not hidden behind the `{` metachar boundary — then
+      // treat every alternative (or the pattern itself, when there are no
+      // braces) identically: any alternative whose derived literal
+      // directory prefix is absolute or carries a `..` segment DENIES the
+      // WHOLE Glob call outright (fail-closed; "legit globs never need
+      // `..`, absolute, or escaping braces"). Ambiguous brace parsing
+      // (nested/unbalanced/multiple groups) denies outright too.
+      const braceResult = expandBraceAlternatives(patternField);
+      const alternatives = braceResult.kind === "expanded" ? braceResult.alternatives : [patternField];
+
+      if (braceResult.kind === "ambiguous") {
+        return {
+          paths: null,
+          reason:
+            `[Cortex Path Guard] Blocked Glob: pattern "${patternField}" has brace syntax ` +
+            `this guard cannot confidently parse (nested, unbalanced, or multiple brace ` +
+            `groups) — denying to stay fail-closed.`,
+        };
+      }
+
+      for (const alt of alternatives) {
+        const altRoot = derivePatternGlobRoot(alt);
+        if (isRiskyGlobPatternRoot(altRoot)) {
+          return {
+            paths: null,
+            reason:
+              `[Cortex Path Guard] Blocked Glob: pattern "${patternField}" resolves to an ` +
+              `absolute path or a ".." traversal segment ("${altRoot}") — Glob's pattern ` +
+              `argument may never be absolute or traverse outside its root; use the ` +
+              `\`path\` argument to point at a different (allowed) root instead.`,
+          };
+        }
+        if (altRoot) {
+          // Safe relative prefix — resolves against `path` when given
+          // (mirrors how Glob itself would search relative to `path`);
+          // with no `path`, pushed as-is and resolved against cwd
+          // downstream (same treatment as every other relative candidate).
+          paths.push(explicitPath === undefined ? altRoot : join(explicitPath, altRoot));
+        }
+      }
     }
+
     return { paths };
   }
 
@@ -506,8 +602,9 @@ async function main(): Promise<void> {
   const extracted = extractCandidatePaths(toolName, input.tool_input);
   if (extracted.paths === null) {
     const reason =
+      extracted.reason ??
       `[Cortex Path Guard] Blocked ${toolName}: no resolvable file_path in the tool ` +
-      `input — denying to stay fail-closed.`;
+        `input — denying to stay fail-closed.`;
     deny(reason);
     await emitBlockEvent(sessionId, reason, toolName, "");
     return;
@@ -531,6 +628,21 @@ async function main(): Promise<void> {
     // absolute on its own, so without this it gets joined onto cwd as a
     // literal relative path and resolves harmlessly inside the allowed dir.
     const expandedPath = expandUserPath(rawPath);
+
+    // R1 fix (cortex#2343 adversarial review round 2): FAIL CLOSED on
+    // anything expandUserPath couldn't confidently resolve (a `~user` form,
+    // or a literal `$` left over from an unmodelled expansion) — see the
+    // identical rationale in bash-guard.hook.ts's checkCommandPaths().
+    if (isUnresolvedShellToken(expandedPath)) {
+      const reason =
+        `[Cortex Path Guard] Blocked ${toolName}: path argument "${rawPath}" contains an ` +
+        `unresolvable shell expansion (a ~user form or a literal "$") — denying to stay ` +
+        `fail-closed.`;
+      deny(reason);
+      await emitBlockEvent(sessionId, reason, toolName, rawPath);
+      return;
+    }
+
     const absPath = isAbsolute(expandedPath) ? expandedPath : resolvePath(process.cwd(), expandedPath);
     const decision = decidePath(toolName, absPath, policy);
     if (!decision.allow) {

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Cortex Path Guard — PreToolUse hook for the file tools (Read/Write/Edit/
- * Glob/Grep) in cortex sessions (EBH-1, cortex#2343, F1/F6).
+ * Glob/Grep/NotebookEdit) in cortex sessions (EBH-1, cortex#2343, F1/F6).
  *
  * ## Why this exists
  *
@@ -36,7 +36,7 @@
  * So instead it reads stdin to EOF (bounded by a hang-stop cap, mirroring
  * skill-guard.hook.ts's more recent, more conservative pattern) and treats
  * an empty/unparseable payload as a DENY, never a pass-through — this hook
- * is registered ONLY on the `Read|Write|Edit|Glob|Grep` matcher, so if it
+ * is registered ONLY on the `Read|Write|Edit|Glob|Grep|NotebookEdit` matcher, so if it
  * runs at all the call is one of ours to gate; an empty read means the
  * payload capture failed, not "this isn't governed".
  *
@@ -61,7 +61,7 @@ import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
 import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
-import { isContainedIn } from "../../common/path-containment";
+import { isContainedIn, expandUserPath } from "../../common/path-containment";
 
 // =============================================================================
 // Hook I/O types
@@ -73,20 +73,66 @@ interface FilePathToolInput {
 
 interface GlobGrepToolInput {
   path?: unknown;
-  pattern?: unknown; // Grep: content regex. Glob: filename glob. NEVER a path.
+  // Grep: content regex — NEVER a path. Glob: a filesystem glob — its
+  // LITERAL directory prefix (everything before the first glob metachar)
+  // IS a path and must be containment-checked (cortex#2343 adversarial
+  // review finding B2) — see {@link derivePatternGlobRoot}.
+  pattern?: unknown;
+}
+
+interface NotebookEditToolInput {
+  notebook_path?: unknown;
 }
 
 interface HookInput {
   session_id?: string;
   tool_name?: string;
-  tool_input?: FilePathToolInput | GlobGrepToolInput | string | null;
+  tool_input?: FilePathToolInput | GlobGrepToolInput | NotebookEditToolInput | string | null;
 }
 
-/** Tools this hook governs. Matches the `cortex-hooks.json` matcher exactly. */
-const GOVERNED_TOOLS = new Set(["Read", "Write", "Edit", "Glob", "Grep"]);
+/**
+ * Tools this hook governs. Matches the `cortex-hooks.json` matcher exactly.
+ * `NotebookEdit` added per cortex#2343 adversarial review finding B4: it is
+ * a grantable, mutating file tool (`src/common/policy/tool-inventory.ts`)
+ * that was previously omitted entirely — any stack granting it got
+ * unchecked arbitrary-path read/write via `notebook_path`. `MultiEdit` is
+ * NOT in `CLAUDE_TOOL_INVENTORY` (verified against tool-inventory.ts) — not
+ * a grantable cortex tool at this version, so it is out of scope here.
+ */
+const GOVERNED_TOOLS = new Set(["Read", "Write", "Edit", "Glob", "Grep", "NotebookEdit"]);
 
 /** Tools whose call MUTATES the filesystem — denied on a `readOnlyDirs` hit. */
-const WRITE_TOOLS = new Set(["Write", "Edit"]);
+const WRITE_TOOLS = new Set(["Write", "Edit", "NotebookEdit"]);
+
+/**
+ * Glob metacharacters that mark the end of a pattern's LITERAL directory
+ * prefix. `minimatch`/glob syntax uses `*`, `?`, `[...]`, and `{...}` for
+ * wildcarding — the first occurrence of any of these ends the literal
+ * (containment-checkable) portion of the pattern.
+ */
+const GLOB_METACHAR_RE = /[*?[{]/;
+
+/**
+ * Derive the containment-checkable directory prefix from a Glob `pattern`
+ * (cortex#2343 adversarial review finding B2 — Glob's `pattern`, unlike
+ * Grep's, IS a filesystem path and can itself be absolute or carry `../`
+ * traversal, e.g. `/etc/*` or `../secret/*`).
+ *
+ * Takes everything before the first glob metachar, then trims back to the
+ * last `/` in that prefix — a partial trailing SEGMENT (e.g. the `fo` in
+ * `fo*o`) is not a real directory boundary and is dropped rather than
+ * mis-containment-checked. Returns `""` when the pattern has no directory
+ * prefix worth checking (e.g. `*.ts`, `**\/*.ts`) — that case relies on the
+ * `path` field (if given) or the session's already-scoped cwd, unaffected
+ * by this fix. Exported for unit tests.
+ */
+export function derivePatternGlobRoot(pattern: string): string {
+  const metaIdx = pattern.search(GLOB_METACHAR_RE);
+  const prefix = metaIdx === -1 ? pattern : pattern.slice(0, metaIdx);
+  const lastSlash = prefix.lastIndexOf("/");
+  if (lastSlash === -1) return "";
+  return prefix.slice(0, lastSlash + 1);
+}
 
 // =============================================================================
 // CORTEX_PATH_GUARD config
@@ -163,13 +209,20 @@ export interface ExtractedPaths {
  *
  *   - Read/Write/Edit: `tool_input.file_path` — REQUIRED; missing/non-string
  *     is malformed (`paths: null`).
- *   - Glob/Grep: `tool_input.path` — OPTIONAL (both tools default to
- *     searching the invoking process's cwd when omitted, which
- *     `dispatch-handler.ts` already sets to an allowed dir — see the module
- *     doc). Absent → `paths: []` (nothing to containment-check, not a
- *     failure). `pattern` is NEVER treated as a path for either tool — for
- *     Grep it's a content regex, for Glob it's a filename glob; neither is a
- *     filesystem root.
+ *   - NotebookEdit: `tool_input.notebook_path` — REQUIRED, same treatment
+ *     (cortex#2343 finding B4).
+ *   - Grep: `tool_input.path` — OPTIONAL (defaults to searching the
+ *     invoking process's cwd when omitted, which `dispatch-handler.ts`
+ *     already sets to an allowed dir — see the module doc). Absent →
+ *     `paths: []` (nothing to containment-check, not a failure). `pattern`
+ *     is NEVER treated as a path for Grep — it's a content regex.
+ *   - Glob: `tool_input.path` (OPTIONAL root) PLUS the literal directory
+ *     prefix of `tool_input.pattern` (cortex#2343 finding B2 — unlike
+ *     Grep's, Glob's `pattern` IS a filesystem path/glob and can itself be
+ *     absolute or carry `../` traversal). A relative pattern prefix is
+ *     resolved against `path` when given; an absolute one is checked as-is
+ *     regardless of `path`. Both candidates are checked when both are
+ *     present. Neither present ⇒ `paths: []` (relies on cwd scope).
  */
 export function extractCandidatePaths(toolName: string, toolInput: HookInput["tool_input"]): ExtractedPaths {
   const input = toolInput && typeof toolInput === "object" ? toolInput : {};
@@ -180,10 +233,41 @@ export function extractCandidatePaths(toolName: string, toolInput: HookInput["to
     return { paths: [fp] };
   }
 
-  if (toolName === "Glob" || toolName === "Grep") {
+  if (toolName === "NotebookEdit") {
+    const np = (input as NotebookEditToolInput).notebook_path;
+    if (typeof np !== "string" || np.trim() === "") return { paths: null };
+    return { paths: [np] };
+  }
+
+  if (toolName === "Grep") {
     const p = (input as GlobGrepToolInput).path;
     if (typeof p !== "string" || p.trim() === "") return { paths: [] };
     return { paths: [p] };
+  }
+
+  if (toolName === "Glob") {
+    const pathField = (input as GlobGrepToolInput).path;
+    const hasExplicitPath = typeof pathField === "string" && pathField.trim() !== "";
+    const explicitPath = hasExplicitPath ? (pathField as string) : undefined;
+
+    const patternField = (input as GlobGrepToolInput).pattern;
+    const patternRoot = typeof patternField === "string" ? derivePatternGlobRoot(patternField) : "";
+
+    const paths: string[] = [];
+    if (explicitPath !== undefined) paths.push(explicitPath);
+    if (patternRoot) {
+      // Absolute prefix (e.g. `/etc/*`) is checked as-is regardless of
+      // `path`. A relative prefix resolves against `path` when given
+      // (mirrors how Glob itself would search relative to `path`); with no
+      // `path`, it's pushed as-is and resolved against cwd downstream (same
+      // treatment as every other relative candidate).
+      paths.push(
+        isAbsolute(patternRoot) || explicitPath === undefined
+          ? patternRoot
+          : join(explicitPath, patternRoot),
+      );
+    }
+    return { paths };
   }
 
   // Not a tool this hook governs (defensive — the matcher should already
@@ -349,8 +433,11 @@ export function decidePath(toolName: string, absPath: string, policy: PathGuardP
       allow: false,
       reason:
         `[Cortex Path Guard] Blocked ${toolName} "${absPath}": this path is inside a ` +
-        `READ-ONLY directory — writes are refused (closes F6, docs/security/reviews/` +
-        `2026-07-23-nws-security-review.md). Reads remain permitted.`,
+        `READ-ONLY directory — writes are refused (docs/security/reviews/` +
+        `2026-07-23-nws-security-review.md F6). Reads remain permitted. Note: this is ` +
+        `the read-only-write MECHANISM; F6 is fully closed in production once ` +
+        `dispatch-handler.ts threads a distinct readOnlyDirs value through to ` +
+        `CORTEX_PATH_GUARD on live sessions (EBH-1b).`,
     };
   }
 
@@ -438,7 +525,13 @@ async function main(): Promise<void> {
   }
 
   for (const rawPath of extracted.paths) {
-    const absPath = isAbsolute(rawPath) ? rawPath : resolvePath(process.cwd(), rawPath);
+    // B1 fix (cortex#2343 adversarial review): expand `~`/`$VAR` BEFORE
+    // isAbsolute/resolve — see the identical rationale in bash-guard.hook.ts's
+    // checkCommandPaths(). A file_path/path token of `~/.ssh/id_rsa` is not
+    // absolute on its own, so without this it gets joined onto cwd as a
+    // literal relative path and resolves harmlessly inside the allowed dir.
+    const expandedPath = expandUserPath(rawPath);
+    const absPath = isAbsolute(expandedPath) ? expandedPath : resolvePath(process.cwd(), expandedPath);
     const decision = decidePath(toolName, absPath, policy);
     if (!decision.allow) {
       deny(decision.reason);

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -1,0 +1,467 @@
+#!/usr/bin/env bun
+/**
+ * Cortex Path Guard — PreToolUse hook for the file tools (Read/Write/Edit/
+ * Glob/Grep) in cortex sessions (EBH-1, cortex#2343, F1/F6).
+ *
+ * ## Why this exists
+ *
+ * Before this hook, NOTHING cortex-owned denied a file-tool call outside a
+ * session's configured `allowedDirs`/`readOnlyDirs` — the boundary was
+ * `--add-dir` (an ADDITIVE grant, not a deny) plus the natural-language
+ * `FILESYSTEM RESTRICTION` / `READ-ONLY RESTRICTION` rules in
+ * `security-preamble.ts`, which an injected instruction can simply ask the
+ * model to ignore (docs/design-session-sandbox.md §1, F1/F6). This hook is
+ * the deterministic Tier-0 guard that design spec commissions for the file
+ * tools; `bash-guard.hook.ts`'s new path checks (cortex#2343 step 3) cover
+ * the equivalent Bash read-command surface.
+ *
+ * ## I/O contract — mirrors bash-guard.hook.ts
+ *
+ *   - Activation gate: only acts when `CORTEX_CHANNEL` (or the legacy
+ *     `GROVE_CHANNEL` read-fallback) is set — a non-cortex session passes
+ *     through UNCHANGED (`{"continue":true}`).
+ *   - `deny(reason)` / `pass()` emit the exact same
+ *     `hookSpecificOutput.permissionDecision` JSON shapes bash-guard.hook.ts
+ *     does, so the reason surfaces to the agent + the Cortex→Discord relay.
+ *   - `grant(reason)` is this hook's own auto-approve terminal — Claude Code
+ *     reads `hookSpecificOutput.permissionDecision:"allow"` and skips the
+ *     normal approval prompt, exactly like bash-guard's grant().
+ *
+ * ## Deliberate divergence from bash-guard on stdin handling
+ *
+ * bash-guard races the stdin read against a 200ms timer and falls back to
+ * `pass()` on a miss — sound for bash-guard because Bash is allow-by-default
+ * there, so a missed read merely defers to Claude Code's own gate. THIS
+ * hook's task explicitly requires FAIL CLOSED on any parse/resolve failure.
+ * So instead it reads stdin to EOF (bounded by a hang-stop cap, mirroring
+ * skill-guard.hook.ts's more recent, more conservative pattern) and treats
+ * an empty/unparseable payload as a DENY, never a pass-through — this hook
+ * is registered ONLY on the `Read|Write|Edit|Glob|Grep` matcher, so if it
+ * runs at all the call is one of ours to gate; an empty read means the
+ * payload capture failed, not "this isn't governed".
+ *
+ * ## Policy source — CORTEX_PATH_GUARD
+ *
+ * `CORTEX_PATH_GUARD` carries `{"allowedDirs":[...],"readOnlyDirs":[...]}`,
+ * written unconditionally by `cc-session.ts` (mirroring how
+ * `CORTEX_BASH_GUARD` is populated — {@link resolvePathGuardEnv} in
+ * `cc-session.ts`). An EMPTY policy (`{}`, unset, or `{allowedDirs:[],
+ * readOnlyDirs:[]}`) is treated as "no restriction configured" and passes
+ * through — this matches the EXISTING contract `security-preamble.ts`
+ * already encodes (`allDirs.length > 0` gates whether the FILESYSTEM
+ * RESTRICTION prose even appears); this hook makes that SAME contract real
+ * instead of advisory, it does not change WHEN restriction applies. A
+ * MALFORMED `CORTEX_PATH_GUARD` (present but not parseable JSON, or not an
+ * object) is a genuine failure, not "empty" — DENY.
+ */
+
+import { isAbsolute, join, resolve as resolvePath } from "path";
+import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
+import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
+import { eventsDir } from "../../common/events-path";
+import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
+import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
+import { isContainedIn } from "../../common/path-containment";
+
+// =============================================================================
+// Hook I/O types
+// =============================================================================
+
+interface FilePathToolInput {
+  file_path?: unknown;
+}
+
+interface GlobGrepToolInput {
+  path?: unknown;
+  pattern?: unknown; // Grep: content regex. Glob: filename glob. NEVER a path.
+}
+
+interface HookInput {
+  session_id?: string;
+  tool_name?: string;
+  tool_input?: FilePathToolInput | GlobGrepToolInput | string | null;
+}
+
+/** Tools this hook governs. Matches the `cortex-hooks.json` matcher exactly. */
+const GOVERNED_TOOLS = new Set(["Read", "Write", "Edit", "Glob", "Grep"]);
+
+/** Tools whose call MUTATES the filesystem — denied on a `readOnlyDirs` hit. */
+const WRITE_TOOLS = new Set(["Write", "Edit"]);
+
+// =============================================================================
+// CORTEX_PATH_GUARD config
+// =============================================================================
+
+export interface PathGuardPolicy {
+  allowedDirs: string[];
+  readOnlyDirs: string[];
+}
+
+export interface PathGuardConfigResult {
+  /** false only for a GENUINE failure (present-but-malformed env value). */
+  ok: boolean;
+  policy: PathGuardPolicy;
+  reason: string;
+}
+
+function toStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string");
+}
+
+/**
+ * Parse `CORTEX_PATH_GUARD`. Absence is a LEGITIMATE empty policy (not a
+ * failure) — see the module doc's "Policy source" section. A present value
+ * that isn't parseable JSON, or doesn't parse to an object, IS a failure —
+ * `ok:false` — callers must DENY rather than silently substitute an empty
+ * policy for a malformed one. Exported for unit tests.
+ */
+export function parsePathGuardConfig(raw: string | undefined): PathGuardConfigResult {
+  if (raw === undefined || raw.trim() === "") {
+    return { ok: true, policy: { allowedDirs: [], readOnlyDirs: [] }, reason: "" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      policy: { allowedDirs: [], readOnlyDirs: [] },
+      reason: `CORTEX_PATH_GUARD is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      policy: { allowedDirs: [], readOnlyDirs: [] },
+      reason: "CORTEX_PATH_GUARD did not parse to a JSON object",
+    };
+  }
+  const obj = parsed as Record<string, unknown>;
+  return {
+    ok: true,
+    policy: {
+      allowedDirs: toStringArray(obj.allowedDirs),
+      readOnlyDirs: toStringArray(obj.readOnlyDirs),
+    },
+    reason: "",
+  };
+}
+
+// =============================================================================
+// tool_input path extraction
+// =============================================================================
+
+export interface ExtractedPaths {
+  /** null = the call is malformed for this tool (a required path is missing). */
+  paths: string[] | null;
+}
+
+/**
+ * Extract the filesystem path(s) this tool call touches, for the tools this
+ * hook governs. Exported for unit tests.
+ *
+ *   - Read/Write/Edit: `tool_input.file_path` — REQUIRED; missing/non-string
+ *     is malformed (`paths: null`).
+ *   - Glob/Grep: `tool_input.path` — OPTIONAL (both tools default to
+ *     searching the invoking process's cwd when omitted, which
+ *     `dispatch-handler.ts` already sets to an allowed dir — see the module
+ *     doc). Absent → `paths: []` (nothing to containment-check, not a
+ *     failure). `pattern` is NEVER treated as a path for either tool — for
+ *     Grep it's a content regex, for Glob it's a filename glob; neither is a
+ *     filesystem root.
+ */
+export function extractCandidatePaths(toolName: string, toolInput: HookInput["tool_input"]): ExtractedPaths {
+  const input = toolInput && typeof toolInput === "object" ? toolInput : {};
+
+  if (toolName === "Read" || toolName === "Write" || toolName === "Edit") {
+    const fp = (input as FilePathToolInput).file_path;
+    if (typeof fp !== "string" || fp.trim() === "") return { paths: null };
+    return { paths: [fp] };
+  }
+
+  if (toolName === "Glob" || toolName === "Grep") {
+    const p = (input as GlobGrepToolInput).path;
+    if (typeof p !== "string" || p.trim() === "") return { paths: [] };
+    return { paths: [p] };
+  }
+
+  // Not a tool this hook governs (defensive — the matcher should already
+  // exclude this call from ever reaching us).
+  return { paths: [] };
+}
+
+// =============================================================================
+// Decision emitters — byte-identical shapes to bash-guard.hook.ts
+// =============================================================================
+
+function pass(): void {
+  console.log(JSON.stringify({ continue: true }));
+}
+
+function grant(reason: string): void {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+}
+
+function deny(reason: string): void {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+}
+
+// =============================================================================
+// Telemetry — `tool.path.blocked`. Mirrors bash-guard.hook.ts's
+// emitBlockEvent exactly (HTTP POST primary, JSONL fallback, best-effort —
+// never throws, never delays or blocks the deny decision).
+// =============================================================================
+
+const INGEST_URL =
+  process.env.CORTEX_INGEST_URL ?? "http://localhost:8766/api/events/ingest";
+const EVENTS_DIR = eventsDir();
+const RAW_DIR = join(EVENTS_DIR, "raw");
+
+function buildBlockEvent(
+  sessionId: string,
+  reason: string,
+  toolName: string,
+  pathPreview: string,
+): Record<string, unknown> {
+  return {
+    event_id: crypto.randomUUID(),
+    event_type: EVENT_TYPES.PATH_BLOCKED,
+    timestamp: new Date().toISOString(),
+    session_id: sessionId,
+    cortex_channel: resolveSurfaceEnv("CHANNEL"),
+    grove_channel: resolveSurfaceEnv("CHANNEL"),
+    agent_id: resolveSurfaceEnv("AGENT_ID"),
+    agent_name: resolveSurfaceEnv("AGENT_NAME"),
+    network_id: resolveSurfaceEnv("NETWORK"),
+    source: { hook: "PreToolUse", tool_name: toolName },
+    payload: {
+      reason,
+      path_preview: pathPreview.slice(0, 200),
+      project: resolveSurfaceEnv("PROJECT"),
+      entity: resolveSurfaceEnv("ENTITY"),
+      principal: resolvePrincipalEnv(""),
+    },
+  };
+}
+
+async function emitBlockEvent(
+  sessionId: string,
+  reason: string,
+  toolName: string,
+  pathPreview: string,
+): Promise<void> {
+  const event = buildBlockEvent(sessionId, reason, toolName, pathPreview);
+
+  try {
+    await fetch(INGEST_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+      signal: AbortSignal.timeout(500),
+    });
+  } catch { /* dashboard down / refused — fall through to JSONL */ }
+
+  try {
+    if (!existsSync(RAW_DIR)) {
+      mkdirSync(RAW_DIR, { recursive: true, mode: 0o700 });
+    }
+    const filePath = join(RAW_DIR, `${sessionId}.jsonl`);
+    appendFileSync(filePath, JSON.stringify(event) + "\n");
+    chmodSync(filePath, 0o600);
+  } catch { /* filesystem unavailable — give up silently */ }
+}
+
+// =============================================================================
+// stdin read — full read to EOF with a hang-stop cap. See the module doc
+// ("Deliberate divergence from bash-guard on stdin handling") for why this
+// hook does NOT use bash-guard's 200ms race.
+// =============================================================================
+
+const STDIN_READ_CAP_MS = 5_000;
+
+async function readStdinToEof(): Promise<string> {
+  const timedOut = Symbol("timedOut");
+  let capTimer: ReturnType<typeof setTimeout> | undefined;
+  const outcome = await Promise.race([
+    Bun.stdin.text(),
+    new Promise<typeof timedOut>((r) => {
+      capTimer = setTimeout(() => {
+        r(timedOut);
+      }, STDIN_READ_CAP_MS);
+    }),
+  ]);
+  if (capTimer !== undefined) clearTimeout(capTimer);
+  if (outcome === timedOut) {
+    throw new Error("path-guard: stdin read exceeded cap before EOF");
+  }
+  return outcome;
+}
+
+// =============================================================================
+// Path decision — pure, exported for unit tests.
+// =============================================================================
+
+export interface PathDecision {
+  allow: boolean;
+  reason: string;
+}
+
+/**
+ * Decide whether `absPath` is permitted for `toolName` under `policy`.
+ * Pure — does its own realpath/containment I/O via `isContainedIn` but
+ * takes no other state, so it's directly unit-testable against a real
+ * temp-dir fixture. Exported for unit tests.
+ */
+export function decidePath(toolName: string, absPath: string, policy: PathGuardPolicy): PathDecision {
+  const inAllowed = policy.allowedDirs.some((d) => isContainedIn(d, absPath));
+  const inReadOnly = !inAllowed && policy.readOnlyDirs.some((d) => isContainedIn(d, absPath));
+
+  if (!inAllowed && !inReadOnly) {
+    return {
+      allow: false,
+      reason:
+        `[Cortex Path Guard] Blocked ${toolName} "${absPath}": path resolves outside every ` +
+        `configured allowedDirs/readOnlyDirs entry. This is a hard security boundary ` +
+        `(EBH-1, cortex#2343) — ask the principal to widen allowedDirs if this path is ` +
+        `genuinely needed.`,
+    };
+  }
+
+  if (WRITE_TOOLS.has(toolName) && inReadOnly && !inAllowed) {
+    return {
+      allow: false,
+      reason:
+        `[Cortex Path Guard] Blocked ${toolName} "${absPath}": this path is inside a ` +
+        `READ-ONLY directory — writes are refused (closes F6, docs/security/reviews/` +
+        `2026-07-23-nws-security-review.md). Reads remain permitted.`,
+    };
+  }
+
+  return { allow: true, reason: `[Cortex Path Guard] Auto-approved: "${absPath}" is within policy scope.` };
+}
+
+// =============================================================================
+// main
+// =============================================================================
+
+async function main(): Promise<void> {
+  // Gate — not a cortex session: pass through silently. Mirrors bash-guard's
+  // gate 1 exactly (resolveSurfaceEnv reads CORTEX_CHANNEL with the legacy
+  // GROVE_CHANNEL fallback).
+  if (!resolveSurfaceEnv("CHANNEL")) {
+    pass();
+    return;
+  }
+
+  let input: HookInput;
+  try {
+    const raw = await readStdinToEof();
+    if (!raw.trim()) {
+      // This hook is registered ONLY on the Read|Write|Edit|Glob|Grep
+      // matcher — an empty payload means capture failed, not "not ours".
+      // FAIL CLOSED (see module doc).
+      deny(
+        "[Cortex Path Guard] Blocked: empty tool input — could not identify the " +
+          "file-tool call; denying to stay fail-closed.",
+      );
+      return;
+    }
+    input = JSON.parse(raw) as HookInput;
+  } catch (err) {
+    deny(
+      `[Cortex Path Guard] Blocked: could not read/parse the tool input (${err instanceof Error ? err.message : String(err)}) — denying to stay fail-closed.`,
+    );
+    return;
+  }
+
+  const toolName = input.tool_name ?? "";
+  if (!GOVERNED_TOOLS.has(toolName)) {
+    // Not one of ours (defensive — shouldn't happen given the matcher).
+    pass();
+    return;
+  }
+
+  const sessionId = input.session_id ?? process.env.CLAUDE_SESSION_ID ?? "unknown";
+
+  const configResult = parsePathGuardConfig(process.env.CORTEX_PATH_GUARD);
+  if (!configResult.ok) {
+    const reason = `[Cortex Path Guard] Blocked ${toolName}: ${configResult.reason} — denying to stay fail-closed.`;
+    deny(reason);
+    await emitBlockEvent(sessionId, reason, toolName, "");
+    return;
+  }
+
+  const { policy } = configResult;
+  if (policy.allowedDirs.length === 0 && policy.readOnlyDirs.length === 0) {
+    // No restriction configured for this session — matches the EXISTING
+    // security-preamble.ts contract (see module doc's "Policy source").
+    pass();
+    return;
+  }
+
+  const extracted = extractCandidatePaths(toolName, input.tool_input);
+  if (extracted.paths === null) {
+    const reason =
+      `[Cortex Path Guard] Blocked ${toolName}: no resolvable file_path in the tool ` +
+      `input — denying to stay fail-closed.`;
+    deny(reason);
+    await emitBlockEvent(sessionId, reason, toolName, "");
+    return;
+  }
+
+  if (extracted.paths.length === 0) {
+    // Glob/Grep with no explicit `path` argument — nothing to containment-
+    // check; relies on the session's cwd already being scoped inside
+    // allowedDirs (dispatch-handler.ts sets cwd to the first allowed dir).
+    grant(
+      "[Cortex Path Guard] Auto-approved: no explicit path argument — relying on the " +
+        "session's already-scoped working directory.",
+    );
+    return;
+  }
+
+  for (const rawPath of extracted.paths) {
+    const absPath = isAbsolute(rawPath) ? rawPath : resolvePath(process.cwd(), rawPath);
+    const decision = decidePath(toolName, absPath, policy);
+    if (!decision.allow) {
+      deny(decision.reason);
+      await emitBlockEvent(sessionId, decision.reason, toolName, absPath);
+      return;
+    }
+  }
+
+  grant(
+    `[Cortex Path Guard] Auto-approved: ${toolName} path(s) resolve within the configured ` +
+      `allowedDirs/readOnlyDirs policy.`,
+  );
+}
+
+// Only execute the gate when run AS a script — mirrors skill-guard.hook.ts's
+// `import.meta.main` guard so unit tests can import the pure helpers
+// (parsePathGuardConfig / extractCandidatePaths / decidePath) without
+// triggering main()'s stdin read.
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    // An unexpected failure anywhere in the gate must fail CLOSED, not open.
+    deny(
+      `[Cortex Path Guard] Blocked: internal hook error (${err instanceof Error ? err.message : String(err)}) — denying to stay fail-closed.`,
+    );
+  });
+}

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -55,13 +55,13 @@
  * object) is a genuine failure, not "empty" — DENY.
  */
 
-import { isAbsolute, join, resolve as resolvePath } from "path";
+import { join } from "path";
 import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
 import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
 import { eventsDir } from "../../common/events-path";
 import { resolveSurfaceEnv } from "../../taps/cc-events/hooks/lib/surface-env";
 import { resolvePrincipalEnv } from "../../taps/cc-events/hooks/lib/principal-env";
-import { isContainedIn, expandUserPath, isUnresolvedShellToken } from "../../common/path-containment";
+import { isContainedIn, reduceTokenToRealPathOrReject } from "../../common/path-containment";
 
 // =============================================================================
 // Hook I/O types
@@ -103,91 +103,6 @@ const GOVERNED_TOOLS = new Set(["Read", "Write", "Edit", "Glob", "Grep", "Notebo
 
 /** Tools whose call MUTATES the filesystem — denied on a `readOnlyDirs` hit. */
 const WRITE_TOOLS = new Set(["Write", "Edit", "NotebookEdit"]);
-
-/**
- * Glob metacharacters that mark the end of a pattern's LITERAL directory
- * prefix, EXCLUDING `{` — brace groups are handled separately by
- * {@link expandBraceAlternatives} so their CONTENTS get inspected rather
- * than treated as an opaque metachar boundary (cortex#2343 adversarial
- * review round 2, finding R2: `{../secret,x}/*` used to stop at `{` and
- * never see the `../secret` traversal hiding inside it).
- */
-const GLOB_METACHAR_RE = /[*?[]/;
-
-/**
- * Derive the containment-checkable directory prefix from a single Glob
- * pattern ALTERNATIVE (braces already resolved — see
- * {@link expandBraceAlternatives}). Takes everything before the first glob
- * metachar, then trims back to the last `/` in that prefix — a partial
- * trailing SEGMENT (e.g. the `fo` in `fo*o`) is not a real directory
- * boundary and is dropped rather than mis-containment-checked. Returns `""`
- * when the pattern has no directory prefix worth checking (e.g. `*.ts`,
- * `**\/*.ts`) — that case relies on the `path` field (if given) or the
- * session's already-scoped cwd. Exported for unit tests.
- */
-export function derivePatternGlobRoot(pattern: string): string {
-  const metaIdx = pattern.search(GLOB_METACHAR_RE);
-  const prefix = metaIdx === -1 ? pattern : pattern.slice(0, metaIdx);
-  const lastSlash = prefix.lastIndexOf("/");
-  if (lastSlash === -1) return "";
-  return prefix.slice(0, lastSlash + 1);
-}
-
-export type BraceExpansionResult =
-  | { kind: "none" } // no brace group at all — treat `pattern` as the sole alternative
-  | { kind: "expanded"; alternatives: string[] } // one clean brace group, resolved
-  | { kind: "ambiguous" }; // nested/unbalanced/multiple brace groups — FAIL CLOSED
-
-/**
- * Expand ONE level of brace alternatives in a Glob pattern:
- * `"{a,b,c}/x"` → `["a/x", "b/x", "c/x"]` (cortex#2343 adversarial review
- * round 2, finding R2 — `derivePatternGlobRoot` alone stops at the first
- * metachar, so `{../secret,x}/*` never got its `../secret` alternative
- * inspected at all).
- *
- * FAILS CLOSED (`kind: "ambiguous"`) rather than guessing on anything this
- * simple one-level parser can't confidently handle: a nested brace group
- * inside the first one, more than one top-level brace group, or an
- * unbalanced `{`/`}`. The instruction from the adversarial review is
- * explicit: "if brace parsing is at all uncertain, DENY the pattern" —
- * legitimate Glob patterns never need nested/multiple brace groups, so
- * denying that shape costs nothing real. Exported for unit tests.
- */
-export function expandBraceAlternatives(pattern: string): BraceExpansionResult {
-  const firstOpen = pattern.indexOf("{");
-  if (firstOpen === -1) return { kind: "none" };
-
-  const firstClose = pattern.indexOf("}", firstOpen);
-  if (firstClose === -1) return { kind: "ambiguous" }; // unbalanced
-
-  const inner = pattern.slice(firstOpen + 1, firstClose);
-  if (inner.includes("{") || inner.includes("}")) return { kind: "ambiguous" }; // nested
-
-  const rest = pattern.slice(firstClose + 1);
-  if (rest.includes("{") || rest.includes("}")) return { kind: "ambiguous" }; // a second group
-
-  const prefix = pattern.slice(0, firstOpen);
-  const options = inner.split(",");
-  const alternatives = options.map((opt) => prefix + opt + rest);
-  return { kind: "expanded", alternatives };
-}
-
-/**
- * True when `patternRoot` (a derived literal directory prefix — may be `""`
- * when the pattern has none) is inherently unsafe for a Glob `pattern`
- * argument: absolute, or carrying a `..` path segment. Per the adversarial
- * review: "legit globs never need `..`, absolute, or escaping braces" — a
- * risky alternative denies the WHOLE Glob call outright rather than being
- * handed to the normal containment check (which could, in principle, still
- * ALLOW an absolute pattern that happens to resolve inside scope — the
- * review wants a strictly narrower, unconditional rule for Glob's pattern
- * argument specifically). Exported for unit tests.
- */
-export function isRiskyGlobPatternRoot(patternRoot: string): boolean {
-  if (patternRoot === "") return false;
-  if (isAbsolute(patternRoot)) return true;
-  return patternRoot.split("/").some((segment) => segment === "..");
-}
 
 // =============================================================================
 // CORTEX_PATH_GUARD config
@@ -253,122 +168,110 @@ export function parsePathGuardConfig(raw: string | undefined): PathGuardConfigRe
 // tool_input path extraction
 // =============================================================================
 
+/**
+ * A raw path/pattern token this hook must reduce+containment-check, paired
+ * with the BASE directory it resolves against when relative. Almost always
+ * `process.cwd()`; the one exception is a Glob `pattern`'s literal prefix,
+ * which resolves against `path` when the call ALSO supplied one (mirroring
+ * how Glob itself would search relative to `path`) — see the Glob branch
+ * below.
+ */
+export interface CandidateToken {
+  raw: string;
+  base: string;
+}
+
 export interface ExtractedPaths {
   /**
-   * null = the call must be DENIED for this tool — either a required path is
-   * missing (malformed call), or (Glob only) the `pattern` argument is
-   * itself unsafe/ambiguous (absolute, carries a `..` segment, or brace
-   * parsing was uncertain — cortex#2343 adversarial review round 2, R2).
+   * null = the call must be DENIED for this tool — a required path is
+   * missing (malformed call). Any AMBIGUITY/RISK in a token's shell/brace/
+   * glob syntax is now detected uniformly by the shared
+   * {@link reduceTokenToRealPathOrReject} reducer at containment-check
+   * time (cortex#2343 adversarial review round 3), not here.
    */
-  paths: string[] | null;
-  /** Populated when `paths` is null — WHY the call must be denied. Falls
+  tokens: CandidateToken[] | null;
+  /** Populated when `tokens` is null — WHY the call must be denied. Falls
    *  back to a generic reason at the call site when absent. */
   reason?: string;
 }
 
 /**
- * Extract the filesystem path(s) this tool call touches, for the tools this
- * hook governs. Exported for unit tests.
+ * Extract the raw filesystem path/pattern token(s) this tool call touches,
+ * for the tools this hook governs. Exported for unit tests. Deliberately
+ * does NO shell/brace/wildcard interpretation itself — that is entirely
+ * {@link reduceTokenToRealPathOrReject}'s job now (cortex#2343 adversarial
+ * review round 3: unifying the token→real-path reduction into ONE shared
+ * function is what stops a fix from landing on one hook/surface and
+ * missing the other).
  *
  *   - Read/Write/Edit: `tool_input.file_path` — REQUIRED; missing/non-string
- *     is malformed (`paths: null`).
+ *     is malformed (`tokens: null`).
  *   - NotebookEdit: `tool_input.notebook_path` — REQUIRED, same treatment
  *     (cortex#2343 finding B4).
  *   - Grep: `tool_input.path` — OPTIONAL (defaults to searching the
  *     invoking process's cwd when omitted, which `dispatch-handler.ts`
  *     already sets to an allowed dir — see the module doc). Absent →
- *     `paths: []` (nothing to containment-check, not a failure). `pattern`
+ *     `tokens: []` (nothing to containment-check, not a failure). `pattern`
  *     is NEVER treated as a path for Grep — it's a content regex.
- *   - Glob: `tool_input.path` (OPTIONAL root) PLUS the literal directory
- *     prefix of `tool_input.pattern` (cortex#2343 finding B2 — unlike
- *     Grep's, Glob's `pattern` IS a filesystem path/glob and can itself be
- *     absolute or carry `../` traversal). A relative pattern prefix is
- *     resolved against `path` when given; an absolute one is checked as-is
- *     regardless of `path`. Both candidates are checked when both are
- *     present. Neither present ⇒ `paths: []` (relies on cwd scope).
+ *   - Glob: `tool_input.path` (OPTIONAL root, base=cwd) PLUS
+ *     `tool_input.pattern` itself (cortex#2343 finding B2 — unlike Grep's,
+ *     Glob's `pattern` IS a filesystem path/glob and can itself be absolute
+ *     or carry `../` traversal) — the pattern token's `base` is `path` when
+ *     given, else cwd, so the reducer resolves a relative pattern prefix
+ *     the same way Glob itself would search relative to `path`.
  */
-export function extractCandidatePaths(toolName: string, toolInput: HookInput["tool_input"]): ExtractedPaths {
+export function extractCandidatePaths(
+  toolName: string,
+  toolInput: HookInput["tool_input"],
+  cwd: string,
+): ExtractedPaths {
   const input = toolInput && typeof toolInput === "object" ? toolInput : {};
 
   if (toolName === "Read" || toolName === "Write" || toolName === "Edit") {
     const fp = (input as FilePathToolInput).file_path;
-    if (typeof fp !== "string" || fp.trim() === "") return { paths: null };
-    return { paths: [fp] };
+    if (typeof fp !== "string" || fp.trim() === "") {
+      return {
+        tokens: null,
+        reason: `[Cortex Path Guard] Blocked ${toolName}: no resolvable file_path in the tool input — denying to stay fail-closed.`,
+      };
+    }
+    return { tokens: [{ raw: fp, base: cwd }] };
   }
 
   if (toolName === "NotebookEdit") {
     const np = (input as NotebookEditToolInput).notebook_path;
-    if (typeof np !== "string" || np.trim() === "") return { paths: null };
-    return { paths: [np] };
+    if (typeof np !== "string" || np.trim() === "") {
+      return {
+        tokens: null,
+        reason: `[Cortex Path Guard] Blocked NotebookEdit: no resolvable notebook_path in the tool input — denying to stay fail-closed.`,
+      };
+    }
+    return { tokens: [{ raw: np, base: cwd }] };
   }
 
   if (toolName === "Grep") {
     const p = (input as GlobGrepToolInput).path;
-    if (typeof p !== "string" || p.trim() === "") return { paths: [] };
-    return { paths: [p] };
+    if (typeof p !== "string" || p.trim() === "") return { tokens: [] };
+    return { tokens: [{ raw: p, base: cwd }] };
   }
 
   if (toolName === "Glob") {
     const pathField = (input as GlobGrepToolInput).path;
     const hasExplicitPath = typeof pathField === "string" && pathField.trim() !== "";
     const explicitPath = hasExplicitPath ? (pathField as string) : undefined;
-
     const patternField = (input as GlobGrepToolInput).pattern;
-    const paths: string[] = [];
-    if (explicitPath !== undefined) paths.push(explicitPath);
 
+    const tokens: CandidateToken[] = [];
+    if (explicitPath !== undefined) tokens.push({ raw: explicitPath, base: cwd });
     if (typeof patternField === "string") {
-      // R2 fix (cortex#2343 adversarial review round 2): brace-aware
-      // traversal/absolute check. Expand ONE level of brace alternatives
-      // FIRST — `{../secret,x}/*` must have its `../secret` alternative
-      // inspected, not hidden behind the `{` metachar boundary — then
-      // treat every alternative (or the pattern itself, when there are no
-      // braces) identically: any alternative whose derived literal
-      // directory prefix is absolute or carries a `..` segment DENIES the
-      // WHOLE Glob call outright (fail-closed; "legit globs never need
-      // `..`, absolute, or escaping braces"). Ambiguous brace parsing
-      // (nested/unbalanced/multiple groups) denies outright too.
-      const braceResult = expandBraceAlternatives(patternField);
-      const alternatives = braceResult.kind === "expanded" ? braceResult.alternatives : [patternField];
-
-      if (braceResult.kind === "ambiguous") {
-        return {
-          paths: null,
-          reason:
-            `[Cortex Path Guard] Blocked Glob: pattern "${patternField}" has brace syntax ` +
-            `this guard cannot confidently parse (nested, unbalanced, or multiple brace ` +
-            `groups) — denying to stay fail-closed.`,
-        };
-      }
-
-      for (const alt of alternatives) {
-        const altRoot = derivePatternGlobRoot(alt);
-        if (isRiskyGlobPatternRoot(altRoot)) {
-          return {
-            paths: null,
-            reason:
-              `[Cortex Path Guard] Blocked Glob: pattern "${patternField}" resolves to an ` +
-              `absolute path or a ".." traversal segment ("${altRoot}") — Glob's pattern ` +
-              `argument may never be absolute or traverse outside its root; use the ` +
-              `\`path\` argument to point at a different (allowed) root instead.`,
-          };
-        }
-        if (altRoot) {
-          // Safe relative prefix — resolves against `path` when given
-          // (mirrors how Glob itself would search relative to `path`);
-          // with no `path`, pushed as-is and resolved against cwd
-          // downstream (same treatment as every other relative candidate).
-          paths.push(explicitPath === undefined ? altRoot : join(explicitPath, altRoot));
-        }
-      }
+      tokens.push({ raw: patternField, base: explicitPath ?? cwd });
     }
-
-    return { paths };
+    return { tokens };
   }
 
   // Not a tool this hook governs (defensive — the matcher should already
   // exclude this call from ever reaching us).
-  return { paths: [] };
+  return { tokens: [] };
 }
 
 // =============================================================================
@@ -599,18 +502,18 @@ async function main(): Promise<void> {
     return;
   }
 
-  const extracted = extractCandidatePaths(toolName, input.tool_input);
-  if (extracted.paths === null) {
+  const extracted = extractCandidatePaths(toolName, input.tool_input, process.cwd());
+  if (extracted.tokens === null) {
     const reason =
       extracted.reason ??
-      `[Cortex Path Guard] Blocked ${toolName}: no resolvable file_path in the tool ` +
+      `[Cortex Path Guard] Blocked ${toolName}: no resolvable path argument in the tool ` +
         `input — denying to stay fail-closed.`;
     deny(reason);
     await emitBlockEvent(sessionId, reason, toolName, "");
     return;
   }
 
-  if (extracted.paths.length === 0) {
+  if (extracted.tokens.length === 0) {
     // Glob/Grep with no explicit `path` argument — nothing to containment-
     // check; relies on the session's cwd already being scoped inside
     // allowedDirs (dispatch-handler.ts sets cwd to the first allowed dir).
@@ -621,34 +524,28 @@ async function main(): Promise<void> {
     return;
   }
 
-  for (const rawPath of extracted.paths) {
-    // B1 fix (cortex#2343 adversarial review): expand `~`/`$VAR` BEFORE
-    // isAbsolute/resolve — see the identical rationale in bash-guard.hook.ts's
-    // checkCommandPaths(). A file_path/path token of `~/.ssh/id_rsa` is not
-    // absolute on its own, so without this it gets joined onto cwd as a
-    // literal relative path and resolves harmlessly inside the allowed dir.
-    const expandedPath = expandUserPath(rawPath);
-
-    // R1 fix (cortex#2343 adversarial review round 2): FAIL CLOSED on
-    // anything expandUserPath couldn't confidently resolve (a `~user` form,
-    // or a literal `$` left over from an unmodelled expansion) — see the
-    // identical rationale in bash-guard.hook.ts's checkCommandPaths().
-    if (isUnresolvedShellToken(expandedPath)) {
-      const reason =
-        `[Cortex Path Guard] Blocked ${toolName}: path argument "${rawPath}" contains an ` +
-        `unresolvable shell expansion (a ~user form or a literal "$") — denying to stay ` +
-        `fail-closed.`;
+  // cortex#2343 adversarial review round 3: EVERY raw token reduces to zero
+  // or more real paths through the ONE shared reducer
+  // (reduceTokenToRealPathOrReject) — the single place `~`/`$VAR` expansion,
+  // fail-closed ambiguity detection, and brace/wildcard-aware traversal
+  // checks happen for BOTH this hook and bash-guard.hook.ts. This hook's
+  // job after that point is unchanged: containment-check every resolved
+  // real path via decidePath().
+  for (const token of extracted.tokens) {
+    const reduced = reduceTokenToRealPathOrReject(token.raw, token.base);
+    if (!reduced.ok) {
+      const reason = `[Cortex Path Guard] Blocked ${toolName}: ${reduced.reason} — denying to stay fail-closed.`;
       deny(reason);
-      await emitBlockEvent(sessionId, reason, toolName, rawPath);
+      await emitBlockEvent(sessionId, reason, toolName, token.raw);
       return;
     }
-
-    const absPath = isAbsolute(expandedPath) ? expandedPath : resolvePath(process.cwd(), expandedPath);
-    const decision = decidePath(toolName, absPath, policy);
-    if (!decision.allow) {
-      deny(decision.reason);
-      await emitBlockEvent(sessionId, decision.reason, toolName, absPath);
-      return;
+    for (const realPath of reduced.reals) {
+      const decision = decidePath(toolName, realPath, policy);
+      if (!decision.allow) {
+        deny(decision.reason);
+        await emitBlockEvent(sessionId, decision.reason, toolName, realPath);
+        return;
+      }
     }
   }
 

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -257,8 +257,7 @@ export function extractCandidatePaths(
 
   if (toolName === "Glob") {
     const pathField = (input as GlobGrepToolInput).path;
-    const hasExplicitPath = typeof pathField === "string" && pathField.trim() !== "";
-    const explicitPath = hasExplicitPath ? (pathField as string) : undefined;
+    const explicitPath = typeof pathField === "string" && pathField.trim() !== "" ? pathField : undefined;
     const patternField = (input as GlobGrepToolInput).pattern;
 
     const tokens: CandidateToken[] = [];
@@ -427,7 +426,7 @@ export function decidePath(toolName: string, absPath: string, policy: PathGuardP
     };
   }
 
-  if (WRITE_TOOLS.has(toolName) && inReadOnly && !inAllowed) {
+  if (WRITE_TOOLS.has(toolName) && inReadOnly) {
     return {
       allow: false,
       reason:

--- a/src/settings/cortex-hooks.json
+++ b/src/settings/cortex-hooks.json
@@ -36,7 +36,7 @@
         ]
       },
       {
-        "matcher": "Read|Write|Edit|Glob|Grep",
+        "matcher": "Read|Write|Edit|Glob|Grep|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/src/settings/cortex-hooks.json
+++ b/src/settings/cortex-hooks.json
@@ -34,6 +34,15 @@
             "command": "${CLAUDE_DIR}/hooks/CortexBashGuard.hook.ts"
           }
         ]
+      },
+      {
+        "matcher": "Read|Write|Edit|Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_DIR}/hooks/CortexPathGuard.hook.ts"
+          }
+        ]
       }
     ]
   }

--- a/src/taps/cc-events/hooks/lib/event-taxonomy.ts
+++ b/src/taps/cc-events/hooks/lib/event-taxonomy.ts
@@ -20,6 +20,11 @@ export const EVENT_TYPES = {
   // `reason` + `command_preview` in the payload so blocks are observable
   // on the dashboard instead of being lost in the Cortex→Discord relay.
   BASH_BLOCKED: "tool.bash.blocked",
+  // EBH-1 (cortex#2343) — emitted by path-guard.hook.ts when a file-tool
+  // (Read/Write/Edit/Glob/Grep) call is denied for resolving outside
+  // allowedDirs, or a write into a readOnlyDir. Mirrors BASH_BLOCKED's
+  // shape/purpose for the new file-tool guard.
+  PATH_BLOCKED: "tool.path.blocked",
   FILE_CHANGED: "tool.file.changed",
   FILE_READ: "tool.file.read",
   AGENT_SPAWNED: "tool.agent.spawned",


### PR DESCRIPTION
## EBH-1 — cortex-owned `PreToolUse` path guard (F1/F6 mechanism)

Closes #2343. Part of epic #2341 (execution-boundary hardening, NWS review response).

Gives cortex a **deterministic, fail-closed** filesystem boundary for the file tools (Read/Write/Edit/Glob/Grep/NotebookEdit) and Bash read-commands (`cat`/`head`/`tail`/`ls`/`wc`/`file`), enforcing `allowedDirs`/`readOnlyDirs` — the boundary the review (F1) showed did not exist, since `--add-dir` is an additive grant, not a jail (confirmed: EBH-0 repro on `main`).

### What it does
- New `path-guard.hook.ts` (file tools) + Bash-guard path checks, both routing every path token through **one shared reducer** `reduceTokenToRealPathOrReject` (`src/common/path-containment.ts`) — realpath + subpath containment, reusing the discipline `loader.ts` already applies to bundle paths.
- Fail-closed by construction: empty/malformed input, unresolved expansion, or any ambiguity → **deny**.
- Registered on `Read|Write|Edit|Glob|Grep|NotebookEdit` + Bash; denials emit `tool.path.blocked` telemetry.

### Adversarial hardening (transparency — this is why it's solid)
This went through **6 rounds of independent adversarial review**, each of which found and closed a real bypass that green unit tests had passed — the whole case for the refute-to-kill lane:
1. `~`/`$VAR` not expanded (`cat $HOME/.ssh/id_rsa`) · 2. Glob `pattern` traversal · 3. `~user` tilde + brace expansion · 4. shell quote-removal (`/allowed/""/../secret`) · 5. backslash escaping · 6. glued flag-value exfil (`file -f<path>`).
Rounds 1–5 were all shell char-expansion; that class is now closed **by construction** via a character whitelist for bash path tokens. Round 6 closed a distinct classification class (path-shaped flag values). 298 tests; each deny cross-checked against real `bash`/`file`.

### Known limitations (documented in-code, honest)
L1 inspects the command **string**, so it is **best-effort against shell word-evaluation and tool-specific path-reading**, not airtight. It is fail-closed (denies on anything it can't classify/resolve), but the **real boundary is the kernel sandbox (L2, EBH-3)** — which denies at the syscall regardless of path spelling. Accepted residuals: shell special params (`$_`) expand-to-empty vs bash (over-deny direction); a future value-taking flag on a newly-added command (mitigated by the path-shaped-flag deny). The web-gateway path (#1758) sets no `CORTEX_CHANNEL`, so the guard is inert there until #1758 lands.

### Scope
- **F1 (out-of-scope reads/writes)** is enforced live end-to-end for the file tools + Bash reads.
- **F6 (read-only write-protection)** — the hook implements the mechanism; it is **not yet live** because dispatch flattens `readOnlyDirs` into `allowedDirs`. Wiring it is **EBH-1b (#2352)**, the load-bearing seam for L2/L3.
- No dispatch-layer / posture / config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zYyCgpkgpdEyE1Zkjpgev
