### PR TITLE
feat(common/auth): GitHub App installation-token minting for atlas/luna-dev bot identities

### DIFF
--- a/src/cli/cortex/commands/__tests__/github-token.test.ts
+++ b/src/cli/cortex/commands/__tests__/github-token.test.ts
@@ -1,0 +1,183 @@
+// cortex#2396 (vision#11) — `cortex github-token` CLI tests. The GitHub API
+// call is injected via `__setFetchForTests` so tests stay hermetic (no real
+// network call, no real private key needed beyond a generated test fixture).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { generateKeyPairSync } from "node:crypto";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  __setFetchForTests,
+  dispatchGithubToken,
+  parseGithubTokenArgs,
+  runGithubTokenList,
+  runGithubTokenMint,
+} from "../github-token";
+import { CliArgsError } from "../_shared/arg-error";
+
+const { privateKey: TEST_PRIVATE_KEY_PEM } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  privateKeyEncoding: { type: "pkcs1", format: "pem" },
+  publicKeyEncoding: { type: "spki", format: "pem" },
+});
+
+describe("parseGithubTokenArgs", () => {
+  test("parses mint with identity + flags", () => {
+    const parsed = parseGithubTokenArgs(["mint", "atlas", "--json"]);
+    expect(parsed.subcommand).toBe("mint");
+    expect(parsed.identity).toBe("atlas");
+    expect(parsed.json).toBe(true);
+  });
+
+  test("parses list", () => {
+    const parsed = parseGithubTokenArgs(["list"]);
+    expect(parsed.subcommand).toBe("list");
+  });
+
+  test("no args → unknown with empty rawSubcommand", () => {
+    const parsed = parseGithubTokenArgs([]);
+    expect(parsed.subcommand).toBe("unknown");
+    expect(parsed.rawSubcommand).toBe("");
+  });
+
+  test("mint without identity throws via missing-positional path (caught by dispatch)", () => {
+    // parseSubcommandArgs throws MissingPositionalError; parseGithubTokenArgs
+    // catches it and degrades to a usable args object (mirrors creds.ts).
+    const parsed = parseGithubTokenArgs(["mint"]);
+    expect(parsed.subcommand).toBe("mint");
+    expect(parsed.identity).toBeUndefined();
+  });
+
+  test("unknown flag throws CliArgsError", () => {
+    expect(() => parseGithubTokenArgs(["mint", "atlas", "--bogus"])).toThrow(CliArgsError);
+  });
+});
+
+describe("runGithubTokenMint + runGithubTokenList (hermetic fixture)", () => {
+  let dir: string;
+  let configPath: string;
+  let keyPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "github-token-cli-"));
+    keyPath = join(dir, "atlas.pem");
+    writeFileSync(keyPath, TEST_PRIVATE_KEY_PEM, "utf8");
+    chmodSync(keyPath, 0o600);
+
+    configPath = join(dir, "apps.yaml");
+    writeFileSync(
+      configPath,
+      `atlas:\n  appId: "4391087"\n  installationId: "148931136"\n  keyPath: "${keyPath}"\n`,
+      "utf8",
+    );
+  });
+
+  afterEach(() => {
+    __setFetchForTests(null);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("mint prints the bare token on stdout, expiry on stderr, exit 0", async () => {
+    __setFetchForTests(
+      (async () =>
+        new Response(
+          JSON.stringify({ token: "ghs_cli_test", expires_at: "2026-07-26T01:00:00Z" }),
+          { status: 201 },
+        )) as unknown as typeof fetch,
+    );
+
+    const result = await runGithubTokenMint({
+      subcommand: "mint",
+      rawSubcommand: "mint",
+      identity: "atlas",
+      config: configPath,
+      json: false,
+      help: false,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("ghs_cli_test\n");
+    expect(result.stderr).toMatch(/atlas.*expires 2026-07-26T01:00:00Z/);
+  });
+
+  test("mint --json wraps token + expiresAt in the envelope", async () => {
+    __setFetchForTests(
+      (async () =>
+        new Response(
+          JSON.stringify({ token: "ghs_json_test", expires_at: "2026-07-26T02:00:00Z" }),
+          { status: 201 },
+        )) as unknown as typeof fetch,
+    );
+
+    const result = await runGithubTokenMint({
+      subcommand: "mint",
+      rawSubcommand: "mint",
+      identity: "atlas",
+      config: configPath,
+      json: true,
+      help: false,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const envelope = JSON.parse(result.stdout);
+    expect(envelope.status).toBe("ok");
+    expect(envelope.items).toEqual([
+      { identity: "atlas", token: "ghs_json_test", expiresAt: "2026-07-26T02:00:00Z" },
+    ]);
+  });
+
+  test("mint with unknown identity exits 1 with a clear stderr message", async () => {
+    const result = await runGithubTokenMint({
+      subcommand: "mint",
+      rawSubcommand: "mint",
+      identity: "nonexistent",
+      config: configPath,
+      json: false,
+      help: false,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/unknown GitHub App identity "nonexistent"/);
+  });
+
+  test("list surfaces configured identity names without secrets", () => {
+    const result = runGithubTokenList({
+      subcommand: "list",
+      rawSubcommand: "list",
+      identity: undefined,
+      config: configPath,
+      json: false,
+      help: false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("atlas\tapp=4391087\tinstallation=148931136\n");
+    expect(result.stdout).not.toContain("BEGIN RSA PRIVATE KEY");
+  });
+
+  test("dispatchGithubToken routes mint through end-to-end", async () => {
+    __setFetchForTests(
+      (async () =>
+        new Response(
+          JSON.stringify({ token: "ghs_dispatch_test", expires_at: "2026-07-26T03:00:00Z" }),
+          { status: 201 },
+        )) as unknown as typeof fetch,
+    );
+
+    const result = await dispatchGithubToken(["mint", "atlas", "--config", configPath]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("ghs_dispatch_test\n");
+  });
+
+  test("dispatchGithubToken with no subcommand exits 2 with usage error", async () => {
+    const result = await dispatchGithubToken([]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/usage error/);
+  });
+
+  test("dispatchGithubToken with unknown subcommand exits 2", async () => {
+    const result = await dispatchGithubToken(["bogus"]);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/unknown subcommand "bogus"/);
+  });
+});

--- a/src/cli/cortex/commands/github-token.ts
+++ b/src/cli/cortex/commands/github-token.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env bun
+/**
+ * `cortex github-token <subcommand>` — mint GitHub App installation tokens
+ * for cortex-hosted bot identities (cortex#2396, vision#11).
+ *
+ * Same shape as `cortex creds` (per-identity credential lifecycle) but for
+ * GitHub App installation tokens instead of NATS user creds — `mint`
+ * prints the short-lived token to stdout for command-substitution capture
+ * (`GH_TOKEN=$(cortex github-token mint atlas)`), mirroring how a caller
+ * would consume any other short-lived credential-minting CLI.
+ *
+ * Usage:
+ *   bun src/cli/cortex/commands/github-token.ts mint <identity> [--config <path>] [--json]
+ *   bun src/cli/cortex/commands/github-token.ts list [--config <path>] [--json]
+ *   bun src/cli/cortex/commands/github-token.ts --help
+ *
+ * Exit codes:
+ *   0  — success
+ *   1  — mint failure (unknown identity, bad key permissions, GitHub API error)
+ *   2  — usage error (bad flag, missing positional)
+ */
+
+import {
+  DEFAULT_GITHUB_APP_IDENTITIES_PATH,
+  GithubAppTokenError,
+  loadGithubAppIdentities,
+  mintTokenForIdentity,
+} from "../../../common/auth/github-app-token";
+import { CliArgsError, MissingPositionalError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { assertExhaustive } from "./_shared/assert-exhaustive";
+import { type ExitResult } from "./_shared/exit-result";
+import { parseSubcommandArgs, type SubcommandSpec } from "./_shared/parser";
+import { boolFlag, valueFlag } from "./_shared/hydrate";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ParsedGithubTokenArgs {
+  subcommand: "mint" | "list" | "help" | "unknown";
+  rawSubcommand: string;
+  identity: string | undefined;
+  config: string | undefined;
+  json: boolean;
+  help: boolean;
+}
+
+export { type ExitResult } from "./_shared/exit-result";
+
+interface IdentityListItem {
+  name: string;
+  appId: string;
+  installationId: string;
+}
+
+// =============================================================================
+// Test-only fetch override — keeps `mint` tests hermetic (no real GitHub
+// API call), same shape as creds.ts's `__setArcRunnerForTests`.
+// =============================================================================
+
+let fetchOverride: typeof fetch | null = null;
+
+/** Test-only setter. Production callers never touch this. Passing `null`
+ *  restores the real global `fetch`. */
+export function __setFetchForTests(impl: typeof fetch | null): void {
+  fetchOverride = impl;
+}
+
+// =============================================================================
+// parseGithubTokenArgs
+// =============================================================================
+
+const GITHUB_TOKEN_SPEC: SubcommandSpec<"mint" | "list"> = {
+  cliName: "github-token",
+  subcommands: {
+    mint: { positionals: ["identity"], flags: { "--config": "value" } },
+    list: { flags: { "--config": "value" } },
+  },
+  universal: { "--help": "bool", "-h": "bool", "--json": "bool" },
+};
+
+export function parseGithubTokenArgs(argv: string[]): ParsedGithubTokenArgs {
+  let parsed;
+  try {
+    parsed = parseSubcommandArgs(GITHUB_TOKEN_SPEC, argv);
+  } catch (err) {
+    if (err instanceof MissingPositionalError) {
+      const sub = err.rawSubcommand;
+      const known = sub === "mint" || sub === "list" ? sub : "unknown";
+      return {
+        subcommand: known,
+        rawSubcommand: sub,
+        identity: undefined,
+        config: undefined,
+        json: false,
+        help: false,
+      };
+    }
+    throw err;
+  }
+
+  return {
+    subcommand: parsed.subcommand,
+    rawSubcommand: parsed.rawSubcommand,
+    identity: parsed.positionals.identity,
+    config: valueFlag(parsed.flags, "--config"),
+    json: boolFlag(parsed.flags, "--json"),
+    help: parsed.help,
+  };
+}
+
+// =============================================================================
+// runGithubTokenMint
+// =============================================================================
+
+export async function runGithubTokenMint(args: ParsedGithubTokenArgs): Promise<ExitResult> {
+  if (args.help) {
+    return { exitCode: 0, stdout: mintHelp(), stderr: "" };
+  }
+  const identity = args.identity ?? "";
+
+  let result;
+  try {
+    result = await mintTokenForIdentity(identity, {
+      configPath: args.config,
+      fetchImpl: fetchOverride ?? undefined,
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    const context = err instanceof GithubAppTokenError ? err.context : undefined;
+    if (args.json) {
+      return {
+        exitCode: 1,
+        stdout: renderJson(envelopeError(reason, context)),
+        stderr: "",
+      };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex github-token mint: ${reason}\n` };
+  }
+
+  if (args.json) {
+    return {
+      exitCode: 0,
+      stdout: renderJson(
+        envelopeOk([{ identity, token: result.token, expiresAt: result.expiresAt }]),
+      ),
+      stderr: "",
+    };
+  }
+  // Bare token on stdout — the intended consumption is command substitution
+  // (`GH_TOKEN=$(cortex github-token mint atlas)`). Diagnostics go to
+  // stderr so they never end up inside the captured env var.
+  return {
+    exitCode: 0,
+    stdout: `${result.token}\n`,
+    stderr: `cortex github-token mint: "${identity}" expires ${result.expiresAt}\n`,
+  };
+}
+
+// =============================================================================
+// runGithubTokenList — configured identity names only, no secrets
+// =============================================================================
+
+export function runGithubTokenList(args: ParsedGithubTokenArgs): ExitResult {
+  if (args.help) {
+    return { exitCode: 0, stdout: listHelp(), stderr: "" };
+  }
+
+  let identities: Record<string, { appId: string; installationId: string; keyPath: string }>;
+  try {
+    identities = loadGithubAppIdentities(args.config);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    const context = err instanceof GithubAppTokenError ? err.context : undefined;
+    if (args.json) {
+      return { exitCode: 1, stdout: renderJson(envelopeError(reason, context)), stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `cortex github-token list: ${reason}\n` };
+  }
+
+  const items: IdentityListItem[] = Object.entries(identities)
+    .map(([name, cfg]) => ({ name, appId: cfg.appId, installationId: cfg.installationId }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (args.json) {
+    return { exitCode: 0, stdout: renderJson(envelopeOk(items)), stderr: "" };
+  }
+  if (items.length === 0) {
+    return {
+      exitCode: 0,
+      stdout: `0 GitHub App identities configured (${args.config ?? DEFAULT_GITHUB_APP_IDENTITIES_PATH})\n`,
+      stderr: "",
+    };
+  }
+  return {
+    exitCode: 0,
+    stdout:
+      items.map((i) => `${i.name}\tapp=${i.appId}\tinstallation=${i.installationId}`).join("\n") +
+      "\n",
+    stderr: "",
+  };
+}
+
+// =============================================================================
+// dispatchGithubToken
+// =============================================================================
+
+export async function dispatchGithubToken(argv: string[]): Promise<ExitResult> {
+  let args: ParsedGithubTokenArgs;
+  try {
+    args = parseGithubTokenArgs(argv);
+  } catch (err) {
+    if (err instanceof CliArgsError) {
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex github-token: ${err.message}\n${topLevelHelp()}`,
+      };
+    }
+    throw err;
+  }
+
+  switch (args.subcommand) {
+    case "mint":
+      return await runGithubTokenMint(args);
+    case "list":
+      return runGithubTokenList(args);
+    case "help":
+      return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
+    case "unknown":
+      if (args.rawSubcommand === "") {
+        return {
+          exitCode: 2,
+          stdout: "",
+          stderr: `cortex github-token: usage error — no subcommand specified.\n${topLevelHelp()}`,
+        };
+      }
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex github-token: unknown subcommand "${args.rawSubcommand}".\n${topLevelHelp()}`,
+      };
+    default:
+      return assertExhaustive(args.subcommand, "github-token");
+  }
+}
+
+// =============================================================================
+// Help text
+// =============================================================================
+
+function topLevelHelp(): string {
+  return `cortex github-token — mint GitHub App installation tokens for cortex-hosted bot identities
+
+Usage:
+  cortex github-token mint <identity> [--config <path>] [--json]
+  cortex github-token list [--config <path>] [--json]
+
+Identities are configured in ${DEFAULT_GITHUB_APP_IDENTITIES_PATH} (or --config),
+mapping a name (e.g. "atlas", "luna-dev") to { appId, installationId, keyPath }.
+Never committed to a repo. keyPath must be chmod 600.
+`;
+}
+
+function mintHelp(): string {
+  return `cortex github-token mint <identity> — mint a short-lived (~1hr) installation access token
+
+Usage:
+  cortex github-token mint <identity> [--config <path>] [--json]
+
+Behavior:
+  - Signs a 10min App JWT (RS256) with the identity's configured private key.
+  - Exchanges it for a GitHub App installation access token.
+  - Prints the bare token to stdout (diagnostics on stderr) — intended for
+    command substitution: GH_TOKEN=$(cortex github-token mint atlas)
+
+Exit codes:
+  0    minted successfully
+  1    unknown identity / key not chmod 600 / GitHub API error
+  2    missing <identity> / bad flag
+`;
+}
+
+function listHelp(): string {
+  return `cortex github-token list — list configured identity names (no secrets)
+
+Usage:
+  cortex github-token list [--config <path>] [--json]
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+if (import.meta.main) {
+  const result = await dispatchGithubToken(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}

--- a/src/common/auth/__tests__/github-app-token.test.ts
+++ b/src/common/auth/__tests__/github-app-token.test.ts
@@ -1,0 +1,206 @@
+/**
+ * cortex#2396 — GitHub App installation-token minting.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { generateKeyPairSync, createVerify } from "node:crypto";
+import {
+  GithubAppTokenError,
+  loadGithubAppIdentities,
+  loadGithubAppIdentity,
+  mintInstallationToken,
+  mintTokenForIdentity,
+  signAppJwt,
+} from "../github-app-token";
+
+function decodeBase64url(input: string): string {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/").padEnd(
+    input.length + ((4 - (input.length % 4)) % 4),
+    "=",
+  );
+  return Buffer.from(padded, "base64").toString("utf8");
+}
+
+// PKCS#1 ("RSA PRIVATE KEY") — the format GitHub actually ships, so the
+// fixture exercises the real code path rather than a PKCS#8 stand-in.
+const { privateKey: TEST_PRIVATE_KEY_PEM, publicKey: TEST_PUBLIC_KEY_PEM } = generateKeyPairSync(
+  "rsa",
+  {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  },
+);
+
+describe("signAppJwt", () => {
+  test("produces a header.payload.signature JWT with iss=appId", () => {
+    const jwt = signAppJwt("4391087", TEST_PRIVATE_KEY_PEM, 1_800_000_000);
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+
+    const header = JSON.parse(decodeBase64url(parts[0] ?? ""));
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+
+    const payload = JSON.parse(decodeBase64url(parts[1] ?? ""));
+    expect(payload.iss).toBe("4391087");
+    expect(payload.iat).toBe(1_800_000_000 - 60);
+    expect(payload.exp).toBe(1_800_000_000 + 600);
+  });
+
+  test("signature verifies against the matching public key", () => {
+    const jwt = signAppJwt("4391087", TEST_PRIVATE_KEY_PEM, 1_800_000_000);
+    const [headerB64, payloadB64, sigB64] = jwt.split(".");
+    const signingInput = `${headerB64}.${payloadB64}`;
+    const signature = Buffer.from(
+      (sigB64 ?? "").replace(/-/g, "+").replace(/_/g, "/"),
+      "base64",
+    );
+
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(signingInput);
+    verifier.end();
+    expect(verifier.verify(TEST_PUBLIC_KEY_PEM, signature)).toBe(true);
+  });
+
+  test("a tampered payload fails verification", () => {
+    const jwt = signAppJwt("4391087", TEST_PRIVATE_KEY_PEM, 1_800_000_000);
+    const [headerB64, , sigB64] = jwt.split(".");
+    const tamperedPayload = Buffer.from(JSON.stringify({ iss: "9999999", iat: 0, exp: 999999999999 }))
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const signingInput = `${headerB64}.${tamperedPayload}`;
+    const signature = Buffer.from((sigB64 ?? "").replace(/-/g, "+").replace(/_/g, "/"), "base64");
+
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(signingInput);
+    verifier.end();
+    expect(verifier.verify(TEST_PUBLIC_KEY_PEM, signature)).toBe(false);
+  });
+});
+
+describe("mintInstallationToken", () => {
+  test("returns the token + expiry on a 2xx response", async () => {
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.github.com/app/installations/148931136/access_tokens");
+      expect((init?.headers as Record<string, string>).Authorization).toMatch(/^Bearer /);
+      return new Response(
+        JSON.stringify({ token: "ghs_abc123", expires_at: "2026-07-26T01:00:00Z" }),
+        { status: 201 },
+      );
+    }) as typeof fetch;
+
+    const result = await mintInstallationToken({
+      appId: "4391087",
+      installationId: "148931136",
+      privateKeyPem: TEST_PRIVATE_KEY_PEM,
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ token: "ghs_abc123", expiresAt: "2026-07-26T01:00:00Z" });
+  });
+
+  test("throws GithubAppTokenError on a non-2xx response", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ message: "Bad credentials" }), {
+        status: 401,
+      })) as unknown as typeof fetch;
+
+    await expect(
+      mintInstallationToken({
+        appId: "4391087",
+        installationId: "148931136",
+        privateKeyPem: TEST_PRIVATE_KEY_PEM,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(GithubAppTokenError);
+  });
+
+  test("throws GithubAppTokenError when the response body is missing token/expires_at", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({}), { status: 201 })) as unknown as typeof fetch;
+
+    await expect(
+      mintInstallationToken({
+        appId: "4391087",
+        installationId: "148931136",
+        privateKeyPem: TEST_PRIVATE_KEY_PEM,
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/missing token\/expires_at/);
+  });
+});
+
+describe("identity config", () => {
+  let dir: string;
+  let configPath: string;
+  let keyPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "github-app-token-"));
+    keyPath = join(dir, "atlas.pem");
+    writeFileSync(keyPath, TEST_PRIVATE_KEY_PEM, "utf8");
+    chmodSync(keyPath, 0o600);
+
+    configPath = join(dir, "apps.yaml");
+    writeFileSync(
+      configPath,
+      `atlas:\n  appId: "4391087"\n  installationId: "148931136"\n  keyPath: "${keyPath}"\n`,
+      "utf8",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("loadGithubAppIdentities parses a valid file", () => {
+    const identities = loadGithubAppIdentities(configPath);
+    expect(identities).toEqual({
+      atlas: { appId: "4391087", installationId: "148931136", keyPath },
+    });
+  });
+
+  test("loadGithubAppIdentity returns the named entry", () => {
+    expect(loadGithubAppIdentity("atlas", configPath)).toEqual({
+      appId: "4391087",
+      installationId: "148931136",
+      keyPath,
+    });
+  });
+
+  test("loadGithubAppIdentity throws listing known identities when the name is unknown", () => {
+    expect(() => loadGithubAppIdentity("luna-dev", configPath)).toThrow(/unknown.*luna-dev.*atlas/s);
+  });
+
+  test("loadGithubAppIdentities throws when the file is missing", () => {
+    expect(() => loadGithubAppIdentities(join(dir, "does-not-exist.yaml"))).toThrow(
+      GithubAppTokenError,
+    );
+  });
+
+  test("loadGithubAppIdentities throws on malformed shape (missing installationId)", () => {
+    writeFileSync(configPath, `atlas:\n  appId: "4391087"\n  keyPath: "${keyPath}"\n`, "utf8");
+    expect(() => loadGithubAppIdentities(configPath)).toThrow(/malformed/);
+  });
+
+  test("mintTokenForIdentity refuses a key file that isn't chmod 600", async () => {
+    chmodSync(keyPath, 0o644);
+    await expect(mintTokenForIdentity("atlas", { configPath })).rejects.toThrow(/chmod 600/);
+  });
+
+  test("mintTokenForIdentity mints end-to-end given a valid identity + key", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({ token: "ghs_end2end", expires_at: "2026-07-26T01:00:00Z" }),
+        { status: 201 },
+      )) as unknown as typeof fetch;
+
+    const result = await mintTokenForIdentity("atlas", { configPath, fetchImpl });
+    expect(result).toEqual({ token: "ghs_end2end", expiresAt: "2026-07-26T01:00:00Z" });
+  });
+});

--- a/src/common/auth/__tests__/github-app-token.test.ts
+++ b/src/common/auth/__tests__/github-app-token.test.ts
@@ -173,6 +173,19 @@ describe("identity config", () => {
     });
   });
 
+  test("loadGithubAppIdentity throws on prototype-chain names instead of resolving Object.prototype members", () => {
+    // Adversarial review finding (cortex#2396 PR #2399): a bare `identities[name]`
+    // + truthy-check resolves "constructor"/"toString"/"__proto__" etc. to
+    // inherited Object.prototype members instead of throwing. Object.hasOwn
+    // closes this; pin it so it can't regress.
+    for (const name of ["constructor", "toString", "__proto__", "hasOwnProperty", "valueOf"]) {
+      expect(() => loadGithubAppIdentity(name, configPath)).toThrow(GithubAppTokenError);
+      expect(() => loadGithubAppIdentity(name, configPath)).toThrow(
+        new RegExp(`unknown GitHub App identity "${name}"`),
+      );
+    }
+  });
+
   test("loadGithubAppIdentity throws listing known identities when the name is unknown", () => {
     expect(() => loadGithubAppIdentity("luna-dev", configPath)).toThrow(/unknown.*luna-dev.*atlas/s);
   });

--- a/src/common/auth/github-app-token.ts
+++ b/src/common/auth/github-app-token.ts
@@ -1,0 +1,235 @@
+/**
+ * GitHub App installation-token minting (cortex#2396, vision#11).
+ *
+ * cortex is the sole runtime hosting the `atlas` and `luna-dev` bot
+ * identities (both are cortex agent bundles per `docs/design-arc-agent-bots.md`),
+ * so the minting capability lives here rather than in a separate ecosystem
+ * repo. Mirrors the shape of `cortex creds issue/revoke/rotate` (per-identity
+ * credential lifecycle) but for GitHub instead of NATS — same precedent,
+ * different wire.
+ *
+ * Flow: App ID + PKCS#1 RSA private key (`.pem`, chmod 600) + installation ID
+ * → sign a short-lived (10min) JWT (RS256) → exchange it for a ~1hr
+ * installation access token via the GitHub Apps REST API. The installation
+ * token is what a caller sets as `GH_TOKEN` for `gh`/`git` to act as the bot
+ * identity instead of the principal's own account.
+ *
+ * Uses `node:crypto` (not WebCrypto) deliberately — unlike
+ * `common/auth/cf-access-jwt.ts`, this module has no CF Worker portability
+ * requirement (it only ever runs in the Bun daemon / CLI), and `node:crypto`
+ * signs PKCS#1 PEM directly without a PKCS#1→PKCS#8 DER conversion step.
+ */
+
+import { createSign } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod/v4";
+import { expandTilde } from "../config/loader";
+import { enforceChmod600 } from "../config/file-permissions";
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+export class GithubAppTokenError extends Error {
+  /** Structured context (identity name, path, HTTP status, etc.) for logging. */
+  public readonly context?: Record<string, string>;
+
+  constructor(message: string, context?: Record<string, string | number>) {
+    super(message);
+    this.name = "GithubAppTokenError";
+    this.context = context
+      ? Object.fromEntries(Object.entries(context).map(([k, v]) => [k, String(v)]))
+      : undefined;
+  }
+}
+
+// =============================================================================
+// JWT signing (App-level auth)
+// =============================================================================
+
+function base64url(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Sign a GitHub App JWT (RS256). `iat` is backdated 60s to tolerate clock
+ * skew between this host and GitHub's, per GitHub's own documented
+ * recommendation; `exp` is capped at 10 minutes — GitHub rejects longer.
+ *
+ * @param nowSeconds Clock override (seconds since epoch) for deterministic tests.
+ */
+export function signAppJwt(appId: string, privateKeyPem: string, nowSeconds?: number): string {
+  const now = nowSeconds ?? Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = { iat: now - 60, exp: now + 600, iss: appId };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = signer.sign(privateKeyPem);
+
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+// =============================================================================
+// Installation-token exchange
+// =============================================================================
+
+export interface MintInstallationTokenOptions {
+  appId: string;
+  installationId: string;
+  privateKeyPem: string;
+  /** `fetch` override for tests (defaults to the global `fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Clock override (seconds since epoch) for deterministic tests. */
+  nowSeconds?: number;
+}
+
+export interface InstallationToken {
+  token: string;
+  /** ISO-8601 timestamp — GitHub caps installation tokens at ~1hr. */
+  expiresAt: string;
+}
+
+/**
+ * Exchange a freshly-signed App JWT for a short-lived installation access
+ * token. Fail-closed: any non-2xx response or a malformed body throws
+ * `GithubAppTokenError` rather than returning a partial/empty token.
+ */
+export async function mintInstallationToken(
+  opts: MintInstallationTokenOptions,
+): Promise<InstallationToken> {
+  const jwt = signAppJwt(opts.appId, opts.privateKeyPem, opts.nowSeconds);
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  const res = await doFetch(
+    `https://api.github.com/app/installations/${opts.installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new GithubAppTokenError(
+      `installation token exchange failed: ${res.status} ${res.statusText}`,
+      { status: res.status, body: body.slice(0, 500) },
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    throw new GithubAppTokenError("installation token response was not valid JSON");
+  }
+
+  const parsed = z
+    .object({ token: z.string().min(1), expires_at: z.string().min(1) })
+    .safeParse(data);
+  if (!parsed.success) {
+    throw new GithubAppTokenError("installation token response missing token/expires_at");
+  }
+
+  return { token: parsed.data.token, expiresAt: parsed.data.expires_at };
+}
+
+// =============================================================================
+// Identity config — ~/.config/metafactory/github-apps/apps.yaml
+// =============================================================================
+
+const GithubAppIdentitySchema = z.object({
+  appId: z.string().min(1),
+  installationId: z.string().min(1),
+  /** Path to the PKCS#1 private key (`.pem`). Tilde-expanded, must be chmod 600. */
+  keyPath: z.string().min(1),
+});
+
+export type GithubAppIdentityConfig = z.infer<typeof GithubAppIdentitySchema>;
+
+const GithubAppIdentitiesFileSchema = z.record(z.string().min(1), GithubAppIdentitySchema);
+
+export const DEFAULT_GITHUB_APP_IDENTITIES_PATH = "~/.config/metafactory/github-apps/apps.yaml";
+
+/**
+ * Load the full identity map. Deliberately NOT baked into cortex's main
+ * `AgentSchema`/`agents.d/` fragment system yet (cortex#2396 scopes this to
+ * the minting capability only) — a flat, principal-owned YAML file outside
+ * any committed path, consistent with compass-core's leak policy: App IDs /
+ * installation IDs / key paths are config-driven, never hardcoded.
+ */
+export function loadGithubAppIdentities(
+  configPath: string = DEFAULT_GITHUB_APP_IDENTITIES_PATH,
+): Record<string, GithubAppIdentityConfig> {
+  const path = expandTilde(configPath);
+  if (!existsSync(path)) {
+    throw new GithubAppTokenError(`no GitHub App identities configured — expected ${path}`, {
+      path,
+    });
+  }
+  const raw: unknown = parseYaml(readFileSync(path, "utf8"));
+  const parsed = GithubAppIdentitiesFileSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new GithubAppTokenError(`malformed GitHub App identities file at ${path}`, {
+      path,
+      issues: parsed.error.issues.map((i) => i.message).join("; "),
+    });
+  }
+  return parsed.data;
+}
+
+export function loadGithubAppIdentity(
+  name: string,
+  configPath: string = DEFAULT_GITHUB_APP_IDENTITIES_PATH,
+): GithubAppIdentityConfig {
+  const identities = loadGithubAppIdentities(configPath);
+  const identity = identities[name];
+  if (!identity) {
+    const known = Object.keys(identities).join(", ") || "(none)";
+    throw new GithubAppTokenError(`unknown GitHub App identity "${name}" — configured: ${known}`, {
+      name,
+    });
+  }
+  return identity;
+}
+
+// =============================================================================
+// End-to-end convenience: identity name → installation token
+// =============================================================================
+
+export interface MintTokenForIdentityOptions {
+  configPath?: string;
+  fetchImpl?: typeof fetch;
+  nowSeconds?: number;
+}
+
+/**
+ * Load an identity by name, read + permission-check its private key, and
+ * mint an installation token in one call. This is the entry point runner
+ * wiring (cortex#2396's tracked follow-up) and the CLI both use.
+ */
+export async function mintTokenForIdentity(
+  name: string,
+  opts: MintTokenForIdentityOptions = {},
+): Promise<InstallationToken> {
+  const identity = loadGithubAppIdentity(name, opts.configPath);
+  const keyPath = expandTilde(identity.keyPath);
+  enforceChmod600(keyPath); // throws if the key isn't owner-only readable
+  const privateKeyPem = readFileSync(keyPath, "utf8");
+
+  return mintInstallationToken({
+    appId: identity.appId,
+    installationId: identity.installationId,
+    privateKeyPem,
+    fetchImpl: opts.fetchImpl,
+    nowSeconds: opts.nowSeconds,
+  });
+}

--- a/src/common/auth/github-app-token.ts
+++ b/src/common/auth/github-app-token.ts
@@ -146,9 +146,19 @@ export async function mintInstallationToken(
 // Identity config — ~/.config/metafactory/github-apps/apps.yaml
 // =============================================================================
 
+// GitHub App IDs and installation IDs are always numeric on the wire — both
+// get interpolated straight into the JWT `iss` claim and the installation-
+// token URL path. Constraining the format here catches a config typo/paste
+// error at load time instead of surfacing it as a confusing GitHub 404/401,
+// and keeps the interpolation points working only with values that can
+// never contain path or claim-breaking characters.
+const NUMERIC_ID_REGEX = /^\d+$/;
+
 const GithubAppIdentitySchema = z.object({
-  appId: z.string().min(1),
-  installationId: z.string().min(1),
+  appId: z.string().regex(NUMERIC_ID_REGEX, "appId must be numeric (GitHub App ID)"),
+  installationId: z
+    .string()
+    .regex(NUMERIC_ID_REGEX, "installationId must be numeric (GitHub installation ID)"),
   /** Path to the PKCS#1 private key (`.pem`). Tilde-expanded, must be chmod 600. */
   keyPath: z.string().min(1),
 });

--- a/src/common/auth/github-app-token.ts
+++ b/src/common/auth/github-app-token.ts
@@ -201,14 +201,23 @@ export function loadGithubAppIdentity(
   configPath: string = DEFAULT_GITHUB_APP_IDENTITIES_PATH,
 ): GithubAppIdentityConfig {
   const identities = loadGithubAppIdentities(configPath);
-  const identity = identities[name];
-  if (!identity) {
+  // Object.hasOwn (not `identities[name]` + truthy-check) — a bare index
+  // lookup on a plain object resolves prototype-chain members for magic
+  // names like "constructor"/"toString"/"__proto__", silently defeating
+  // this fail-closed check instead of throwing the intended clear error
+  // (adversarial review finding, cortex#2396 PR #2399).
+  if (!Object.hasOwn(identities, name)) {
     const known = Object.keys(identities).join(", ") || "(none)";
     throw new GithubAppTokenError(`unknown GitHub App identity "${name}" — configured: ${known}`, {
       name,
     });
   }
-  return identity;
+  // `noUncheckedIndexedAccess` types this `| undefined`; TS doesn't connect
+  // `Object.hasOwn` to index-signature narrowing. Safe: the hasOwn check
+  // above guarantees this is a genuine own property that passed
+  // GithubAppIdentitySchema validation on load.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return identities[name]!;
 }
 
 // =============================================================================

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -336,6 +336,7 @@ import { dispatchQuickstart } from "./cli/cortex/commands/quickstart";
 import { dispatchPlugin } from "./cli/cortex/commands/plugin";
 import { dispatchConfig } from "./cli/cortex/commands/config";
 import { dispatchCreds } from "./cli/cortex/commands/creds";
+import { dispatchGithubToken } from "./cli/cortex/commands/github-token";
 import { dispatchStepUp } from "./cli/cortex/commands/stepup";
 // #1352 — `agents` + `migrate-config` were complete standalone `import.meta.main`
 // scripts, unreachable from the installed binary while docs
@@ -7020,6 +7021,23 @@ if (import.meta.main) {
     .helpOption(false)
     .action(async (args: string[]) => {
       const result = await dispatchCreds(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  // cortex#2396 (vision#11) — mint GitHub App installation tokens for
+  // cortex-hosted bot identities (atlas, luna-dev). Same passthrough shape
+  // as `creds`: `dispatchGithubToken` owns its own arg parsing.
+  program
+    .command("github-token")
+    .description("Mint GitHub App installation tokens for cortex-hosted bot identities")
+    .argument("[args...]", "github-token subcommand + flags (see `cortex github-token --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchGithubToken(args);
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
       process.exit(result.exitCode);


### PR DESCRIPTION
## Summary

- `src/common/auth/github-app-token.ts` — App ID + PKCS#1 private key + installation ID → signed JWT (RS256, `node:crypto`) → short-lived (~1hr) GitHub App installation access token. `node:crypto` (not WebCrypto) is deliberate: unlike `cf-access-jwt.ts`, this module never runs in a CF Worker, and `node:crypto` signs PKCS#1 PEM directly without a PKCS#1→PKCS#8 DER conversion.
- `src/cli/cortex/commands/github-token.ts` — `cortex github-token mint <identity>` / `list`, mirroring `cortex creds`' subcommand-spec/JSON-envelope conventions. `mint` prints the bare token on stdout (diagnostics on stderr) for command-substitution capture: `GH_TOKEN=$(cortex github-token mint atlas)`.
- Identity config: `~/.config/metafactory/github-apps/apps.yaml` (App ID / installation ID / key path per identity) — never committed; the private key path must be chmod 600 (enforced via the existing `enforceChmod600` gate, same one NATS creds and the operator signing key already use).
- Registered in `src/cortex.ts` next to `creds`.

## Why cortex, not compass-core

vision#11 says the identity *standard* is written up in compass-core — but the actual minting code belongs here, since cortex is the sole runtime hosting both bot identities (Atlas and Luna-dev are cortex agent bundles per `docs/design-arc-agent-bots.md`, which also establishes the precedent this mirrors: `cortex creds issue/revoke/rotate` for NATS, same shape for GitHub).

## Scope

Deliberately limited to the minting capability + CLI. **Not included** (real, separate follow-up, tracked on this issue): auto-injecting `GH_TOKEN` per session when cortex spawns an Atlas/luna-dev session (touches dispatch/session-spawn code, deserves its own PR + review).

## Test plan

- [x] `bun test src/common/auth/__tests__/github-app-token.test.ts` — 13 tests: JWT structure/signature verification (real RSA keypair, tamper detection), installation-token exchange success/failure paths, identity config load/validation/chmod-600 enforcement.
- [x] `bun test src/cli/cortex/commands/__tests__/github-token.test.ts` — 12 tests: arg parsing, mint (text + `--json`), list (no secrets in output), dispatch routing, usage errors.
- [x] `bunx tsc --noEmit` — clean.
- [x] `bunx eslint` on all changed files — clean.
- [x] Manually verified end-to-end against the real GitHub Apps (outside this PR, via a scratch script) — a JWT signed with the real Atlas private key, exchanged for a real installation token, successfully posted a comment on vision#11 attributed to `metafactory-atlas[bot]`.

Closes #2396
Refs: the-metafactory/vision#11
