### PR TITLE
fix(runner): EBH-1f — harden floor-derivation trust root + correct the overclaim

### DIFF
--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -2409,6 +2409,8 @@ describe("bash-guard.hook — round 8: git path-check coverage + `--` end-of-opt
 import {
   checkCommandPaths,
   COMMAND_FLAG_POLICIES,
+  DEFAULT_CONFIG,
+  deriveFloorCommandHeadWords,
   FLOOR_COMMAND_HEAD_WORDS,
   PATH_CHECK_OPT_OUT_COMMANDS,
 } from "../bash-guard.hook";
@@ -2601,6 +2603,152 @@ describe("bash-guard.hook — round 9: floor coverage (cortex#2370 regression gu
       }
     } finally {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// =============================================================================
+// EBH-1f (cortex#2374) — adversarial review of round 9 (#2371) found that
+// `deriveFloorCommandHeadWords` only ever understood ONE regex shape
+// (`^plainword`). Every other legal floor-rule shape either derived NOTHING
+// (silently exempting that command from path-checking — the exact bypass
+// class rounds 7/8/9 each closed) or, for `^cats?\b`, derived the WRONG word
+// ("cats") while the real runtime head word ("cat") stayed unchecked.
+//
+// The round-9 "floor coverage" test above CANNOT catch this: it derives its
+// own ground truth via `FLOOR_COMMAND_HEAD_WORDS`, i.e. the very function
+// with the blind spot. This describe block covers the gap two ways:
+//   1. Feeds each problem shape through the REAL exported
+//      `deriveFloorCommandHeadWords` and asserts it now throws LOUDLY
+//      (naming the offending pattern) instead of silently returning nothing
+//      or the wrong word.
+//   2. An INDEPENDENT shape assertion against the live `DEFAULT_CONFIG.rules`
+//      that hard-codes the expected head word per pattern and does NOT call
+//      `deriveFloorCommandHeadWords` at all — so it cannot share that
+//      function's blind spot, and fails if a pattern's shape (not just its
+//      command) changes unexpectedly.
+// =============================================================================
+describe("bash-guard.hook — EBH-1f: floor rule shape hardening (cortex#2374 regression guard)", () => {
+  describe("deriveFloorCommandHeadWords — unsupported shapes throw loudly (no silent empty/wrong derivation)", () => {
+    test("alternation ^(curl|wget)\\s+ throws naming the pattern (the issue's own example)", () => {
+      const pattern = "^(curl|wget)\\s+";
+      expect(() => deriveFloorCommandHeadWords([{ pattern }])).toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining(pattern),
+        }),
+      );
+    });
+
+    test("alternation ^(cat|less)\\b throws — previously derived NOTHING, silently exempting both commands", () => {
+      const pattern = "^(cat|less)\\b";
+      expect(() => deriveFloorCommandHeadWords([{ pattern }])).toThrow(
+        expect.objectContaining({ message: expect.stringContaining(pattern) }),
+      );
+    });
+
+    test("character class ^[Cc]at\\b throws — previously derived NOTHING, silently exempting the command", () => {
+      const pattern = "^[Cc]at\\b";
+      expect(() => deriveFloorCommandHeadWords([{ pattern }])).toThrow(
+        expect.objectContaining({ message: expect.stringContaining(pattern) }),
+      );
+    });
+
+    test("leading whitespace ^\\s*cat\\b throws — previously derived NOTHING, silently exempting the command", () => {
+      const pattern = "^\\s*cat\\b";
+      expect(() => deriveFloorCommandHeadWords([{ pattern }])).toThrow(
+        expect.objectContaining({ message: expect.stringContaining(pattern) }),
+      );
+    });
+
+    test("optional-suffix ^cats?\\b throws — previously derived the WRONG word (\"cats\" instead of \"cat\")", () => {
+      const pattern = "^cats?\\b";
+      // Guard the OLD behaviour didn't sneak back in: the buggy derivation
+      // used to silently succeed with "cats". Assert throw, not a wrong word.
+      expect(() => deriveFloorCommandHeadWords([{ pattern }])).toThrow(
+        expect.objectContaining({ message: expect.stringContaining(pattern) }),
+      );
+    });
+
+    test("a single bad rule throws even when mixed with otherwise-good rules", () => {
+      const rules = [{ pattern: "^cat\\b" }, { pattern: "^(curl|wget)\\s+" }];
+      expect(() => deriveFloorCommandHeadWords(rules)).toThrow();
+    });
+  });
+
+  describe("deriveFloorCommandHeadWords — supported shapes still derive correctly (no regression)", () => {
+    test("^cat\\b derives \"cat\"", () => {
+      expect(deriveFloorCommandHeadWords([{ pattern: "^cat\\b" }])).toEqual(new Set(["cat"]));
+    });
+
+    test("^pwd$ derives \"pwd\"", () => {
+      expect(deriveFloorCommandHeadWords([{ pattern: "^pwd$" }])).toEqual(new Set(["pwd"]));
+    });
+
+    test("^gh\\s+pr\\s+(view|list)\\b derives \"gh\" (alternation LATER in the pattern is fine — only the HEAD word must be a plain identifier)", () => {
+      expect(
+        deriveFloorCommandHeadWords([{ pattern: "^gh\\s+pr\\s+(view|list)\\b" }]),
+      ).toEqual(new Set(["gh"]));
+    });
+  });
+
+  test("FLOOR_COMMAND_HEAD_WORDS itself loaded without throwing — proves every live DEFAULT_CONFIG rule is currently the supported shape", () => {
+    // This is really just re-asserting module load succeeded (if a live rule
+    // had an unsupported shape, importing this module at the top of this
+    // test file would already have thrown and no test here would run) — but
+    // spelled out explicitly so a future reader doesn't have to infer it.
+    expect(FLOOR_COMMAND_HEAD_WORDS.size).toBeGreaterThan(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Independent, non-re-derived shape assertion. Deliberately does NOT call
+  // deriveFloorCommandHeadWords — it hard-codes the expected head word for
+  // every CURRENT DEFAULT_CONFIG pattern and checks the live rule list
+  // against that fixed map. A future edit that changes a pattern's TEXT
+  // (e.g. `^cat\b` → `^cats?\b`) has no matching entry in this map and fails
+  // this test, independent of whatever deriveFloorCommandHeadWords does with
+  // it.
+  // ---------------------------------------------------------------------------
+  test("independent shape assertion: every DEFAULT_CONFIG pattern matches its hard-coded expected head word (does not call deriveFloorCommandHeadWords)", () => {
+    const EXPECTED_PATTERN_TO_HEAD_WORD: Readonly<Record<string, string>> = {
+      "^gh\\s+pr\\s+(view|list|diff|checks|status|comment)\\b": "gh",
+      "^gh\\s+issue\\s+(view|list|status|comment)\\b": "gh",
+      "^gh\\s+repo\\s+view\\b": "gh",
+      "^git\\s+(log|diff|show|status|branch|fetch|remote|rev-parse)\\b": "git",
+      "^ls\\b": "ls",
+      "^pwd$": "pwd",
+      "^echo\\b": "echo",
+      "^cat\\b": "cat",
+      "^head\\b": "head",
+      "^tail\\b": "tail",
+      "^wc\\b": "wc",
+      "^which\\b": "which",
+      "^file\\b": "file",
+    };
+
+    // Same length, in EITHER direction: catches a rule ADDED to DEFAULT_CONFIG
+    // without a matching hard-coded entry above, and an entry above that no
+    // longer corresponds to a live rule.
+    expect(DEFAULT_CONFIG.rules.length).toBe(Object.keys(EXPECTED_PATTERN_TO_HEAD_WORD).length);
+
+    for (const rule of DEFAULT_CONFIG.rules) {
+      const expectedWord = EXPECTED_PATTERN_TO_HEAD_WORD[rule.pattern];
+      // Pattern TEXT must be a key in the hard-coded map at all — if a
+      // pattern's shape (or command) silently changed, it won't match any
+      // key here and this fails, without ever calling the derivation.
+      expect(expectedWord).toBeDefined();
+
+      // Independent (non-regex-parser) check that the pattern's head word is
+      // what we expect: the pattern string, minus its leading "^", must
+      // start with the expected word, and the character immediately after
+      // the word must be a boundary character/sequence — checked with plain
+      // string operations, not the SUPPORTED_FLOOR_RULE_SHAPE regex, so this
+      // assertion cannot share that regex's own blind spot either.
+      const word = expectedWord!;
+      const afterCaret = rule.pattern.slice(1);
+      expect(afterCaret.startsWith(word)).toBe(true);
+      const boundary = afterCaret.slice(word.length, word.length + 2);
+      const isBoundary = boundary.startsWith("\\b") || boundary.startsWith("\\s") || boundary.startsWith("$");
+      expect(isBoundary).toBe(true);
     }
   });
 });

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -63,13 +63,22 @@
  * skipping the check. A regression test derives the floor's command list
  * from `DEFAULT_CONFIG.rules` itself and fails if any of them lacks a policy
  * or an opt-out — see `bash-guard.hook.test.ts`'s "round 9" describe block —
- * so widening the floor without declaring the new command's path posture is
- * now a CI failure, not a silent bypass. That posture — fail closed on
- * ambiguity AND on coverage gaps — is what makes this guard SAFE, but it is
- * NOT airtight by construction the way a real parser + kernel boundary
- * would be. The kernel sandbox (L2, EBH-2/EBH-3,
- * `docs/design-session-sandbox.md`) is the actual boundary; this guard is
- * Tier-0 defense-in-depth in front of it.
+ * so widening the floor with a rule of the SUPPORTED pattern shape (see
+ * `deriveFloorCommandHeadWords`) without declaring the new command's path
+ * posture is a CI failure, not a silent bypass. That guarantee is scoped to
+ * the supported shape: `deriveFloorCommandHeadWords` only understands an
+ * anchored `^` + plain word + `\b`/`\s`/`$` boundary; a floor rule of ANY
+ * other shape (alternation, a character class, a leading `\s*`, an optional
+ * suffix like `s?`, …) THROWS at module load (EBH-1f, cortex#2374) rather
+ * than silently deriving nothing or the wrong word — the round-9 coverage
+ * test above shares the same derivation and so shares the same scope: it
+ * protects supported-shape rules; unsupported shapes now hard-fail the
+ * build instead of passing it silently. That two-part posture — fail
+ * closed on ambiguity, on coverage gaps, AND on an unparseable floor rule
+ * — is what makes this guard SAFE, but it is NOT airtight by construction
+ * the way a real parser + kernel boundary would be. The kernel sandbox
+ * (L2, EBH-2/EBH-3, `docs/design-session-sandbox.md`) is the actual
+ * boundary; this guard is Tier-0 defense-in-depth in front of it.
  *
  * Accepted residuals (deliberately not chased further — over-deny, not
  * under-deny, direction):
@@ -195,7 +204,12 @@ interface GuardConfig {
   repos?: string[];  // Global repo whitelist (applies to all gh commands)
 }
 
-const DEFAULT_CONFIG: GuardConfig = {
+// Exported (read-only in practice — see AllowRule) so tests can assert
+// against the REAL floor patterns directly, e.g. the EBH-1f (cortex#2374)
+// independent shape test that hard-codes an expected head word per pattern
+// WITHOUT calling deriveFloorCommandHeadWords, so it cannot share that
+// function's blind spot.
+export const DEFAULT_CONFIG: GuardConfig = {
   rules: [
     // gh: READ-ONLY porcelain SUBCOMMANDS only (cortex#2335). Two vectors are
     // closed here:
@@ -408,9 +422,35 @@ function rejectsChaining(command: string): boolean {
  * the regression test that makes a round 10 of this class impossible: it
  * derives the same command list from the SAME live `DEFAULT_CONFIG.rules`
  * this module ships and fails if any of them is neither opted out nor
- * flag-policied — so widening the floor without declaring the new command's
- * path posture is now a CI failure, not a silent bypass.
+ * flag-policied — so widening the floor with a rule of the shape this
+ * derivation supports, without declaring the new command's path posture,
+ * is a CI failure.
+ *
+ * That guarantee is scoped to the shape `deriveFloorCommandHeadWords` can
+ * parse (EBH-1f, cortex#2374 — adversarial review of this very function):
+ * derivation used to match ONLY `^plainword` and silently return NOTHING
+ * for any other legal rule shape — `^(cat|less)\b`, `^[Cc]at\b`, and
+ * `^\s*cat\b` each derived no word at all (both exempting their command
+ * from path-checking with zero signal), and `^cats?\b` derived the WRONG
+ * word ("cats") while the real runtime head word ("cat") stayed
+ * unchecked. Because a word missing from `FLOOR_COMMAND_HEAD_WORDS` never
+ * enters `PATH_CHECKED_COMMANDS`, and the runtime gate is `if (headWord &&
+ * PATH_CHECKED_COMMANDS.has(headWord))`, that was a SILENT FULL BYPASS —
+ * `checkCommandPaths` was never even called — not a fail-closed deny. The
+ * round-9 coverage test could not catch it either: it derives its own
+ * "ground truth" via this same function, so it shares the blind spot.
+ * `deriveFloorCommandHeadWords` now parses a narrow, PRECISELY-checked
+ * shape and THROWS (at module load, since `FLOOR_COMMAND_HEAD_WORDS` below
+ * calls it eagerly) for any pattern it cannot confidently reduce to a
+ * single head word — see the shape regex and its comment just below. An
+ * independent test in `bash-guard.hook.test.ts` (the "EBH-1f: floor rule
+ * shape hardening" describe block) hard-codes the expected word for every
+ * `DEFAULT_CONFIG` pattern WITHOUT calling this function, so it cannot
+ * share this function's blind spot and will fail if a pattern's shape
+ * changes unexpectedly.
  */
+const SUPPORTED_FLOOR_RULE_SHAPE = /^\^([A-Za-z][A-Za-z0-9_]*)(?:\\b|\\s|\$)/;
+
 export function deriveFloorCommandHeadWords(rules: readonly AllowRule[]): Set<string> {
   const words = new Set<string>();
   for (const rule of rules) {
@@ -418,8 +458,40 @@ export function deriveFloorCommandHeadWords(rules: readonly AllowRule[]): Set<st
     // `\s`/`\b`/`$` boundary (see DEFAULT_CONFIG above) — the same shape
     // main()/extractCommandPaths already assume when reading a COMMAND
     // string's head word, applied here to a RULE PATTERN string instead.
-    const m = /^\^([A-Za-z][A-Za-z0-9_]*)/.exec(rule.pattern);
-    if (m?.[1]) words.add(m[1].toLowerCase());
+    // This parses the pattern's SOURCE TEXT (it does not compile/execute
+    // the pattern as a regex) — `SUPPORTED_FLOOR_RULE_SHAPE` requires the
+    // captured identifier to be IMMEDIATELY followed by one of the three
+    // literal boundary forms above; the regex engine backtracks the greedy
+    // identifier match, so a shape like `^cats?\b` (where "cats" is
+    // followed by "?", "cat" by "s", "ca" by "t", … — none a boundary)
+    // fails to match ANY prefix rather than settling for the wrong one.
+    const m = SUPPORTED_FLOOR_RULE_SHAPE.exec(rule.pattern);
+    if (!m?.[1]) {
+      // FAIL LOUD, not silent. A rule this parser cannot confidently
+      // reduce to a single head word must never be treated as
+      // contributing NO word — that is exactly how `^(cat|less)\b`,
+      // `^[Cc]at\b`, and `^\s*cat\b` each silently exempted their command
+      // from path-checking (EBH-1f, cortex#2374). Throwing at module load
+      // turns an unparseable floor rule into a build/boot failure instead
+      // of a silent exemption.
+      throw new Error(
+        // NOTE: the pattern is interpolated RAW (not JSON.stringify'd) so
+        // its literal backslashes appear in the message exactly as they do
+        // in the source rule — JSON.stringify would double-escape them
+        // (`\b` → `\\b` in the JSON text), which is confusing to read and
+        // awkward for a caller/test to substring-match against the pattern
+        // it passed in.
+        `[Cortex Bash Guard] deriveFloorCommandHeadWords: floor rule pattern ` +
+          `"${rule.pattern}" does not match the supported shape ` +
+          `(anchored "^" + a plain command word + one of \\b / \\s / $ as the ` +
+          `next literal characters). An unparseable floor rule must not ` +
+          `silently exempt its command from path-checking — rewrite the ` +
+          `pattern to the supported shape, or extend this parser (and its ` +
+          `independent, non-re-derived shape test in bash-guard.hook.test.ts) ` +
+          `to cover the new shape before shipping it.`,
+      );
+    }
+    words.add(m[1].toLowerCase());
   }
   return words;
 }


### PR DESCRIPTION
## EBH-1f — harden the floor-derivation trust root + correct the overclaim

Closes #2374. Part of epic #2341. Follow-up to the adversarial review of #2371, which found that the round-9 guard-rail **cannot detect its own blind spot**.

### The problem
`deriveFloorCommandHeadWords()` only parsed the shape `^plainword`. Anything else silently misfired:

| Rule shape | Derived | Consequence |
|---|---|---|
| `^(curl\|wget)\s+` | *nothing* | command silently exempt from path-checking |
| `^[Cc]at\b` | *nothing* | silently exempt |
| `^cats?\b` | `cats` | **false coverage** — real `cat` unchecked |
| `^\s*cat\b` | *nothing* | silently exempt |

A missing word never enters `PATH_CHECKED_COMMANDS`, and the runtime gate is `if (headWord && PATH_CHECKED_COMMANDS.has(headWord))` — so `checkCommandPaths()` is **never called at all**: a silent bypass, not a fail-closed deny. And the round-9 coverage test derives its ground truth from that same function, so it **shared the blind spot** (proven: a policy-less `^tar\b` went red, a policy-less `^(?:curl|wget)\s+` stayed green).

Not exploitable today — no current rule has those shapes — but it silently reintroduces the rounds 7/8/9 class the moment someone adds a floor rule using alternation, an idiom the repo already uses one token later in the `git` rule.

### The fix
- **Hard-fail on unsupported shapes.** `SUPPORTED_FLOOR_RULE_SHAPE` requires `^` + plain identifier + an explicit boundary (`\b`/`\s`/`$`). Anything else **throws at module load**, naming the offending pattern. An unparseable floor rule is now a build failure, never a silent exemption — fail-closed over best-effort.
- **Independent shape assertion that cannot share the blind spot.** A new test hard-codes the expected command word per pattern and checks `DEFAULT_CONFIG.rules` with plain string ops — it never calls the derivation or its regex.
- **Overclaim corrected.** The module doc no longer says widening the floor "is now a CI failure, not a silent bypass" (true only for supported shapes). It now scopes the guarantee precisely and states the hard-fail behaviour.
- Alternation support deliberately **not** implemented — hard-fail is simpler and strictly safer.

### Verified (my independent run)
- `^(curl|wget)\s+`, `^[Cc]at\b`, `^cats?\b`, `^\s*cat\b` → **all throw**
- `^cat\b` → `cat`; `^gh\s+pr\s+(view|list)\b` → `gh` (alternation *after* the head word still fine)
- **16/16 rounds 1–9 decisions unchanged** — `file -flist`, `git diff --no-index`, `gh … --body-file`, `cat -- <oos>`, `~root`, brace, plain out-of-scope all deny; `git diff HEAD~1`, `gh pr view`, `cat -- f.txt`, `ls -lh`, `head -n20`, `*.log`, `pwd`, `echo`, in-scope reads all allow
- Suites 428 green across `src/runner/hooks/`; tsc, `lint:errors`, both vocab gates clean on touched files

This is a pure hardening + honesty change: **no live guard decision changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
