### PR TITLE
feat(manifest): declare owns {config,state,userData} + scripts.purge

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -246,6 +246,84 @@ scripts:
   # arc#138) — the first thing `arc remove` does, non-aborting on failure.
   # No-ops on Darwin / systemd-less hosts.
   preremove: ./scripts/preremove.sh
+  # cortex#2338: `arc purge`'s non-declarable cleanup (arc#359 step 4) — the
+  # ONE leftover class `owns:` below cannot express as a static path: LIVE
+  # supervised per-stack instances (systemd `cortex@<slug>`/`nats@<slug>`;
+  # darwin `ai.meta-factory.{cortex,nats}.<slug>.plist`, never arc-tracked —
+  # plist-render.sh writes these directly, not via `provides.files`). Fires
+  # via arc's `scripts.purge` hook, AFTER `owns.config`/`owns.state` are
+  # already deleted — see scripts/lib/purge-supervision.sh's header for why
+  # that ordering means this script deliberately does NOT read the (by then
+  # gone) cortex config dir to discover stacks, unlike `preremove.sh` above.
+  # Non-aborting on failure, matching every other lifecycle script here.
+  purge: ./scripts/purge.sh
+
+# owns: the runtime-created config/state trees `arc purge cortex` deletes,
+# plus the one workspace root it must NEVER touch (cortex#2338, arc#359).
+#
+# Scope is DELIBERATELY narrower than the field-test leftover inventory this
+# issue started from (cortex#2331) — two trees this manifest does NOT declare,
+# and why:
+#
+#   - `~/.config/nats` (rendered <slug>.conf / <slug>.creds / cortex-<slug>.nk
+#     signing seed): NOT declared. This directory is SHARED — arc's OWN nats
+#     identity provisioning writes here too (arc/src/lib/identity-provision.ts
+#     ~/.config/nats/<agent-id>.nk, ~/.config/nats/creds/), independent of
+#     cortex. Only the seed carries a "cortex-" prefix; the rendered
+#     `<slug>.conf`/`<slug>.creds` do not, and <slug> is principal-chosen, so a
+#     glob can't safely distinguish cortex's files from a neighbor's without
+#     risking a false-positive delete. cortex's OWN teardown code
+#     (stack-lib.ts resolveStackArtifacts, `cortex stack delete`) treats the
+#     seed as RETIRED-not-deleted by default (key destruction is a conscious
+#     `--purge-seeds` act) — a blanket owns.config sweep here would be MORE
+#     destructive than cortex's own explicit teardown UX. Left out; the
+#     principal cleans this by hand (`cortex stack delete --purge-seeds`) if
+#     seed destruction is actually wanted.
+#   - `~/.claude/{relay,events}` (relay-policy.yaml, raw/published event
+#     JSONL): NOT declared. postinstall.sh creates these, but per this issue's
+#     own review, `~/.claude` is Claude-Code-hook territory another hook or
+#     package could also write into (events-path.ts explicitly calls
+#     `~/.claude/events/raw` the "hook-substrate boundary" that stays put
+#     across every XDG wave for exactly this reason). Left out with this note
+#     rather than guessed at.
+#
+# The per-stack DATA dir (`~/.local/share/metafactory/cortex`,
+# src/common/data-path.ts) is ALSO entirely excluded from owns.config/state —
+# not an oversight, see the userData entry below.
+owns:
+  config:
+    # Exclusively cortex's own — canonical XDG config root
+    # (src/common/config/config-path.ts cortexConfigDir). No userData lives
+    # under it; personas/agents.d/stacks/system are all cortex-generated.
+    - "~/.config/metafactory/cortex"
+  state:
+    # Exclusively cortex's own — canonical XDG state root
+    # (src/common/state-path.ts cortexStateDir): pidfiles, degraded markers,
+    # rotating logs, the relay pidfile, and the DD-10 network-cache. No
+    # userData lives under it.
+    - "~/.local/state/metafactory/cortex"
+  userData:
+    # THE never-sweep guarantee this issue exists to protect (arc#359's
+    # apt `/home` guarantee). Per-stack coding-tier agent workspaces
+    # (src/common/data-path.ts canonicalWorkspaceDir, cortex#2097) —
+    # `<dataDir>/<slug>/workspace` — are the dispatch cwd a bot session
+    # actually reads/writes as its checkout. They live NESTED inside the
+    # broader data dir (`~/.local/share/metafactory/cortex`, which also holds
+    # the MC db + published-events buffer) — see the manifest-level note
+    # above for why that whole tree is left OUT of owns.config/state rather
+    # than declaring the MC-db/events siblings as purgeable: arc's owns
+    # containment validator (arc/src/lib/owns.ts validateOwns) computes a
+    # glob's containment root at the segment BEFORE the first glob character,
+    # so a wildcarded slug (`*/workspace`) roots at the DATA DIR ITSELF —
+    # identical to any sibling config/state entry declared one level down
+    # (`.../cortex/mc`, `.../cortex/events`), which `validateOwns` would then
+    # reject as an overlap (the never-delete class must not contain, nor be
+    # contained by, a deletable one). Declaring the workspace glob here with
+    # NO sibling config/state entries inside the data dir avoids that
+    # conflict — and is the safer read anyway: better to leave real state
+    # (MC db, published events) as an undeclared leftover than to risk a
+    # containment shape arc might resolve unsafely on a future host layout.
+    - "~/.local/share/metafactory/cortex/*/workspace"
 
 # Dependencies — cortex#79 pins arc >= 0.25.0. That's the release that
 # ships the stable `arc.nats.v1` JSON contract on the four `arc nats *`

--- a/scripts/__tests__/manifest-owns-purge.test.ts
+++ b/scripts/__tests__/manifest-owns-purge.test.ts
@@ -1,0 +1,143 @@
+// cortex#2338 — arc-manifest.yaml `owns:` + `scripts.purge` declaration
+// tests. Mirrors manifest-hooks-casing.test.ts's pattern: parse the manifest
+// directly and assert shape/safety properties, rather than depending on arc
+// as a library (arc is a sibling CLI repo, not an npm dependency here).
+//
+// The safety rules replicated below (entry shape, containment/overlap) are
+// deliberately kept BYTE-FOR-BYTE equivalent to arc's own load-time gate
+// (arc/src/lib/owns.ts validateOwns + containmentRoot/pathsNest) — the two
+// checks are independent implementations of the SAME contract, so a
+// regression here should also fail `arc validate` (verified separately by
+// running the real `arc validate` against this repo — see the PR notes) and
+// vice versa. If arc's rules ever change, this file's replica must be
+// updated to match — that drift risk is the tradeoff for not depending on
+// arc as a library.
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { parse } from "yaml";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const MANIFEST_PATH = join(REPO_ROOT, "arc-manifest.yaml");
+
+type OwnsClass = "config" | "state" | "userData";
+const OWNS_CLASSES: OwnsClass[] = ["config", "state", "userData"];
+
+interface Manifest {
+  owns?: Partial<Record<OwnsClass, string[]>>;
+  scripts?: Record<string, string>;
+}
+
+const manifest = parse(readFileSync(MANIFEST_PATH, "utf-8")) as Manifest;
+
+// ─── Replica of arc/src/lib/owns.ts's per-entry safety rules ──────────────
+function entryViolations(entry: string): string[] {
+  const rules: string[] = [];
+  if (entry.startsWith("/")) {
+    rules.push(`must be ~-rooted, not an absolute path ('${entry}')`);
+    return rules;
+  }
+  if (!entry.startsWith("~/")) {
+    rules.push(`must start with '~/' (got '${entry}')`);
+    return rules;
+  }
+  const tail = entry.slice(2);
+  const segments = tail.split("/").filter((s) => s.length > 0);
+  if (segments.length === 0) {
+    rules.push("has an empty tail after '~/' — this would sweep the whole home tree");
+    return rules;
+  }
+  if (segments.includes("..")) {
+    rules.push(`must not contain a '..' segment ('${entry}')`);
+  }
+  if (segments[0] === "*" || segments[0] === "**") {
+    rules.push(`must not begin with a '*'/'**' segment ('${entry}')`);
+  }
+  return rules;
+}
+
+// ─── Replica of arc's containmentRoot / pathsNest (home is opaque here —
+// comparison is purely on the tilde-relative tail, which is equivalent for
+// nesting purposes since every entry shares the same ~ root). ─────────────
+const GLOB_MAGIC_RE = /[*?[\]{}]/;
+
+function containmentRoot(entry: string): string {
+  const tail = entry.startsWith("~/") ? entry.slice(2) : entry.replace(/^~/, "");
+  const solid: string[] = [];
+  for (const seg of tail.split("/")) {
+    if (seg.length === 0) continue;
+    if (GLOB_MAGIC_RE.test(seg)) break;
+    solid.push(seg);
+  }
+  return solid.join("/");
+}
+
+function pathsNest(a: string, b: string): boolean {
+  return a === b || a.startsWith(b + "/") || b.startsWith(a + "/");
+}
+
+describe("arc-manifest.yaml — owns: declaration (cortex#2338)", () => {
+  test("manifest declares owns.config, owns.state, and owns.userData (sanity — guards a parse regression silently passing everything)", () => {
+    expect(manifest.owns).toBeDefined();
+    expect(manifest.owns?.config?.length ?? 0).toBeGreaterThan(0);
+    expect(manifest.owns?.state?.length ?? 0).toBeGreaterThan(0);
+    expect(manifest.owns?.userData?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  test("every owns entry is a safe ~-rooted path (arc's validateOwns entry rules)", () => {
+    for (const cls of OWNS_CLASSES) {
+      for (const entry of manifest.owns?.[cls] ?? []) {
+        const violations = entryViolations(entry);
+        expect(violations).toEqual([]);
+      }
+    }
+  });
+
+  test("owns.userData never overlaps a declared owns.config/owns.state entry (arc's never-delete containment rule)", () => {
+    const deletables = [
+      ...(manifest.owns?.config ?? []).map((entry) => ({ entry, cls: "config" as const })),
+      ...(manifest.owns?.state ?? []).map((entry) => ({ entry, cls: "state" as const })),
+    ];
+    for (const ud of manifest.owns?.userData ?? []) {
+      const udRoot = containmentRoot(ud);
+      for (const del of deletables) {
+        const delRoot = containmentRoot(del.entry);
+        const overlaps = pathsNest(udRoot, delRoot);
+        expect(overlaps).toBe(false);
+      }
+    }
+  });
+
+  test("owns.config/owns.state entries are cortex-exclusive canonical XDG trees, not the shared ~/.config/nats or ~/.claude/{relay,events} dirs (cortex#2338 shared-tree caution)", () => {
+    const deletables = [...(manifest.owns?.config ?? []), ...(manifest.owns?.state ?? [])];
+    for (const entry of deletables) {
+      expect(entry.startsWith("~/.config/nats")).toBe(false);
+      expect(entry.startsWith("~/.claude/relay")).toBe(false);
+      expect(entry.startsWith("~/.claude/events")).toBe(false);
+    }
+  });
+
+  test("owns.userData names the per-stack workspace root under the data dir (the coding-tier agent's checkout — never-delete guarantee)", () => {
+    const userData = manifest.owns?.userData ?? [];
+    expect(userData).toContain("~/.local/share/metafactory/cortex/*/workspace");
+  });
+});
+
+describe("arc-manifest.yaml — scripts.purge (cortex#2338)", () => {
+  test("scripts.purge is declared and points at an existing, executable file", () => {
+    const rel = manifest.scripts?.purge;
+    expect(rel).toBeDefined();
+    const abs = join(REPO_ROOT, rel!.replace(/^\.\//, ""));
+    expect(existsSync(abs)).toBe(true);
+    const mode = statSync(abs).mode;
+    // eslint-disable-next-line no-bitwise
+    expect((mode & 0o100) !== 0).toBe(true); // owner-executable bit set
+  });
+
+  test("scripts/purge.sh sources purge-supervision.sh and calls both sweep functions", () => {
+    const script = readFileSync(join(REPO_ROOT, "scripts", "purge.sh"), "utf-8");
+    expect(script).toContain("purge-supervision.sh");
+    expect(script).toContain("purge_systemd_instances");
+    expect(script).toContain("purge_launchd_instances");
+  });
+});

--- a/scripts/__tests__/purge-supervision.sh
+++ b/scripts/__tests__/purge-supervision.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# cortex#2338 — unit tests for scripts/lib/purge-supervision.sh: the
+# `scripts.purge` supervisor sweep (systemd unit-glob disable, launchd
+# LaunchAgents filename-glob bootout+remove), and the platform no-ops.
+#
+# Tests run entirely in a scratch $HOME; no live ~/Library/LaunchAgents,
+# ~/.config/systemd/user, systemctl, or launchctl is touched — all mocked via
+# PATH override / an injected LAUNCH_DIR arg, same pattern as
+# scripts/__tests__/systemd-remove.sh. `uname` is ALSO mocked so both the
+# Linux and Darwin paths are exercised regardless of the host actually
+# running this suite.
+#
+# The critical property under test (cortex#2338's whole reason for existing):
+# BOTH functions must clean up WITHOUT reading a cortex config dir — neither
+# function is ever passed one, and purge_launchd_instances is proven to find
+# plists via a LaunchAgents dir that has no cortex config dir anywhere near
+# it.
+#
+# Run:
+#   bash scripts/__tests__/purge-supervision.sh
+#
+# Exit code: 0 = all pass, non-zero = failure count.
+
+set -euo pipefail
+
+# ─── Test harness ─────────────────────────────────────────────────
+PASS=0
+FAIL=0
+
+pass() { printf '  ✓ %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  ✗ %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    pass "${label}"
+  else
+    fail "${label}: expected «${expected}» got «${actual}»"
+  fi
+}
+
+assert_true() {
+  local label="$1"; shift
+  if "$@"; then pass "${label}"; else fail "${label}"; fi
+}
+
+assert_file_exists() {
+  local label="$1" path="$2"
+  if [ -f "${path}" ]; then pass "${label}"; else fail "${label}: not found: ${path}"; fi
+}
+
+assert_file_missing() {
+  local label="$1" path="$2"
+  if [ ! -e "${path}" ]; then pass "${label}"; else fail "${label}: still present: ${path}"; fi
+}
+
+# ─── Fixtures ─────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+TMPHOME="$(mktemp -d)"
+trap 'rm -rf "${TMPHOME}"' EXIT
+export HOME="${TMPHOME}"
+
+MOCK_BIN="${TMPHOME}/mock-bin"
+mkdir -p "${MOCK_BIN}"
+
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Linux"
+EOF
+chmod +x "${MOCK_BIN}/uname"
+
+export SYSTEMCTL_LOG="${TMPHOME}/systemctl.log"
+# FAIL_DISABLE=1 → the glob disable call itself exits 1 (simulates "no
+# matching units" — systemctl's own behavior when a glob matches nothing).
+cat > "${MOCK_BIN}/systemctl" <<'EOF'
+#!/bin/sh
+printf 'systemctl %s\n' "$*" >> "${SYSTEMCTL_LOG:-/dev/null}"
+if [ "$1" = "--user" ] && [ "$2" = "disable" ] && [ "$3" = "--now" ]; then
+  [ "${FAIL_DISABLE:-0}" = "1" ] && exit 1
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "${MOCK_BIN}/systemctl"
+
+export LAUNCHCTL_LOG="${TMPHOME}/launchctl.log"
+cat > "${MOCK_BIN}/launchctl" <<'EOF'
+#!/bin/sh
+printf 'launchctl %s\n' "$*" >> "${LAUNCHCTL_LOG:-/dev/null}"
+exit 0
+EOF
+chmod +x "${MOCK_BIN}/launchctl"
+
+export PATH="${MOCK_BIN}:${PATH}"
+
+# Source AFTER HOME/PATH are set — same convention as systemd-remove.sh's
+# suite. Deliberately: source only purge-supervision.sh (which itself sources
+# systemd-render.sh) — never a cortex config dir fixture anywhere in this
+# suite, proving neither function needs one.
+# shellcheck source=scripts/lib/purge-supervision.sh
+source "${SCRIPT_DIR}/lib/purge-supervision.sh"
+
+export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
+mkdir -p "${SYSTEMD_HOST_MARKER}"
+
+LAUNCH_DIR="${TMPHOME}/LaunchAgents"
+
+reset_launch_dir() {
+  rm -rf "${LAUNCH_DIR}"
+  mkdir -p "${LAUNCH_DIR}"
+}
+
+# ─── Section 1: purge_systemd_instances ────────────────────────────
+printf '\n=== purge_systemd_instances ===\n'
+
+: > "${SYSTEMCTL_LOG}"
+purge_systemd_instances
+assert_eq "exactly one glob disable call" "1" \
+  "$(grep -c '^systemctl --user disable --now' "${SYSTEMCTL_LOG}")"
+assert_eq "the call globs cortex@* and nats@* together" "1" \
+  "$(grep -Fc "systemctl --user disable --now cortex@* nats@*" "${SYSTEMCTL_LOG}")"
+
+# `set -e` caller survival even when the glob call fails (e.g. "no matching
+# units" — systemctl exits non-zero on an empty glob match).
+export FAIL_DISABLE=1
+: > "${SYSTEMCTL_LOG}"
+SETE_OUT="$(mktemp)"
+set +e
+bash -c "set -e; source '${SCRIPT_DIR}/lib/purge-supervision.sh'; purge_systemd_instances; echo SCRIPT_COMPLETED" > "${SETE_OUT}" 2>&1
+SETE_RC=$?
+set -e
+assert_eq "a 'set -e' caller completes despite the glob disable failing" "0" "${SETE_RC}"
+assert_true "the caller ran past the guarded call" grep -qF "SCRIPT_COMPLETED" "${SETE_OUT}"
+rm -f "${SETE_OUT}"
+unset FAIL_DISABLE
+
+# Darwin → no-op, zero systemctl calls.
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Darwin"
+EOF
+: > "${SYSTEMCTL_LOG}"
+purge_systemd_instances
+assert_eq "Darwin → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
+
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Linux"
+EOF
+
+# systemd-less Linux host → no-op.
+export SYSTEMD_HOST_MARKER="${TMPHOME}/no-such-run-systemd-system"
+rm -rf "${HOME}/.config/systemd/user"
+: > "${SYSTEMCTL_LOG}"
+purge_systemd_instances
+assert_eq "systemd-less Linux → zero systemctl calls" "0" "$(wc -l < "${SYSTEMCTL_LOG}" | tr -d ' ')"
+export SYSTEMD_HOST_MARKER="${TMPHOME}/fake-run-systemd-system"
+mkdir -p "${SYSTEMD_HOST_MARKER}"
+
+# ─── Section 2: purge_launchd_instances ────────────────────────────
+printf '\n=== purge_launchd_instances ===\n'
+
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Darwin"
+EOF
+
+reset_launch_dir
+: > "${LAUNCH_DIR}/ai.meta-factory.cortex.work.plist"
+: > "${LAUNCH_DIR}/ai.meta-factory.cortex.halden.plist"
+: > "${LAUNCH_DIR}/ai.meta-factory.cortex.relay.plist"
+: > "${LAUNCH_DIR}/ai.meta-factory.nats.work.plist"
+: > "${LAUNCH_DIR}/ai.meta-factory.nats.halden.plist"
+: > "${LAUNCH_DIR}/some.unrelated.app.plist"
+: > "${LAUNCHCTL_LOG}"
+purge_launchd_instances "${LAUNCH_DIR}"
+assert_file_missing "cortex work plist removed" "${LAUNCH_DIR}/ai.meta-factory.cortex.work.plist"
+assert_file_missing "cortex halden plist removed" "${LAUNCH_DIR}/ai.meta-factory.cortex.halden.plist"
+assert_file_missing "relay plist removed (matches the cortex.* glob)" "${LAUNCH_DIR}/ai.meta-factory.cortex.relay.plist"
+assert_file_missing "nats work plist removed" "${LAUNCH_DIR}/ai.meta-factory.nats.work.plist"
+assert_file_missing "nats halden plist removed" "${LAUNCH_DIR}/ai.meta-factory.nats.halden.plist"
+assert_file_exists "an unrelated plist is left untouched" "${LAUNCH_DIR}/some.unrelated.app.plist"
+assert_eq "five bootout calls (one per cortex/nats plist)" "5" \
+  "$(grep -c '^launchctl bootout' "${LAUNCHCTL_LOG}")"
+assert_true "bootout is never called for the unrelated plist" \
+  bash -c "! grep -qF 'some.unrelated.app.plist' '${LAUNCHCTL_LOG}'"
+
+# No matching plists → clean no-op, zero launchctl calls.
+reset_launch_dir
+: > "${LAUNCH_DIR}/some.unrelated.app.plist"
+: > "${LAUNCHCTL_LOG}"
+purge_launchd_instances "${LAUNCH_DIR}"
+assert_eq "no matching plists → zero launchctl calls" "0" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+assert_file_exists "the unrelated plist still untouched" "${LAUNCH_DIR}/some.unrelated.app.plist"
+
+# Missing LaunchAgents dir entirely → clean no-op, never mkdir's it.
+NO_SUCH_DIR="${TMPHOME}/does-not-exist-LaunchAgents"
+: > "${LAUNCHCTL_LOG}"
+purge_launchd_instances "${NO_SUCH_DIR}"
+assert_eq "missing LaunchAgents dir → zero launchctl calls" "0" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+assert_file_missing "missing LaunchAgents dir is never created" "${NO_SUCH_DIR}"
+
+# Linux → no-op regardless of LAUNCH_DIR contents (never touches launchctl).
+cat > "${MOCK_BIN}/uname" <<'EOF'
+#!/bin/sh
+echo "Linux"
+EOF
+reset_launch_dir
+: > "${LAUNCH_DIR}/ai.meta-factory.cortex.work.plist"
+: > "${LAUNCHCTL_LOG}"
+purge_launchd_instances "${LAUNCH_DIR}"
+assert_eq "Linux → zero launchctl calls" "0" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
+assert_file_exists "Linux → plist left untouched" "${LAUNCH_DIR}/ai.meta-factory.cortex.work.plist"
+
+# ─── Results ──────────────────────────────────────────────────────
+printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/scripts/__tests__/purge-supervision.test.ts
+++ b/scripts/__tests__/purge-supervision.test.ts
@@ -1,0 +1,28 @@
+// bun-test wrapper for scripts/__tests__/purge-supervision.sh so the
+// `scripts.purge` supervisor sweep (systemd unit-glob disable, launchd
+// LaunchAgents filename-glob bootout+remove — cortex#2338) is gated by
+// `bun test`, not just runnable by hand. Mirrors systemd-remove.test.ts's
+// pattern (spawn the shell suite, assert exit 0).
+//
+// The shell suite runs entirely in a scratch $HOME with mocked uname/
+// systemctl/launchctl — no live ~/Library/LaunchAgents or
+// ~/.config/systemd/user is touched, so this runs identically on the Linux
+// CI runner and a macOS dev box.
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SUITE = join(REPO_ROOT, "scripts", "__tests__", "purge-supervision.sh");
+
+describe("purge-supervision shell suite (cortex#2338)", () => {
+  test("systemd unit-glob disable + launchd filename-glob bootout/remove + platform no-ops pass (exit 0)", () => {
+    const res = spawnSync("bash", [SUITE], { cwd: REPO_ROOT, encoding: "utf8" });
+    const out = `${res.stdout}${res.stderr}`;
+    // Surface the shell suite's own trace when it fails so the failing case is
+    // visible in the bun-test output.
+    if (res.status !== 0) throw new Error(`shell suite failed (exit ${res.status}):\n${out}`);
+    expect(res.status).toBe(0);
+    expect(out).toContain("0 failed");
+  });
+});

--- a/scripts/lib/purge-supervision.sh
+++ b/scripts/lib/purge-supervision.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Cortex purge-time supervisor sweep (cortex#2338) — backs `arc purge cortex`'s
+# `scripts.purge` hook (scripts/purge.sh).
+#
+# WHY THIS DOES NOT READ THE CORTEX CONFIG DIR (unlike preremove.sh's
+# disable_cortex_systemd_instances, scripts/lib/systemd-remove.sh): arc's
+# purge flow (arc#359, arc/src/commands/purge.ts) deletes the package's
+# declared `owns.config`/`owns.state` trees BEFORE running `scripts.purge`.
+# cortex's `owns.config` entry IS the canonical config dir
+# (~/.config/metafactory/cortex) — the exact tree `discover_stack_slugs`
+# (scripts/lib/plist-render.sh) reads to enumerate stacks. By the time this
+# script runs, that tree is already gone, so config-dir-based discovery would
+# silently find zero stacks and no-op the very cleanup it exists to do.
+#
+# Both functions below ask the SUPERVISOR directly instead of the config dir:
+#   - purge_systemd_instances  — a `systemctl` unit-name GLOB (`cortex@*`,
+#     `nats@*`), expanded by systemd itself against its own unit registry.
+#   - purge_launchd_instances  — a FILENAME glob against the on-disk
+#     LaunchAgents dir (never arc-tracked — plist-render.sh writes these
+#     directly, not via `provides.files`, so nothing else ever removes them).
+#
+# Neither depends on the cortex config dir surviving, so both still work
+# correctly after `owns.config` is deleted. This also makes them a genuine
+# safety net independent of `scripts.preremove` (which already disables Linux
+# instances EARLIER, while the config dir is still intact) — a unit
+# re-enabled between preremove and purge, or one preremove's discovery
+# missed, is still caught here.
+#
+# Usage (in the calling script):
+#   source "${SCRIPT_DIR}/lib/purge-supervision.sh"
+#   purge_systemd_instances
+#   purge_launchd_instances
+#
+# Both are no-ops (return 0, no external calls) on the "wrong" platform, and
+# every external call is best-effort — this runs during `arc purge`, AFTER
+# `arc remove` already succeeded; nothing here may abort the purge.
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# systemd-render.sh provides systemd_host_detected + run_with_timeout — reused
+# rather than forked, so the two "is this a systemd host" checks (render side,
+# purge side) can never drift apart.
+# shellcheck source=scripts/lib/systemd-render.sh
+source "${LIB_DIR}/systemd-render.sh"
+
+# Disable + stop EVERY loaded cortex@*/nats@* instance, discovered by systemd
+# itself via unit-name globbing — no config-dir read. Tolerates "no matching
+# units" (a plain host, a systemd-less host, or one preremove already fully
+# cleaned) as a clean no-op, never a failure.
+purge_systemd_instances() {
+  if [ "$(uname)" = "Darwin" ]; then
+    return 0
+  fi
+  if ! systemd_host_detected; then
+    return 0
+  fi
+  if ! command -v systemctl >/dev/null 2>&1; then
+    return 0
+  fi
+  if run_with_timeout systemctl --user disable --now 'cortex@*' 'nats@*' >/dev/null 2>&1; then
+    echo "  ✓ any loaded cortex@*/nats@* instances disabled"
+  else
+    echo "  ⊘ no matching cortex@*/nats@* instances (nothing loaded, or already clean)"
+  fi
+}
+
+# Bootout + delete every rendered launchd plist under LaunchAgents whose
+# filename matches cortex's naming convention, discovered by FILENAME GLOB —
+# not the cortex config dir. `ai.meta-factory.cortex.*.plist` covers BOTH the
+# per-slug daemon instances AND the single relay plist
+# (`ai.meta-factory.cortex.relay.plist`); `ai.meta-factory.nats.*.plist`
+# covers the per-slug nats-server instances (stack-lib.ts resolveStackArtifacts).
+#
+# Args: $1 LAUNCH_DIR — defaults to ${HOME}/Library/LaunchAgents (overridable
+#       for tests).
+purge_launchd_instances() {
+  if [ "$(uname)" != "Darwin" ]; then
+    return 0
+  fi
+  local launch_dir="${1:-${HOME}/Library/LaunchAgents}"
+  [ -d "${launch_dir}" ] || return 0
+
+  local domain plist found=0
+  domain="gui/$(id -u)"
+  for plist in "${launch_dir}"/ai.meta-factory.cortex.*.plist "${launch_dir}"/ai.meta-factory.nats.*.plist; do
+    [ -f "${plist}" ] || continue
+    found=1
+    launchctl bootout "${domain}" "${plist}" >/dev/null 2>&1 || true
+    rm -f "${plist}"
+    echo "  ✓ $(basename "${plist}") unloaded + removed"
+  done
+  if [ "${found}" -eq 0 ]; then
+    echo "  ⊘ no cortex/nats launchd plists found in ${launch_dir} — nothing to purge"
+  fi
+}

--- a/scripts/purge.sh
+++ b/scripts/purge.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Cortex purge (cortex#2338) — `arc purge cortex`'s scripts.purge hook.
+#
+# Fires via arc's `scripts.purge` (arc#359, arc/src/commands/purge.ts step 4):
+# AFTER `arc remove cortex` (which already ran scripts.preremove — Linux
+# instance disable, while the config dir was still intact — see
+# preremove.sh) AND after arc deletes cortex's declared owns.config/
+# owns.state trees. Handles the one leftover class that can't be a static
+# `owns:` path AND can't rely on the (by then deleted) config dir to
+# discover: LIVE supervised per-stack instances.
+#
+# See scripts/lib/purge-supervision.sh's header for why this is
+# supervisor-native (systemctl unit-glob / launchd LaunchAgents
+# filename-glob) rather than config-dir-based stack discovery.
+#
+# Non-aborting per the arc contract (arc's purge continues + warns regardless
+# of this script's exit code) — scripted defensively anyway, matching every
+# other lifecycle script in this repo.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/purge-supervision.sh
+source "${SCRIPT_DIR}/lib/purge-supervision.sh"
+
+echo "Running Cortex purge..."
+purge_systemd_instances
+purge_launchd_instances
+echo "✓ Cortex purge complete"


### PR DESCRIPTION
Closes #2338

`arc purge cortex` (arc#359) previously purged nothing beyond a plain `arc remove`, because cortex's manifest declared no `owns:` scope. This declares that scope, plus the `scripts.purge` hook for the one leftover class a static path can't express.

## What `owns:` declares, and why those three trees

Each entry is the **canonical** output of one of cortex's own path resolvers — verified against the resolvers, not assumed:

| class | entry | resolver |
|---|---|---|
| `config` | `~/.config/metafactory/cortex` | `cortexConfigDir()` — `src/common/config/config-path.ts` |
| `state` | `~/.local/state/metafactory/cortex` | `cortexStateDir()` — `src/common/state-path.ts` |
| `userData` | `~/.local/share/metafactory/cortex/*/workspace` | `canonicalWorkspaceDir(slug)` — `src/common/data-path.ts` |

`config` and `state` are the two trees written **exclusively** by cortex's own canonical XDG resolvers — personas, `agents.d`, stacks, `system/` on the config side; pidfiles, degraded markers, rotating logs, the relay pidfile and the DD-10 network-cache on the state side. Both are apt-conffiles/`/var`-shaped: deletable.

`userData` is the **never-delete guarantee** this issue exists to protect (arc#359's apt `/home` equivalent). `<dataDir>/<slug>/workspace` is the dispatch cwd a coding-tier bot session actually reads and writes as its checkout (cortex#2097). `arc purge` names it and keeps it — it is never a deletion target.

The three trees live in three different XDG roots (`.config` / `.local/state` / `.local/share`), so the never-delete class cannot be reached from either deletable one. Expanded on a real multi-stack host, the plan is exactly two deletions and thirteen kept workspaces; arc's own `validateOwns` returns zero violations.

## Deliberately left OUT of `owns`

- **`~/.config/nats`** (rendered `<slug>.conf` / `<slug>.creds` / `cortex-<slug>.nk` signing seed) — a **shared** tree. arc's own NATS identity provisioning writes here too (`arc/src/lib/identity-provision.ts` → `~/.config/nats/<agent-id>.nk`, `~/.config/nats/creds/`), independent of cortex. Only the seed carries a `cortex-` prefix; the rendered `<slug>.conf`/`<slug>.creds` do not, and `<slug>` is principal-chosen — so no glob can safely tell cortex's files from a neighbour's. On top of that, cortex's **own** teardown (`cortex stack delete`, `stack-lib.ts retiredSeedPath`) treats the signing seed as **retired-not-deleted** by default; key destruction is an explicit `--purge-seeds` act. Sweeping it from `owns.config` would make `arc purge` *more* destructive than cortex's own teardown UX.
- **`~/.claude/{relay,events}`** (relay-policy.yaml, raw/published event JSONL) — `postinstall.sh` creates these, but `~/.claude` is Claude-Code-hook territory that other hooks and packages also write into. `events-path.ts` explicitly calls `~/.claude/events/raw` the "hook-substrate boundary" that stays put across every XDG wave, for exactly this reason.

The per-stack **data** dir (`~/.local/share/metafactory/cortex` — MC db, published-events buffer) is also entirely absent from `owns.config`/`owns.state`. That is deliberate, not an oversight: see arc#368 below. Those two are known, accepted leftovers after a purge.

## Supervisor-native discovery in `scripts.purge`

`arc purge` deletes `owns.config`/`owns.state` **before** it runs `scripts.purge` (`arc/src/commands/purge.ts`, step (a) then step (b) — the script is snapshotted to a temp dir first so it survives `remove()` deleting the repo). That ordering is load-bearing here: `owns.config` **is** the config dir that `discover_stack_slugs` (`scripts/lib/plist-render.sh`) reads to enumerate stacks. A config-dir-based purge script would therefore find zero stacks and silently no-op the exact cleanup it exists to do.

So `scripts/lib/purge-supervision.sh` asks the **supervisor** directly instead:

- `purge_systemd_instances` — a `systemctl --user disable --now 'cortex@*' 'nats@*'` unit-name **glob**, expanded by systemd against its own unit registry.
- `purge_launchd_instances` — a **filename** glob over `~/Library/LaunchAgents` for `ai.meta-factory.{cortex,nats}.*.plist` (never arc-tracked: `plist-render.sh` writes these directly, not via `provides.files`, so nothing else would ever remove them).

Neither depends on the config dir surviving. This also makes them a genuine safety net independent of `scripts.preremove` (which disables Linux instances earlier, while the config dir is still intact) — a unit re-enabled between preremove and purge, or one preremove's discovery missed, is still caught. Both are no-ops on the wrong platform and every external call is best-effort; nothing here may abort a purge.

## Upstream limitations found during this work

- **arc#367** — `scripts.purge` runs *after* arc deletes the `owns` trees, so any purge script that reads its own config dir to enumerate instances silently no-ops. Worked around here via the supervisor-native discovery above.
- **arc#368** — a glob's containment root is computed at the segment *before* the first glob character, so `*/workspace` roots at the whole data dir and would collide with any sibling declaration one level down (`.../cortex/mc`, `.../cortex/events`). `validateOwns` would reject that as a userData↔deletable overlap. Rather than risk a containment shape that could put the coding agent's workspace on the wrong side of that line, the MC db and events buffer are left undeclared. cortex's data dir is the worked example on that issue.

## Verification

- `bun test scripts/__tests__/` — 111 pass, 2 skip, 0 fail
- `bunx tsc --noEmit` — clean (exit 0)
- `arc validate` — **zero** `owns.*` violations (the 5 reported violations — `schema`, `license`, `authors`/`author`, `namespace` — are pre-existing on `main` and untouched by this purely-additive diff)
- arc's real `validateOwns` + `expandOwnsEntry` run against this manifest on a live multi-stack host: 2 deletable paths, both outside `~/.local/share`; 13 workspace paths named and kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArLAsEG9JoXUzkrotpUgAU
