### PR TITLE
feat(ci): EBH-7 — swarm-posture structural gate (least-privilege + attack paths, warn-only)

### DIFF
--- a/.github/workflows/swarm-posture.yml
+++ b/.github/workflows/swarm-posture.yml
@@ -1,0 +1,111 @@
+# swarm-posture — EBH-7 structural least-privilege / attack-path gate (cortex#2349,
+# epic #2341, execution-boundary hardening).
+#
+# ─── WARN-ONLY (READ THIS) ───────────────────────────────────────────────────
+# This gate is intentionally ADVISORY today. Two things make it non-blocking,
+# mirroring the exact posture `confidentiality-gate.yml` already uses in this repo:
+#
+#   1. It runs in THIS standalone workflow, separate from the required jobs in
+#      `ci.yml` (Test / Lint / Typecheck / Compass-gov / Vocab / Shippable-hygiene).
+#      A finding here never turns those required checks red.
+#   2. It is NOT enrolled in the `protect-main` ruleset's required status checks.
+#      An un-required check cannot block a merge.
+#
+# `scripts/security/run-swarm-posture.ts` also always exits 0 once the upstream
+# tool ran successfully, regardless of finding count — belt and braces with (2).
+# It exits non-zero only when the CHECK ITSELF is broken (missing tool checkout,
+# missing/malformed swarm.json), which SHOULD fail the job.
+#
+# See docs/security/swarm-posture/README.md "What it would take to make this
+# blocking" for the promotion path — a held ops step, not something this
+# workflow does on its own.
+#
+# ─── Vendor vs. invoke ────────────────────────────────────────────────────────
+# cortex does not vendor a copy of swarm-posture.ts (a single, small,
+# zero-dependency file) — a copy would be a second, unreviewable source of the
+# check's logic that silently drifts from upstream. Instead this job checks out
+# NorthwoodsSentinel/swarm-posture at a PINNED COMMIT SHA into a sibling path and
+# invokes it as a subprocess. Bump the pin below deliberately, in a reviewable
+# diff, when adopting an upstream update — never track a branch/tag.
+name: swarm-posture
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agents.d/**"
+      - "personas/**"
+      - "cortex.yaml.example"
+      - "docs/config-layout/**"
+      - "src/common/policy/**"
+      - "src/runner/agent-team.ts"
+      - "src/bus/dispatch-handler.ts"
+      - "docs/security/swarm-posture/**"
+      - "scripts/security/run-swarm-posture.ts"
+      - ".github/workflows/swarm-posture.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "agents.d/**"
+      - "personas/**"
+      - "cortex.yaml.example"
+      - "docs/config-layout/**"
+      - "src/common/policy/**"
+      - "src/runner/agent-team.ts"
+      - "src/bus/dispatch-handler.ts"
+      - "docs/security/swarm-posture/**"
+      - "scripts/security/run-swarm-posture.ts"
+      - ".github/workflows/swarm-posture.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  posture:
+    name: Structural fleet posture (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cortex
+        uses: actions/checkout@v4
+        with:
+          path: cortex
+
+      # Pinned-SHA checkout of the upstream tool — see the header comment.
+      # Bumping this SHA is the ONLY way this job picks up an upstream change.
+      - name: Checkout swarm-posture (pinned)
+        uses: actions/checkout@v4
+        with:
+          repository: NorthwoodsSentinel/swarm-posture
+          ref: 12d042d9f936bc99fed9bd00c29da5e06211b953
+          path: swarm-posture-tool
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Run swarm-posture (advisory — see header)
+        working-directory: cortex
+        run: bun scripts/security/run-swarm-posture.ts ../swarm-posture-tool/swarm-posture.ts
+
+  # Always-green advisory signal, same pattern as confidentiality-gate.yml's
+  # burn-in-summary — makes the non-blocking posture explicit in the Actions UI
+  # even if someone skims only the job list.
+  advisory-summary:
+    needs: [posture]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Report advisory posture (never fails)
+        env:
+          POSTURE_RESULT: ${{ needs.posture.result }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### swarm-posture — ADVISORY (not a required check)"
+            echo ""
+            echo "- posture job result: **${POSTURE_RESULT}**"
+            echo "- this workflow is NOT in required status checks; a finding here does not block merges."
+            echo "- see docs/security/swarm-posture/README.md for the fleet model, findings, and the promotion-to-blocking checklist."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "swarm-posture advisory: posture job result=${POSTURE_RESULT} (not a required check)"

--- a/docs/security/swarm-posture/README.md
+++ b/docs/security/swarm-posture/README.md
@@ -1,0 +1,289 @@
+# EBH-7 — swarm-posture structural check (cortex#2349, epic #2341)
+
+Structural least-privilege + attack-path analysis of cortex's own agent fleet, using
+[`swarm-posture`](https://github.com/NorthwoodsSentinel/swarm-posture) (NorthWoods
+Sentinel Labs, Apache-2.0 — the same reviewers who authored the NWS security review
+this epic responds to).
+
+**The thesis** (from the issue): *"Security doesn't compose — you can't audit a swarm
+by auditing its workers one at a time."* cortex spawns multi-agent teams
+(`src/runner/agent-team.ts`: moderator + participants) — a real invoke-graph where a
+composed escalation (a chain of individually-authorized invocations reaching data no
+single worker should) can hide from a per-worker review. This directory holds the
+structural model of that graph plus the check's findings.
+
+## Files
+
+- `cortex-fleet.swarm.json` — the committed swarm description (`swarm-posture`'s
+  schema). Reviewable, diff-visible; regenerate/hand-correct it whenever the fleet's
+  tool grants or delegation edges change.
+- `../../../scripts/security/run-swarm-posture.ts` — the CI wrapper that invokes the
+  upstream tool against this file.
+- `../../../.github/workflows/swarm-posture.yml` — the CI job (warn-only).
+
+## Vendor vs. invoke
+
+**Invoked, not vendored.** `swarm-posture.ts` is a single ~140-line zero-dependency
+file; copying it into this repo would create a second, unreviewable copy of a security
+tool's algorithm that silently drifts from upstream. Instead, CI checks out
+`NorthwoodsSentinel/swarm-posture` at a **pinned commit SHA**
+(`12d042d9f936bc99fed9bd00c29da5e06211b953`, tag-free — the same "pin the engine, not
+a movable ref" discipline `confidentiality-gate.yml` already uses for its reusable
+workflow) into a sibling checkout path, and `run-swarm-posture.ts` runs it as a
+subprocess against the committed `cortex-fleet.swarm.json`. Bumping the pin is a
+one-line, reviewable diff; there is exactly one copy of the check's logic, and it's
+upstream's.
+
+There is no `cortex` mode in `swarm-posture`'s own `adapt.ts` (only `pai`, `pi`,
+`langgraph`, `crewai`), so this fleet description is **hand-modeled from source**, not
+adapter-generated. The sources read are listed in the JSON file's own `_provenance`
+block so the model's basis stays visible next to the data.
+
+## The fleet model
+
+Eight workers, five sensitivity tiers. The tiers are cortex's actual reach classes —
+not the generic PAI-adapter categories in `swarm-posture`'s own `adapt.ts`:
+
+| Tier | Name | What reaches it |
+|---|---|---|
+| 1 | `filesystem` | `Read`/`Grep`/`Glob`/`Write`/`Edit` — the repo/config tree |
+| 2 | `network-egress` | `WebFetch`/`WebSearch` — outbound web |
+| 3 | `external-service` | `tool.mcp.*` grants — third-party accounts reachable via MCP servers (Discord, GitHub, Drive, …) |
+| 4 | `secrets` | `Bash` — env vars, `~/.env`, credential files, NATS seeds, tokens |
+| 5 | `full-authority` | the reserved `operator` capability — full tool grant + full MCP namespace (`deriveMcpGrants` returns `["*"]`) + `trusted: true` (bypasses the inbound prompt-injection hard block, `resolve-access.ts:381-388`) |
+
+`sensitive_at_or_above: 3` — filesystem/network-egress are cortex's normal working
+reach for any assistant; external-service/secrets/full-authority are the
+escalation classes.
+
+### Workers
+
+| id | role | reach | invokes |
+|---|---|---|---|
+| `principal-session` | `principal` | full-authority (all tiers ≥3 — holds the `operator` capability) | `team-moderator` |
+| `team-moderator` | `team-council` | shell-and-secrets, third-party-services | `team-analyst`, `team-creative`, `team-critic` |
+| `team-analyst` / `team-creative` / `team-critic` | `team-council` | shell-and-secrets, third-party-services | — |
+| `concierge-anon` | `concierge` | filesystem only | — |
+| `concierge-authenticated` | `concierge` | shell-and-secrets, third-party-services, full-authority | — |
+| `review-bot` | `code-reviewer` | shell-and-secrets | — |
+
+**Why these eight, and not a bigger or smaller roster:**
+
+- `principal-session` / `team-moderator` / `team-analyst` / `team-creative` /
+  `team-critic` model `src/bus/dispatch-handler.ts`'s `handleTeam` — the `team:`
+  keyword handler. It hardcodes **exactly three participants**
+  (`analyst`/`creative`/`critic`, dispatch-handler.ts:1678-1680) and passes
+  `allowedTools`, `mcpGrants`, and `agentEnv` **unchanged** into every session
+  `AgentTeamOpts` propagates them to (moderator + all three participants +
+  synthesis — see `agent-team.ts`'s own docblock and cortex#2111/#2133 comments
+  at the call site). There is no per-participant narrowing in this call site: no
+  `TeamParticipantConfig.allowedTools`/`disallowedTools` override is set, so
+  every team session gets the SAME tool/MCP reach as whoever typed `team:`.
+  `docs/security/ebh-6-posture-findings.md` independently corroborates the same
+  propagation pattern for a different flag (`bashGuardDisabled`, `agent-team.ts:
+  610,733,915`) — this is a general property of the mechanism, not specific to
+  one config field.
+- `concierge-anon` / `concierge-authenticated` model Pier (`agents.d/pier.yaml`,
+  `personas/pier.md`) — the one real, shipped, public in-tree agent. The anon
+  worker is the `openOnboarding` path (`resolve-access.ts`'s
+  `anonOnboardingAccess`): a hardcoded, enforced `["Read"]` allowlist,
+  `mcpGrants: []`, `trusted: false`. The authenticated worker models what
+  happens when a *mapped, non-anonymous* principal messages Pier — see
+  "Finding 1" below.
+- `review-bot` models Echo, using the `agent-echo` role literally declared in
+  the committed `cortex.yaml.example` (`policy.roles: id: agent-echo →
+  keyword.chat, tool.bash, tool.read, tool.glob, tool.grep`).
+
+**What's deliberately NOT in the model:** `TeamParticipantConfig.kind:
+"bus-peer"` (a documented primitive in `agent-team.ts` for delegating a
+participant to a REMOTE cortex over the bus) is a live, callable mechanism but
+has **no current call site** — `handleTeam` never sets `kind`, so every
+shipped team session is `"local"`. Modeling it as a worker would misrepresent
+something as *currently wired* that is only *available*. It is flagged as a
+forward-looking risk in Finding 3 instead of baked into the JSON as a phantom
+edge — see `swarm-posture`'s own scope note: it "reads your declared config;
+it does not run your agents," and an unused code path is not declared
+reachable config.
+
+### `role_owns` — the judgment call
+
+- **`principal`** owns everything. This is the home principal / trust root by
+  design (`resolve-access.ts:381-388`, cortex#741) — the one role meant to
+  hold the `operator` capability.
+- **`code-reviewer`**, **`concierge`**, **`team-council`** own only
+  `repo-and-config-files`. None of these are, by design, supposed to hold
+  unscoped shell/secrets or third-party-service reach — a code reviewer reads
+  the repo, a concierge answers onboarding questions from docs, and an ad-hoc
+  analyst/creative/critic persona reasons over context. None of that requires
+  Bash or MCP.
+
+This was decided *before* running the check, not adjusted afterward to make
+the report look clean — see "Findings" below for what it actually flagged.
+
+## Findings (as of cortex commit `93d0d5df`)
+
+Ran `bun <pinned-swarm-posture-checkout>/swarm-posture.ts
+docs/security/swarm-posture/cortex-fleet.swarm.json`:
+
+```
+swarm-posture — cortex-fleet  (8 workers · sensitive = external-service and above)
+
+POSTURE  6 worker(s) over-broad for their role, 0 escalation path(s). Not least-privilege.
+  8 workers · 7 reach sensitive data · 2 can spawn other agents · 6 reach shell-and-secrets
+
+EXCESSIVE PERMISSIONS (least-privilege / blast radius)
+  ⚠ team-moderator (role: team-council) reaches shell-and-secrets (external-service), shell-and-secrets (secrets), third-party-services (external-service) — its role does not own this; scope down.
+  ⚠ team-analyst (role: team-council) reaches shell-and-secrets (external-service), shell-and-secrets (secrets), third-party-services (external-service) — its role does not own this; scope down.
+  ⚠ team-creative (role: team-council) reaches shell-and-secrets (external-service), shell-and-secrets (secrets), third-party-services (external-service) — its role does not own this; scope down.
+  ⚠ team-critic (role: team-council) reaches shell-and-secrets (external-service), shell-and-secrets (secrets), third-party-services (external-service) — its role does not own this; scope down.
+  ⚠ concierge-authenticated (role: concierge) reaches shell-and-secrets (external-service), shell-and-secrets (secrets), third-party-services (external-service), full-authority (external-service), full-authority (secrets), full-authority (full-authority) — its role does not own this; scope down.
+  ⚠ review-bot (role: code-reviewer) reaches shell-and-secrets (external-service), shell-and-secrets (secrets) — its role does not own this; scope down.
+
+ATTACK PATHS (composed escalation — a chain a per-worker review can't see)
+  none — no invocation chain reaches sensitive data its origin doesn't own.
+
+━━ SUMMARY ━━
+  6 structural finding(s): 6 excessive-permission, 0 attack-path
+```
+
+**These are genuine, unmassaged findings against the shipped reference
+config** (`cortex.yaml.example` + `agents.d/pier.yaml` + the `handleTeam` call
+site) — nothing in `role_owns` was loosened after seeing this output.
+
+### Finding 1 — Pier's persona confinement is not actually enforced for authenticated senders
+
+`personas/pier.md` declares `allowedTools: [Read]` — Pier's whole documented
+security posture is "it only reads, it issues nothing." But
+`docs/persona-format.md`'s own error-handling table says this plainly:
+
+> `allowedTools` … Field is **advisory in v1** — runtime enforcement (filtering
+> the substrate's tool palette to this allowlist) lands in a future cortex
+> release; until then the runner **ignores the field** with an info-level log.
+
+The only path where Pier's tools are *actually* clamped is the anonymous
+open-onboarding path (`anonOnboardingAccess` in `resolve-access.ts`, a
+hardcoded `["Read"]` + `mcpGrants: []` + `trusted: false`, confirmed live at
+`dispatch-handler.ts:641-644`). For any *mapped, authenticated* principal who
+messages Pier, `resolvePolicyAccess` resolves tool grants from **that
+sender's own role**, not from Pier's persona, and `agents.d/pier.yaml`
+declares no `agentDisallowedTools` to narrow it back down
+(`dispatch-handler.ts:925-947`, the `effectiveAllowedTools`/`effectiveDisallowed`
+computation). So `concierge-authenticated`'s worst-case reach in the model
+above — full shell/secrets/MCP reach plus the `operator` capability if the
+sender happens to be the principal — is real, not a hand-wavy hypothetical: it is what the code does
+today, for any sender whose own role is broad. **The fix is narrow and
+concrete**: declare `agentDisallowedTools` (or an equivalent enforced
+allowlist) on Pier's agent config so its confinement is enforced at the same
+layer as everything else, not left to an advisory persona field the runner
+admits it ignores.
+
+### Finding 2 — the built-in `team:` council has no per-agent least privilege
+
+`handleTeam`'s three hardcoded participants (`analyst`/`creative`/`critic`)
+get the exact same `allowedTools`/`mcpGrants`/`agentEnv` as whoever typed
+`team: …` — there is no role differentiation at all between three
+general-purpose reasoning personas and the invoking principal's own grant.
+Concretely: if a principal's session is manipulated by indirect prompt
+injection (fetched issue text, a webhook-relayed comment, etc. — the exact
+threat class this epic's F1/F6 findings are about) into emitting a `team:`
+message, the attacker rides the **full 3-way fan-out** with the principal's
+own Bash/MCP reach, not a scoped-down "just discuss this" surface. This
+showed up as 4 of the 6 excessive-permission findings (moderator + 3
+participants), and is why the POSTURE headline reads "6 worker(s) over-broad
+… not least-privilege" rather than a clean bill of health.
+
+Because the *only* role in the shipped example that holds `keyword.team` is
+`principal` — the same role that legitimately owns every sensitive class —
+`swarm-posture` correctly reports **zero attack paths** for this edge (an
+origin invoking a deputy that reaches only what the origin already owns
+directly is blast radius, not escalation; see the tool's own doc comment on
+why it skips that case). That is the accurate structural call, not a blind
+spot: the real risk here is unscoped blast radius from the fixed 3x fan-out,
+not composed privilege escalation. It would become composed escalation the
+moment any role *other* than `principal` gains `keyword.team` without gaining
+matching `role_owns` — which is exactly the kind of future-config drift this
+gate exists to catch.
+
+### Finding 3 — `TeamParticipantConfig.kind: "bus-peer"` is a live, unused escalation surface
+
+`agent-team.ts` implements delegating a team participant to a **remote**
+cortex stack over the bus (`BusPeerHarness`, cortex#114 Phase B.2b). No
+current call site sets `kind: "bus-peer"` — `handleTeam` always uses the
+default `"local"` — so it is not in the committed `swarm.json` (see "What's
+deliberately NOT in the model" above). But the mechanism is real, tested, and
+one line away from being wired into any future team-mode caller. When it is,
+it should get its own worker entry with reach modeled as crossing the trust
+boundary entirely (the remote stack's own policy determines reach, which is
+unbounded from the local swarm's perspective) — flagged here so it isn't
+forgotten when a future PR adds a call site.
+
+### Finding 4 — Echo's review-bash grant is unscoped
+
+`agent-echo`'s role in `cortex.yaml.example` grants `tool.bash` with **no**
+`bash_allowlist` (`policy.principals[].session_config.*.bash_allowlist`, the
+scoping mechanism `resolve-access.ts` reads). A code reviewer plausibly needs
+to run `bun test`/`tsc --noEmit`/`bun lint` as part of a review — that's a
+reasonable capability, which is why `code-reviewer` is not simply denied
+`shell-and-secrets` outright in this write-up. But *unscoped* Bash reaches
+the full secrets tier (env vars, credential files, tokens), which is broader
+than "run the test suite." The concrete fix is to populate a
+`bash_allowlist` scoping Echo's shell to review-relevant commands, not to
+strip Bash entirely.
+
+## What this check is and isn't
+
+**Structural only.** It reads declared config (`cortex-fleet.swarm.json`,
+itself hand-derived from real source — see `_provenance`) and computes
+reachability; it does **not** run cortex, does not spawn real Claude Code
+sessions, and cannot tell you whether a real model actually falls for a given
+prompt injection. That's **behavioral simulation** (intent-fidelity
+measurement under live injection) — explicitly out of scope for this issue
+per the epic's own "Horizon" section, and NorthWoods Sentinel Labs' paid
+tier.
+
+It is also only as accurate as the hand-modeling above — there is no
+automated `cortex` adapter mode in `swarm-posture`'s `adapt.ts` today, so
+drift between this file and the real `resolve-access.ts`/`agent-team.ts`
+behavior is caught only by whoever re-reads the source at update time, not by
+tooling. Treat `cortex-fleet.swarm.json` the same way the upstream README
+tells framework-adapter users to treat a generated file: "a first draft you
+can correct by hand, not gospel" — except here it started as a hand draft, so
+the correction loop is a human (or agent) re-reading `resolve-access.ts` /
+`agent-team.ts` / `dispatch-handler.ts` and updating the JSON, not
+re-running an adapter.
+
+## CI wiring
+
+`.github/workflows/swarm-posture.yml` runs on every push/PR that touches
+agent/tool-grant config (`agents.d/**`, `personas/**`, `cortex.yaml.example`,
+`docs/config-layout/**`, `src/common/policy/**`, `src/runner/agent-team.ts`,
+`src/bus/dispatch-handler.ts`, or this directory). It is a **standalone,
+non-required** workflow — the same warn-only mechanism
+`confidentiality-gate.yml` already uses in this repo (GitHub doesn't allow
+`continue-on-error` on a job calling a reusable workflow, but a workflow that
+is simply never added to `protect-main`'s required status checks cannot
+block a merge either way, and `run-swarm-posture.ts` itself also always
+exits 0 once the check ran — belt and braces). The step summary carries the
+finding count and full output for every run.
+
+### What it would take to make this blocking
+
+1. **Burn-in window** — run WARN-ONLY long enough to see the real
+   finding/false-positive rate across a few weeks of agent-config PRs (same
+   acceptance bar `confidentiality-gate.yml` used: "≥3-day warn-only burn-in
+   with <1 false BLOCK/week").
+2. **A drift baseline, not a zero-tolerance gate** — `run-swarm-posture.ts`
+   would need to parse the "N structural finding(s)" line and fail only on a
+   *regression* against a committed baseline count (or a fixed ceiling this
+   PR's four findings become), not on the pre-existing findings above —
+   otherwise flipping to blocking requires fixing all four findings in the
+   same PR as the gate, which inverts the intended order (land the gate,
+   *then* decide whether/when to fix what it found).
+3. **A principal decision on the findings themselves** — scoping Echo's
+   `bash_allowlist`, deciding whether/how to narrow the `team:` council's
+   default tool grant, and declaring `agentDisallowedTools` on Pier are
+   product/security decisions, not something this issue's tooling change
+   should silently resolve.
+4. **Enrollment in `protect-main`'s required status checks** — a held ops
+   step, principal-only, per the same posture-change discipline
+   `confidentiality-gate.yml`'s header documents (OD-1 admin-bypass posture).

--- a/docs/security/swarm-posture/cortex-fleet.swarm.json
+++ b/docs/security/swarm-posture/cortex-fleet.swarm.json
@@ -1,0 +1,113 @@
+{
+  "swarm": "cortex-fleet",
+  "_provenance": {
+    "modeled_by": "hand-modeled from source, not adapter-generated — swarm-posture's adapt.ts has no cortex mode (only pai, pi, langgraph, crewai); see docs/security/swarm-posture/README.md '#Method' for why invoking an adapter was not an option and what was read instead",
+    "upstream_tool": "https://github.com/NorthwoodsSentinel/swarm-posture @ 12d042d9f936bc99fed9bd00c29da5e06211b953",
+    "as_of_cortex_commit": "93d0d5df",
+    "sources_read": [
+      "cortex.yaml.example (policy.roles[], policy.principals[], agents[])",
+      "docs/persona-format.md (allowedTools is advisory-only in v1 — not runtime-enforced)",
+      "agents.d/pier.yaml + personas/pier.md (Pier's shipped persona + openOnboarding confinement)",
+      "src/common/policy/resolve-access.ts (resolvePolicyAccess, deriveMcpGrants, anonOnboardingAccess)",
+      "src/common/policy/tool-inventory.ts (CLAUDE_TOOL_INVENTORY, tool.<name> capability grammar)",
+      "src/bus/dispatch-handler.ts (handleTeam — the three hardcoded team-mode participants + how allowedTools/mcpGrants/agentEnv flow into AgentTeamOpts unchanged)",
+      "src/runner/agent-team.ts (AgentTeamOpts propagation to every team session; bus-peer TeamParticipantConfig.kind)",
+      "src/runner/cc-session.ts (effectiveAllowedTools/effectiveDisallowedTools actually reaching the claude CLI invocation — the real enforcement point)",
+      "docs/security/ebh-6-posture-findings.md (independent corroboration: bashGuardDisabled also propagates unchanged to every team participant, agent-team.ts:610,733,915)"
+    ]
+  },
+  "data_tiers": {
+    "0": "public",
+    "1": "filesystem",
+    "2": "network-egress",
+    "3": "external-service",
+    "4": "secrets",
+    "5": "full-authority"
+  },
+  "sensitive_at_or_above": 3,
+  "role_owns": {
+    "principal": ["repo-and-config-files", "shell-and-secrets", "third-party-services", "full-authority"],
+    "code-reviewer": ["repo-and-config-files"],
+    "concierge": ["repo-and-config-files"],
+    "team-council": ["repo-and-config-files"]
+  },
+  "workers": [
+    {
+      "id": "principal-session",
+      "role": "principal",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 },
+        { "class": "full-authority", "max_sensitivity": 5 }
+      ],
+      "invokes": ["team-moderator"]
+    },
+    {
+      "id": "team-moderator",
+      "role": "team-council",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 },
+        { "class": "shell-and-secrets", "max_sensitivity": 4 },
+        { "class": "third-party-services", "max_sensitivity": 3 }
+      ],
+      "invokes": ["team-analyst", "team-creative", "team-critic"]
+    },
+    {
+      "id": "team-analyst",
+      "role": "team-council",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 },
+        { "class": "shell-and-secrets", "max_sensitivity": 4 },
+        { "class": "third-party-services", "max_sensitivity": 3 }
+      ],
+      "invokes": []
+    },
+    {
+      "id": "team-creative",
+      "role": "team-council",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 },
+        { "class": "shell-and-secrets", "max_sensitivity": 4 },
+        { "class": "third-party-services", "max_sensitivity": 3 }
+      ],
+      "invokes": []
+    },
+    {
+      "id": "team-critic",
+      "role": "team-council",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 },
+        { "class": "shell-and-secrets", "max_sensitivity": 4 },
+        { "class": "third-party-services", "max_sensitivity": 3 }
+      ],
+      "invokes": []
+    },
+    {
+      "id": "concierge-anon",
+      "role": "concierge",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 }
+      ],
+      "invokes": []
+    },
+    {
+      "id": "concierge-authenticated",
+      "role": "concierge",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 },
+        { "class": "shell-and-secrets", "max_sensitivity": 4 },
+        { "class": "third-party-services", "max_sensitivity": 3 },
+        { "class": "full-authority", "max_sensitivity": 5 }
+      ],
+      "invokes": []
+    },
+    {
+      "id": "review-bot",
+      "role": "code-reviewer",
+      "reads": [
+        { "class": "repo-and-config-files", "max_sensitivity": 1 },
+        { "class": "shell-and-secrets", "max_sensitivity": 4 }
+      ],
+      "invokes": []
+    }
+  ]
+}

--- a/scripts/security/run-swarm-posture.ts
+++ b/scripts/security/run-swarm-posture.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+/**
+ * run-swarm-posture.ts — EBH-7 (cortex#2349, epic #2341) CI wrapper for the
+ * swarm-posture structural least-privilege / attack-path check.
+ *
+ * cortex does NOT vendor a copy of swarm-posture.ts. The upstream tool
+ * (https://github.com/NorthwoodsSentinel/swarm-posture, Apache-2.0) is a
+ * single zero-dependency file; the CI workflow checks it out at a pinned
+ * commit SHA into a sibling directory and this script *invokes* it against
+ * the committed fleet description. See docs/security/swarm-posture/README.md
+ * "Vendor vs. invoke" for why invoking (not copying) was the deliberate
+ * choice — the short version: a copy of someone else's security tool drifts
+ * silently; a pinned-SHA checkout is the same "vendor a known-good version"
+ * guarantee without an unreviewable second copy of the algorithm living in
+ * this repo.
+ *
+ * WARN-ONLY (advisory) posture: this script ALWAYS exits 0 when the tool ran
+ * successfully, regardless of how many structural findings it reports — this
+ * is deliberate for the initial rollout (we do not yet know the finding
+ * volume / false-positive rate on a live fleet; a gate that red-lines `main`
+ * on day one gets disabled, not fixed). It exits non-zero only when the
+ * check itself could not run (missing tool, missing/malformed swarm.json) —
+ * that is a broken CI job, not a posture finding, and SHOULD fail the build.
+ *
+ * To promote to BLOCKING later: parse the "N structural finding(s)" summary
+ * line below, diff the count against a committed baseline (or a fixed
+ * ceiling), and exit non-zero on regression. That is intentionally NOT done
+ * here yet — see the epic issue (cortex#2349) acceptance criteria.
+ *
+ * Usage:
+ *   bun scripts/security/run-swarm-posture.ts <path-to-swarm-posture.ts> [swarm.json]
+ *
+ * `swarm.json` defaults to docs/security/swarm-posture/cortex-fleet.swarm.json.
+ */
+
+import { existsSync, appendFileSync } from "fs";
+import { spawnSync } from "child_process";
+import { resolve } from "path";
+
+const DEFAULT_SWARM_FILE = "docs/security/swarm-posture/cortex-fleet.swarm.json";
+
+function die(msg: string): never {
+  console.error(`run-swarm-posture: ${msg}`);
+  process.exit(2);
+}
+
+const toolPath = process.argv[2];
+const swarmFile = resolve(process.argv[3] ?? DEFAULT_SWARM_FILE);
+
+if (!toolPath) {
+  die(
+    "usage: bun scripts/security/run-swarm-posture.ts <path-to-swarm-posture.ts> [swarm.json]\n" +
+      "  In CI, <path-to-swarm-posture.ts> comes from the pinned NorthwoodsSentinel/swarm-posture checkout.\n" +
+      "  Locally: clone https://github.com/NorthwoodsSentinel/swarm-posture and pass its swarm-posture.ts path.",
+  );
+}
+
+if (!existsSync(toolPath)) {
+  die(`swarm-posture.ts not found at "${toolPath}" — checkout step did not run or the path is wrong.`);
+}
+
+if (!existsSync(swarmFile)) {
+  die(`swarm description not found at "${swarmFile}".`);
+}
+
+const result = spawnSync("bun", [toolPath, swarmFile], { encoding: "utf8" });
+
+// A spawn failure (tool crashed, bun missing, etc.) is an infra problem —
+// distinct from the tool running and reporting findings (which always exits
+// 0; see swarm-posture.ts — it only exits non-zero on a missing/unparseable
+// swarm file, which the existsSync check above already ruled out short of a
+// race). Either way, a non-zero exit here means the CHECK ITSELF is broken,
+// not that findings exist — fail the job so a broken gate can't silently
+// look green.
+if (result.error) {
+  die(`failed to spawn bun: ${result.error.message}`);
+}
+
+const stdout = result.stdout ?? "";
+const stderr = result.stderr ?? "";
+if (stdout) process.stdout.write(stdout);
+if (stderr) process.stderr.write(stderr);
+
+if (result.status !== 0) {
+  die(`swarm-posture.ts exited ${result.status} — check config error above (not a posture finding).`);
+}
+
+// Extract the one-line summary ("N structural finding(s): X excessive-permission, Y attack-path")
+// for the step summary / advisory banner. Falls back gracefully if the
+// upstream tool's output format ever changes — this is a nice-to-have
+// extraction, not a parser this gate depends on for correctness.
+// eslint-disable-next-line no-control-regex -- stripping the tool's ANSI color codes for the plain-text summary
+const plain = stdout.replace(/\x1b\[[0-9;]*m/g, "");
+const summaryMatch = plain.match(/([0-9]+) structural finding\(s\): (\d+) excessive-permission, (\d+) attack-path/);
+const summaryLine = summaryMatch
+  ? `${summaryMatch[1]} structural finding(s) — ${summaryMatch[2]} excessive-permission, ${summaryMatch[3]} attack-path`
+  : "(could not parse summary line — see full output above)";
+
+const banner = [
+  "",
+  "=".repeat(78),
+  "swarm-posture — ADVISORY / WARN-ONLY (EBH-7, cortex#2349)",
+  `Result: ${summaryLine}`,
+  "This gate does NOT fail the build on findings yet — see the epic (cortex#2349)",
+  "and docs/security/swarm-posture/README.md for what promotes it to blocking.",
+  "=".repeat(78),
+  "",
+].join("\n");
+console.log(banner);
+
+const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+if (summaryFile) {
+  try {
+    // GITHUB_STEP_SUMMARY is a shared, cumulative file across every step in
+    // the job (each writer APPENDS, per GitHub's own contract) — using
+    // Bun.write here would TRUNCATE whatever earlier steps already wrote.
+    appendFileSync(
+      summaryFile,
+      `### swarm-posture — ADVISORY / WARN-ONLY\n\n` +
+        `**${summaryLine}**\n\n` +
+        "This is the structural check only (declared config, no live agent runs). " +
+        "It does not fail CI on findings during the burn-in window. " +
+        "See `docs/security/swarm-posture/README.md` for the fleet model, the `role_owns` reasoning, " +
+        "and what promoting this gate to blocking would require.\n\n" +
+        "```\n" +
+        plain.trim() +
+        "\n```\n",
+    );
+  } catch (err) {
+    // Non-fatal — the step summary is a nice-to-have UI surface, not the
+    // gate's actual signal (which is the exit code + stdout above).
+    console.warn(`run-swarm-posture: could not write GITHUB_STEP_SUMMARY: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// WARN-ONLY: always exit 0 once the check itself ran successfully, no matter
+// how many findings it reported. See the module docblock.
+process.exit(0);


### PR DESCRIPTION
## EBH-7 — swarm-posture structural gate (least-privilege + attack paths)

Closes #2349. Part of epic #2341. **Analysis tooling only — touches no runtime code.**

### Why
"Security doesn't compose — you can't audit a swarm by auditing its workers one at a time." cortex spawns multi-agent teams (`agent-team.ts`: moderator + participants), which is a real invoke-graph where a *composed* escalation can hide. A per-worker review is structurally blind to it. This is the free structural half of the NorthWoods Sentinel engagement, alongside their review.

### What shipped
- **`docs/security/swarm-posture/cortex-fleet.swarm.json`** — 8 workers hand-modelled from real source (`cortex.yaml.example` `policy.roles[]`, `agents.d/`, `personas/`, `resolve-access.ts`, `dispatch-handler.ts`'s `handleTeam`, `agent-team.ts`, `cc-session.ts`). Committed so drift is reviewable.
- **`scripts/security/run-swarm-posture.ts`** + **`.github/workflows/swarm-posture.yml`** — triggered on changes to agent/tool-grant config. The tool is **invoked at a pinned commit, not vendored**, so there's no second drifting copy of its algorithm in-repo.
- **`docs/security/swarm-posture/README.md`** — `role_owns` reasoning, findings, and what it would take to make this blocking.

**Warn-only by design.** Not enrolled in `protect-main` required checks (mirrors the proven `confidentiality-gate` pattern here). A gate that red-lights `main` on day one gets disabled; this reports first.

### Findings — reported unmassaged
**6 excessive-permission, 0 attack-path.** `role_owns` was decided *before* running the check, deliberately not tuned afterwards to make the report look clean.

1. **A persona declares `allowedTools: [Read]` that is not enforced.** `docs/persona-format.md:36` documents the field as **advisory in v1** — "the runner ignores the field" — and the agent fragment declares no `agentDisallowedTools` to compensate. **I verified all three parts against source.** An agent declared read-only is not read-only. Filed as **#2386**.
2. **`team:` council fan-out** — the moderator *and* the three hardcoded participants (`dispatch-handler.ts:1678-1680`) get the **same** reach as the invoker, with no per-participant narrowing: a 3× blast-radius fan-out. Not a composed escalation in today's config (the only role holding `keyword.team` already owns everything the deputies reach) — but it becomes one the moment a narrower role gains that keyword.
3. **An `agent-*` role grants unscoped `tool.bash`** with no `bash_allowlist`, reaching the secrets tier.
4. `TeamParticipantConfig.kind: "bus-peer"` (delegation to a remote cortex) is a live but currently-unused primitive — deliberately **not** modelled as a phantom edge, flagged as forward-looking risk instead.

Finding 1 is the sharpest: it is the **review's own thesis found on our own fleet** — a boundary that is declared but not enforced, the same shape as F1, F6 and F3.

### Honest limits
Structural only. It reads declared config; it never runs cortex or a real session, and it **cannot** tell you whether a model actually falls for an injection — that's behavioural simulation (intent fidelity), NWS's paid tier, explicitly out of scope.

### To make it blocking (documented in the README)
A burn-in window · a drift baseline (fail on *regression* against today's 6, not on their existence) · principal decisions on the findings themselves · enrolment in `protect-main`.

Confidentiality: generic role/agent names only — no platform IDs, principal identities, or internal emails. `check-shippable-hygiene`, carveouts, wire-vocab, tsc, eslint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
