### PR TITLE
fix(bus): EBH-1b — wire readOnlyDirs through the dispatch seam (F6 goes live)

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -1323,6 +1323,48 @@ describe("DispatchHandler — dispatch cwd fallback (cortex#2097)", () => {
     await handler.shutdown();
   });
 
+  // EBH-1b (cortex#2352) — readOnlyDirs threading through the direct
+  // (non-bus) dispatch path into CCSessionOpts. Proves acceptance criterion
+  // 1: a live-shaped dispatch with a configured readOnlyDirs produces a
+  // CCSessionOpts with a NON-EMPTY readOnlyDirs, AND acceptance criterion 3:
+  // the `--add-dir` union (opts.allowedDirs) is UNCHANGED — it still
+  // includes the read-only dir, exactly as before this slice — only the
+  // guard projection (resolvePathGuardEnv, tested separately in
+  // cc-session.test.ts) subtracts it.
+  test("configured readOnlyDirs: CCSessionOpts.readOnlyDirs is non-empty AND allowedDirs union is unchanged (EBH-1b)", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig({
+        claude: {
+          timeoutMs: 120_000,
+          asyncTimeoutMs: 900_000,
+          additionalArgs: [],
+          allowedTools: [],
+          disallowedTools: [],
+          allowedDirs: ["/configured/dir"],
+          readOnlyDirs: ["/configured/readonly"],
+        },
+      }),
+      securityPreamble: "",
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+      stack: "acme",
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    const opts = optsLog()[0]!;
+    // The distinct field the guard projection consumes.
+    expect(opts.readOnlyDirs).toEqual(["/configured/readonly"]);
+    // The union `--add-dir` still receives — byte-identical to pre-EBH-1b:
+    // both the writable and the read-only dir are present so reads of the
+    // read-only dir keep working via Claude Code's own --add-dir grant.
+    expect(opts.allowedDirs).toEqual(["/configured/dir", "/configured/readonly"]);
+
+    await handler.shutdown();
+  });
+
   test("claude.workspaceDir set explicitly: dispatch uses it verbatim, `~` expands", async () => {
     const { factory, optsLog } = makeStubFactory([successResult()]);
     const adapter = new MockAdapter();
@@ -1808,6 +1850,8 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     prompt: "user prompt here",
     resumeSessionId: undefined,
     allowedDirs: ["/Users/andreas/Developer/cortex"],
+    // EBH-1b (cortex#2352)
+    readOnlyDirs: [],
     disallowedTools: ["WebSearch"],
     timeoutMs: 120_000,
     cwd: "/Users/andreas/Developer/cortex",

--- a/src/bus/__tests__/dispatch-source-publisher.test.ts
+++ b/src/bus/__tests__/dispatch-source-publisher.test.ts
@@ -130,6 +130,7 @@ function baseOpts(
     prompt: "user prompt",
     resumeSessionId: undefined,
     allowedDirs: [],
+    readOnlyDirs: [],
     disallowedTools: [],
     allowedSkills: undefined,
     timeoutMs: undefined,
@@ -280,6 +281,31 @@ describe("dispatch-source-publisher — F-1b subject principal derivation (corte
     );
     const payload = runtime.subjectPublishes[0]!.envelope.payload;
     expect("allowed_skills" in payload).toBe(false);
+  });
+
+  // ── EBH-1b (cortex#2352) — readOnlyDirs rides the payload read_only_dirs ────
+
+  test("readOnlyDirs non-empty → payload carries read_only_dirs distinctly from allowed_dirs", async () => {
+    const runtime = makeRecordingRuntime();
+    await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, {
+        allowedDirs: ["/work", "/ro"],
+        readOnlyDirs: ["/ro"],
+      }),
+    );
+    const payload = runtime.subjectPublishes[0]!.envelope.payload;
+    // allowed_dirs is the UNCHANGED union (still grants --add-dir read access
+    // to the read-only dir); read_only_dirs is the distinct EBH-1b field the
+    // runner's guard projection subtracts from allowedDirs.
+    expect(payload.allowed_dirs).toEqual(["/work", "/ro"]);
+    expect(payload.read_only_dirs).toEqual(["/ro"]);
+  });
+
+  test("readOnlyDirs empty → payload OMITS read_only_dirs (mirrors allowed_dirs' own omit-when-empty rule)", async () => {
+    const runtime = makeRecordingRuntime();
+    await publishInboundChatDispatchEnvelope(baseOpts(runtime, { readOnlyDirs: [] }));
+    const payload = runtime.subjectPublishes[0]!.envelope.payload;
+    expect("read_only_dirs" in payload).toBe(false);
   });
 
   // ── GV-2 (cortex#1077) — channel/network label dual-write shim ──────────────

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -507,6 +507,8 @@ export class DispatchHandler extends EventEmitter {
     targetAgent?: DispatchTargetAgent;
     resumeSessionId: string | undefined;
     allowedDirs: string[];
+    /** EBH-1b (cortex#2352) — read-only dirs, carried distinctly (see InboundChatDispatchPublishOpts). */
+    readOnlyDirs: string[];
     disallowedTools: string[];
     /** cortex#1167 — explicit tool allowlist (anon open-onboarding path only). */
     allowedTools?: string[];
@@ -1047,6 +1049,10 @@ export class DispatchHandler extends EventEmitter {
           targetAgent,
           resumeSessionId: existingSession?.sessionId,
           allowedDirs: invokeDirs,
+          // EBH-1b (cortex#2352) — the distinct read-only set, carried
+          // alongside the union `invokeDirs` so the runner's guard
+          // projection can subtract it (see cc-session.ts resolvePathGuardEnv).
+          readOnlyDirs,
           disallowedTools: effectiveDisallowed,
           // cortex#1167 — explicit tool ALLOWLIST. Set only on the anon
           // open-onboarding path (`access.allowedTools`); undefined for every
@@ -1088,13 +1094,13 @@ export class DispatchHandler extends EventEmitter {
       // 12. Route by mode
       switch (parsed.mode) {
         case "async":
-          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
+          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, readOnlyDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
           break;
         case "team":
-          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
+          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, readOnlyDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
           break;
         default:
-          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
+          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, readOnlyDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
           break;
       }
     } catch (error) {
@@ -1118,6 +1124,8 @@ export class DispatchHandler extends EventEmitter {
     prompt: string,
     resumeSessionId: string | undefined,
     invokeDirs: string[],
+    /** EBH-1b (cortex#2352) — the distinct read-only subset of invokeDirs. */
+    readOnlyDirs: string[],
     disallowedTools: string[],
     attachmentSessionId: string,
     sessionKey: string,
@@ -1188,6 +1196,10 @@ export class DispatchHandler extends EventEmitter {
       // re-denied in cc-session's resolveAgentEnv before it hits the child env).
       ...(agentEnv !== undefined && { agentEnv }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
+      // EBH-1b (cortex#2352) — the distinct read-only set; cc-session's
+      // resolvePathGuardEnv subtracts this from allowedDirs before writing
+      // CORTEX_PATH_GUARD, so a write into one of these is denied.
+      readOnlyDirs: readOnlyDirs.length > 0 ? readOnlyDirs : undefined,
       cwd,
       bashAllowlist,
       bashGuardDisabled,
@@ -1491,6 +1503,8 @@ export class DispatchHandler extends EventEmitter {
     prompt: string,
     resumeSessionId: string | undefined,
     invokeDirs: string[],
+    /** EBH-1b (cortex#2352) — the distinct read-only subset of invokeDirs. */
+    readOnlyDirs: string[],
     disallowedTools: string[],
     attachmentSessionId: string,
     sessionKey: string,
@@ -1541,6 +1555,8 @@ export class DispatchHandler extends EventEmitter {
       // re-denied in cc-session's resolveAgentEnv before it hits the child env).
       ...(agentEnv !== undefined && { agentEnv }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
+      // EBH-1b (cortex#2352) — see the handleSync literal's comment.
+      readOnlyDirs: readOnlyDirs.length > 0 ? readOnlyDirs : undefined,
       cwd,
       project: groveProject,
       entity: groveEntity,
@@ -1641,6 +1657,8 @@ export class DispatchHandler extends EventEmitter {
     msg: InboundMessage,
     teamContent: string,
     invokeDirs: string[],
+    /** EBH-1b (cortex#2352) — the distinct read-only subset of invokeDirs. */
+    readOnlyDirs: string[],
     disallowedTools: string[],
     bashGuardDisabled?: boolean,
     bashAllowlist?: CCSessionOpts["bashAllowlist"],
@@ -1690,6 +1708,8 @@ export class DispatchHandler extends EventEmitter {
       // env passthrough (resolved + CLAUDE_* re-denied in cc-session).
       ...(agentEnv !== undefined && { agentEnv }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
+      // EBH-1b (cortex#2352) — see the handleSync literal's comment.
+      readOnlyDirs: readOnlyDirs.length > 0 ? readOnlyDirs : undefined,
       timeoutMs: this.config.claude.asyncTimeoutMs,
       bashGuardDisabled,
       bashAllowlist,

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -29,6 +29,17 @@ export interface InboundChatDispatchPublishOpts {
   prompt: string;
   resumeSessionId: string | undefined;
   allowedDirs: string[];
+  /**
+   * EBH-1b (cortex#2352) — directories the session may READ but not modify.
+   * Emitted on the payload as `read_only_dirs` (see below) so the runner's
+   * `CORTEX_PATH_GUARD` projection (`resolvePathGuardEnv`, cc-session.ts)
+   * carries a distinct value instead of a dispatch-handler-side flatten
+   * into `allowedDirs` — that flatten is what left F6 silently inert in
+   * production before this slice. `allowedDirs` (above) is UNCHANGED and
+   * still carries the union including these dirs, so `--add-dir` keeps
+   * granting read access to them (claude-invoker.ts is untouched).
+   */
+  readOnlyDirs: string[];
   disallowedTools: string[];
   /**
    * cortex#1167 — EXPLICIT tool ALLOWLIST emitted as `allowed_tools` on the
@@ -297,6 +308,9 @@ export async function publishInboundChatDispatchEnvelope(
       mcp_grants: opts.mcpGrants,
     }),
     ...(opts.allowedDirs.length > 0 && { allowed_dirs: opts.allowedDirs }),
+    // EBH-1b (cortex#2352) — carry the distinct read-only set so the runner
+    // can project a `CORTEX_PATH_GUARD` that actually denies writes into it.
+    ...(opts.readOnlyDirs.length > 0 && { read_only_dirs: opts.readOnlyDirs }),
     ...(opts.timeoutMs !== undefined && { timeout_ms: opts.timeoutMs }),
     ...(opts.cwd !== undefined && { cwd: opts.cwd }),
     ...(opts.additionalArgs !== undefined &&

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -255,6 +255,16 @@ export interface DispatchRuntime {
    */
   allowedDirs?: string[];
   /**
+   * EBH-1b (cortex#2352) — filesystem read-only subset. Substrates that
+   * enforce a filesystem boundary distinguishing read from write (CC's
+   * `path-guard.hook.ts` / `bash-guard.hook.ts` via `CORTEX_PATH_GUARD`)
+   * consume this; others ignore. Distinct from `allowedDirs` above: the CC
+   * harness's `resolvePathGuardEnv` subtracts this set from `allowedDirs`
+   * before projecting the guard policy, so a dir present in both resolves
+   * to read-only (the safe default) rather than silently writable.
+   */
+  readOnlyDirs?: string[];
+  /**
    * Bash guard allowlist config. CC's `bash-guard.hook.ts` reads this
    * via the `CORTEX_BASH_GUARD` env var and refuses any `Bash` tool
    * invocation whose command doesn't match the allowlist. Future

--- a/src/gateway/__tests__/bus-inbound-sink.test.ts
+++ b/src/gateway/__tests__/bus-inbound-sink.test.ts
@@ -158,6 +158,9 @@ describe("BusInboundSink", () => {
     if (opts === undefined) throw new Error("expected publishFn to have been called");
 
     expect(opts.allowedDirs).toEqual([]);
+    // EBH-1b (cortex#2352) — the gateway grants no dirs at all, so there is
+    // nothing to carve a read-only subset out of.
+    expect(opts.readOnlyDirs).toEqual([]);
   });
 
   // ── Test 3: fail-closed Skill deny on the gateway path (cortex#701) ──────────

--- a/src/gateway/bus-inbound-sink.ts
+++ b/src/gateway/bus-inbound-sink.ts
@@ -172,6 +172,10 @@ export class BusInboundSink implements GatewayInboundSink {
       // responseRoutingFromMessage() — consistent with decision.responseRouting.
       // We do NOT double-stamp it here.
       allowedDirs: [],
+      // EBH-1b (cortex#2352) — the gateway grants no dirs at all (allowedDirs
+      // above is already `[]`), so there is nothing to carve a read-only
+      // subset out of. Mirrors allowedDirs for forward-compat.
+      readOnlyDirs: [],
       // cortex#701 — the gateway grants NO skills and emits the bare `Skill`
       // deny so the bound stack's harness (which consumes this envelope via
       // the runner subscription, NOT via dispatch-handler — so it never runs

--- a/src/runner/__tests__/cc-session.test.ts
+++ b/src/runner/__tests__/cc-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { CCSession, type CCSessionOpts } from "../cc-session";
+import { CCSession, type CCSessionOpts, resolvePathGuardEnv } from "../cc-session";
 import { testClaude } from "../../common/test-utils";
 
 describe("CCSession", () => {
@@ -113,5 +113,60 @@ describe("CCSession args", () => {
       additionalArgs: ["--verbose"],
     });
     expect(session).toBeInstanceOf(CCSession);
+  });
+});
+
+/**
+ * EBH-1b (cortex#2352) — `resolvePathGuardEnv` is the single projection point
+ * that turns `CCSessionOpts.allowedDirs`/`readOnlyDirs` into the
+ * `CORTEX_PATH_GUARD` value path-guard.hook.ts's `decidePath` reads. THE
+ * correctness subtlety this slice closes: without subtracting `readOnlyDirs`
+ * from `allowedDirs`, a dispatch path that builds `allowedDirs` as a UNION
+ * including the read-only set (dispatch-handler.ts's `invokeDirs`) would put
+ * a read-only dir in BOTH emitted lists — `decidePath`'s `inAllowed` check
+ * would be `true` and the write-deny branch (which requires `!inAllowed`)
+ * would never fire, leaving F6 silently inert even with `readOnlyDirs`
+ * populated. These tests prove the subtraction actually happens.
+ */
+describe("resolvePathGuardEnv — EBH-1b allowedDirs/readOnlyDirs subtraction (cortex#2352)", () => {
+  test("no opts ⇒ the safe default {allowedDirs:[],readOnlyDirs:[]} (no restriction configured)", () => {
+    expect(JSON.parse(resolvePathGuardEnv({}))).toEqual({ allowedDirs: [], readOnlyDirs: [] });
+  });
+
+  test("disjoint allowedDirs/readOnlyDirs pass through unchanged", () => {
+    const out = JSON.parse(
+      resolvePathGuardEnv({ allowedDirs: ["/work"], readOnlyDirs: ["/ro"] }),
+    );
+    expect(out).toEqual({ allowedDirs: ["/work"], readOnlyDirs: ["/ro"] });
+  });
+
+  test("THE subtraction: a dir in BOTH lists is excluded from the emitted allowedDirs and kept in readOnlyDirs (read-only wins)", () => {
+    // Mirrors dispatch-handler.ts's invokeDirs shape: allowedDirs is a UNION
+    // that also contains the read-only dir (kept that way so --add-dir still
+    // grants read access via claude-invoker.ts, which reads opts.allowedDirs
+    // directly and never sees this function's output).
+    const out = JSON.parse(
+      resolvePathGuardEnv({
+        allowedDirs: ["/work", "/ro"],
+        readOnlyDirs: ["/ro"],
+      }),
+    );
+    expect(out).toEqual({ allowedDirs: ["/work"], readOnlyDirs: ["/ro"] });
+    // The proof that matters: the overlapping dir does NOT appear in the
+    // emitted allowedDirs, so decidePath's `inAllowed` is false for it and
+    // the write-deny branch (WRITE_TOOLS && inReadOnly) can fire.
+    expect(out.allowedDirs).not.toContain("/ro");
+  });
+
+  test("readOnlyDirs without a matching allowedDirs entry is unaffected (no accidental exclusion)", () => {
+    const out = JSON.parse(
+      resolvePathGuardEnv({ allowedDirs: ["/work"], readOnlyDirs: ["/ro"] }),
+    );
+    expect(out.allowedDirs).toEqual(["/work"]);
+  });
+
+  test("undefined allowedDirs with a defined readOnlyDirs ⇒ allowedDirs stays []", () => {
+    const out = JSON.parse(resolvePathGuardEnv({ readOnlyDirs: ["/ro"] }));
+    expect(out).toEqual({ allowedDirs: [], readOnlyDirs: ["/ro"] });
   });
 });

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -707,6 +707,8 @@ describe("dispatch-listener — success path", () => {
         allowed_tools: ["Read", "Edit"],
         disallowed_tools: ["Bash"],
         allowed_dirs: ["/tmp"],
+        // EBH-1b (cortex#2352) — carried distinctly from allowed_dirs.
+        read_only_dirs: ["/tmp/ro"],
         timeout_ms: 60_000,
         cwd: "/tmp",
         additional_args: ["--verbose"],
@@ -732,6 +734,9 @@ describe("dispatch-listener — success path", () => {
     expect(opts.disallowedTools).toEqual(["Bash", "Skill"]);
     expect(opts.allowedSkills).toBeUndefined();
     expect(opts.allowedDirs).toEqual(["/tmp"]);
+    // EBH-1b (cortex#2352) — the bus-mediated path (payload → buildDispatchRequest
+    // → ClaudeCodeHarness.buildCCOpts) carries readOnlyDirs distinctly end-to-end.
+    expect(opts.readOnlyDirs).toEqual(["/tmp/ro"]);
     expect(opts.timeoutMs).toBe(60_000);
     expect(opts.cwd).toBe("/tmp");
     expect(opts.additionalArgs).toEqual(["--verbose"]);
@@ -739,6 +744,39 @@ describe("dispatch-listener — success path", () => {
     expect(opts.entity).toBe("issue/12");
     expect(opts.principal).toBe("andreas");
     expect(opts.resumeSessionId).toBe("prior-session");
+  });
+
+  // EBH-1b (cortex#2352) — old-listener compatibility. A payload from a
+  // pre-EBH-1b publisher (or any source that never sets read_only_dirs)
+  // must not crash the listener and must leave the guard's readOnlyDirs at
+  // today's empty-policy behaviour.
+  test("payload omitting read_only_dirs ⇒ opts.readOnlyDirs stays undefined, no crash (old-listener compat)", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope({
+        prompt: "do the work",
+        allowed_dirs: ["/tmp"],
+        // read_only_dirs deliberately omitted.
+      }),
+      CANONICAL_CORTEX_CHAT_SUBJECT,
+    );
+    await settle(() => r.published);
+
+    expect(optsCaptured).toHaveLength(1);
+    const opts = optsCaptured[0]!;
+    expect(opts.allowedDirs).toEqual(["/tmp"]);
+    expect(opts.readOnlyDirs).toBeUndefined();
   });
 
   // GV-2 (cortex#1077) — channel/network label vocabulary migration. The

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -138,6 +138,13 @@ export interface AgentTeamOpts {
    */
   agentEnv?: Record<string, string>;
   allowedDirs?: string[];
+  /**
+   * EBH-1b (cortex#2352) — propagated to ALL team sessions (moderator +
+   * participants + synthesis) exactly like `allowedDirs`. Distinct field so
+   * cc-session's `resolvePathGuardEnv` can subtract it from `allowedDirs`
+   * when projecting `CORTEX_PATH_GUARD` — see cc-session.ts.
+   */
+  readOnlyDirs?: string[];
   timeoutMs?: number;
   /** Bash guard config — propagated to all team sessions (moderator + participants) */
   bashGuardDisabled?: boolean;
@@ -317,6 +324,8 @@ export class AgentTeamHarness implements SessionHarness {
       ...(req.tools.allow.length > 0 && { allowedTools: [...req.tools.allow] }),
       ...(req.tools.deny !== undefined && { disallowedTools: [...req.tools.deny] }),
       ...(req.runtime?.allowedDirs !== undefined && { allowedDirs: req.runtime.allowedDirs }),
+      // EBH-1b (cortex#2352) — see AgentTeamOpts.readOnlyDirs doc.
+      ...(req.runtime?.readOnlyDirs !== undefined && { readOnlyDirs: req.runtime.readOnlyDirs }),
       // ST-P1 (cortex#964) — thread the dispatch-level parent session id onto
       // the team so the moderator session is parented to the dispatch.
       ...(req.runtime?.parentSessionId !== undefined && { parentSessionId: req.runtime.parentSessionId }),
@@ -606,6 +615,8 @@ export class AgentTeam extends EventEmitter {
       ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
       ...(this.opts.agentEnv !== undefined && { agentEnv: this.opts.agentEnv }),
       allowedDirs: this.opts.allowedDirs,
+      // EBH-1b (cortex#2352) — see AgentTeamOpts.readOnlyDirs doc.
+      readOnlyDirs: this.opts.readOnlyDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
       bashAllowlist: this.opts.bashAllowlist,
@@ -729,6 +740,11 @@ export class AgentTeam extends EventEmitter {
       ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
       ...(this.opts.agentEnv !== undefined && { agentEnv: this.opts.agentEnv }),
       allowedDirs: config.dirs ?? this.opts.allowedDirs,
+      // EBH-1b (cortex#2352) — see AgentTeamOpts.readOnlyDirs doc. No
+      // per-participant readOnlyDirs override exists (mirrors `dirs`'s
+      // absence of one for readOnlyDirs specifically); the team-level set
+      // always applies.
+      readOnlyDirs: this.opts.readOnlyDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
       bashAllowlist: this.opts.bashAllowlist,
@@ -911,6 +927,8 @@ export class AgentTeam extends EventEmitter {
       ...(this.opts.mcpGrants !== undefined && { mcpGrants: this.opts.mcpGrants }),
       ...(this.opts.agentEnv !== undefined && { agentEnv: this.opts.agentEnv }),
       allowedDirs: this.opts.allowedDirs,
+      // EBH-1b (cortex#2352) — see AgentTeamOpts.readOnlyDirs doc.
+      readOnlyDirs: this.opts.readOnlyDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
       bashAllowlist: this.opts.bashAllowlist,

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -45,12 +45,13 @@ export interface CCSessionOpts {
    * EBH-1 (cortex#2343) — directories the session may READ but not modify.
    * Passed to path-guard.hook.ts / bash-guard.hook.ts's path checks via the
    * `CORTEX_PATH_GUARD` env var (mirrors `allowedDirs`'s own role there).
-   * Distinct from `allowedDirs` so a write into one of these is DENIED while
-   * a read is permitted — see {@link resolvePathGuardEnv}. NOTE: this field
-   * is wired and unit-tested but NOT YET populated by any live dispatch
-   * path (dispatch-handler.ts still flattens readOnlyDirs into the merged
-   * allowedDirs list it builds) — F6 closes in production once that
-   * threading lands (EBH-1b, a separate slice).
+   * Distinct from `allowedDirs` so a write into one of these is DENIED
+   * (closes F6) while a read is permitted — see {@link resolvePathGuardEnv}.
+   * EBH-1b (cortex#2352) threads a distinct value through every live
+   * dispatch path (dispatch-handler.ts no longer flattens this into the
+   * merged `allowedDirs` it builds for `CORTEX_PATH_GUARD` purposes —
+   * `resolvePathGuardEnv` subtracts `readOnlyDirs` from `allowedDirs` before
+   * emitting, so a dir in both wins as read-only, the safe default).
    */
   readOnlyDirs?: string[];
   timeoutMs?: number;
@@ -287,14 +288,27 @@ export function resolveBashGuardEnv(
  *     resolved (may legitimately both be `[]` — the hooks treat an empty
  *     policy as "no restriction configured", matching the EXISTING
  *     `security-preamble.ts` contract; see path-guard.hook.ts's module doc).
+ *
+ * **EBH-1b (cortex#2352) correctness subtlety — the subtraction.**
+ * `opts.allowedDirs` is `invokeDirs`, a caller-built UNION that also
+ * includes `readOnlyDirs` (kept that way deliberately so `--add-dir` still
+ * grants read access to read-only dirs — see `claude-invoker.ts`, which
+ * reads `opts.allowedDirs` UNCHANGED and never sees this function's output).
+ * If this function emitted that union verbatim as the guard's `allowedDirs`,
+ * a read-only dir would sit in BOTH lists, `decidePath`'s `inAllowed` check
+ * would be `true`, and the write-deny branch (which requires `!inAllowed`)
+ * would never fire — F6 would stay silently inert even with `readOnlyDirs`
+ * populated. So the guard's `allowedDirs` is the caller's `allowedDirs`
+ * MINUS `readOnlyDirs`; `readOnlyDirs` is carried unchanged. Overlap rule:
+ * a dir present in both inputs resolves to READ-ONLY in the emitted policy —
+ * the safe default.
  */
 export function resolvePathGuardEnv(
   opts: Pick<CCSessionOpts, "allowedDirs" | "readOnlyDirs">,
 ): string {
-  return JSON.stringify({
-    allowedDirs: opts.allowedDirs ?? [],
-    readOnlyDirs: opts.readOnlyDirs ?? [],
-  });
+  const readOnlyDirs = opts.readOnlyDirs ?? [];
+  const allowedDirs = (opts.allowedDirs ?? []).filter((d) => !readOnlyDirs.includes(d));
+  return JSON.stringify({ allowedDirs, readOnlyDirs });
 }
 
 export class CCSession extends EventEmitter {

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -245,6 +245,15 @@ export interface DispatchTaskReceivedPayload {
    */
   mcp_grants?: string[];
   allowed_dirs?: string[];
+  /**
+   * EBH-1b (cortex#2352) — the distinct read-only subset of `allowed_dirs`.
+   * `undefined` (a pre-EBH-1b publisher, or any source that doesn't set it)
+   * → `buildDispatchRequest` leaves `runtime.readOnlyDirs` unset, and
+   * `resolvePathGuardEnv` (cc-session.ts) treats an unset `readOnlyDirs` as
+   * `[]` — today's behaviour, unchanged, no crash. See
+   * `DispatchRuntime.readOnlyDirs`.
+   */
+  read_only_dirs?: string[];
   timeout_ms?: number;
   cwd?: string;
   additional_args?: string[];
@@ -1267,6 +1276,8 @@ function buildDispatchRequest(
   const runtime: NonNullable<DispatchRequest["runtime"]> = {};
   if (payload.cwd !== undefined) runtime.cwd = payload.cwd;
   if (payload.allowed_dirs !== undefined) runtime.allowedDirs = payload.allowed_dirs;
+  // EBH-1b (cortex#2352) — mirrors allowed_dirs's mapping exactly.
+  if (payload.read_only_dirs !== undefined) runtime.readOnlyDirs = payload.read_only_dirs;
   if (payload.additional_args !== undefined) runtime.additionalArgs = payload.additional_args;
   // GV-2 (cortex#1077): read the canonical `cortex_*` label first, fall back
   // to the legacy `grove_*` alias (a pre-GV-2 source still sends grove only).

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -3,10 +3,7 @@
  *
  * Covers every acceptance-criterion bullet from issue #2343:
  *   - Read/Write/Edit/Glob/Grep of a path outside `allowedDirs` → deny.
- *   - Write/Edit/NotebookEdit targeting a `readOnlyDir` → deny (the
- *     read-only-write MECHANISM this hook enforces; F6 goes fully live once
- *     dispatch-handler.ts threads a distinct readOnlyDirs through to
- *     CORTEX_PATH_GUARD on live sessions — EBH-1b, a separate slice); Read →
+ *   - Write/Edit/NotebookEdit targeting a `readOnlyDir` → deny (F6); Read →
  *     allow.
  *   - A symlink INSIDE an allowed dir pointing OUTSIDE it → deny (realpath'd
  *     before the containment check).
@@ -267,13 +264,13 @@ describe("decidePath", () => {
     expect(d.allow).toBe(true);
   });
 
-  test("Write inside readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
+  test("Write inside readOnlyDir ⇒ deny (F6)", () => {
     const d = decidePath("Write", join(readOnlyDir, "f.txt"), { allowedDirs: [], readOnlyDirs: [readOnlyDir] });
     expect(d.allow).toBe(false);
     expect(d.reason).toContain("READ-ONLY");
   });
 
-  test("Edit inside readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
+  test("Edit inside readOnlyDir ⇒ deny (F6)", () => {
     const d = decidePath("Edit", join(readOnlyDir, "f.txt"), { allowedDirs: [], readOnlyDirs: [readOnlyDir] });
     expect(d.allow).toBe(false);
   });
@@ -382,7 +379,7 @@ describe("path-guard.hook — containment enforcement (spawned)", () => {
     });
   }
 
-  test("Write into readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
+  test("Write into readOnlyDir ⇒ deny (closes F6)", () => {
     const r = runHook("Write", { file_path: join(readOnlyDir, "secret.yaml") }, policyEnv());
     expect(r.status).toBe(0);
     expectDenyDecision(r.stdout);
@@ -390,7 +387,7 @@ describe("path-guard.hook — containment enforcement (spawned)", () => {
     expect(out.hookSpecificOutput.permissionDecisionReason).toContain("READ-ONLY");
   });
 
-  test("Edit into readOnlyDir ⇒ deny (read-only-write mechanism)", () => {
+  test("Edit into readOnlyDir ⇒ deny (closes F6)", () => {
     const r = runHook(
       "Edit",
       { file_path: join(readOnlyDir, "secret.yaml"), old_string: "a", new_string: "b" },

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -453,11 +453,8 @@ export function decidePath(toolName: string, absPath: string, policy: PathGuardP
       allow: false,
       reason:
         `[Cortex Path Guard] Blocked ${toolName} "${absPath}": this path is inside a ` +
-        `READ-ONLY directory — writes are refused (docs/security/reviews/` +
-        `2026-07-23-nws-security-review.md F6). Reads remain permitted. Note: this is ` +
-        `the read-only-write MECHANISM; F6 is fully closed in production once ` +
-        `dispatch-handler.ts threads a distinct readOnlyDirs value through to ` +
-        `CORTEX_PATH_GUARD on live sessions (EBH-1b).`,
+        `READ-ONLY directory — writes are refused (closes F6, docs/security/reviews/` +
+        `2026-07-23-nws-security-review.md). Reads remain permitted.`,
     };
   }
 

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -389,6 +389,8 @@ describe("ClaudeCodeHarness — DispatchRequest → CCSessionOpts mapping", () =
       runtime: {
         cwd: "/work",
         allowedDirs: ["/work", "/tmp"],
+        // EBH-1b (cortex#2352) — carried distinctly from allowedDirs.
+        readOnlyDirs: ["/tmp"],
         additionalArgs: ["--verbose"],
         channel: "grove",
         network: "metafactory",
@@ -402,6 +404,8 @@ describe("ClaudeCodeHarness — DispatchRequest → CCSessionOpts mapping", () =
 
     expect(cap.opts[0]?.cwd).toBe("/work");
     expect(cap.opts[0]?.allowedDirs).toEqual(["/work", "/tmp"]);
+    // EBH-1b (cortex#2352)
+    expect(cap.opts[0]?.readOnlyDirs).toEqual(["/tmp"]);
     expect(cap.opts[0]?.additionalArgs).toEqual(["--verbose"]);
     expect(cap.opts[0]?.channel).toBe("grove");
     expect(cap.opts[0]?.network).toBe("metafactory");

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -403,6 +403,9 @@ export class ClaudeCodeHarness implements SessionHarness {
     if (runtime) {
       if (runtime.cwd !== undefined) opts.cwd = runtime.cwd;
       if (runtime.allowedDirs !== undefined) opts.allowedDirs = runtime.allowedDirs;
+      // EBH-1b (cortex#2352) — carried distinctly so resolvePathGuardEnv can
+      // subtract it from allowedDirs when projecting CORTEX_PATH_GUARD.
+      if (runtime.readOnlyDirs !== undefined) opts.readOnlyDirs = runtime.readOnlyDirs;
       if (runtime.bashAllowlist !== undefined) opts.bashAllowlist = runtime.bashAllowlist;
       if (runtime.bashGuardDisabled !== undefined) opts.bashGuardDisabled = runtime.bashGuardDisabled;
       if (runtime.additionalArgs !== undefined) opts.additionalArgs = runtime.additionalArgs;


### PR DESCRIPTION
## EBH-1b — wire `readOnlyDirs` through the dispatch seam (F6 goes live)

Closes #2352. Part of epic #2341. **This is the load-bearing seam the L2/L3 sandbox ladder rides on.**

### The bug
F6 was not merely inert — **read-only dirs were silently WRITABLE**. `dispatch-handler.ts:1005-1007` flattened `readOnlyDirs` into the single `invokeDirs` array that became `CCSessionOpts.allowedDirs`, so every read-only path also counted as *allowed*, and `decidePath()`'s write-deny branch (which requires `!inAllowed`) never fired. `CCSessionOpts.readOnlyDirs` was never populated on any real dispatch path.

### The 5 changes
1. **Wire, additive + forward-compatible** — optional `read_only_dirs` on the dispatch payload (`dispatch-source-publisher.ts`, `dispatch-handler.ts` opts + envelope), mapped listener-side exactly as `allowed_dirs` already is. Absent field ⇒ `[]` ⇒ today's behaviour, so an older listener is unaffected.
2. **dispatch-handler** — `allowedDirs: invokeDirs` left **byte-unchanged** at all three sites; `readOnlyDirs` threaded alongside through `handleSync`/`handleAsync`/`handleTeam`.
3. **The correctness subtlety** — `resolvePathGuardEnv` now emits `allowedDirs = allowedDirs MINUS readOnlyDirs`. Without this, an overlapping dir sits in *both* lists, `inAllowed` is true, and the write-deny branch never fires — i.e. **the bug survives its own fix**. Overlap rule: **read-only wins**.
4. **`--add-dir` unchanged** — it keeps the full union, so read-only dirs stay *readable*; only the guard env gets the split.
5. **F6 claim restored** in `path-guard.hook.ts` (it was deliberately stripped as an overclaim in EBH-1c) now that it is genuinely live.

Also threaded through `common/substrates/types.ts`, `substrates/claude-code/harness.ts` and `runner/agent-team.ts` — required by the issue's own "all dispatch paths carry it" criterion, including bus-sync via the listener and team dispatch.

### Verified — my independent check of the crux
```
resolvePathGuardEnv({ allowedDirs: ["/w/work", "/w/readonly"], readOnlyDirs: ["/w/readonly"] })
  → allowedDirs : ["/w/work"]
  → readOnlyDirs: ["/w/readonly"]
```
**The subtraction works — read-only wins**, so the write-deny branch actually fires. That was the predicted failure mode; it does not occur.

Also confirmed: `--add-dir` union byte-unchanged (a test asserts the full union still reaches `opts.allowedDirs` while `opts.readOnlyDirs` stays distinct); coverage across bus-sync, sync, async, team, plus the #1758 gateway path.

### Why this matters beyond F6
After this, `cc-session` is the **single projection point** for the resolved filesystem policy: `resolvePathGuardEnv(opts)` (L1) sits beside future `resolveSandboxProfile(opts)` (L2) and `resolveEgressAllow(opts)` (L3) — same input, same point, **zero new dispatch plumbing**.

### Tests / gates
Targeted suite (9 files) **350 pass / 0 fail**. Broader `src/{bus,runner,gateway,substrates}`: branch and `origin/main` baseline show **identical** pre-existing failures (myelin module-resolution) — zero regressions, confirmed by running both. tsc and `lint:errors` identical to baseline; carveouts + wire-vocab PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
