### PR TITLE
fix(runner): EBH-1h — allow bare numeric short flags on head/tail

### DIFF
--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -3136,3 +3136,124 @@ describe("bash-guard.hook — EBH-1g: guard-off (G-300) path containment (cortex
   });
 });
 
+// =============================================================================
+// EBH-1h (cortex#2384) — bare numeric short flags (`head -5`, `tail -3`).
+//
+// `head`/`tail` accept a bare numeric count as shorthand for `-n <count>`
+// (`head -5` == `head -n 5`). COMMAND_FLAG_POLICIES never modeled this shape,
+// and since round 9 an unrecognised flag on a path-checked command denies the
+// WHOLE command — so this ordinary, everyday form was wrongly denied. Fixed
+// by `CommandFlagPolicy.bareNumericCount`, set ONLY on `head`/`tail`.
+// =============================================================================
+describe("bash-guard.hook — EBH-1h: bare numeric short flags (cortex#2384)", () => {
+  let root: string;
+  let allowedDir: string;
+  let secretDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "bash-guard-ebh1h-matrix-"));
+    allowedDir = join(root, "allowed");
+    secretDir = join(root, "secret");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(secretDir, { recursive: true });
+    writeFileSync(join(secretDir, "canary.txt"), "EBH-1H-CANARY-MARKER\n");
+    writeFileSync(join(allowedDir, "f.txt"), "one\ntwo\nthree\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    return {
+      CORTEX_CHANNEL: "test-channel",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+    };
+  }
+
+  // ---- ALLOW: bare numeric short flag, in-scope path ----
+
+  test("head -5 f.txt ⇒ ALLOW", () => {
+    const r = runHook("head -5 f.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("tail -3 f.txt ⇒ ALLOW", () => {
+    const r = runHook("tail -3 f.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("head -20 f.txt ⇒ ALLOW", () => {
+    const r = runHook("head -20 f.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  // ---- DENY: bare numeric short flag, out-of-scope path (path still containment-checked) ----
+
+  test("head -5 <out-of-scope> ⇒ DENY (the path argument is still containment-checked)", () => {
+    const r = runHook(
+      `head -5 ${join(secretDir, "canary.txt")}`,
+      policyEnv(),
+      "Bash",
+      "test-session",
+      allowedDir,
+    );
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("tail -3 <out-of-scope> ⇒ DENY (the path argument is still containment-checked)", () => {
+    const r = runHook(
+      `tail -3 ${join(secretDir, "canary.txt")}`,
+      policyEnv(),
+      "Bash",
+      "test-session",
+      allowedDir,
+    );
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  // ---- DENY: unknown, non-numeric flags on head/tail still deny (round-9 behaviour preserved) ----
+
+  test("head -x f.txt ⇒ DENY (unrecognised non-numeric short flag)", () => {
+    const r = runHook("head -x f.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecisionReason).toContain("unrecognised flag");
+  });
+
+  test("tail --bogus f.txt ⇒ DENY (unrecognised long flag)", () => {
+    const r = runHook("tail --bogus f.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecisionReason).toContain("unrecognised flag");
+  });
+
+  // ---- DENY: NOT generalised beyond head/tail — same bare-numeric shape on
+  // an unrelated path-checked command still denies exactly as before. ----
+
+  test("ls -5 ⇒ DENY (bare numeric short flag NOT modeled for ls)", () => {
+    const r = runHook("ls -5", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecisionReason).toContain("unrecognised flag");
+  });
+
+  test("cat -5 f.txt ⇒ DENY (bare numeric short flag NOT modeled for cat)", () => {
+    const r = runHook("cat -5 f.txt", policyEnv(), "Bash", "test-session", allowedDir);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecisionReason).toContain("unrecognised flag");
+  });
+});
+

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -212,6 +212,21 @@
  *   - The L2 sandbox (EBH-2/EBH-3, `docs/design-session-sandbox.md`) is
  *     still the actual boundary that makes this moot regardless of the L1
  *     posture chosen here — see that doc for the un-bypassable remedy.
+ *
+ * ## EBH-1h — bare numeric short flags (cortex#2384)
+ *
+ * A pre-existing round-7 gap, surfaced by the EBH-1g work: `head`/`tail`
+ * accept a bare numeric short flag (`head -5` == `head -n 5`) that
+ * `COMMAND_FLAG_POLICIES` never modeled, so — since round 9's "unrecognised
+ * flag on a path-checked command denies the whole command" posture — ordinary
+ * `head -5 f.txt` / `tail -3 f.txt` were wrongly denied (over-deny, not a
+ * bypass, but everyday friction). Fixed by a new, narrowly-scoped
+ * `CommandFlagPolicy.bareNumericCount` flag, set ONLY on `head`'s and
+ * `tail`'s policy entries: `classifyFlagToken` now recognises a token
+ * matching `^-\d+$` as a safe numeric-count flag for those two commands
+ * specifically (see that function and the flag's own doc comment) — never
+ * captured as a candidate path, and never generalised to any other
+ * path-checked command (`ls -5` / `cat -5` remain denied exactly as before).
  */
 
 import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
@@ -764,6 +779,25 @@ interface CommandFlagPolicy {
    * (defense in depth, and what lets a bare `--flag` with no `=` pass too).
    */
   longValue: ReadonlySet<string>;
+  /**
+   * EBH-1h (cortex#2384) — when true, a BARE NUMERIC short flag (a token
+   * matching `^-\d+$`, e.g. `-5`, `-20`) is classified as a numeric COUNT
+   * flag: safe, and — same as any other classified-safe flag — NOT captured
+   * as a candidate path. Modeled ONLY for `head`/`tail` (see their policy
+   * entries below): they are the two POSIX commands whose short-option
+   * grammar accepts a bare count as shorthand for `-n <count>` (`head -5` ==
+   * `head -n 5`). `COMMAND_FLAG_POLICIES` never modeled this shorthand, and
+   * since round 9 (cortex#2370) an unrecognised flag on a path-checked
+   * command denies the WHOLE command — so `head -5 f.txt` / `tail -3 f.txt`
+   * were denied outright even though they're ordinary, safe, everyday usage
+   * (not a security hole: fails safe, over-deny not under-deny — but
+   * friction real enough to train people to widen the allowlist or turn the
+   * guard off). Deliberately narrow and opt-in per command, not a global
+   * `^-\d+$` carve-out: `ls`/`cat`/`wc`/`file`/`git`/`gh` have no such
+   * shorthand in their own flag grammars, so a bare `-5` there stays exactly
+   * as unrecognised (and denied) as it was before this fix.
+   */
+  bareNumericCount?: boolean;
 }
 
 export const COMMAND_FLAG_POLICIES: Readonly<Record<string, CommandFlagPolicy>> = {
@@ -778,12 +812,16 @@ export const COMMAND_FLAG_POLICIES: Readonly<Record<string, CommandFlagPolicy>> 
     shortValue: new Set(["n", "c"]),
     longBoolean: new Set(),
     longValue: new Set(["lines", "bytes"]),
+    // EBH-1h (cortex#2384) — `head -5` is POSIX shorthand for `head -n 5`.
+    bareNumericCount: true,
   },
   tail: {
     shortBoolean: new Set(["q", "v", "f"]),
     shortValue: new Set(["n", "c"]),
     longBoolean: new Set(["follow"]),
     longValue: new Set(["lines", "bytes"]),
+    // EBH-1h (cortex#2384) — `tail -3` is POSIX shorthand for `tail -n 3`.
+    bareNumericCount: true,
   },
   ls: {
     shortBoolean: new Set(["l", "a", "A", "h", "R", "t", "r", "S", "1", "d", "F", "G"]),
@@ -987,6 +1025,14 @@ type FlagClassification =
   | { kind: "deny" };
 
 /**
+ * cortex#2384 (EBH-1h) — a token matching exactly one leading `-` followed by
+ * one or more digits and nothing else (`-5`, `-20`; NOT `-5x`, NOT `--5`,
+ * NOT `-5.0`). Checked against {@link CommandFlagPolicy.bareNumericCount}
+ * before any other classification in {@link classifyFlagToken} below.
+ */
+const BARE_NUMERIC_FLAG_RE = /^-\d+$/;
+
+/**
  * Classify a single `-`-prefixed token against one command's
  * {@link CommandFlagPolicy}. Called ONLY after {@link isPathShapedFlagValue}
  * has already cleared the token (that check still runs first and keeps its
@@ -996,6 +1042,17 @@ type FlagClassification =
  * Exported for unit tests.
  */
 export function classifyFlagToken(tok: string, policy: CommandFlagPolicy): FlagClassification {
+  // EBH-1h (cortex#2384) — `head -5` / `tail -3`: a bare numeric short flag
+  // is POSIX shorthand for `-n <count>` on these two commands only (see
+  // {@link CommandFlagPolicy.bareNumericCount}). Checked first, ahead of the
+  // long-flag and short-flag classification below, since `-5` would
+  // otherwise fall into the single-char-body branch (`body === "5"`, which
+  // is on neither command's `shortBoolean` nor `shortValue` set — every
+  // digit AS A FLAG LETTER is deliberately absent from both) and deny. This
+  // classifies the token as "safe" — same as any other whitelisted flag — so
+  // it is skipped by the caller and never captured as a candidate path.
+  if (policy.bareNumericCount && BARE_NUMERIC_FLAG_RE.test(tok)) return { kind: "safe" };
+
   if (tok.startsWith("--")) {
     const body = tok.slice(2);
     const eqIdx = body.indexOf("=");


### PR DESCRIPTION
## EBH-1h — allow bare numeric short flags on `head`/`tail`

Closes #2384. Part of epic #2341. **This widens what the guard permits**, so the review bar is the critical property: it must open no path.

### The problem
`head`/`tail` accept a bare numeric count shorthand (`head -5` is `head -n 5`). `COMMAND_FLAG_POLICIES` never modelled it, so round 9's "unmodelled flag on a path-checked command denies" rejected everyday usage — while the `-n 5` and `-n5` forms were correctly allowed.

Not a hole — it fails safe — but a guard that rejects ordinary usage trains people to widen the allowlist or switch it off, which is how a control dies.

### The fix — deliberately narrow
New optional `CommandFlagPolicy.bareNumericCount`, set **only** on `head` and `tail`. `classifyFlagToken` matches a bare `-<digits>` token when that field is set and returns `safe` — the token is **never** captured as a candidate path (resolving it against cwd would either false-allow or confusingly deny).

### Verified — my independent run, 22/22
- **The critical property:** a bare numeric flag followed by an **out-of-scope path** still **denies**, for both `head` and `tail`. The path is still containment-checked; the widening opens nothing.
- **Not generalised:** the same shorthand on `ls` and `cat` still **denies**.
- **Unknown flags still denied:** `head -x f.txt`, `tail --bogus f.txt`.
- **Rounds 1–9 unchanged:** `file -flist`, `git diff --no-index <oos>`, `gh … --body-file <oos>`, `cat -- <oos>`, tilde-user, brace → deny; `git diff HEAD~1`, `gh pr view 1`, `cat -- f.txt`, `ls -lh`, `head -n20`, `*.log`, `pwd` → allow.
- **Guard-off (EBH-1g) correct both ways:** in-scope passes, out-of-scope denies.

Suites: bash-guard 290 pass (was 281, +9 new), path-guard 106 pass. tsc and `lint:errors` identical to the `origin/main` baseline; carveouts + wire-vocab PASS.

An adversarial refute-to-kill pass is running against the widening specifically; this will not merge until it clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
