### PR TITLE
fix(bus): EBH-6b — sovereignty posture config key + honest docs (F3)

### DIFF
--- a/docs/design-bot-packs.md
+++ b/docs/design-bot-packs.md
@@ -274,11 +274,17 @@ That is the practical meaning of "hot".
 - **No ambient fleet credentials.** Per-task brains get none. Daemon brains
   get their own scoped NATS creds (A.2) — addressable, revocable
   (`cortex creds revoke yarrow`), never the stack key.
-- **Policy stays in cortex.** M6 trust lists, capability gates,
-  `modelClass` sovereignty enforcement, envelope signing (M3) all happen on
-  the cortex side of the seam. A brain emitting `dispatch` for a capability
+- **Policy stays in cortex.** M6 trust lists, capability gates, the
+  `modelClass` sovereignty gate, envelope signing (M3) all happen on the
+  cortex side of the seam. A brain emitting `dispatch` for a capability
   outside its manifest is refused with `wont_do` — same fail-closed posture
-  as pulse's enforcement gate.
+  as pulse's enforcement gate. **Caveat (EBH-6b, cortex#2380):** the
+  sovereignty gate itself is audit-only by default — a violation is detected
+  and logged (`system.access.denied`), not denied, until a principal opts
+  in via `policy.sovereignty.enforce` (default `false`); see
+  `docs/security/hardening-plan.md` §F3 for the prerequisite (#2117/#2201)
+  before that opt-in is meaningful. The capability-outside-manifest
+  `wont_do` refusal above is a separate, always-on check.
 - **Resource caps** (v1: timeouts + maxConcurrent + maxRestarts; later:
   rlimits/containers) are host-side manifest fields.
 

--- a/docs/security/hardening-plan.md
+++ b/docs/security/hardening-plan.md
@@ -15,7 +15,7 @@
 |---|---|---|
 | **F1** | File tools have no `PreToolUse` hook; `cat`/`head`/`tail` allowlisted, no path check | `cortex-hooks.json:30`; `bash-guard.hook.ts:126–128` |
 | **F6** | `readOnlyDirs` write-protection is a preamble sentence | `security-preamble.ts:67–77` |
-| **F3** | Sovereignty (confidential-never-reaches-frontier) defaults to log-only | `review-consumer.ts:500` (`?? false`) |
+| **F3** | Sovereignty (confidential-never-reaches-frontier) audit-only by default, in BOTH consumers | `review-consumer.ts:500`, `brain-consumer.ts:390` (`?? false`) |
 | **F4** | Principal-DM disables the Bash guard entirely | `bash-guard.hook.ts:150` |
 
 > Line numbers pinned to `origin/main` @ `059f619d` (2026-07-24). The review was authored against `f6f4b06d`; the bash-guard anchors shifted +18 after #2337 (cortex#2335) tightened the same file's `gh` floor — F1/F4 remain valid, EBH-1 must coordinate with that direction.
@@ -45,8 +45,8 @@ L1–L3 are designed in [`design-session-sandbox.md`](../design-session-sandbox.
 
 ## 3. Cross-cutting decisions (not sandboxing, but owed a call)
 
-- **F3 — Sovereignty posture.** Decide and *document* whether production runs `sovereigntyEnforce: true`. The decision core is already fail-closed; this is a config + model-class↔signing-identity binding question. If log-only is a deliberate staging step, say so in the posture doc so no one mistakes "observed" for "enforced."
-- **F4 — Principal-DM integrity.** The guard-off DM context is only as safe as (a) no relay path forwarding untrusted content into it and (b) the principal↔platform-ID mapping being immutable config. Treat the mapping as security-critical; land G-301 (#42 lineage).
+- **F3 — Sovereignty posture. Resolved (EBH-6b, cortex#2380).** The EBH-6 investigation (`docs/security/ebh-6-posture-findings.md`) found the deeper gap: `sovereigntyEnforce` wasn't just defaulted off, it was **constructor-only** — no `cortex.yaml` / config-split field could reach it in either consumer, so no principal action could turn it on. EBH-6b promoted it to a real config key, `policy.sovereignty.enforce` (boolean, **default `false`**), threaded to BOTH `review-consumer.ts` and `brain-consumer.ts`'s `sovereigntyEnforce` option from the SAME resolved value in `cortex.ts`. The decision core (`sovereignty-gate.ts`) is sound and fail-closed. **This is posture-visibility, not enforcement:** every deployment today still runs audit-only (violations are detected and logged via `system.access.denied`, never denied) until a principal explicitly sets the key — and setting it before the model-class↔signing-identity binding lands (#2117; PR #2201, open, CI-red as of EBH-6) buys less than it appears to, because `runtime.modelClass` is self-declared and spoofable until then. No default, template, or example ships `enforce: true`.
+- **F4 — Principal-DM integrity.** The guard-off DM context is only as safe as (a) no relay path forwarding untrusted content into it and (b) the principal↔platform-ID mapping being immutable config. Treat the mapping as security-critical. (The review's compensating-control citation here — "land G-301 (#42 lineage)" — was stale: `#42` is an unrelated, already-merged migration PR, and G-301 has no design section, blueprint entry, or issue anywhere in the repo; see `docs/security/ebh-6-posture-findings.md` §F4-4. The real follow-up is **#2377** (F4 residual — Bash guard-off path-awareness).)
 - **Structural posture as CI (swarm-posture).** cortex spawns multi-agent teams (`agent-team.ts`: moderator + participants) — a real invoke-graph where composed escalation can hide ("security doesn't compose"). Wire a structural least-privilege + attack-path check as a continuous gate on the fleet's tool grants. Rob's paid horizon — behavioral simulation / intent-fidelity measurement under live injection — is the dynamic complement; this static review is half one.
 
 ---

--- a/src/__tests__/cortex.sovereignty-posture-boot.test.ts
+++ b/src/__tests__/cortex.sovereignty-posture-boot.test.ts
@@ -1,0 +1,166 @@
+/**
+ * EBH-6b (cortex#2380) — `policy.sovereignty.enforce` boot-posture wiring.
+ *
+ * Pins the acceptance contract from the EBH-6 investigation
+ * (`docs/security/ebh-6-posture-findings.md` §F3): `sovereigntyEnforce` was
+ * constructor-only — no `cortex.yaml` field could ever reach it, so no
+ * principal action could turn it on, in EITHER `review-consumer.ts` or
+ * `brain-consumer.ts` (the review only named the former). This file pins,
+ * at the full `startCortex` boot-integration grain:
+ *
+ *   - `policy` absent (or `policy.sovereignty` absent) ⇒ the boot log
+ *     reports `sovereignty.enforce=false` — byte-identical audit-only
+ *     posture to today.
+ *   - `policy.sovereignty.enforce: true` ⇒ the boot log reports
+ *     `sovereignty.enforce=true`, and BOTH the review-consumer lane and the
+ *     brain-consumer lane resolve the SAME value (no asymmetry).
+ *
+ * This is a posture-VISIBILITY change, not a posture flip — nothing here
+ * asserts that any default or template ships `enforce: true`; every test
+ * below opts in explicitly, the way a principal now can.
+ *
+ * Modelled on `cortex.security-posture-boot.test.ts` (same
+ * `withCapturedConsoleLog` + hermetic-agents-dir pattern).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import { PolicySchema } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
+
+function minimalConfig(): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-sovereignty-posture-test-published" },
+  });
+}
+
+function createRecordingRuntime(): MyelinRuntime {
+  return {
+    enabled: false,
+    onEnvelope(_handler: EnvelopeHandler) {
+      return { unregister: () => {} };
+    },
+    publish: async (_envelope: Envelope) => {},
+    stop: async () => {},
+  };
+}
+
+function withCapturedConsoleLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; logs: string[] }> {
+  const original = console.log.bind(console);
+  const logs: string[] = [];
+  console.log = (...args: unknown[]): void => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+  return fn()
+    .then((result) => {
+      console.log = original;
+      return { result, logs };
+    })
+    .catch((err: unknown) => {
+      console.log = original;
+      throw err;
+    });
+}
+
+// Hermetic agents.d/ (mirrors cortex.security-posture-boot.test.ts) — every
+// boot points at an EMPTY tmp dir so the suite never falls back to the
+// principal's live `~/.config/cortex/agents.d/`.
+const HERMETIC_AGENTS_DIR = mkdtempSync(
+  join(tmpdir(), "cortex-sovereignty-posture-agents-hermetic-"),
+);
+
+const COMMON_OPTS = {
+  disableConfigWatcher: true,
+  disableDashboard: true,
+  disableOutboundPoller: true,
+  principal: { id: "test-op" },
+  agentsDir: HERMETIC_AGENTS_DIR,
+} as const;
+
+describe("startCortex — EBH-6b sovereignty.enforce posture wiring (cortex#2380)", () => {
+  test("policy absent ⇒ boot log reports sovereignty.enforce=false (audit-only)", async () => {
+    const runtime = createRecordingRuntime();
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), { ...COMMON_OPTS, injectRuntime: runtime }),
+    );
+
+    const postureLines = logs.filter((l) =>
+      l.includes("cortex: security posture — sovereignty.enforce="),
+    );
+    expect(postureLines.length).toBe(1);
+    expect(postureLines[0]!).toContain("sovereignty.enforce=false");
+    expect(postureLines[0]!).toContain("audit-only");
+
+    await handle.stop();
+  });
+
+  test("policy.sovereignty declared with no enforce ⇒ still resolves false", async () => {
+    const runtime = createRecordingRuntime();
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        ...COMMON_OPTS,
+        injectRuntime: runtime,
+        policy: PolicySchema.parse({}),
+      }),
+    );
+
+    const postureLines = logs.filter((l) =>
+      l.includes("cortex: security posture — sovereignty.enforce="),
+    );
+    expect(postureLines.length).toBe(1);
+    expect(postureLines[0]!).toContain("sovereignty.enforce=false");
+
+    await handle.stop();
+  });
+
+  test("policy.sovereignty.enforce: true ⇒ boot log reports sovereignty.enforce=true (violations DENIED)", async () => {
+    const runtime = createRecordingRuntime();
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        ...COMMON_OPTS,
+        injectRuntime: runtime,
+        policy: PolicySchema.parse({ sovereignty: { enforce: true } }),
+      }),
+    );
+
+    const postureLines = logs.filter((l) =>
+      l.includes("cortex: security posture — sovereignty.enforce="),
+    );
+    expect(postureLines.length).toBe(1);
+    expect(postureLines[0]!).toContain("sovereignty.enforce=true");
+    expect(postureLines[0]!).toContain("violations DENIED");
+
+    await handle.stop();
+  });
+
+  test("policy.sovereignty.enforce: false explicit ⇒ same audit-only posture as absent", async () => {
+    const runtime = createRecordingRuntime();
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        ...COMMON_OPTS,
+        injectRuntime: runtime,
+        policy: PolicySchema.parse({ sovereignty: { enforce: false } }),
+      }),
+    );
+
+    const postureLines = logs.filter((l) =>
+      l.includes("cortex: security posture — sovereignty.enforce="),
+    );
+    expect(postureLines.length).toBe(1);
+    expect(postureLines[0]!).toContain("sovereignty.enforce=false");
+    expect(postureLines[0]!).toContain("audit-only");
+
+    await handle.stop();
+  });
+});

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -1681,6 +1681,31 @@ describe("PolicySchema — CO-1 offerings (epic cortex#939)", () => {
   });
 });
 
+describe("PolicySchema — sovereignty.enforce (EBH-6b, cortex#2380)", () => {
+  test("absent policy.sovereignty ⇒ undefined (read site defaults to false)", () => {
+    // Mirrors federated/public/offerings/admission: no default object at the
+    // schema layer — `resolvedPolicy?.sovereignty?.enforce ?? false` at the
+    // read site (`cortex.ts`) is the single source of the false default.
+    const parsed = PolicySchema.parse({});
+    expect(parsed.sovereignty).toBeUndefined();
+  });
+
+  test("policy.sovereignty declared with no enforce ⇒ enforce defaults false", () => {
+    const parsed = PolicySchema.parse({ sovereignty: {} });
+    expect(parsed.sovereignty?.enforce).toBe(false);
+  });
+
+  test("policy.sovereignty.enforce: true parses true", () => {
+    const parsed = PolicySchema.parse({ sovereignty: { enforce: true } });
+    expect(parsed.sovereignty?.enforce).toBe(true);
+  });
+
+  test("policy.sovereignty.enforce: false parses false", () => {
+    const parsed = PolicySchema.parse({ sovereignty: { enforce: false } });
+    expect(parsed.sovereignty?.enforce).toBe(false);
+  });
+});
+
 describe("MIRROR sync — cortex cross-cutting schemas vs AgentConfigSchema", () => {
   // Minimum AgentConfig that exposes inner defaults on every cross-cutting block.
   //

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -2683,6 +2683,34 @@ export const PolicySchema = z.object({
    * (role keys, principal ids) are checked in the superRefine below.
    */
   admission: AdmissionPolicySchema.optional(),
+  /**
+   * EBH-6b (cortex#2380) — posture-VISIBILITY for the consumer-side
+   * sovereignty gate (`evaluateSovereignty`, `src/bus/sovereignty-gate.ts`).
+   * `enforce: true` threads to the `sovereigntyEnforce` constructor option on
+   * BOTH `ReviewConsumer` (`src/bus/review-consumer.ts`) and `BrainConsumer`
+   * (`src/bus/brain-consumer.ts`) — before this field, that option was
+   * reachable ONLY from a test constructor arg, so no config edit could ever
+   * turn it on (the gap the EBH-6 investigation found,
+   * `docs/security/ebh-6-posture-findings.md` §F3).
+   *
+   * **`.optional()`, deliberately no default** — mirrors `federated`/`public`/
+   * `offerings`/`admission`: an absent block resolves to `enforce: false` at
+   * the read site (`resolvedPolicy?.sovereignty?.enforce ?? false` in
+   * `cortex.ts`), byte-identical to today's constructor-only-false posture.
+   *
+   * **This is a posture-VISIBILITY change, not a posture flip.** The decision
+   * core (`evaluateSovereignty`) is sound and fail-closed; the gap this field
+   * closes is purely "no config key could reach the flag." Setting
+   * `enforce: true` in a stack's own `policy:` block is a deliberate
+   * principal decision — no default, template, or example ships it on. Do
+   * NOT flip it without the model-class↔signing-identity binding (#2117,
+   * PR #2201, open/CI-red as of EBH-6): until that lands, an agent's
+   * `runtime.modelClass` is self-declared and spoofable, so `enforce: true`
+   * denies less than a principal reading "enforce" would expect.
+   */
+  sovereignty: z.object({
+    enforce: z.boolean().default(false),
+  }).optional(),
   // v2.0.0 cutover (cortex#297) — `parallel_mode_enabled` retired with
   // the parallel-mode plumbing in adapters. PolicyEngine is the sole
   // authorisation gate; legacy role-resolver is gone.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1239,6 +1239,24 @@ export async function startCortex(
     );
   }
 
+  // EBH-6b (cortex#2380) — resolve `policy.sovereignty.enforce` ONCE here,
+  // then thread the SAME value into both `wireReviewConsumers` and
+  // `wireBrainConsumers` below (never resolve it twice — that's exactly the
+  // review-consumer/brain-consumer asymmetry the EBH-6 investigation found,
+  // `docs/security/ebh-6-posture-findings.md` §F3). Default `false`
+  // (audit-only: a sovereignty violation is logged via `system.access.denied`
+  // but not denied) — this is a posture-VISIBILITY change, not a posture
+  // flip; nothing here enables enforcement, it only makes "turn it on" a
+  // config edit instead of a code change. Logged unconditionally (like the
+  // `security.signing` posture line below) so "is sovereignty enforced
+  // here?" is answerable from the boot log without reading code.
+  const sovereigntyEnforce = resolvedPolicy?.sovereignty?.enforce ?? false;
+  console.log(
+    `cortex: security posture — sovereignty.enforce=${String(sovereigntyEnforce)} ` +
+      `(${sovereigntyEnforce ? "violations DENIED" : "violations logged, NOT denied — audit-only"}; ` +
+      `see docs/security/hardening-plan.md §F3)`,
+  );
+
   // Bus runtime (M2-M6) — no-op when `config.nats?` is absent. Tests inject
   // a recording fake via `options.injectRuntime` to assert observable
   // wire-up side-effects without standing up a real NATS server.
@@ -2399,6 +2417,7 @@ export async function startCortex(
     ...(stackNKeyPubForVerifier !== undefined && { stackNKeyPubForVerifier }),
     systemEventSource,
     runtime,
+    sovereigntyEnforce,
     buildSessionOpts: (agent) => buildReviewSessionOpts(config, agent),
     makeOfferAdmission,
     federatedNetworks: resolvedPolicy?.federated?.networks ?? [],
@@ -2629,6 +2648,7 @@ export async function startCortex(
     stack: derivedStack.stack,
     systemEventSource,
     runtime,
+    sovereigntyEnforce,
     ...(surfacePrincipalGate !== undefined && { surfacePrincipalGate }),
     brainPresenceHolder,
     brainConsumers,

--- a/src/runner/__tests__/brain-consumer-boot.test.ts
+++ b/src/runner/__tests__/brain-consumer-boot.test.ts
@@ -539,3 +539,105 @@ describe("wireBrainConsumers — per-agent failure isolation", () => {
     expect(brainConsumers).toHaveLength(1);
   });
 });
+
+describe("wireBrainConsumers — EBH-6b sovereignty.enforce threading (cortex#2380)", () => {
+  /** A frontier-declared agent — mismatched against `mismatchedEnvelope()`
+   *  below (Stage 1b violation), mirroring `review-consumer-boot.test.ts`'s
+   *  companion coverage for the review lane. */
+  function frontierAgent(maxConcurrent?: number): BrainBootAgent {
+    return {
+      id: "yarrow",
+      persona: personaPath,
+      runtime: {
+        capabilities: ["soc.compose.flow"],
+        modelClass: "frontier",
+        ...(maxConcurrent !== undefined && { maxConcurrent }),
+        brain: {
+          kind: "exec",
+          run: "bun {pack}/brain/main.ts",
+          lifecycle: "per-task",
+          secrets: [],
+          dispatch_capabilities: [],
+          maxRestarts: 3,
+        },
+      },
+    };
+  }
+
+  /** local/local-only/frontier_ok:false — a frontier-declared agent claiming
+   *  this is the consumer-side sovereignty gate's violation case. */
+  function mismatchedEnvelope(): Envelope {
+    return {
+      id: crypto.randomUUID(),
+      source: "andreas.work.pilot",
+      type: "tasks.soc.compose.flow",
+      timestamp: new Date().toISOString(),
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 0,
+        frontier_ok: false,
+        model_class: "local-only",
+      },
+      payload: { scenario: "test" },
+    };
+  }
+
+  test("sovereigntyEnforce: true threads through — the constructed consumer denies before the brain runs", async () => {
+    const runtime = fakeRuntime();
+    const brainConsumers: BrainConsumer[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({ runtime, brainConsumers, sovereigntyEnforce: true }),
+    );
+
+    await startForAgent(frontierAgent());
+    expect(brainConsumers).toHaveLength(1);
+
+    const decision = await brainConsumers[0]!.processEnvelope(
+      mismatchedEnvelope(),
+      "local.andreas.work.brain.soc.compose.flow",
+      null,
+      "soc.compose.flow",
+    );
+
+    // The sovereignty gate runs BEFORE the brain is ever invoked
+    // (brain-consumer.ts step 2, before spawn), so "term" here proves the
+    // opt threaded from `WireBrainConsumersOpts.sovereigntyEnforce` into the
+    // constructed `BrainConsumer`'s private `sovereigntyEnforce` field — no
+    // real brain process spawns.
+    expect(decision.kind).toBe("term");
+    if (decision.kind === "term") expect(decision.reason).toContain("wont_do");
+  });
+
+  test("sovereigntyEnforce omitted ⇒ the constructed consumer stays audit-only (default false)", async () => {
+    const runtime = fakeRuntime();
+    const brainConsumers: BrainConsumer[] = [];
+    const { startForAgent } = wireBrainConsumers(
+      baseOpts({ runtime, brainConsumers }), // sovereigntyEnforce omitted
+    );
+
+    await startForAgent(frontierAgent());
+    expect(brainConsumers).toHaveLength(1);
+    const consumer = brainConsumers[0]!;
+
+    // Force the SHUTDOWN guard (brain-consumer.ts step 2b, immediately AFTER
+    // the sovereignty gate) to nak before the brain ever spawns — a safe way
+    // to prove the sovereignty gate did NOT terminate the request above it,
+    // without needing a real per-task brain run. No subscribers/in-flight
+    // tasks are registered (start() was never called), so stop() settles
+    // immediately.
+    await consumer.stop();
+
+    const decision = await consumer.processEnvelope(
+      mismatchedEnvelope(),
+      "local.andreas.work.brain.soc.compose.flow",
+      null,
+      "soc.compose.flow",
+    );
+
+    // NOT "term" — if sovereigntyEnforce had somehow defaulted true, this
+    // mismatched request would have been denied (term) before ever reaching
+    // the shutdown guard below it.
+    expect(decision.kind).toBe("nak");
+  });
+});

--- a/src/runner/__tests__/review-consumer-boot.test.ts
+++ b/src/runner/__tests__/review-consumer-boot.test.ts
@@ -35,6 +35,7 @@ import type {
 } from "../../bus/myelin/runtime";
 import type { MyelinSubscriber } from "../../bus/myelin/subscriber";
 import { ReviewConsumer } from "../../bus/review-consumer";
+import { createReviewRequestEvent, type ReviewEventSource } from "../../bus/review-events";
 
 interface RecordingRuntime extends MyelinRuntime {
   subscribePullCalls: MyelinSubscribePullOpts[];
@@ -231,5 +232,91 @@ describe("wireReviewConsumers — per-agent failure isolation", () => {
     expect(stderr).toContain("synthetic buildSessionOpts failure");
     // The failure happened before `makeConsumer`/`.push()` ran.
     expect(reviewConsumers).toHaveLength(0);
+  });
+});
+
+describe("wireReviewConsumers — EBH-6b sovereignty.enforce threading (cortex#2380)", () => {
+  const SOURCE: ReviewEventSource = {
+    principal: "andreas",
+    agent: "cortex",
+    instance: "local",
+  };
+
+  /** A frontier-declared agent — mismatched against the default local-only
+   *  request built by `mismatchedRequest()` below (Stage 1b violation). */
+  function frontierAgent(maxConcurrent?: number): ReviewBootAgent {
+    return {
+      id: "echo",
+      displayName: "Echo",
+      trust: [],
+      runtime: {
+        substrate: "claude-code",
+        capabilities: ["code-review.typescript"],
+        modelClass: "frontier",
+        ...(maxConcurrent !== undefined && { maxConcurrent }),
+      },
+    };
+  }
+
+  /** `createReviewRequestEvent` defaults sovereignty to local/local-only/
+   *  frontier_ok:false — a frontier-declared agent claiming this is the
+   *  consumer-side sovereignty gate's violation case. */
+  function mismatchedRequest(): Envelope {
+    return createReviewRequestEvent({
+      source: SOURCE,
+      flavor: "typescript",
+      payload: { repo: "the-metafactory/cortex", pr: 1, reviewer: "echo" },
+    });
+  }
+
+  test("sovereigntyEnforce: true threads through — the constructed consumer denies before the pipeline runs", async () => {
+    const runtime = fakeRuntime();
+    const reviewConsumers: ReviewConsumer[] = [];
+    const { startForAgent } = wireReviewConsumers(
+      baseOpts({ runtime, reviewConsumers, sovereigntyEnforce: true }),
+    );
+
+    await startForAgent(frontierAgent());
+    expect(reviewConsumers).toHaveLength(1);
+
+    const decision = await reviewConsumers[0]!.processEnvelope(
+      mismatchedRequest(),
+      "local.andreas.work.tasks.code-review.typescript",
+      null,
+    );
+
+    // The sovereignty gate runs BEFORE the pipeline is ever invoked (§3b in
+    // review-consumer.ts), so "term" here proves the opt threaded all the
+    // way from `WireReviewConsumersOpts.sovereigntyEnforce` into the
+    // constructed `ReviewConsumer`'s private `sovereigntyEnforce` field —
+    // no real CC session spawns.
+    expect(decision.kind).toBe("term");
+    if (decision.kind === "term") expect(decision.reason).toContain("wont_do");
+  });
+
+  test("sovereigntyEnforce omitted ⇒ the constructed consumer stays audit-only (default false)", async () => {
+    const runtime = fakeRuntime();
+    const reviewConsumers: ReviewConsumer[] = [];
+    const { startForAgent } = wireReviewConsumers(
+      baseOpts({ runtime, reviewConsumers }), // sovereigntyEnforce omitted
+    );
+
+    // maxConcurrent: 0 forces the concurrency gate (§4, immediately AFTER the
+    // sovereignty gate) to nak before the pipeline ever spawns a CC session —
+    // proves the sovereignty gate did NOT terminate the request above it,
+    // without needing a real pipeline run.
+    await startForAgent(frontierAgent(0));
+    expect(reviewConsumers).toHaveLength(1);
+
+    const decision = await reviewConsumers[0]!.processEnvelope(
+      mismatchedRequest(),
+      "local.andreas.work.tasks.code-review.typescript",
+      null,
+    );
+
+    // NOT "term" — if sovereigntyEnforce had somehow defaulted true, this
+    // mismatched request would have been denied (term) before ever reaching
+    // the concurrency gate below it.
+    expect(decision.kind).toBe("nak");
   });
 });

--- a/src/runner/brain-consumer-boot.ts
+++ b/src/runner/brain-consumer-boot.ts
@@ -195,6 +195,15 @@ export interface WireBrainConsumersOpts {
   /** The (possibly dormant) MyelinRuntime the consumer subscribes against. */
   runtime: MyelinRuntime;
   /**
+   * EBH-6b (cortex#2380) — resolved `policy.sovereignty.enforce` (default
+   * `false`), threaded verbatim to every `BrainConsumer` this wiring
+   * constructs. Omitted/`false` ⇒ the consumer's own `?? false` default
+   * (audit-only — see `docs/security/hardening-plan.md` §F3). `cortex.ts`
+   * resolves this ONCE and passes the SAME value here and to
+   * `wireReviewConsumers` — the two lanes must never diverge on this flag.
+   */
+  sovereigntyEnforce?: boolean;
+  /**
    * B-3 (design-bot-packs.md §4, §6, §8) — the shared surface-reply gate for
    * `ask_principal` effects. Undefined ⇒ the consumer keeps its DenyAll
    * default (fail-closed — no configured surface identity to verify a reply
@@ -459,6 +468,12 @@ export function wireBrainConsumers(
           principalGate: opts.surfacePrincipalGate,
         }),
         ...(stateRecorder !== undefined && { stateRecorder }),
+        // EBH-6b (cortex#2380) — resolved `policy.sovereignty.enforce`,
+        // verbatim from opts. Omitted ⇒ BrainConsumer's own `?? false`
+        // default (audit-only), same as before this field existed.
+        ...(opts.sovereigntyEnforce !== undefined && {
+          sovereigntyEnforce: opts.sovereigntyEnforce,
+        }),
       };
       // cortex#2215 — wire cortex#2206's `create_private_thread` capability
       // for exactly the agents its ADR intends: `openOnboarding: true` (the

--- a/src/runner/review-consumer-boot.ts
+++ b/src/runner/review-consumer-boot.ts
@@ -116,6 +116,17 @@ export interface WireReviewConsumersOpts {
   /** The (possibly dormant) MyelinRuntime the consumer subscribes against. */
   runtime: MyelinRuntime;
   /**
+   * EBH-6b (cortex#2380) — resolved `policy.sovereignty.enforce` (default
+   * `false`), threaded verbatim to every `ReviewConsumer` this wiring
+   * constructs. Omitted/`false` ⇒ the consumer's own `?? false` default
+   * (audit-only: a sovereignty violation is logged, not denied — see
+   * `docs/security/hardening-plan.md` §F3). `cortex.ts` resolves this ONCE
+   * from `resolvedPolicy?.sovereignty?.enforce ?? false` and passes the SAME
+   * value here and to `wireBrainConsumers` — the two consumer lanes must
+   * never diverge on this flag.
+   */
+  sovereigntyEnforce?: boolean;
+  /**
    * §3 review-session opts, pre-curried with `config` + `process.cwd()` by
    * the caller (`buildReviewSessionOpts` stays exported from `cortex.ts`
    * — this module doesn't import it, avoiding a `cortex.ts` ⇄
@@ -319,6 +330,12 @@ export function wireReviewConsumers(
           agent: consumerAgent,
           source: opts.systemEventSource,
           runtime: opts.runtime,
+          // EBH-6b (cortex#2380) — resolved `policy.sovereignty.enforce`,
+          // verbatim from opts. Omitted ⇒ ReviewConsumer's own `?? false`
+          // default (audit-only), same as before this field existed.
+          ...(opts.sovereigntyEnforce !== undefined && {
+            sovereigntyEnforce: opts.sovereigntyEnforce,
+          }),
           // CC session factory — spawns a real `claude` process. Mirrors the
           // default factory inside `ClaudeCodeHarness` (the harness keeps its
           // own copy private; we don't re-export to avoid the symbol leaking

--- a/src/runner/security-preamble.ts
+++ b/src/runner/security-preamble.ts
@@ -15,7 +15,12 @@ import type { AgentConfig } from "../common/types/config";
  * read the conversation. Verification and config-immutability rules remain
  * enforced even when bash/filesystem restrictions are skipped.
  *
- * See G-301 (issue #42) for planned additional authentication controls.
+ * EBH-6b (cortex#2380) correction: this docblock used to cite "G-301 (issue
+ * #42)" for planned additional authentication controls — that citation was
+ * stale. #42 is an unrelated, already-merged migration PR, and G-301 has no
+ * design section, blueprint entry, or issue anywhere in the repo (see
+ * `docs/security/ebh-6-posture-findings.md` §F4-4). The real follow-up
+ * tracking this gap is #2377.
  */
 export interface SecurityPreambleOpts {
   /** Skip bash guard guidance (principal DM mode) */


### PR DESCRIPTION
## EBH-6b — make the sovereignty posture real and honest (F3)

Closes #2380. Part of epic #2341. **This is a posture-VISIBILITY change, not a posture flip — enforcement stays off everywhere.**

### Why
The review rated F3 *"Low if staged intentionally; Medium if believed-enforcing"* — a framing that assumed a flag someone could flip. The EBH-6 investigation (#2376) found **there is no flag**: `sovereigntyEnforce` was constructor-only, `true` only in tests, in **two** consumers (`review-consumer.ts:500` **and** `brain-consumer.ts:390` — the review named only the first). So violations were logged, never denied, and **no principal action could change that**. Re-rated **Medium**: the risk didn't grow, the gap between documented intent and reality did.

### What shipped
**(i) Config key, default off.** `policy.sovereignty.enforce` (`z.boolean().default(false)`, block optional) threaded into both consumers' boot paths.

The asymmetry trap is closed structurally: `cortex.ts:1253` resolves the value **once** and passes the *same* value to both `wireReviewConsumers` (`:2420`) and `wireBrainConsumers` (`:2651`) — one consumer wired and the other left constructor-only is exactly the bug the investigation found, and it can't recur by construction.

**Posture visibility** — boot now logs, mirroring the existing `security.signing` line:
```
cortex: security posture — sovereignty.enforce=false
  (violations logged, NOT denied — audit-only; see docs/security/hardening-plan.md §F3)
```

**(ii) Docs stop claiming a guarantee.** `hardening-plan.md` §F3 rewritten to state plainly that violations are *detected and logged, not denied*, naming the real prerequisite (#2117 / PR #2201). `design-bot-packs.md` overclaim softened. Historical review/investigation docs deliberately left as dated records.

**(iii) Stale citation fixed.** "G-301 (issue #42)" corrected in `hardening-plan.md` **and** in a `security-preamble.ts` code comment the agent found by grep that the issue hadn't spotted — #42 is an unrelated merged PR; G-301 exists nowhere as trackable work. Both now point at #2377.

### Verified (my independent checks)
- Single resolve → both consumers ✅ · default `false` at schema ✅ · no `sovereigntyEnforce` left constructor-only ✅ · **not enabled in any template or example** ✅ · boot line honest ✅
- Touched-area tests **200 pass / 0 fail**; new posture-boot test **4/4**
- tsc, `lint:errors`, both vocab gates green

### On the full-suite failures — honest note
The branch's full run shows **12 failures**. The agent verified them against the unmodified base commit in a throwaway worktree and reports they fail identically (plugin-loader resolving real adapter bundles locally; this session's own `CORTEX_*` env vars leaking into a subprocess test). **My own attempt at an independent baseline was environment-contaminated** (different test count, many errors) so I could not confirm that locally — **I'm letting CI be the arbiter rather than assert it.** If CI is red, this goes back.

### Held per instruction
Default `false` everywhere · no template/example enables it · enabling remains a separate principal decision that also needs the model-class↔identity binding to be meaningful · `bash-guard.hook.ts`/`path-guard.hook.ts` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
