### PR TITLE
feat(bus/runner): mint + inject a per-session GitHub App identity for agents that declare one (#2406)

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -2944,3 +2944,158 @@ describe("persona allowedTools — EBH-7a dispatch-seam enforcement (cortex#2386
     await handler.shutdown();
   });
 });
+
+
+/**
+ * cortex#2406 (vision#11) — per-session GitHub App identity injection on the
+ * DIRECT dispatch path (`handleMessage` → handleSync/handleAsync/handleTeam).
+ *
+ * The bus-mediated path is covered separately in
+ * `runner/__tests__/dispatch-listener.test.ts`. BOTH need their own coverage:
+ * a single injection point would leave the other silently uncovered, which is
+ * exactly the coverage-drift class EBH-1e/1g hit twice for path-checking.
+ */
+describe("DispatchHandler — GitHub identity injection (cortex#2406)", () => {
+  /** An obvious placeholder — never a real credential (PUBLIC repo). */
+  const FAKE_MINTED_TOKEN = "ghs_EXAMPLE_PLACEHOLDER_NOT_A_REAL_TOKEN";
+
+  test("target agent with a declared identity gets a freshly-minted GH_TOKEN on its session env", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const mintedFor: string[] = [];
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+      githubEnvResolver: async (identityName) => {
+        mintedFor.push(identityName);
+        return { GH_TOKEN: FAKE_MINTED_TOKEN };
+      },
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "open a PR" }), {
+      id: "atlas",
+      displayName: "Atlas",
+      github: { identityName: "atlas" },
+    });
+
+    // Minted exactly once, for the declared identity, at dispatch time.
+    expect(mintedFor).toEqual(["atlas"]);
+    expect(optsLog()[0]?.agentEnv).toEqual({ GH_TOKEN: FAKE_MINTED_TOKEN });
+    await handler.shutdown();
+  });
+
+  test("OPT-IN: an agent with NO declared identity never mints and gets NO GitHub credential", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    let mintCalls = 0;
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+      githubEnvResolver: async () => {
+        mintCalls++;
+        return { GH_TOKEN: "should-never-be-minted" };
+      },
+    });
+
+    // `github` omitted entirely — the pre-#2406 agent shape.
+    await handler.handleMessage(adapter, makeMsg({ content: "hello" }), {
+      id: "holly",
+      displayName: "Holly",
+    });
+
+    // Absence is the DEFAULT, not an error: no mint attempted, no credential,
+    // and the session still runs exactly as it did before #2406.
+    expect(mintCalls).toBe(0);
+    expect(optsLog()).toHaveLength(1);
+    expect(optsLog()[0]?.agentEnv?.GH_TOKEN).toBeUndefined();
+    expect(adapter.sentMessages.map((m) => m.text)).toEqual([
+      "All good — here's your answer.",
+    ]);
+    await handler.shutdown();
+  });
+
+  test("FAIL CLOSED: mint failure refuses the dispatch — no session spawns, no ambient-credential fallback", async () => {
+    const { factory, optsLog, spawnCount } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+      githubEnvResolver: async () => {
+        throw new Error("installation token exchange failed: 401 Unauthorized");
+      },
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "open a PR" }), {
+      id: "atlas",
+      displayName: "Atlas",
+      github: { identityName: "atlas" },
+    });
+
+    // The load-bearing assertion: the session must NOT start. Starting it
+    // without GH_TOKEN would let `gh`/`git` silently fall back to whatever
+    // ambient credential the host has (the principal's own `gh auth`) — the
+    // exact identity leak this feature exists to close. An empty-string or
+    // stale token would be just as wrong, so we assert on "no spawn at all".
+    expect(spawnCount()).toBe(0);
+    expect(optsLog()).toHaveLength(0);
+
+    // ...and it is AUDIBLE: the principal is told, rather than left to puzzle
+    // over a confusing downstream `gh` auth error.
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]?.text).toMatch(/GitHub identity credential/i);
+    await handler.shutdown();
+  });
+
+  test("the MINTED token wins over a static env.GH_TOKEN (runtime half of the load-time reject)", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+      githubEnvResolver: async () => ({ GH_TOKEN: FAKE_MINTED_TOKEN }),
+    });
+
+    // `AgentSchema` refuses this pair at config LOAD (cortex#2406), so it can
+    // only arrive from a non-schema caller. If the static value won, the
+    // session would run on a long-lived credential while the config claims a
+    // short-lived bot identity — silent identity confusion, unauditable after
+    // the fact. The minted value must win.
+    await handler.handleMessage(adapter, makeMsg({ content: "open a PR" }), {
+      id: "atlas",
+      displayName: "Atlas",
+      github: { identityName: "atlas" },
+      env: { GH_TOKEN: "static-long-lived-value-that-must-not-win" },
+    });
+
+    expect(optsLog()[0]?.agentEnv?.GH_TOKEN).toBe(FAKE_MINTED_TOKEN);
+    await handler.shutdown();
+  });
+
+  test("a non-colliding env: passthrough survives alongside the minted token", async () => {
+    const { factory, optsLog } = makeStubFactory([successResult()]);
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+      githubEnvResolver: async () => ({ GH_TOKEN: FAKE_MINTED_TOKEN }),
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "open a PR" }), {
+      id: "atlas",
+      displayName: "Atlas",
+      github: { identityName: "atlas" },
+      env: { GOOGLE_APPLICATION_CREDENTIALS: "/tmp/sa.json" },
+    });
+
+    expect(optsLog()[0]?.agentEnv).toEqual({
+      GH_TOKEN: FAKE_MINTED_TOKEN,
+      GOOGLE_APPLICATION_CREDENTIALS: "/tmp/sa.json",
+    });
+    await handler.shutdown();
+  });
+});

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -71,6 +71,9 @@ import {
   handleOrchestratorCommand,
   ORCHESTRATOR_CAPABILITY,
 } from "../runner/orchestrator-command";
+// cortex#2406 (vision#11) — mint a fresh GH_TOKEN for the target agent's
+// declared GitHub App identity, if any.
+import { resolveGithubEnvForAgent } from "../common/auth/github-app-token";
 import { join } from "path";
 
 /** Read version from arc-manifest.yaml (cached after first read). */
@@ -155,6 +158,17 @@ interface DispatchTargetAgent {
    * injected receiving-stack-authoritatively in the dispatch-listener.
    */
   env?: Record<string, string>;
+  /**
+   * cortex#2406 (vision#11) — the agent's declared GitHub App identity (see
+   * `AgentSchema.github`). Carried per-target-agent (narrowest scope). When
+   * set, `handleMessage` mints a FRESH installation token for this identity
+   * before routing to the sync/async/team handlers and merges `GH_TOKEN`
+   * onto the env object passed as their `agentEnv` argument — never a
+   * boot-time snapshot, since installation tokens expire in ~1hr. Applies to
+   * the DIRECT dispatch paths; the canonical bus-mediated path mints via its
+   * own `agentGithubIdentityById` map in the dispatch-listener.
+   */
+  github?: { identityName: string };
 }
 
 export interface DispatchHandlerOpts {
@@ -191,6 +205,15 @@ export interface DispatchHandlerOpts {
    * binary. Mirrors the `ClaudeCodeHarness` factory-injection pattern.
    */
   ccSessionFactory?: CCSessionFactory;
+  /**
+   * cortex#2406 (vision#11) — Optional GitHub identity env resolver
+   * injection. Default calls the real `resolveGithubEnvForAgent` (mints a
+   * live installation token via the GitHub Apps API). Tests inject a
+   * deterministic fake (resolve for the happy path, reject for the
+   * fail-closed path) without touching real GitHub credentials or network.
+   * Mirrors the `ccSessionFactory` injection pattern immediately above.
+   */
+  githubEnvResolver?: (identityName: string) => Promise<Record<string, string>>;
   /**
    * cortex#360 — Optional chat-path retry tuning. Default 3 total
    * attempts (initial + 2 retries) bounded by a 20-minute wall-clock
@@ -294,6 +317,11 @@ export class DispatchHandler extends EventEmitter {
    * factory (only the `CCSession` instance is fresh per attempt).
    */
   private readonly ccSessionFactory: CCSessionFactory;
+  /**
+   * cortex#2406 (vision#11) — GitHub identity env resolver. Default calls
+   * the real `resolveGithubEnvForAgent`. Tests inject a fake.
+   */
+  private readonly githubEnvResolver: (identityName: string) => Promise<Record<string, string>>;
   /** cortex#360 — Chat-path retry config (maxAttempts + wall-clock cap). */
   private readonly retryMaxAttempts: number;
   private readonly retryMaxTotalMs: number;
@@ -331,6 +359,7 @@ export class DispatchHandler extends EventEmitter {
     this.runtime = opts.runtime;
     this.systemEventSource = opts.systemEventSource;
     this.ccSessionFactory = opts.ccSessionFactory ?? ((sessionOpts) => new CCSession(sessionOpts));
+    this.githubEnvResolver = opts.githubEnvResolver ?? ((name) => resolveGithubEnvForAgent(name));
     this.retryMaxAttempts = opts.retry?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
     this.retryMaxTotalMs = opts.retry?.maxTotalMs ?? DEFAULT_RETRY_MAX_TOTAL_MS;
     this.stack = opts.stack;
@@ -1175,16 +1204,43 @@ export class DispatchHandler extends EventEmitter {
         );
       }
 
+      // cortex#2406 (vision#11) — mint a FRESH GH_TOKEN for the target agent's
+      // declared GitHub identity, if any, right before routing. Never a
+      // boot-time snapshot (installation tokens expire in ~1hr). FAIL CLOSED:
+      // a mint failure refuses the dispatch rather than starting a session
+      // without its declared identity's token — silently proceeding could let
+      // `gh`/`git` fall back to whatever ambient credential the host has
+      // (the principal's own `gh auth`), the exact identity leak this exists
+      // to close.
+      let effectiveAgentEnv = targetAgent?.env;
+      if (targetAgent?.github?.identityName !== undefined) {
+        try {
+          const githubEnv = await this.githubEnvResolver(targetAgent.github.identityName);
+          effectiveAgentEnv = { ...githubEnv, ...targetAgent?.env };
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          console.error(
+            `dispatch-handler: GH_TOKEN mint FAILED for agent=${targetAgent.id} ` +
+              `identity=${targetAgent.github.identityName} — refusing dispatch: ${detail}`,
+          );
+          await adapter.postResponse(
+            { instanceId: msg.instanceId, channelId: msg.channelId, threadId: msg.threadId },
+            "I can't process that message right now — my GitHub identity credential couldn't be minted.",
+          );
+          return;
+        }
+      }
+
       // 12. Route by mode
       switch (parsed.mode) {
         case "async":
-          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, readOnlyDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
+          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, readOnlyDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, effectiveAgentEnv);
           break;
         case "team":
-          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, readOnlyDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
+          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, readOnlyDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, effectiveAgentEnv);
           break;
         default:
-          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, readOnlyDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, targetAgent?.env);
+          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, readOnlyDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveChannel, effectiveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants, effectiveAllowedTools, effectiveAdditionalArgs, mcpGrants, effectiveAgentEnv);
           break;
       }
     } catch (error) {

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -1216,7 +1216,15 @@ export class DispatchHandler extends EventEmitter {
       if (targetAgent?.github?.identityName !== undefined) {
         try {
           const githubEnv = await this.githubEnvResolver(targetAgent.github.identityName);
-          effectiveAgentEnv = { ...githubEnv, ...targetAgent?.env };
+          // Spread order is load-bearing: the MINTED value goes LAST so it wins
+          // over any static `env.GH_TOKEN` in the passthrough map. `AgentSchema`
+          // already refuses that pair at config load (cortex#2406), so in
+          // practice this collision cannot reach here from config — this is the
+          // runtime half of that pairing, defending the non-schema callers
+          // (a test, a future direct constructor) the load-time check can't see.
+          // Getting the order backwards would silently run the session on a
+          // long-lived credential while the config claims a bot identity.
+          effectiveAgentEnv = { ...targetAgent.env, ...githubEnv };
         } catch (err) {
           const detail = err instanceof Error ? err.message : String(err);
           console.error(

--- a/src/common/auth/github-app-token.ts
+++ b/src/common/auth/github-app-token.ts
@@ -252,3 +252,26 @@ export async function mintTokenForIdentity(
     nowSeconds: opts.nowSeconds,
   });
 }
+
+/**
+ * cortex#2406 (vision#11) — the runner-wiring entry point. Given an agent's
+ * declared `AgentSchema.github.identityName` (or `undefined` for an agent
+ * with no GitHub identity), resolve the env map to merge onto that agent's
+ * session: `{ GH_TOKEN: <freshly minted token> }`, or `{}` when the agent
+ * has no declared identity.
+ *
+ * DELIBERATELY throws (does not catch) on mint failure — the caller
+ * (`dispatch-handler.ts` / `dispatch-listener.ts`) MUST fail the dispatch
+ * closed rather than start a session without its declared identity's
+ * token. Swallowing the error here would make that fail-open by default,
+ * one `catch {}` away from silently letting `gh`/`git` fall back to
+ * whatever ambient credential the host has.
+ */
+export async function resolveGithubEnvForAgent(
+  identityName: string | undefined,
+  opts: MintTokenForIdentityOptions = {},
+): Promise<Record<string, string>> {
+  if (identityName === undefined) return {};
+  const { token } = await mintTokenForIdentity(identityName, opts);
+  return { GH_TOKEN: token };
+}

--- a/src/common/auth/github-app-token.ts
+++ b/src/common/auth/github-app-token.ts
@@ -266,6 +266,32 @@ export async function mintTokenForIdentity(
  * token. Swallowing the error here would make that fail-open by default,
  * one `catch {}` away from silently letting `gh`/`git` fall back to
  * whatever ambient credential the host has.
+ *
+ * ## `GH_TOKEN` only — deliberately NOT also `GITHUB_TOKEN`
+ *
+ * `gh` reads `GH_TOKEN` first and falls back to `GITHUB_TOKEN`, so setting the
+ * higher-priority name alone covers both `gh` and the `git` credential helper
+ * `gh auth setup-git` installs. cortex's own scoped-forge path already made
+ * this call — `runner/dev-consumer-boot.ts` sets exactly `GH_TOKEN` on the
+ * child env for every `gh` invocation — so matching it keeps ONE idiom.
+ *
+ * Setting both would also cost a second entry in the deny-by-default
+ * `ALLOWED_AGENT_ENV_KEYS` allowlist (`agent-env.ts`) — widening a reviewed
+ * trust-path control to buy an alias the higher-priority name already covers.
+ * If a substrate is ever found that reads ONLY `GITHUB_TOKEN`, add it then, as
+ * its own reviewed allowlist change with the motivating case named. That is
+ * precisely the process that file documents.
+ *
+ * ## The returned value is a LIVE CREDENTIAL — never log it
+ *
+ * Unlike every other value in an agent's `env:` passthrough map (a non-secret
+ * literal such as a path, or an unresolved `env:NAME` reference), this map's
+ * value is the secret ITSELF. It is handed straight to the session's process
+ * env and must not be logged, echoed into a bus event, or written to disk.
+ * `resolveAgentEnv` (session-settings.ts) upholds this — it logs keys and ref
+ * NAMES only, never values. Pinned by the containment suites in
+ * `runner/__tests__/agent-env-passthrough.test.ts` (the resolve layer) and
+ * `runner/__tests__/dispatch-listener.test.ts` (logs + bus event payloads).
  */
 export async function resolveGithubEnvForAgent(
   identityName: string | undefined,

--- a/src/common/config/__tests__/agent-env.test.ts
+++ b/src/common/config/__tests__/agent-env.test.ts
@@ -59,8 +59,12 @@ describe("AgentEnvSchema — accepts ONLY allowlisted keys", () => {
     expect(AgentEnvSchema.safeParse({}).success).toBe(true);
   });
 
-  test("ALLOWED_AGENT_ENV_KEYS is seeded with exactly GOOGLE_APPLICATION_CREDENTIALS", () => {
-    expect([...ALLOWED_AGENT_ENV_KEYS]).toEqual(["GOOGLE_APPLICATION_CREDENTIALS"]);
+  test("ALLOWED_AGENT_ENV_KEYS is seeded with exactly GOOGLE_APPLICATION_CREDENTIALS and GH_TOKEN", () => {
+    // cortex#2406 (vision#11) — GH_TOKEN added for per-dispatch-minted
+    // GitHub App installation tokens. See the module doc's "GH_TOKEN"
+    // paragraph for why a dynamically-minted value still fits this
+    // allowlist's destination-key-safety invariant.
+    expect([...ALLOWED_AGENT_ENV_KEYS]).toEqual(["GOOGLE_APPLICATION_CREDENTIALS", "GH_TOKEN"]);
   });
 });
 

--- a/src/common/config/agent-env.ts
+++ b/src/common/config/agent-env.ts
@@ -47,10 +47,21 @@
 // is simply not passed), which is the only safe direction for a trust-path
 // control.
 //
-// The allowlist is seeded with exactly one name — `GOOGLE_APPLICATION_CREDENTIALS`,
-// the credential PATH the `gws` Google Drive skill needs and the sole motivating
-// case today. {@link isAllowedAgentEnvKey} is the SINGLE SOURCE OF TRUTH for the
-// permit, used in BOTH places that must agree:
+// The allowlist is seeded with `GOOGLE_APPLICATION_CREDENTIALS` — the credential
+// PATH the `gws` Google Drive skill needs — plus `GH_TOKEN` (cortex#2406,
+// vision#11): a scoped, short-lived, revocable GitHub App installation token, not
+// a loader/shell/PATH hijack vector (it cannot execute code, redirect a process,
+// or widen the session's own authority the way the classes above do — its risk
+// plane is "misuse of a scoped API credential", a different concern from "session
+// hijack via env var shape"). UNLIKE every other allowlisted key, `GH_TOKEN`'s
+// value is NEVER a static config literal or `env:NAME` reference — it is minted
+// FRESH per dispatch by the caller (`dispatch-handler.ts` / `dispatch-listener.ts`,
+// via `resolveGithubEnvForAgent`) and merged into the env map at dispatch time.
+// The trigger for minting is a SEPARATE schema field
+// (`AgentSchema.github.identityName`), not this map's literal/ref grammar — this
+// allowlist only gates which DESTINATION keys may land on a child session's env,
+// independent of how the value was produced. {@link isAllowedAgentEnvKey} is the
+// SINGLE SOURCE OF TRUTH for the permit, used in BOTH places that must agree:
 //
 //   1. Config LOAD  — {@link AgentEnvSchema} rejects any non-allowlisted key at
 //      parse time, so a stack whose config declares an unblessed passthrough
@@ -114,9 +125,13 @@ export const AGENT_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
  * passthrough permits. Deny-by-default: a name not in this set is refused at
  * BOTH config load ({@link AgentEnvSchema}) and session build (`resolveAgentEnv`).
  *
- * Seeded with EXACTLY the one var a supported skill needs today:
+ * Seeded with:
  *   - `GOOGLE_APPLICATION_CREDENTIALS` — the service-account credential PATH the
  *     `gws` Google Drive skill reads.
+ *   - `GH_TOKEN` (cortex#2406, vision#11) — a freshly-minted, per-dispatch GitHub
+ *     App installation token for an agent with a declared `github.identityName`.
+ *     See the module doc's "GH_TOKEN" paragraph for why a dynamically-minted
+ *     value still fits this allowlist's destination-key-safety invariant.
  *
  * To permit a NEW variable, add its exact name here in a cortex PR and have a
  * reviewer weigh it against the session-hijack classes in the module doc. This
@@ -125,7 +140,7 @@ export const AGENT_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
  * (epic #2164 + the PR #2171 adversarial finding: the denylist was proven
  * un-completable).
  */
-export const ALLOWED_AGENT_ENV_KEYS = ["GOOGLE_APPLICATION_CREDENTIALS"] as const;
+export const ALLOWED_AGENT_ENV_KEYS = ["GOOGLE_APPLICATION_CREDENTIALS", "GH_TOKEN"] as const;
 
 /** O(1) membership backing for {@link isAllowedAgentEnvKey}. */
 const ALLOWED_AGENT_ENV_KEY_SET: ReadonlySet<string> = new Set(ALLOWED_AGENT_ENV_KEYS);

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -2123,3 +2123,59 @@ describe("ReflexTargetSchema (F-6 prompt XOR handler)", () => {
     expect(ReflexTargetSchema.safeParse({ ...reviewBase, capability: "code-review.elvish", review: true }).success).toBe(false);
   });
 });
+
+/**
+ * cortex#2406 (vision#11) — the OPT-IN GitHub App identity field, and the
+ * load-time rejection of the one configuration that would make an agent's
+ * effective GitHub identity ambiguous.
+ */
+describe("AgentSchema.github — per-agent GitHub App identity (cortex#2406)", () => {
+  test("OPT-IN: the field is optional — an agent that omits it parses unchanged", () => {
+    const parsed = AgentSchema.parse(minAgent());
+    // Absence is the DEFAULT, not an error. Every pre-#2406 agent config must
+    // keep parsing byte-identically and get NO GitHub credential at dispatch.
+    expect(parsed.github).toBeUndefined();
+  });
+
+  test("a declared identity name parses", () => {
+    const parsed = AgentSchema.parse(minAgent({ github: { identityName: "atlas" } }));
+    expect(parsed.github?.identityName).toBe("atlas");
+  });
+
+  test("an empty identity name is rejected (it would name no apps.yaml entry)", () => {
+    expect(() => AgentSchema.parse(minAgent({ github: { identityName: "" } }))).toThrow();
+  });
+
+  test("REJECTS declaring both github.identityName and a static env.GH_TOKEN", () => {
+    // Two different GitHub identities for one session: one minted per dispatch
+    // and short-lived, one static and long-lived. Whichever wins, the other is
+    // silently ignored and the agent's effective identity becomes unauditable.
+    // Refusing at load is the only honest resolution.
+    const result = AgentSchema.safeParse(
+      minAgent({
+        github: { identityName: "atlas" },
+        env: { GH_TOKEN: "env:SOME_LONG_LIVED_PAT" },
+      }),
+    );
+    expect(result.success).toBe(false);
+    const message = result.success ? "" : result.error.issues.map((i) => i.message).join(" ");
+    expect(message).toMatch(/two different GitHub identities/i);
+  });
+
+  test("github.identityName WITHOUT a colliding env key is fine (other passthroughs unaffected)", () => {
+    const parsed = AgentSchema.parse(
+      minAgent({
+        github: { identityName: "atlas" },
+        env: { GOOGLE_APPLICATION_CREDENTIALS: "/tmp/sa.json" },
+      }),
+    );
+    expect(parsed.github?.identityName).toBe("atlas");
+    expect(parsed.env?.GOOGLE_APPLICATION_CREDENTIALS).toBe("/tmp/sa.json");
+  });
+
+  test("a static env.GH_TOKEN alone still parses (no github block ⇒ no contradiction)", () => {
+    const parsed = AgentSchema.parse(minAgent({ env: { GH_TOKEN: "env:MY_PAT" } }));
+    expect(parsed.env?.GH_TOKEN).toBe("env:MY_PAT");
+    expect(parsed.github).toBeUndefined();
+  });
+});

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1064,6 +1064,30 @@ export const AgentSchema = z.object({
    * to the pre-#2133 session env).
    */
   env: AgentEnvSchema.optional(),
+  /**
+   * cortex#2406 (vision#11) — OPT-IN GitHub App identity for this agent.
+   * `identityName` names an entry in `~/.config/metafactory/github-apps/apps.yaml`
+   * (see `src/common/auth/github-app-token.ts`). When set, cortex mints a
+   * FRESH installation access token PER DISPATCH (never a boot-time snapshot
+   * — installation tokens expire in ~1hr, the daemon can run for days) and
+   * injects it as `GH_TOKEN` via the SAME `env:` passthrough mechanism above
+   * (`GH_TOKEN` is one of the names in `ALLOWED_AGENT_ENV_KEYS`), so this
+   * agent's `gh`/`git` calls act as its own bot identity (e.g. `atlas[bot]`)
+   * instead of the principal's own account.
+   *
+   * Fail-closed: if minting fails, the dispatch is REFUSED rather than
+   * starting the session without `GH_TOKEN` — silently proceeding could let
+   * `gh`/`git` fall back to whatever ambient credential the host has (the
+   * principal's own `gh auth`), which is the exact identity leak this field
+   * exists to close. See `dispatch-handler.ts` / `dispatch-listener.ts`.
+   *
+   * Additive: existing agents omit this key and are unaffected.
+   */
+  github: z
+    .object({
+      identityName: z.string().min(1),
+    })
+    .optional(),
 });
 // cortex#245 — the previous `at least one presence block` refine was
 // dropped to admit headless agents (bus-only participants with no

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1088,6 +1088,34 @@ export const AgentSchema = z.object({
       identityName: z.string().min(1),
     })
     .optional(),
+}).superRefine((agent, ctx) => {
+  // cortex#2406 — REJECT the contradictory pair at LOAD time. An agent that
+  // declares BOTH a `github.identityName` (⇒ cortex mints a fresh installation
+  // token and sets it as GH_TOKEN) AND a static `env.GH_TOKEN` passthrough has
+  // named two different GitHub identities for one session, and exactly one of
+  // them wins SILENTLY. That silence IS the identity-confusion class this field
+  // exists to close: the agent reads as acting like `atlas[bot]` while actually
+  // carrying whatever long-lived credential the static entry resolves to.
+  //
+  // Refusing the combination is the only honest resolution — any precedence
+  // rule still leaves a reader unable to tell which identity a session ran as.
+  // The runtime independently re-asserts the same outcome as defence-in-depth
+  // (both dispatch paths let the MINTED value win over the passthrough map), so
+  // a non-schema caller cannot reintroduce the ambiguity. Two layers, one
+  // answer — the same load-time/runtime pairing `agent-env.ts` documents.
+  if (agent.github !== undefined && agent.env?.GH_TOKEN !== undefined) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["env", "GH_TOKEN"],
+      message:
+        `agent declares BOTH 'github.identityName' (cortex mints a fresh, short-lived ` +
+        `GitHub App installation token per dispatch) AND a static 'env.GH_TOKEN' ` +
+        `passthrough. Those are two different GitHub identities for one session and ` +
+        `only one can win, leaving the agent's effective identity ambiguous. Declare ` +
+        `exactly ONE: keep 'github.identityName' for a short-lived, revocable bot ` +
+        `identity (preferred), or drop it and keep the static 'env.GH_TOKEN' reference.`,
+    });
+  }
 });
 // cortex#245 — the previous `at least one presence block` refine was
 // dropped to admit headless agents (bus-only participants with no

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -886,7 +886,7 @@ function resolvePrincipalId(
 }
 
 function targetAgentForDispatch(
-  agent: Pick<Agent, "id" | "displayName" | "persona" | "openOnboarding" | "openOnboardingAllowedTools" | "runtime" | "agentDisallowedTools" | "strictMcpConfig" | "env">,
+  agent: Pick<Agent, "id" | "displayName" | "persona" | "openOnboarding" | "openOnboardingAllowedTools" | "runtime" | "agentDisallowedTools" | "strictMcpConfig" | "env" | "github">,
   configDir: string,
 ): {
   id: string;
@@ -898,6 +898,7 @@ function targetAgentForDispatch(
   agentDisallowedTools?: string[];
   strictMcpConfig?: boolean;
   env?: Record<string, string>;
+  github?: { identityName: string };
 } {
   const expandedPersona = expandTilde(agent.persona);
   return {
@@ -933,6 +934,12 @@ function targetAgentForDispatch(
     // (resolved + CLAUDE_* re-denied in cc-session). The canonical bus-mediated
     // sync path is injected receiving-stack-authoritatively in the listener.
     ...(agent.env !== undefined && { env: agent.env }),
+    // cortex#2406 (vision#11) — carry the agent's declared GitHub identity so
+    // the DIRECT dispatch paths mint a fresh GH_TOKEN per dispatch (never a
+    // boot-time snapshot — see dispatch-handler.ts). Same asymmetry as `env`
+    // above: the bus-mediated path mints via its own boot-time-resolved
+    // agentGithubIdentityById map in the listener.
+    ...(agent.github !== undefined && { github: agent.github }),
   };
 }
 
@@ -3877,6 +3884,18 @@ export async function startCortex(
   for (const a of mergedAgents) {
     if (a.env !== undefined) agentEnvById.set(a.id, a.env);
   }
+  // cortex#2406 (vision#11) — BOOT snapshot of each agent's declared GitHub App
+  // IDENTITY NAME, keyed by agent id. Safe to snapshot at boot (unlike the
+  // minted TOKEN itself, which is never cached — see resolveGithubEnvForAgent):
+  // `identityName` is a small, non-expiring config string, not a credential.
+  // The dispatch-listener uses it to mint a FRESH installation token per
+  // dispatch, receiving-stack-authoritatively (same asymmetry as agentEnvById).
+  const agentGithubIdentityById = new Map<string, string>();
+  for (const a of mergedAgents) {
+    if (a.github?.identityName !== undefined) {
+      agentGithubIdentityById.set(a.id, a.github.identityName);
+    }
+  }
   const inferenceRegistry = createInferenceRegistry(
     config.inference ?? { providers: {}, profiles: {} },
   );
@@ -3902,6 +3921,7 @@ export async function startCortex(
     stack: derivedStack.stack,
     agentRuntimesById,
     agentEnvById,
+    agentGithubIdentityById,
     inferenceRegistry,
     ...(policyEngine !== undefined && { policyEngine }),
     trustResolver,

--- a/src/runner/__tests__/agent-env-passthrough.test.ts
+++ b/src/runner/__tests__/agent-env-passthrough.test.ts
@@ -285,3 +285,81 @@ describe("agent env reaches the session env via buildSessionEnv (start() composi
     expect(env.CLAUDE_CONFIG_DIR).toBe("/real/home");
   });
 });
+
+/**
+ * cortex#2406 (vision#11) — `GH_TOKEN` is the FIRST allowlisted key whose value
+ * is a live secret rather than a path or an unresolved `env:NAME` reference.
+ * `agent-env.ts` states the old invariant plainly: "a config dump shows
+ * `env:NAME` and never the secret value". A minted installation token voids
+ * that assumption, so the no-value-logging property `resolveAgentEnv` relies on
+ * has to be PINNED here rather than inherited.
+ */
+describe("resolveAgentEnv — GH_TOKEN value containment (cortex#2406)", () => {
+  /** Obviously fake, distinctive enough that a substring search can't collide. */
+  const SENTINEL = "ghs_SENTINEL_r3s0lv3_pr0be_NOT_A_REAL_TOKEN";
+
+  function captureStderr(): { dump: () => string; restore: () => void } {
+    const chunks: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: unknown): boolean => {
+      chunks.push(String(chunk));
+      return true;
+    };
+    return {
+      dump: () => chunks.join(""),
+      restore: () => {
+        process.stderr.write = orig;
+      },
+    };
+  }
+
+  test("a minted GH_TOKEN passes through as a literal and is never written to stderr", () => {
+    const cap = captureStderr();
+    let resolved: Record<string, string>;
+    try {
+      resolved = resolveAgentEnv({ GH_TOKEN: SENTINEL }, {});
+    } finally {
+      cap.restore();
+    }
+
+    // Positive control — it really did travel the resolve path, so the
+    // negative assertion below is not vacuous. A raw token is a LITERAL (it
+    // has no `env:` prefix), so it must pass through verbatim rather than
+    // being mistaken for an unresolvable secret reference and dropped.
+    expect(resolved.GH_TOKEN).toBe(SENTINEL);
+    expect(cap.dump()).not.toContain(SENTINEL);
+  });
+
+  test("even on the DROP paths, no value is echoed — only keys and ref NAMES", () => {
+    const cap = captureStderr();
+    try {
+      // A denied key, and a denied ref source, both carrying the sentinel as
+      // their VALUE. These are the paths that DO log — so they are exactly
+      // where a careless diagnostic would leak a credential.
+      resolveAgentEnv({ LD_PRELOAD: SENTINEL }, {});
+      resolveAgentEnv({ GH_TOKEN: "env:CLAUDE_CODE_OAUTH_TOKEN" }, {});
+      resolveAgentEnv({ GH_TOKEN: "env:UNSET_VAR_NAME" }, {});
+    } finally {
+      cap.restore();
+    }
+
+    const logged = cap.dump();
+    // The drop lines were emitted (the paths really ran)...
+    expect(logged).toContain("LD_PRELOAD");
+    expect(logged).toContain("GH_TOKEN");
+    // ...but no VALUE ever appears.
+    expect(logged).not.toContain(SENTINEL);
+  });
+
+  test("a resolved GH_TOKEN secret-ref value is not echoed either", () => {
+    const cap = captureStderr();
+    let resolved: Record<string, string>;
+    try {
+      resolved = resolveAgentEnv({ GH_TOKEN: "env:SOME_PAT" }, { SOME_PAT: SENTINEL });
+    } finally {
+      cap.restore();
+    }
+    expect(resolved.GH_TOKEN).toBe(SENTINEL);
+    expect(cap.dump()).not.toContain(SENTINEL);
+  });
+});

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -4159,3 +4159,202 @@ describe("dispatch-listener — GH_TOKEN identity minting (cortex#2406, vision#1
     await listener.stop();
   });
 });
+
+/**
+ * cortex#2406 (vision#11) — THE credential-containment regression suite.
+ *
+ * `GH_TOKEN` breaks an invariant the rest of the per-agent `env:` machinery
+ * was built on. Every OTHER value in that map is either a non-secret literal
+ * (a credential PATH) or an UNRESOLVED `env:NAME` reference — `agent-env.ts`
+ * says so explicitly: "a config dump shows `env:NAME` and never the secret
+ * value". A minted installation token is the secret ITSELF, travelling through
+ * the same pipes. Nothing downstream was written with that in mind, so the
+ * containment has to be PINNED rather than assumed.
+ *
+ * These tests fail loudly if any future change starts echoing the session env
+ * into a log line, a bus event, or an error path.
+ */
+describe("dispatch-listener — GitHub credential containment (cortex#2406)", () => {
+  /**
+   * A distinctive, obviously-fake sentinel. Never a real credential (PUBLIC
+   * repo). Distinctive enough that a substring search over captured output
+   * cannot collide with unrelated text.
+   */
+  const SENTINEL = "ghs_SENTINEL_c0nt41nm3nt_pr0be_NOT_A_REAL_TOKEN";
+
+  /** Capture EVERY console/stream sink a leak could plausibly reach. */
+  function captureAllOutput(): { dump: () => string; restore: () => void } {
+    const chunks: string[] = [];
+    const record = (...args: unknown[]): void => {
+      chunks.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
+    };
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    const origLog = console.log;
+    const origError = console.error;
+    const origWarn = console.warn;
+    const origInfo = console.info;
+    const origDebug = console.debug;
+
+    process.stdout.write = (chunk: unknown): boolean => {
+      chunks.push(String(chunk));
+      return true;
+    };
+    process.stderr.write = (chunk: unknown): boolean => {
+      chunks.push(String(chunk));
+      return true;
+    };
+    console.log = record;
+    console.error = record;
+    console.warn = record;
+    console.info = record;
+    console.debug = record;
+
+    return {
+      dump: () => chunks.join("\n"),
+      restore: () => {
+        process.stdout.write = origOut;
+        process.stderr.write = origErr;
+        console.log = origLog;
+        console.error = origError;
+        console.warn = origWarn;
+        console.info = origInfo;
+        console.debug = origDebug;
+      },
+    };
+  }
+
+  test("the minted token reaches the session env and NOTHING else — not logs, not event payloads", async () => {
+    const cortex = agentFixtureForRunner({ id: "cortex" });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: false,
+      agentGithubIdentityById: new Map([["cortex", "atlas"]]),
+      githubEnvResolver: async () => ({ GH_TOKEN: SENTINEL }),
+    });
+    await listener.start();
+
+    const cap = captureAllOutput();
+    try {
+      r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+      await settle(() => r.published);
+    } finally {
+      cap.restore();
+    }
+
+    // POSITIVE control: the token DID travel the intended path. Without this
+    // the negative assertions below could pass by simply never minting, which
+    // would make the whole suite vacuous.
+    expect(optsCaptured[0]?.agentEnv?.GH_TOKEN).toBe(SENTINEL);
+
+    // (1) Never logged. Covers cortex-trace stage lines, the dispatch-listener's
+    // own stderr diagnostics, and any console sink in the spawn path.
+    expect(cap.dump()).not.toContain(SENTINEL);
+
+    // (2) Never in a bus event payload. These envelopes cross to the
+    // dispatching stack and land in the audit trail — a credential riding one
+    // would outlive the session and escape the host entirely.
+    const publishedJson = JSON.stringify(r.published);
+    expect(publishedJson).not.toContain(SENTINEL);
+
+    // (3) Belt-and-braces: the envelopes did carry real content, so (2) is not
+    // passing merely because nothing was published.
+    expect(r.published.length).toBeGreaterThan(0);
+    expect(r.published.map((e) => e.type)).toContain("dispatch.task.completed");
+
+    await listener.stop();
+  });
+
+  test("the fail-closed event payload carries a FIXED reason, never the raw mint error", async () => {
+    const cortex = agentFixtureForRunner({ id: "cortex" });
+    const resolver = runnerResolverWith(cortex);
+
+    // A mint error shaped like the real one: `GithubAppTokenError` interpolates
+    // the host key PATH and a 500-char slice of GitHub's raw response body, so
+    // an error path that echoes `err.message` onto the bus ships host- and
+    // credential-adjacent material off the executing stack.
+    const LEAKY_ERROR_DETAIL =
+      "installation token exchange failed: 401 — key /home/principal/.config/" +
+      "metafactory/github-apps/atlas-private-key.pem appId 000000 installationId 000000";
+
+    const r = recordingRuntime();
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: false,
+      agentGithubIdentityById: new Map([["cortex", "atlas"]]),
+      githubEnvResolver: async () => {
+        throw new Error(LEAKY_ERROR_DETAIL);
+      },
+    });
+    await listener.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    // Fail-closed: no session at all.
+    expect(optsCaptured).toHaveLength(0);
+
+    const failed = r.published.find((e) => e.type === "dispatch.task.failed");
+    expect(failed).toBeDefined();
+
+    // The raw error must NOT ride the bus — not in `reason.detail`, not
+    // anywhere else in the envelope.
+    expect(JSON.stringify(failed)).not.toContain("private-key.pem");
+    expect(JSON.stringify(failed)).not.toContain(LEAKY_ERROR_DETAIL);
+
+    // But the refusal is still AUDIBLE and self-explanatory to the dispatcher.
+    const payload = failed?.payload as { reason?: { kind?: string; detail?: string } };
+    expect(payload.reason?.kind).toBe("cant_do");
+    expect(payload.reason?.detail).toMatch(/could not mint .*GitHub App identity/i);
+    expect(payload.reason?.detail).toMatch(/refused/i);
+
+    await listener.stop();
+  });
+
+  test("an agent with no declared identity leaves the session env free of any GitHub credential", async () => {
+    const cortex = agentFixtureForRunner({ id: "cortex" });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: false,
+      // No agentGithubIdentityById at all — absence is the DEFAULT, not an error.
+    });
+    await listener.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    // Not an empty string, not a stale value — absent. An empty GH_TOKEN would
+    // produce a confusing downstream `gh` auth error instead of clean fallback.
+    expect(optsCaptured[0]?.agentEnv?.GH_TOKEN).toBeUndefined();
+    expect(r.published.map((e) => e.type)).toContain("dispatch.task.completed");
+
+    await listener.stop();
+  });
+});

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -4022,3 +4022,140 @@ describe("dispatch-listener — M3 payload encryption (cortex#1241, ADR-0019)", 
     await listener.stop();
   });
 });
+
+describe("dispatch-listener — GH_TOKEN identity minting (cortex#2406, vision#11)", () => {
+  test("receiving agent with a declared GitHub identity gets a freshly-minted GH_TOKEN on its session env", async () => {
+    const cortex = agentFixtureForRunner({ id: "cortex" });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    let mintCalls = 0;
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: false,
+      agentGithubIdentityById: new Map([["cortex", "atlas"]]),
+      githubEnvResolver: async (identityName) => {
+        mintCalls++;
+        expect(identityName).toBe("atlas");
+        return { GH_TOKEN: "ghs_minted_test_token" };
+      },
+    });
+    await listener.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    expect(mintCalls).toBe(1);
+    expect(optsCaptured[0]?.agentEnv).toEqual({ GH_TOKEN: "ghs_minted_test_token" });
+    expect(r.published.map((e) => e.type)).toContain("dispatch.task.completed");
+    await listener.stop();
+  });
+
+  test("a declared env: passthrough is preserved alongside the minted GH_TOKEN (no clobber)", async () => {
+    const cortex = agentFixtureForRunner({ id: "cortex" });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: false,
+      agentEnvById: new Map([["cortex", { GOOGLE_APPLICATION_CREDENTIALS: "/sa.json" }]]),
+      agentGithubIdentityById: new Map([["cortex", "atlas"]]),
+      githubEnvResolver: async () => ({ GH_TOKEN: "ghs_minted_test_token" }),
+    });
+    await listener.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    expect(optsCaptured[0]?.agentEnv).toEqual({
+      GH_TOKEN: "ghs_minted_test_token",
+      GOOGLE_APPLICATION_CREDENTIALS: "/sa.json",
+    });
+    await listener.stop();
+  });
+
+  test("FAIL CLOSED: mint failure refuses the dispatch — no CC session spawned, no ambient-credential fallback", async () => {
+    const cortex = agentFixtureForRunner({ id: "cortex" });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: false,
+      agentGithubIdentityById: new Map([["cortex", "atlas"]]),
+      githubEnvResolver: async () => {
+        throw new Error("installation token exchange failed: 401 Unauthorized");
+      },
+    });
+    await listener.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    // No CC session ever spawned — the fail-closed path must return BEFORE
+    // reaching the harness, never fall through to a session without GH_TOKEN
+    // (which could silently use whatever ambient `gh` credential the host has).
+    expect(optsCaptured).toHaveLength(0);
+
+    const failed = r.published.find((e) => e.type === "dispatch.task.failed");
+    expect(failed).toBeDefined();
+    const payload = failed?.payload as { reason?: { kind?: string }; error_summary?: string };
+    expect(payload.reason?.kind).toBe("cant_do");
+    expect(payload.error_summary).toMatch(/GitHub identity credential could not be minted/);
+    await listener.stop();
+  });
+
+  test("an agent with NO declared GitHub identity is byte-unchanged (no mint call, no GH_TOKEN)", async () => {
+    const cortex = agentFixtureForRunner({ id: "cortex" });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    let mintCalls = 0;
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: false,
+      // agentGithubIdentityById omitted entirely — the pre-#2406 shape.
+      githubEnvResolver: async () => {
+        mintCalls++;
+        return { GH_TOKEN: "should-never-be-called" };
+      },
+    });
+    await listener.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    expect(mintCalls).toBe(0);
+    expect(optsCaptured[0]?.agentEnv).toBeUndefined();
+    await listener.stop();
+  });
+});

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -2254,11 +2254,19 @@ async function handleDispatchEnvelope(
     try {
       const resolveEnv = githubEnvResolver ?? resolveGithubEnvForAgent;
       const githubEnv = await resolveEnv(receivingGithubIdentity);
-      effectiveAgentEnv = { ...githubEnv, ...receivingAgentEnv };
+      // Spread order is load-bearing: the MINTED value goes LAST so it wins
+      // over any static `GH_TOKEN` in the passthrough map. `AgentSchema`
+      // already refuses that pair at config load (cortex#2406); this is the
+      // runtime half of that pairing, defending non-schema callers the
+      // load-time check cannot see. Backwards, it would silently run the
+      // session on a long-lived credential while config claims a bot identity.
+      effectiveAgentEnv = { ...receivingAgentEnv, ...githubEnv };
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
+      // LOCAL stderr carries the diagnostic detail (mint failed ⇒ no token
+      // exists to leak, and this stream stays on the executing host).
       process.stderr.write(
-        `[runner/dispatch-listener] GH_TOKEN mint FAILED for agent=${receivingAgentId} ` +
+        `[runner/dispatch-listener] GitHub identity mint FAILED for agent=${receivingAgentId} ` +
           `identity=${receivingGithubIdentity} on envelope ${envelope.id} — refusing dispatch ` +
           `rather than starting a session without its declared identity: ${detail}\n`,
       );
@@ -2270,7 +2278,23 @@ async function handleDispatchEnvelope(
         startedAt: now,
         failedAt: now,
         errorSummary: "refused — GitHub identity credential could not be minted",
-        reason: { kind: "cant_do", detail },
+        // cortex#2406 — the PUBLISHED reason is a FIXED string, deliberately
+        // NOT the raw `detail` above. This event crosses the bus to the
+        // dispatching stack and lands in the audit trail, so it must not echo
+        // an error message whose content we do not control end-to-end: mint
+        // errors can carry the host's key PATH, the App/installation IDs, and
+        // a 500-char slice of GitHub's raw response body
+        // (`GithubAppTokenError` context, `github-app-token.ts`). Keeping the
+        // wire copy fixed means no credential-adjacent material can ride an
+        // error path off this host; the operator reads the specific cause in
+        // the local stderr line above, where it belongs.
+        reason: {
+          kind: "cant_do",
+          detail:
+            "the receiving stack could not mint this agent's GitHub App identity " +
+            "credential; the dispatch was refused rather than run under an " +
+            "unintended identity (see the receiving stack's logs for the cause)",
+        },
       });
       await runtime.publish(failed);
       return;

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -2286,7 +2286,7 @@ async function handleDispatchEnvelope(
         // a 500-char slice of GitHub's raw response body
         // (`GithubAppTokenError` context, `github-app-token.ts`). Keeping the
         // wire copy fixed means no credential-adjacent material can ride an
-        // error path off this host; the operator reads the specific cause in
+        // error path off this host; the principal reads the specific cause in
         // the local stderr line above, where it belongs.
         reason: {
           kind: "cant_do",

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -126,6 +126,9 @@ import {
   createDispatchTaskFailedEvent,
   type ResponseRouting,
 } from "../bus/dispatch-events";
+// cortex#2406 (vision#11) — mint a fresh GH_TOKEN for a receiving agent's
+// declared GitHub App identity, receiving-stack-authoritatively.
+import { resolveGithubEnvForAgent } from "../common/auth/github-app-token";
 import type { TrustResolver } from "../common/agents/trust-resolver";
 import type { FederatedPeerResolution } from "../common/registry";
 import {
@@ -311,6 +314,15 @@ export interface DispatchListenerOptions {
    */
   ccSessionFactory?: CCSessionFactory;
   /**
+   * cortex#2406 (vision#11) — Optional GitHub identity env resolver
+   * injection. Default calls the real `resolveGithubEnvForAgent` (mints a
+   * live installation token via the GitHub Apps API). Tests inject a
+   * deterministic fake (resolve for the happy path, reject for the
+   * fail-closed path) without touching real GitHub credentials or network.
+   * Mirrors the `ccSessionFactory` injection pattern immediately above.
+   */
+  githubEnvResolver?: (identityName: string) => Promise<Record<string, string>>;
+  /**
    * Optional AgentTeam factory for delegate-mode dispatches. Production
    * omits this; tests inject a fake to prove routing without spawning
    * moderator/participant CC sessions.
@@ -445,6 +457,17 @@ export interface DispatchListenerOptions {
    * receiving-side authority. Absent / no entry ⇒ no passthrough.
    */
   agentEnvById?: Map<string, Record<string, string>>;
+  /**
+   * cortex#2406 (vision#11) — the RECEIVING agents' declared GitHub App identity
+   * NAMES indexed by agent id (a boot snapshot of `AgentSchema.github.identityName`
+   * — the name itself doesn't expire; only the token minted from it does, so a
+   * boot-time map is safe here unlike `agentEnvById`'s values). When present, the
+   * handler mints a FRESH installation token for the `receivingAgentId`'s declared
+   * identity and injects `GH_TOKEN` onto `req.runtime.agentEnv`
+   * receiving-stack-AUTHORITATIVELY (same trust boundary as `agentEnvById` — never
+   * the inbound wire). Absent / no entry ⇒ no identity ⇒ no token minted.
+   */
+  agentGithubIdentityById?: Map<string, string>;
   /**
    * API-P1.3 (#2063) — the inference registry the `api-agent` substrate resolves
    * its profile through. Threaded to `HarnessResolver`. Absent on stacks with no
@@ -844,12 +867,14 @@ export function createDispatchListener(
     runtime,
     source,
     ccSessionFactory,
+    githubEnvResolver,
     agentTeamFactory,
     policyEngine,
     trustResolver,
     receivingAgentId,
     agentRuntimesById,
     agentEnvById,
+    agentGithubIdentityById,
     inferenceRegistry,
     principalId,
     stackIdentity,
@@ -924,6 +949,7 @@ export function createDispatchListener(
         runtime,
         source,
         ccSessionFactory,
+        githubEnvResolver,
         agentTeamFactory,
         policyEngine,
         stack: opts.stack,
@@ -934,6 +960,7 @@ export function createDispatchListener(
         receivingAgentId,
         agentRuntimesById,
         agentEnvById,
+        agentGithubIdentityById,
         inferenceRegistry,
         stackIdentity,
         stackNKeyPub,
@@ -1355,6 +1382,8 @@ interface DispatchHandlerContext {
   runtime: MyelinRuntime;
   source: SystemEventSource;
   ccSessionFactory: CCSessionFactory | undefined;
+  /** cortex#2406 (vision#11) — GitHub identity env resolver. Default (when undefined) is `resolveGithubEnvForAgent`. */
+  githubEnvResolver: ((identityName: string) => Promise<Record<string, string>>) | undefined;
   agentTeamFactory: AgentTeamFactory | undefined;
   policyEngine: PolicyEngine | undefined;
   stack: string | undefined;
@@ -1373,6 +1402,8 @@ interface DispatchHandlerContext {
   agentRuntimesById: Map<string, AgentRuntime> | undefined;
   /** cortex#2133 — receiving agents' declared `env:` passthrough maps by id (receiving-stack-authoritative). */
   agentEnvById: Map<string, Record<string, string>> | undefined;
+  /** cortex#2406 (vision#11) — receiving agents' declared GitHub App identity names by id (receiving-stack-authoritative; a fresh token is minted per dispatch from the name, never boot-cached). */
+  agentGithubIdentityById: Map<string, string> | undefined;
   /** API-P1.3 (#2063) — inference registry the `api-agent` substrate resolves through. */
   inferenceRegistry: InferenceRegistry | undefined;
   /** cortex#480 — receiving stack's signing DID for own-stack trust. */
@@ -1440,6 +1471,7 @@ async function handleDispatchEnvelope(
     runtime,
     source,
     ccSessionFactory,
+    githubEnvResolver,
     agentTeamFactory,
     policyEngine,
     stack,
@@ -1450,6 +1482,7 @@ async function handleDispatchEnvelope(
     receivingAgentId,
     agentRuntimesById,
     agentEnvById,
+    agentGithubIdentityById,
     inferenceRegistry,
     stackIdentity,
     stackNKeyPub,
@@ -2200,10 +2233,54 @@ async function handleDispatchEnvelope(
   // nothing injected (default: no passthrough).
   const receivingAgentEnv =
     receivingAgentId !== undefined ? agentEnvById?.get(receivingAgentId) : undefined;
-  if (receivingAgentEnv !== undefined) {
-    const runtime = req.runtime ?? {};
-    runtime.agentEnv = receivingAgentEnv;
-    req.runtime = runtime;
+  let effectiveAgentEnv = receivingAgentEnv;
+
+  // cortex#2406 (vision#11) — RECEIVING-STACK-AUTHORITATIVE GitHub identity.
+  // Same trust boundary as the `env:` passthrough directly above: the
+  // identity NAME is looked up in the EXECUTING stack's own boot-snapshotted
+  // config, never the wire. Unlike that passthrough, the TOKEN is minted
+  // FRESH right here, every dispatch — installation tokens expire in ~1hr
+  // and this listener can run for days between two dispatches to the same
+  // agent, so caching the token (rather than just the identity name) would
+  // silently hand a session an expired credential.
+  //
+  // FAIL CLOSED on mint failure: refuse the dispatch rather than let the
+  // session start without its declared identity's token, which could
+  // silently fall back to whatever ambient `gh` credential the host has
+  // (the principal's own). Mirrors the `malformed_principal` refusal above.
+  const receivingGithubIdentity =
+    receivingAgentId !== undefined ? agentGithubIdentityById?.get(receivingAgentId) : undefined;
+  if (receivingGithubIdentity !== undefined) {
+    try {
+      const resolveEnv = githubEnvResolver ?? resolveGithubEnvForAgent;
+      const githubEnv = await resolveEnv(receivingGithubIdentity);
+      effectiveAgentEnv = { ...githubEnv, ...receivingAgentEnv };
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `[runner/dispatch-listener] GH_TOKEN mint FAILED for agent=${receivingAgentId} ` +
+          `identity=${receivingGithubIdentity} on envelope ${envelope.id} — refusing dispatch ` +
+          `rather than starting a session without its declared identity: ${detail}\n`,
+      );
+      const now = new Date();
+      const failed = createDispatchTaskFailedEvent({
+        source,
+        taskId: payload.task_id,
+        agentId: payload.agent_id,
+        startedAt: now,
+        failedAt: now,
+        errorSummary: "refused — GitHub identity credential could not be minted",
+        reason: { kind: "cant_do", detail },
+      });
+      await runtime.publish(failed);
+      return;
+    }
+  }
+
+  if (effectiveAgentEnv !== undefined) {
+    const reqRuntime = req.runtime ?? {};
+    reqRuntime.agentEnv = effectiveAgentEnv;
+    req.runtime = reqRuntime;
   }
 
   // cortex#2111 (adversarial-review MAJOR) — RECEIVING-STACK-AUTHORITATIVE


### PR DESCRIPTION
Wires the runner half of #2396. #2399 shipped the ability to mint GitHub App installation tokens (`cortex github-token mint <identity>`) but deliberately deferred the session-spawn wiring: *"auto-injecting `GH_TOKEN` per session when cortex spawns an Atlas/luna-dev session… touches dispatch/session-spawn code, deserves its own PR."* This is that PR. Without it an agent bundle with a GitHub-writing capability cannot authenticate — Atlas cannot edit its plan issue or open PRs.

## Provenance — this adopts an interrupted session's work

**I did not author all of this.** I found ~370 lines of uncommitted implementation in an abandoned worktree, matching #2406's design, with no commits/branch/PR and no live process on it. Rather than rebuild it I committed it verbatim first (`cd04f7c8`, marked SALVAGED and explicitly not asserted correct), then audited and completed it in `6da9028a`. The two commits are a deliberate review boundary: **`cd04f7c8` is the prior session's work, `6da9028a` is mine.** Reviewing the second commit alone shows exactly what I changed and why.

## How it works

An agent opts in with one field:

```yaml
# agents.d/atlas.yaml
github:
  identityName: atlas   # names an entry in ~/.config/metafactory/github-apps/apps.yaml
```

At dispatch, cortex mints a **fresh** installation credential and merges it onto the session env through the existing per-agent `env:` passthrough (`agent-env.ts`) — so `cc-session.ts` / `buildSessionEnv` / `session-settings.ts` needed no changes at all.

**Two injection points, because there are two dispatch paths.** `dispatch-handler.ts` (direct: sync/async/team) and `dispatch-listener.ts` (bus-mediated, receiving-stack-authoritative). Wiring one and not the other is precisely the coverage-drift class EBH-1e/1g hit twice for path-checking, so both are wired and both are tested.

### Against the four design requirements

1. **Short-lived by construction.** Minted per dispatch, never cached. Only the identity NAME is boot-snapshotted (`agentGithubIdentityById`) — a non-expiring config string, not a credential. This matters: the daemon runs for days and installation tokens expire in ~1hr, so a boot-time token snapshot would hand sessions an expired credential.
2. **Opt-in per agent.** No `github` block ⇒ no mint call, no credential, byte-identical to pre-#2406. Absence is the default, never an error — pinned by a test on each path.
3. **Never logged or echoed.** See below.
4. **Fail-closed and audible.** Mint failure REFUSES the dispatch. The session never starts, and the principal is told. Starting without the credential would let `gh`/`git` fall back to the host's ambient `gh auth` — the principal's own account — which is the exact identity leak this exists to close. An empty or stale value would be equally wrong, so the tests assert *no spawn at all*.

## What I changed on top of the salvaged work

**1. Precedence was backwards — silent identity confusion.** Both paths spread the minted value FIRST (`{...githubEnv, ...agentEnv}`), so a static `env.GH_TOKEN` silently overrode the freshly minted identity. The agent would read as acting as its bot while actually carrying a long-lived credential — unauditable after the fact.

Fixed at both call sites, and `AgentSchema` now refuses the pair outright at config **load**. Two GitHub identities for one session isn't a precedence question, it's a config error: whichever wins, no reader can tell afterwards which one ran. Load-time reject + runtime re-assert is the same two-layer pairing `agent-env.ts` already documents. Fragments parse through `AgentSchema` (`loader.ts:1360`), so this covers `agents.d/` — where these identities will actually be declared.

**2. Raw mint errors were published onto the bus.** The fail-closed path put `err.message` into `reason.detail` of a `dispatch.task.failed` envelope — which crosses to the dispatching stack and lands in the audit trail. `GithubAppTokenError` messages carry the host key PATH, the App/installation IDs, and a 500-char slice of GitHub's raw response body. The published reason is now a fixed string; the specific cause stays on the executing host's stderr.

**3. The direct dispatch path had zero tests.** Only the bus-mediated path was covered. Added 5 tests over `handleMessage`.

## Credential containment is pinned, not assumed

`GH_TOKEN` is the **first** allowlisted key whose value is a live secret. Every other value in that map is a non-secret path or an unresolved `env:NAME` reference — `agent-env.ts` states the old invariant plainly: *"a config dump shows `env:NAME` and never the secret value."* A minted token voids that assumption while travelling the same pipes, so downstream code was not written with it in mind. New suites assert the token:

- reaches the session env (**positive control** — without it the negative assertions could pass by simply never minting);
- appears in **no** log sink (stdout, stderr, every `console.*`), including cortex-trace stage lines;
- appears in **no** published bus event payload;
- is not echoed on the DROP paths in `resolveAgentEnv` — which are the paths that actually log.

I also confirmed by reading the path that the token never reaches disk: `createIsolatedSettings` writes only curated hooks/permissions with no env block, and `buildSessionEnv` is a pure transform.

## Decision recorded: `GH_TOKEN` only, not also `GITHUB_TOKEN`

`gh` reads `GH_TOKEN` first and falls back to `GITHUB_TOKEN`, so the higher-priority name alone covers `gh` and the `git` credential helper `gh auth setup-git` installs. cortex already made this call — `runner/dev-consumer-boot.ts` sets exactly `GH_TOKEN` on the child env. Adding the alias would cost a second entry in a reviewed deny-by-default allowlist to buy nothing. If a substrate is ever found that reads only `GITHUB_TOKEN`, that should be its own reviewed allowlist change with the motivating case named.

## Verification

- **797 scoped tests pass** across 26 files (scoped to what this touches, per CLAUDE.md — the full cortex suite was not run).
- `bunx tsc --noEmit` clean.
- `eslint` clean on all 11 touched files.
- Pre-push confidentiality scan clean; all fixtures use obvious placeholders (`ghs_EXAMPLE_PLACEHOLDER_NOT_A_REAL_TOKEN`, zeroed IDs).

## What I could NOT verify — please weigh this

**End-to-end authentication was never exercised.** No live App credentials exist in this environment, so every test drives an **injected fake resolver**; no test has called the real GitHub API through this path. What is proven is the wiring, the precedence, the fail-closed refusal, and the containment. What is *assumed* is that `mintTokenForIdentity` works against live GitHub — which #2399 established separately, not here — and that setting `GH_TOKEN` alone is sufficient for `gh`/`git` in a spawned session, which I verified by reading cortex's own `dev-consumer-boot.ts` precedent rather than by running it.

The first real-world exercise will be declaring `github: { identityName: atlas }` on the live `agents.d/*.yaml` fragment. That config change is deliberately **out of scope** here (per #2406), so this can land without touching a running identity.

Closes #2406
Refs #2396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArLAsEG9JoXUzkrotpUgAU
