### PR TITLE
fix(manifest): strict arc/v1 migration — 4 of 5 validate violations (#2397)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,10 @@
 # arc-manifest.yaml -- cortex
 # See: https://github.com/the-metafactory/arc
 
+# Strict arc/v1 schema (cortex#2397). Declaring the canonical literal is what
+# lets `arc validate` certify this manifest; the deprecated `pai/v1` alias is
+# rejected in strict mode (arc#280).
+schema: arc/v1
 name: "cortex"
 # v4.0.0 BREAKING (cortex#436 R2.I/R2.G/R3) — the legacy principal-identity
 # config keys are no longer accepted: the top-level `operator:` block, the cloud
@@ -14,15 +18,41 @@ tier: community
 # Preview-scope description (cortex#2285 C1): states the supported envelope up
 # front so the registry listing sets expectations before anyone installs.
 description: "Layer-7 collaboration surface for the metafactory ecosystem (preview: single principal · Discord surface · macOS/Debian/container · federation experimental, unreleased)"
-authors:
-  - "Andreas Aastroem"
-  - "Jens-Christian Fischer"
+# SPDX identifier, matching LICENSE (GNU AGPL v3) and package.json's
+# "license": "AGPL-3.0-only". Required by strict arc/v1 (cortex#2397).
+license: "AGPL-3.0-only"
+# Singular `author` map (cortex#2397). Strict arc/v1 rejects the plural
+# `authors:` list shape — it is the shape behind arc's authors-list display bug
+# (arc#278/#275) — and requires exactly one `{ name, github }` maintainer.
+#
+# This is a SCHEMA change, not an attribution change. Co-author
+# Jens-Christian Fischer (github.com/jcfischer) is unchanged and remains
+# credited in README.md ("Authors:" line and the footer), which is the surface
+# that carries full attribution. The manifest field names the primary
+# maintainer contact only, because the schema admits exactly one.
+author:
+  name: "Andreas Aastroem"
+  github: "mellanon"
 repository: "the-metafactory/cortex"
 # Publish scope (cortex#2285 C1). `arc publish` resolves the namespace with
 # three-tier priority — --scope flag, then THIS key (`manifest.namespace`,
 # arc src/lib/publish.ts resolvePublishScope), then the account default from
 # /auth/me — so declaring it here makes `arc publish . --dry-run` pass with
 # no flag.
+#
+# DELIBERATELY BARE — do NOT add a leading `@` without reading cortex#2397.
+# `arc validate` currently flags this key (`must match ^@[a-z0-9-]+$`,
+# arc src/lib/validate-manifest.ts NAMESPACE_RE), but arc's own publish client
+# contradicts that rule: `ensurePackageExists` builds its URL as
+# encodeURIComponent(`@${scope}`) (arc src/lib/publish.ts) where `scope` is
+# THIS value verbatim from `resolvePublishScope`. Writing "@metafactory" here
+# would therefore request `%40%40metafactory` — a double sigil — and send the
+# sigil-bearing string as the create-package body's bare `namespace` field.
+# arc's README documents the bare form too ("namespace: my-namespace").
+# The sigil belongs to the DISPLAY/server representation, not to this key.
+# Resolving this is a cross-repo decision (fix arc's regex vs. fix arc's
+# publish path vs. change the published scope) — tracked in cortex#2397, held
+# for Andreas. This is the one violation intentionally left open.
 namespace: "metafactory"
 
 # Registry listing status — documented STOP-AND-ASK outcome (cortex#2285 C1).


### PR DESCRIPTION
Makes cortex's `arc-manifest.yaml` pass arc's strict `arc/v1` validator. **4 of the 5 violations are fixed. The 5th (`namespace`) is a cross-repo decision I deliberately did not make unilaterally — it needs Andreas. Details at the bottom.**

## Validator output

Before (`bun ~/Developer/arc/src/cli.ts validate .` against `origin/main`):

```
schema: is required and must be the literal 'arc/v1' (arc#280)
license: is required and must be a non-empty string
authors: the 'authors:' list shape is rejected — use the singular 'author: {name, github}' map (arc#278)
author: is required as a singular map { name, github }
namespace: when present must match ^@[a-z0-9-]+$; got "metafactory"
```

After (this branch):

```
namespace: when present must match ^@[a-z0-9-]+$; got "metafactory"
```

## Each violation and its fix

| # | Field | Problem | Fix |
|---|---|---|---|
| 1 | `schema` | missing | Added `schema: arc/v1`, the canonical literal strict mode requires (the `pai/v1` alias is rejected — arc#280). |
| 2 | `license` | missing | Added `license: "AGPL-3.0-only"`. Verified against both `LICENSE` (GNU AGPL v3) and `package.json`'s `"license": "AGPL-3.0-only"` — no new licensing claim, just the SPDX id the schema wants. |
| 3 | `authors` | plural list shape rejected | Removed. Strict arc/v1 rejects it at source: it is the shape behind arc's authors-list display bug (arc#278/#275). |
| 4 | `author` | singular map missing | Added `author: { name: "Andreas Aastroem", github: "mellanon" }`. |
| 5 | `namespace` | fails `^@[a-z0-9-]+$` | **Not fixed — see below.** |

### On #3/#4 — this is a schema change, not an attribution change

The schema admits exactly one `{ name, github }` maintainer, so the two-name list could not survive as-is. Co-author **Jens-Christian Fischer** (github.com/jcfischer) is **not** being de-credited: he remains in `README.md` on the `**Authors:**` line and in the footer, which is the surface that carries full attribution. A comment in the manifest records this so the narrowing does not read as a silent drop. Both handles were already public in `README.md` — no new identifiers introduced.

## STOP-AND-ASK: the `namespace` decision

I did not change this, and I recommend not changing it without deciding the question properly. **arc contradicts itself here**, so "just add the `@`" is not obviously safe:

- **arc's validator** requires the sigil: `NAMESPACE_RE = /^@[a-z0-9-]+$/` (`arc/src/lib/validate-manifest.ts`). Its unit tests assert `@metafactory` passes and `metafactory` fails, and the passing fixture uses `namespace: "@metafactory"`.
- **arc's publish client treats this key as the BARE scope and adds the sigil itself.** `resolvePublishScope` returns `manifest.namespace` verbatim; `ensurePackageExists` then builds the URL as ``encodeURIComponent(`@${scope}`)`` and errors with ``You do not own namespace @${scope}`` (`arc/src/lib/publish.ts`). With `"@metafactory"` here that requests `%40%40metafactory` — a **double sigil** — and posts the sigil-bearing string as the create-package body's bare `namespace` field.
- **arc's README documents the bare form**: `namespace: my-namespace`, resolved for display as `@my-namespace`. Several of arc's own publish tests use bare values (`manifest-ns`, `testns`).
- The sigil-bearing values that *do* appear in arc (`@metafactory` in registry-install / upgrade tests, `metafactory-api.ts`'s `` `${pkg.namespace}/${pkg.name}` ``) are **server response** shapes, not manifest inputs.

So the sigil appears to belong to the display/server representation, while this key is the bare scope. The current bare value was also a **deliberate, documented choice** (cortex#2285 C1) precisely so `arc publish . --dry-run` resolves with no flag.

**Options for Andreas:**

1. **Fix arc's regex** to accept the bare form (and/or accept both) — treats the validator as the thing that is wrong. Lowest blast radius for publishing.
2. **Fix arc's publish path** to stop prepending `@`, then set `@metafactory` here — makes the manifest sigil-bearing everywhere, but changes arc's publish client and must land in arc *first*.
3. **Change the published scope** — only if `@metafactory` is genuinely the intended registry identity and the double-sigil path is a bug nobody has hit yet.

Getting this wrong breaks publishing, so it stays as-is until that is settled. An inline comment now warns against "helpfully" adding the `@` without reading #2397.

## Side-effect check — no declaration changed semantics

Parsed both YAML versions and compared every top-level key as JSON:

```
ADDED      author        REMOVED    authors       ADDED  license   ADDED  schema
IDENTICAL  capabilities  IDENTICAL  dependencies  IDENTICAL  depends_on
IDENTICAL  owns          IDENTICAL  provides      IDENTICAL  scripts
IDENTICAL  description   IDENTICAL  name          IDENTICAL  namespace
IDENTICAL  repository    IDENTICAL  tier          IDENTICAL  type   IDENTICAL  version
```

- `capabilities`, `owns`, `depends_on`, `provides`, `scripts` — **byte-identical JSON**. No capability, dependency, or ownership declaration moved.
- **`owns:` and `scripts.purge` (from #2395) are untouched** — `owns` keys still `[config, state, userData]`, `scripts.purge` still `./scripts/purge.sh`.
- `version` unchanged at `6.12.0` — no release is being cut.
- The only deleted lines in the whole diff are the three `authors:` list lines.
- No cortex code reads the manifest's `authors` field (every `authors` hit in the tree is the unrelated `skip_authors` reflex config).

## Verification

- `bunx tsc --noEmit` → exit 0.
- `bun test` scoped to the arc-manifest readers (`release`, `pier-fragment`, `release-consumer`, `hook-compat-symlinks`) → **114 pass, 0 fail**. Full suite not run (large), per scope.
- Pre-push confidentiality scan → clean.

## Note on issue linkage

Deliberately **`Refs #2397`, not `Closes #2397`.** The issue's acceptance criteria require *zero* violations **and** the namespace question settled explicitly; one violation and that decision are still open. Auto-closing on merge would drop the pending cross-repo decision on the floor. Please close #2397 manually once the namespace call is made — or say the word and I will switch it to `Closes`.

Refs #2397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArLAsEG9JoXUzkrotpUgAU
