### PR TITLE
fix(stack): code capability grants the Write tool (create new files) (#2331 finding 8)

### DIFF
--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -28,6 +28,7 @@ import {
   CODE_GH_ISSUE_VERBS,
   type ScaffoldInputs,
 } from "../stack-lib";
+import { NetworkClaudeSchema } from "../../../../common/types/config";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -413,6 +414,37 @@ describe("renderScaffold — code capability (cortex#2331 7a)", () => {
     const ghRule = parsed.claude?.bashAllowlist?.rules.find((r) => r.pattern.startsWith("^gh"));
     expect(ghRule).toBeDefined();
     expect(ghRule?.repos).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // cortex#2331 finding 8 — the `code` capability grants the Write tool
+  // ---------------------------------------------------------------------------
+
+  test("(finding 8, a) code scaffold does NOT disallow Write (grants file creation)", () => {
+    const files = renderScaffold({ ...base, capabilities: ["chat", "code"], grantedRepos: ["the-metafactory/cortex"] });
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    const parsed = parseYaml(system?.contents ?? "") as { claude?: { disallowedTools?: string[] } };
+    expect(parsed.claude?.disallowedTools).toEqual([]);
+    expect(parsed.claude?.disallowedTools).not.toContain("Write");
+  });
+
+  test("(finding 8, b) chat-only scaffold STILL disallows Write (unchanged floor)", () => {
+    const files = renderScaffold(base);
+    const system = files.find((f) => f.relPath === "system/system.yaml");
+    const parsed = parseYaml(system?.contents ?? "") as { claude?: { disallowedTools?: string[] } };
+    expect(parsed.claude?.disallowedTools).toEqual(["Write"]);
+    expect(parsed.claude?.disallowedTools).toContain("Write");
+  });
+
+  test("(finding 8, c) both scaffolds' claude block parses against the config schema", () => {
+    for (const caps of [["chat"], ["chat", "code"]]) {
+      const files = renderScaffold({ ...base, capabilities: caps, grantedRepos: ["the-metafactory/cortex"] });
+      const system = files.find((f) => f.relPath === "system/system.yaml");
+      const parsed = parseYaml(system?.contents ?? "") as { claude?: unknown };
+      // The `claude` mapping (allowedTools/disallowedTools/bashAllowlist shape)
+      // must satisfy the security-override schema after the finding-8 change.
+      expect(() => NetworkClaudeSchema.parse(parsed.claude)).not.toThrow();
+    }
   });
 });
 

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -525,6 +525,35 @@ function renderBashAllowlistYaml(allowlist: BashAllowlist): string {
 }
 
 /**
+ * cortex#2331 finding 8 — the `claude.disallowedTools` block for a CHAT-only
+ * stack: `Write` stays disallowed (the default floor — a chat agent can Edit
+ * existing files but never CREATE new ones). Byte-for-byte the block that
+ * shipped before finding 8. Emitted indented to sit INSIDE the `claude:` mapping.
+ */
+function renderChatDisallowedTools(): string {
+  return "  disallowedTools:\n    - Write";
+}
+
+/**
+ * cortex#2331 finding 8 — the `claude.disallowedTools` block for a CODE-capable
+ * stack: `Write` is NOT disallowed, so the software-factory agent gets the Write
+ * tool and can CREATE new files (add a module/test), not only Edit existing
+ * ones. This is a capability-scoped widening (code stacks only) — the exact
+ * complement of 7a's code-capability bash allowlist. Chat scaffolds are
+ * unchanged (see `renderChatDisallowedTools`).
+ */
+function renderCodeDisallowedTools(): string {
+  return [
+    "  # cortex#2331 finding 8 — this stack declares the `code` capability, so `Write`",
+    "  # is NOT disallowed: a software-factory agent must CREATE new files (add a",
+    "  # module/test), not only Edit existing ones. Chat-only scaffolds keep",
+    "  # `disallowedTools: [Write]`. This is the capability-scoped complement of the",
+    "  # 7a code bash allowlist above.",
+    "  disallowedTools: []",
+  ].join("\n");
+}
+
+/**
  * Render the full born-aligned config-split skeleton for a new stack. Derived
  * from `docs/config-layout/` with the `research`/`andreas`/`ivy` placeholders
  * substituted for the real slug / principal / agent, keeping `<REPLACE_ME>`
@@ -544,9 +573,17 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   const bashAllowlistBlock = hasCode
     ? renderBashAllowlistYaml(codeCapabilityBashAllowlist(grantedRepos))
     : "";
+  // cortex#2331 finding 8 — the scaffolded system.yaml disallows the `Write`
+  // tool by default, which lets a chat agent Edit existing files but never
+  // CREATE new ones. A `code`-capability stack (software-factory tier) MUST be
+  // able to add a new module/test file, so a code scaffold DROPS `Write` from
+  // `disallowedTools` (grants the tool). Chat-only scaffolds are UNCHANGED —
+  // they keep `disallowedTools: [Write]` exactly as today. Same seam as 7a's
+  // bash allowlist: the capability, not the global floor, carries the widening.
+  const disallowedToolsBlock = hasCode ? renderCodeDisallowedTools() : renderChatDisallowedTools();
 
   return [
-    { relPath: "system/system.yaml", contents: systemYaml(slug, seedPath, bashAllowlistBlock) },
+    { relPath: "system/system.yaml", contents: systemYaml(slug, seedPath, bashAllowlistBlock, disallowedToolsBlock) },
     { relPath: "surfaces/surfaces.yaml", contents: surfacesYaml(agentId, stackId) },
     { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath, hasCode) },
     { relPath: `${slug}.yaml`, contents: pointerYaml(slug) },
@@ -554,7 +591,12 @@ export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
   ];
 }
 
-function systemYaml(slug: string, seedPath: string, bashAllowlistBlock: string): string {
+function systemYaml(
+  slug: string,
+  seedPath: string,
+  bashAllowlistBlock: string,
+  disallowedToolsBlock: string,
+): string {
   // The cross-cutting substrate layer — substituted from
   // docs/config-layout/system/system.yaml. NO active `identity:` block: the
   // authoritative, auto-provisioned signing identity is per-stack and lives in
@@ -575,8 +617,7 @@ claude:
   asyncTimeoutMs: 900000
   additionalArgs: []
   allowedTools: []
-  disallowedTools:
-    - Write
+${disallowedToolsBlock}
 ${bashAllowlistBlock === "" ? "" : bashAllowlistBlock + "\n"}  # workspaceDir — the dispatched CC session's cwd when no allowedDirs/
   # dirRestrictions resolve one (a bare stack — cortex#2097). Scoped to this
   # stack so its dispatched sessions never inherit the daemon's own cwd


### PR DESCRIPTION
Code-capability stacks now grant the Write tool (create new files) — the completion of the software-factory loop (#2331 finding 8, principal-approved).

## Problem
The scaffolded system.yaml shipped `disallowedTools: [Write]` for every stack, so even a `code`-capability agent could Edit existing files but not CREATE new ones — a coding agent that can't add a module/test isn't really a software factory.

## Fix (mirrors the 7a hasCode seam)
`renderScaffold` gates a `disallowedToolsBlock` on `hasCode`: a code scaffold emits `disallowedTools: []` (Write available); a chat scaffold keeps `disallowedTools: [Write]` unchanged. Write is the only entry that differs by capability.

## Scope
Widens exactly one thing for code stacks only — the Write tool. No bash/gh verbs (7a handled those), no schema change, no runtime-enforcement change. Write stays governed by the session's allowedDirs/workspace cwd, so file creation is scoped to the stack's workspace, not arbitrary paths.

## Tests
3 added: code scaffold → disallowedTools == [] (no Write); chat scaffold → == [Write] (unchanged); both parse against the schema. `bun test stack-lib` → 43 pass, 0 fail. tsc + eslint clean. Chat `system.yaml` rendered from this branch vs origin/main → byte-identical (verified).

Closes #2331 finding 8.

Generated with Claude Code
