### PR TITLE
feat(runner): EBH-3a — macos-sbpl SessionSandbox backend, audit-capable, enforcement off (#2345)

### DIFF
--- a/docs/security/hardening-plan.md
+++ b/docs/security/hardening-plan.md
@@ -35,11 +35,28 @@ A ladder, cheapest-and-most-owned first. Maps onto the review's Tier 0–3 (§6)
 |---|---|---|---|---|
 | **L0** | ~~**Repro** the `--add-dir` question~~ **✅ DONE 2026-07-24** — `--add-dir` is an *additive grant, not a jail*; both Read and Bash `cat` read an out-of-scope canary ([result](reviews/2026-07-24-ebh0-add-dir-repro.md)) | **F1 = clean High** (severity locked) | done | — |
 | **L1** | Cortex-owned `PreToolUse` **path guard** for file tools + Bash read-command paths; reuse `loader.ts` normalize+contain | F1 (cortex-owned side), F6 | S | — |
-| **L2** | **OS session jail** per `claude --print` (sandbox-exec / bwrap+landlock+seccomp) | F1, F6 by construction | M | choke point |
+| **L2** | **OS session jail** per `claude --print` (sandbox-exec / bwrap+landlock+seccomp) | **v1 `guarded`:** F6 by construction; F1 **only for the enumerated sensitive set** — *not* by construction. **v2 `strict`:** F1 by construction | M | choke point |
 | **L3** | **Egress allowlist** (filtering proxy, deny-by-default) | exfiltration containment | M | L2 net-ns |
 | **L4** | **Plugin process isolation** + registry signing | F2 | L | trigger-gated |
 
 L1–L3 are designed in [`design-session-sandbox.md`](../design-session-sandbox.md). L1 (in-process guard) and L2 (kernel jail) are **not redundant** — L1 is the precise, observable, agent-visible boundary for the common case; L2 is the un-bypassable floor that holds even when L1 is missing or bypassed (which #1758 proves happens). L3 ensures a read that clears both still can't leave the box.
+
+> **⚠️ What L2 v1 does NOT close (measured, 2026-07-26, EBH-3a review).** The v1 `guarded`
+> posture is `(allow default)` + an enumerated denylist, because E4 measured that a strict
+> `(deny default)` SIGABRTs the session. So **F1 is narrowed, not closed**: everything not
+> named is still readable. Probing the generated profile on a real host read **11** credential
+> stores straight through it — `~/.gnupg`, `~/.docker/config.json`, `~/.config/gh/hosts.yml`,
+> `~/Library/Keychains`, `~/.gitconfig`, shell histories, `~/.claude.json`, `~/.soma`, … (only
+> `~/.ssh`, `~/.aws` and the cortex config tree are denied).
+>
+> **A denylist cannot be completed by adding entries** — that is the structural point, not a
+> backlog item. Enumerating more paths raises the cost of the attack; it never establishes a
+> boundary. The boundary arrives with v2 `strict` (deny-default + explicit allow), and only
+> there is "by construction" an honest phrase.
+>
+> Practical consequence: **do not describe L2 v1 as "the session is jailed."** It is
+> "these specific secrets are protected, and read-only means read-only." The sensitive-set
+> gap must be closed before `mode: audit` is ever enabled anywhere — tracked as **#2409**.
 
 ---
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -63,6 +63,7 @@ import {
 
 import { buildSecurityPreamble } from "./runner/security-preamble";
 import { assertPromptFilterReady } from "./runner/prompt-filter";
+import { getSandboxCapabilityProbe } from "./runner/session-sandbox";
 import { DispatchHandler } from "./bus/dispatch-handler";
 import {
   makeSubjectPlaceholderSubstituter,
@@ -955,6 +956,20 @@ export async function startCortex(
   // wrapper) maps a throw here to `console.error` + `process.exit(1)`, same as
   // every other fatal boot check.
   assertPromptFilterReady("cortex start");
+
+  // EBH-3a (cortex#2345) — warm the sandbox capability probe at boot. This is
+  // the "live boot path" DD-7 always intended (`session-sandbox.ts`'s DD-7
+  // doc) — EBH-2 deliberately did NOT call it from `CCSession.start()`
+  // itself, because that per-session choke point is where many tests assert
+  // an exact `Bun.spawn` call count (a probe-triggered subprocess spawn from
+  // inside it perturbs those counts — see that module's HARD-HOLD doc).
+  // AWAITED (not fire-and-forget) so: (a) the resolved backend is logged
+  // deterministically as part of boot output, and (b) every `CCSession`
+  // spawned by this daemon after `startCortex` resolves sees the WARMED sync
+  // snapshot (`createSessionSandbox` reads it synchronously — an unwarmed
+  // probe falls back to `none`, byte-identical to pre-EBH-3a). The probe
+  // itself never throws (see its own doc) — this call cannot fail boot.
+  await getSandboxCapabilityProbe();
 
   const expandedConfigPath = options.configPath
     ? options.configPath.replace(/^~/, process.env.HOME ?? "~")

--- a/src/runner/__tests__/cc-session-macos-sandbox-e2e.test.ts
+++ b/src/runner/__tests__/cc-session-macos-sandbox-e2e.test.ts
@@ -1,0 +1,118 @@
+/**
+ * EBH-3a (cortex#2345) — REAL end-to-end acceptance test: "A real dispatched
+ * session completes end-to-end under audit: streaming, --resume, hooks,
+ * event pipeline, gh."
+ *
+ * This is deliberately NOT a mock. It spawns the real `claude` CLI (via the
+ * real `CCSession`, the real `MacosSbplSandbox`, the real DD-9 canary, the
+ * real v1 `guarded` SBPL profile) with `sandboxMode: "audit"`, and asserts
+ * on the actual result — a genuine claude round-trip, then a genuine
+ * `--resume` round-trip of the SAME session, both wrapped in
+ * `sandbox-exec -f`.
+ *
+ * ## OQ-2 (design-session-sandbox-platforms.md §9) — honest status
+ *
+ * OQ-2 asks for an `fs_usage`/`strace`-level enumeration of every path a
+ * real `claude --print --resume` session touches, to pin the compatibility
+ * contract empirically rather than by assumption. `fs_usage` (and `dtruss`)
+ * both require root; this environment has no passwordless `sudo` (confirmed:
+ * `sudo -n true` fails with "a password is required"). **That enumeration
+ * could NOT be produced here — this is a real, disclosed gap, not silently
+ * assumed away.**
+ *
+ * What THIS test provides instead, which is real evidence for the actual
+ * question that matters for `audit` mode's rollout gate (design doc §6):
+ * "does the v1 `guarded` profile — a NARROW denylist of enumerated sensitive
+ * paths, not a broad allowlist — break a real session?" Since v1 `guarded`
+ * never tries to enumerate everything a session legitimately touches (that's
+ * v2 `strict`'s job), the decisive signal is not "list every path" but
+ * "does a real session run clean under the denylist, with ZERO
+ * `system.security.sandbox-denial` events for legitimate activity". This
+ * test asserts exactly that, on TWO real round-trips (a fresh session, then
+ * a `--resume` of it) — which is the closest honest substitute for OQ-2's
+ * `fs_usage` sweep that a non-root environment allows.
+ */
+
+import { afterEach, beforeEach, describe, expect } from "bun:test";
+import { CCSession } from "../cc-session";
+import {
+  getSandboxCapabilityProbe,
+  resetSandboxCapabilityProbeForTests,
+  type SandboxDenialEvent,
+} from "../session-sandbox";
+import { hasClaude, testClaude } from "../../common/test-utils";
+
+const isDarwin = process.platform === "darwin";
+
+describe.skipIf(!isDarwin || !hasClaude)(
+  "EBH-3a acceptance — real CCSession end-to-end under mode: 'audit' (macos-sbpl)",
+  () => {
+    beforeEach(async () => {
+      resetSandboxCapabilityProbeForTests();
+      // Warm the probe BEFORE constructing any CCSession — mirrors what
+      // `startCortex` does at real boot. Without this, `createSessionSandbox`
+      // falls back to `NoneSandbox` (the safe default for an un-warmed
+      // probe) and this test would exercise nothing new.
+      const probe = await getSandboxCapabilityProbe();
+      expect(probe.resolvedBackend).toBe("macos-sbpl");
+    });
+
+    afterEach(() => {
+      resetSandboxCapabilityProbeForTests();
+    });
+
+    testClaude(
+      "fresh session + --resume of it BOTH complete successfully with ZERO sandbox-denial events",
+      async () => {
+        const denials: SandboxDenialEvent[] = [];
+
+        const first = new CCSession({
+          prompt: "Say just the word hi, nothing else",
+          channel: "test",
+          timeoutMs: 45_000,
+          sandboxMode: "audit",
+        });
+        first.on("security-event", (event: unknown) => {
+          const e = event as { type: string };
+          if (e.type === "system.security.sandbox-denial") {
+            denials.push(event as SandboxDenialEvent);
+          }
+        });
+
+        const firstResult = await first.start().wait();
+        expect(firstResult.success).toBe(true);
+        expect(firstResult.exitCode).toBe(0);
+        expect(firstResult.sessionId).toBeDefined();
+        expect(firstResult.response.length).toBeGreaterThan(0);
+
+        const second = new CCSession({
+          prompt: "Say just the word bye, nothing else",
+          channel: "test",
+          timeoutMs: 45_000,
+          sandboxMode: "audit",
+          resumeSessionId: firstResult.sessionId,
+        });
+        second.on("security-event", (event: unknown) => {
+          const e = event as { type: string };
+          if (e.type === "system.security.sandbox-denial") {
+            denials.push(event as SandboxDenialEvent);
+          }
+        });
+
+        const secondResult = await second.start().wait();
+        expect(secondResult.success).toBe(true);
+        expect(secondResult.exitCode).toBe(0);
+        expect(secondResult.response.length).toBeGreaterThan(0);
+
+        // The decisive OQ-2 substitute (module doc): a real session,
+        // including a real --resume continuity round-trip, produced ZERO
+        // denials under the v1 guarded profile. Not proof the profile is
+        // complete for a v2 strict allowlist — proof it does not break
+        // legitimate traffic, which is what `audit` mode exists to show
+        // before any `enforce` flip (design doc §6).
+        expect(denials).toHaveLength(0);
+      },
+      60_000,
+    );
+  },
+);

--- a/src/runner/__tests__/cc-session.test.ts
+++ b/src/runner/__tests__/cc-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { CCSession, type CCSessionOpts, resolvePathGuardEnv, deriveSandboxProfile } from "../cc-session";
+import { resetSandboxCapabilityProbeForTests } from "../session-sandbox";
 import { testClaude } from "../../common/test-utils";
 
 describe("CCSession", () => {
@@ -232,6 +233,17 @@ describe("deriveSandboxProfile — EBH-2 policy → SandboxProfile projection (c
  */
 describe("CCSession — EBH-2 SessionSandbox routing", () => {
   testClaude("emits exactly one security-event (none backend) per session", async () => {
+    // EBH-3a (cortex#2345) — `createSessionSandbox` now resolves a REAL
+    // `macos-sbpl` backend when the boot capability probe has been warmed
+    // AND resolves it (session-sandbox.ts). In the full test-suite run
+    // (one process, `bun test` default), an EARLIER file's `startCortex()`
+    // call can warm that MODULE-LEVEL sync cache before this test runs —
+    // this test's whole point is the `none` backend's OWN observable
+    // contract (fires `sandbox-unavailable`), so it resets the cache first
+    // to deterministically get `NoneSandbox`, regardless of suite ordering
+    // or what ran before it. Mirrors `session-sandbox.test.ts`'s own
+    // `afterEach(resetSandboxCapabilityProbeForTests)` discipline.
+    resetSandboxCapabilityProbeForTests();
     const session = new CCSession({
       prompt: "Say just the word hi",
       channel: "test",

--- a/src/runner/__tests__/session-sandbox-macos.test.ts
+++ b/src/runner/__tests__/session-sandbox-macos.test.ts
@@ -1,0 +1,672 @@
+/**
+ * EBH-3a (cortex#2345) — tests for the `macos-sbpl` `SessionSandbox` backend.
+ *
+ * macOS-ONLY: every test in this file spawns a real `sandbox-exec` (and, for
+ * the denial-observation tests, a real `log stream`). CI is `ubuntu-latest`
+ * only (no macOS runner — see `.github/workflows/ci.yml`), so the whole file
+ * is gated with `describe.skipIf(process.platform !== "darwin")`, matching
+ * the established pattern for platform-gated integration coverage in this
+ * repo (`cc-plugin-dir-pin.integration.test.ts`'s `test.skipIf(!CLAUDE_BIN)`).
+ * On a real macOS dev host (where this was authored and run) every test here
+ * executes for real — no mocking of `sandbox-exec`/`log stream` themselves,
+ * because the whole point of EBH-3a is empirically-verified enforcement, not
+ * a simulation of it.
+ *
+ * Fixture discipline: every test that exercises the built-in "sensitive set"
+ * (config dir / ssh / aws / settings.json / hooks) does so against a
+ * FIXTURE `$HOME` (`opts.homeDir` override) — never the real developer
+ * machine's `~/.ssh` etc. A profile that accidentally denied (or, worse,
+ * appeared to pass while silently not covering) the REAL `~/.ssh` on the
+ * machine running these tests would be its own small incident.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { SandboxProfile } from "../session-sandbox";
+import {
+  generateMacosSbplProfile,
+  MacosSbplSandbox,
+  parseSandboxDenialLogLine,
+  runMacosCanarySelfTest,
+} from "../session-sandbox-macos";
+
+const isDarwin = process.platform === "darwin";
+
+/** `Subprocess.stdout`'s static type is `number | ReadableStream | undefined`
+ *  (the `number` arm covers fd-passthrough opts this file never uses) — a
+ *  small runtime-checked helper so every test that reads a spawned child's
+ *  stdout doesn't repeat the narrowing. */
+async function readAllStdout(stdout: number | ReadableStream<Uint8Array> | undefined): Promise<string> {
+  if (typeof stdout !== "object" || stdout === null) return "";
+  return new Response(stdout).text();
+}
+
+function baseProfile(overrides: Partial<SandboxProfile> = {}): SandboxProfile {
+  return {
+    readWrite: [],
+    readOnly: [],
+    execAllow: [],
+    egressAllow: [],
+    mode: "audit",
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// generateMacosSbplProfile — pure function, runs everywhere (no sandbox-exec)
+// -----------------------------------------------------------------------------
+
+describe("generateMacosSbplProfile", () => {
+  let fixtureHome: string;
+
+  beforeEach(() => {
+    // realpathSync immediately — `tmpdir()` on macOS is itself under
+    // `/var/folders/...`, and `/var` is ALSO a symlink to `/private/var`
+    // (the same E3 shape as `/tmp` → `/private/tmp`). The generator
+    // correctly resolves every path before it enters the profile (that's
+    // the whole point of this module), so a test that compares against the
+    // UNRESOLVED fixture path would be asserting the wrong thing — this is
+    // the fixture-side half of the same E3 discipline the generator itself
+    // implements.
+    fixtureHome = realpathSync(mkdtempSync(join(tmpdir(), "cortex-sbpl-fixture-home-")));
+  });
+
+  afterEach(() => {
+    rmSync(fixtureHome, { recursive: true, force: true });
+  });
+
+  test("always opens with '(version 1)' then '(allow default)' — DD-10 v1 guarded posture", () => {
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    const lines = generated.text.split("\n");
+    expect(lines[0]).toBe("(version 1)");
+    expect(lines[1]).toBe("(allow default)");
+  });
+
+  test("never emits '(deny default)' — E4 forbids strict deny-default for v1", () => {
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    expect(generated.text).not.toContain("deny default");
+  });
+
+  test("denies read+write on the config dir tree (CONFIG IMMUTABILITY, F1)", () => {
+    // The config dir need not exist — resolveProspectiveRealpath tolerates
+    // a not-yet-created leaf by walking up to the nearest existing ancestor
+    // (fixtureHome itself, created by mkdtempSync).
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    const configDir = join(fixtureHome, ".config", "metafactory", "cortex");
+    expect(generated.text).toContain(`(deny file-read* (subpath "${configDir}"))`);
+    expect(generated.text).toContain(`(deny file-write* (subpath "${configDir}"))`);
+  });
+
+  test("denies read+write on ~/.ssh and ~/.aws (arbitrary-secret read, F1)", () => {
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    const ssh = join(fixtureHome, ".ssh");
+    const aws = join(fixtureHome, ".aws");
+    expect(generated.text).toContain(`(deny file-read* (subpath "${ssh}"))`);
+    expect(generated.text).toContain(`(deny file-write* (subpath "${ssh}"))`);
+    expect(generated.text).toContain(`(deny file-read* (subpath "${aws}"))`);
+    expect(generated.text).toContain(`(deny file-write* (subpath "${aws}"))`);
+  });
+
+  test("denies WRITE (not read) on settings.json and hooks/ — self-modification, compat contract needs hook read+exec", () => {
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    const settings = join(fixtureHome, ".claude", "settings.json");
+    const hooks = join(fixtureHome, ".claude", "hooks");
+    expect(generated.text).toContain(`(deny file-write* (subpath "${settings}"))`);
+    expect(generated.text).not.toContain(`(deny file-read* (subpath "${settings}"))`);
+    expect(generated.text).toContain(`(deny file-write* (subpath "${hooks}"))`);
+    expect(generated.text).not.toContain(`(deny file-read* (subpath "${hooks}"))`);
+  });
+
+  test("readOnly dirs get WRITE-deny only (F6) — read stays allowed via (allow default)", () => {
+    const roDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-ro-"));
+    try {
+      const generated = generateMacosSbplProfile(
+        baseProfile({ readOnly: [roDir] }),
+        { homeDir: fixtureHome },
+      );
+      const real = realpathSync(roDir);
+      expect(generated.text).toContain(`(deny file-write* (subpath "${real}"))`);
+      expect(generated.text).not.toContain(`(deny file-read* (subpath "${real}"))`);
+    } finally {
+      rmSync(roDir, { recursive: true, force: true });
+    }
+  });
+
+  test("extraDenyPaths get read+write deny — the generic 'out of scope' escape hatch", () => {
+    const otherDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-other-stack-"));
+    try {
+      const generated = generateMacosSbplProfile(baseProfile(), {
+        homeDir: fixtureHome,
+        extraDenyPaths: [otherDir],
+      });
+      const real = realpathSync(otherDir);
+      expect(generated.text).toContain(`(deny file-read* (subpath "${real}"))`);
+      expect(generated.text).toContain(`(deny file-write* (subpath "${real}"))`);
+      expect(generated.resolvedDenyPaths).toContain(real);
+    } finally {
+      rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  test("E3 REGRESSION (generator-level): extraDenyPaths given a SYMLINK resolves+denies the REAL target, not the literal alias", () => {
+    // The generator-side half of the E3 discipline: prove
+    // generateMacosSbplProfile itself resolves a symlinked INPUT before
+    // writing the deny rule, using a real filesystem symlink (not `/tmp`,
+    // which the dedicated real-sandbox-exec E3 tests below already cover
+    // for the well-known-alias case). A caller passing a symlinked path
+    // into extraDenyPaths (e.g. a stack dir reached via a symlinked
+    // Developer/ checkout) must still get the REAL target denied.
+    const realTargetParent = mkdtempSync(join(tmpdir(), "cortex-sbpl-e3gen-real-"));
+    const realTarget = join(realTargetParent, "actual-dir");
+    mkdirSync(realTarget);
+    const symlinkParent = mkdtempSync(join(tmpdir(), "cortex-sbpl-e3gen-link-"));
+    const symlinkPath = join(symlinkParent, "via-symlink");
+    symlinkSync(realTarget, symlinkPath);
+    try {
+      const generated = generateMacosSbplProfile(baseProfile(), {
+        homeDir: fixtureHome,
+        extraDenyPaths: [symlinkPath], // the UNRESOLVED alias, deliberately
+      });
+      const resolvedReal = realpathSync(realTarget);
+      // The deny rule targets the RESOLVED real path…
+      expect(generated.text).toContain(`(deny file-read* (subpath "${resolvedReal}"))`);
+      // …NOT the literal symlink path string.
+      expect(generated.text).not.toContain(symlinkPath);
+      expect(generated.resolvedDenyPaths).toContain(resolvedReal);
+    } finally {
+      rmSync(realTargetParent, { recursive: true, force: true });
+      rmSync(symlinkParent, { recursive: true, force: true });
+    }
+  });
+
+  test("readWrite/execAllow/egressAllow are NOT projected into the text — (allow default) already covers them", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-work-"));
+    try {
+      const generated = generateMacosSbplProfile(
+        baseProfile({ readWrite: [workDir], execAllow: ["claude"], egressAllow: ["api.anthropic.com"] }),
+        { homeDir: fixtureHome },
+      );
+      expect(generated.text).not.toContain(realpathSync(workDir));
+      expect(generated.text).not.toContain("process-exec");
+      expect(generated.text).not.toContain("api.anthropic.com");
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a path that fails to realpath-resolve (NUL byte) is EXCLUDED from the profile and reported in `unresolved` — fail closed, not fail open", () => {
+    const nulPath = join(fixtureHome, "a") + String.fromCharCode(0) + "b";
+    const generated = generateMacosSbplProfile(baseProfile(), {
+      homeDir: fixtureHome,
+      extraDenyPaths: [nulPath],
+    });
+    expect(generated.text).not.toContain(String.fromCharCode(0));
+    const unresolvedInputs = generated.unresolved.map((u) => u.input);
+    expect(unresolvedInputs).toContain(nulPath);
+  });
+
+  test("SBPL string-literal escaping: a path containing a double quote is escaped, not left to break the profile syntax", () => {
+    // Construct (don't create on disk — just prove the escaping happens on
+    // the STRING regardless of whether the path resolves) a deny entry with
+    // an embedded quote via extraDenyPaths pointing at a real dir, then spot
+    // check the quoting helper indirectly: a resolvable dir with no quote
+    // never needs escaping, so assert on the direct sbplQuote-shaped output
+    // by using a dir name that legitimately contains a quote character.
+    const quotedDirName = 'weird"name';
+    const parent = mkdtempSync(join(tmpdir(), "cortex-sbpl-quote-"));
+    const quotedDir = join(parent, quotedDirName);
+    try {
+      mkdirSync(quotedDir);
+      const generated = generateMacosSbplProfile(baseProfile(), {
+        homeDir: fixtureHome,
+        extraDenyPaths: [quotedDir],
+      });
+      const real = realpathSync(quotedDir);
+      const escaped = real.replace(/"/g, '\\"');
+      expect(generated.text).toContain(escaped);
+      // No UNESCAPED quote should appear inside a subpath string literal.
+      expect(generated.text).not.toContain(`"${real}"`.replace('\\"', '"'));
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// parseSandboxDenialLogLine — pure parser, verified against THIS host's real
+// `log stream --style ndjson` output shape (module doc comment)
+// -----------------------------------------------------------------------------
+
+describe("parseSandboxDenialLogLine", () => {
+  const REAL_LINE = JSON.stringify({
+    eventMessage: "Sandbox: cat(2081) deny(1) file-read-data /private/tmp/x/secret.txt",
+    timestamp: "2026-07-26 01:42:39.367453+1200",
+  });
+
+  test("parses a real-shaped denial line for the matching pid", () => {
+    const denial = parseSandboxDenialLogLine(REAL_LINE, 2081);
+    expect(denial).toBeDefined();
+    expect(denial?.path).toBe("/private/tmp/x/secret.txt");
+    expect(denial?.reason).toBe("file-read-data denied");
+    expect(denial?.timestamp).toBe("2026-07-26 01:42:39.367453+1200");
+  });
+
+  test("write-deny operation shape (file-write-create) also parses", () => {
+    const line = JSON.stringify({
+      eventMessage: "Sandbox: tee(3894) deny(1) file-write-create /private/tmp/x/out.txt",
+      timestamp: "2026-07-26 01:43:57.575665+1200",
+    });
+    const denial = parseSandboxDenialLogLine(line, 3894);
+    expect(denial?.reason).toBe("file-write-create denied");
+  });
+
+  test("a denial for a DIFFERENT pid is ignored (undefined)", () => {
+    expect(parseSandboxDenialLogLine(REAL_LINE, 9999)).toBeUndefined();
+  });
+
+  test("malformed (non-JSON) lines never throw — return undefined", () => {
+    expect(parseSandboxDenialLogLine("Filtering the log data using…", 2081)).toBeUndefined();
+    expect(parseSandboxDenialLogLine("", 2081)).toBeUndefined();
+    expect(parseSandboxDenialLogLine("{not json", 2081)).toBeUndefined();
+  });
+
+  test("a well-formed JSON line with an unrelated eventMessage is ignored", () => {
+    const line = JSON.stringify({ eventMessage: "some other kernel line", timestamp: "x" });
+    expect(parseSandboxDenialLogLine(line, 2081)).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Everything below spawns real `sandbox-exec` (and, for denial tests, real
+// `log stream`) — macOS only.
+// -----------------------------------------------------------------------------
+
+describe.skipIf(!isDarwin)("DD-9 canary self-test — runMacosCanarySelfTest (real sandbox-exec)", () => {
+  test("passes on this host: EPERM on the unresolved /tmp alias, deny rule authored against the resolved realpath", async () => {
+    const result = await runMacosCanarySelfTest();
+    expect(result.passed).toBe(true);
+    expect(result.detail).toContain("EPERM");
+  }, 15_000);
+
+  test("E3 regression, exact repro shape: a deny rule authored against the UNRESOLVED /tmp alias silently fails to deny", async () => {
+    // This directly reproduces docs/design-session-sandbox-platforms.md's E3
+    // finding on THIS host: the profile generator must NEVER do what this
+    // test deliberately does (author a deny rule against an unresolved
+    // path) — that's exactly why generateMacosSbplProfile always resolves
+    // first. This test proves the underlying platform hazard is real, which
+    // is what makes the canary (and the resolver) necessary in the first
+    // place, not a redundant check.
+    const marker = `cortex-e3-regression-${Date.now()}`;
+    const unresolvedDir = join("/tmp", marker);
+    const unresolvedFile = join(unresolvedDir, "secret.txt");
+    mkdirSync(unresolvedDir, { recursive: true });
+    writeFileSync(unresolvedFile, "should-be-unreadable");
+    const profileDir = mkdtempSync(join(tmpdir(), "cortex-e3-profile-"));
+    try {
+      const badProfilePath = join(profileDir, "bad.sb");
+      // Deliberately UNRESOLVED — the exact anti-pattern DD-9 exists to catch.
+      writeFileSync(
+        badProfilePath,
+        `(version 1)\n(allow default)\n(deny file-read* (subpath "${unresolvedDir}"))\n`,
+      );
+      const proc = Bun.spawn(["sandbox-exec", "-f", badProfilePath, "/bin/cat", unresolvedFile], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      // The E3 failure: the read SUCCEEDS despite the deny rule "covering"
+      // the same literal path string used to read it.
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("should-be-unreadable");
+    } finally {
+      rmSync(unresolvedDir, { recursive: true, force: true });
+      rmSync(profileDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("the correct form (resolved realpath) DOES deny the same content via the unresolved alias — proves the mitigation, not just the hazard", async () => {
+    const marker = `cortex-e3-fixed-${Date.now()}`;
+    const unresolvedDir = join("/tmp", marker);
+    const unresolvedFile = join(unresolvedDir, "secret.txt");
+    mkdirSync(unresolvedDir, { recursive: true });
+    writeFileSync(unresolvedFile, "should-be-unreadable");
+    const resolvedDir = realpathSync(unresolvedDir);
+    const profileDir = mkdtempSync(join(tmpdir(), "cortex-e3-profile-fixed-"));
+    try {
+      const goodProfilePath = join(profileDir, "good.sb");
+      writeFileSync(
+        goodProfilePath,
+        `(version 1)\n(allow default)\n(deny file-read* (subpath "${resolvedDir}"))\n`,
+      );
+      const proc = Bun.spawn(["sandbox-exec", "-f", goodProfilePath, "/bin/cat", unresolvedFile], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("Operation not permitted");
+    } finally {
+      rmSync(unresolvedDir, { recursive: true, force: true });
+      rmSync(profileDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});
+
+describe.skipIf(!isDarwin)("The four §5 'stops' — real sandbox-exec, fixture $HOME, forced enforce", () => {
+  let fixtureHome: string;
+  let allowedDir: string;
+  let otherStackDir: string;
+
+  beforeEach(() => {
+    // realpathSync immediately — see the same-named fixture in the
+    // `generateMacosSbplProfile` describe block above for why: `tmpdir()`
+    // on macOS is itself under the `/var` → `/private/var` symlink (the E3
+    // shape), and these tests read files via `fixtureHome`-joined paths
+    // that must match what the generator resolved into the profile.
+    fixtureHome = realpathSync(mkdtempSync(join(tmpdir(), "cortex-sbpl-stops-home-")));
+    mkdirSync(join(fixtureHome, ".ssh"), { recursive: true });
+    writeFileSync(join(fixtureHome, ".ssh", "id_ed25519"), "FAKE-PRIVATE-KEY");
+    mkdirSync(join(fixtureHome, ".config", "metafactory", "cortex", "system"), { recursive: true });
+    writeFileSync(
+      join(fixtureHome, ".config", "metafactory", "cortex", "system", "system.yaml"),
+      "token: FAKE-TOKEN",
+    );
+    allowedDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-stops-allowed-"));
+    writeFileSync(join(allowedDir, "readonly.txt"), "ro-content");
+    otherStackDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-stops-other-stack-"));
+    writeFileSync(join(otherStackDir, "secret.txt"), "other-stack-secret");
+  });
+
+  afterEach(() => {
+    rmSync(fixtureHome, { recursive: true, force: true });
+    rmSync(allowedDir, { recursive: true, force: true });
+    rmSync(otherStackDir, { recursive: true, force: true });
+  });
+
+  function runUnderProfile(argv: string[], extraDenyPaths: string[] = []): { exitCode: number; stdout: string; stderr: string } {
+    const profile = baseProfile({ readOnly: [allowedDir] });
+    const generated = generateMacosSbplProfile(profile, { homeDir: fixtureHome, extraDenyPaths });
+    const profileDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-stops-profile-"));
+    try {
+      const profilePath = join(profileDir, "stop.sb");
+      writeFileSync(profilePath, generated.text);
+      const result = Bun.spawnSync(["sandbox-exec", "-f", profilePath, ...argv], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return {
+        exitCode: result.exitCode,
+        stdout: result.stdout.toString(),
+        stderr: result.stderr.toString(),
+      };
+    } finally {
+      rmSync(profileDir, { recursive: true, force: true });
+    }
+  }
+
+  test("stop 1 — out-of-scope read (another stack's repo) is denied via extraDenyPaths", () => {
+    const target = join(otherStackDir, "secret.txt");
+    const r = runUnderProfile(["/bin/cat", target], [otherStackDir]);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("Operation not permitted");
+    expect(r.stdout).not.toContain("other-stack-secret");
+  });
+
+  test("stop 2 — config-dir read is denied (CONFIG IMMUTABILITY)", () => {
+    const target = join(fixtureHome, ".config", "metafactory", "cortex", "system", "system.yaml");
+    const r = runUnderProfile(["/bin/cat", target]);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("Operation not permitted");
+    expect(r.stdout).not.toContain("FAKE-TOKEN");
+  });
+
+  test("stop 3 — ~/.ssh read is denied", () => {
+    const target = join(fixtureHome, ".ssh", "id_ed25519");
+    const r = runUnderProfile(["/bin/cat", target]);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("Operation not permitted");
+    expect(r.stdout).not.toContain("FAKE-PRIVATE-KEY");
+  });
+
+  test("stop 4 — write into a readOnlyDir is denied (F6)", () => {
+    const target = join(allowedDir, "readonly.txt");
+    const r = runUnderProfile(["/usr/bin/tee", target], []);
+    // tee still exits non-zero here because the write is denied — spot
+    // check via stderr rather than relying on tee's own exit-code contract.
+    expect(r.stderr).toContain("Operation not permitted");
+  });
+
+  test("positive control — reading INSIDE the readOnlyDir (not writing) stays allowed", () => {
+    const target = join(allowedDir, "readonly.txt");
+    const r = runUnderProfile(["/bin/cat", target]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("ro-content");
+  });
+});
+
+describe.skipIf(!isDarwin)("MacosSbplSandbox — spawn() mode gating", () => {
+  test("mode 'off' — byte-identical Bun.spawn pass-through, no .sb profile, no canary", () => {
+    const spy = spyOn(Bun, "spawn");
+    try {
+      const sandbox = new MacosSbplSandbox();
+      const profile = baseProfile({ mode: "off" });
+      const proc = sandbox.spawn(["/bin/echo", "hi"], profile, {
+        env: {},
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [argv] = spy.mock.calls[0] as [string[], unknown];
+      expect(argv).toEqual(["/bin/echo", "hi"]);
+      expect(sandbox.canaryResult).toBeUndefined();
+      proc.kill();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("mode 'audit' wraps argv with sandbox-exec -f <profile> and runs the canary", async () => {
+    const sandbox = new MacosSbplSandbox();
+    const profile = baseProfile({ mode: "audit" });
+    const proc = sandbox.spawn(["/bin/echo", "hi"], profile, {
+      env: {},
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await readAllStdout(proc.stdout);
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("hi");
+    expect(sandbox.canaryResult?.passed).toBe(true);
+  }, 15_000);
+
+  test("audit mode with a FAILING canary logs a warning but still launches (does not block)", async () => {
+    // Force the canary to observe "READ_OK" (the E3 failure shape) by
+    // mocking Bun.spawnSync ONLY for the canary's own subprocess — spawn()
+    // itself uses the async Bun.spawn for the actual session, so this does
+    // not interfere with the real launch.
+    const spy = spyOn(Bun, "spawnSync").mockImplementation(
+      (() => ({
+        exitCode: 0,
+        stdout: Buffer.from("READ_OK"),
+        stderr: Buffer.from(""),
+        success: true,
+        resourceUsage: undefined,
+        signalCode: undefined,
+      })) as unknown as typeof Bun.spawnSync,
+    );
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const sandbox = new MacosSbplSandbox();
+      const profile = baseProfile({ mode: "audit" });
+      const proc = sandbox.spawn(["/bin/echo", "hi"], profile, {
+        env: {},
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const exitCode = await proc.exited;
+      expect(exitCode).toBe(0); // still launched — audit does not block
+      expect(sandbox.canaryResult?.passed).toBe(false);
+      const warned = stderrSpy.mock.calls.some((c) =>
+        String(c[0]).includes("DD-9 canary self-test failed in audit mode"),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      spy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  }, 15_000);
+
+  test("enforce mode with a FAILING canary REFUSES to launch (throws) — DD-9 fail-closed, HELD (mechanism only, no live caller sets 'enforce')", () => {
+    const spy = spyOn(Bun, "spawnSync").mockImplementation(
+      (() => ({
+        exitCode: 0,
+        stdout: Buffer.from("READ_OK"),
+        stderr: Buffer.from(""),
+        success: true,
+        resourceUsage: undefined,
+        signalCode: undefined,
+      })) as unknown as typeof Bun.spawnSync,
+    );
+    try {
+      const sandbox = new MacosSbplSandbox();
+      const profile = baseProfile({ mode: "enforce" });
+      expect(() =>
+        sandbox.spawn(["/bin/echo", "hi"], profile, { env: {}, stdout: "pipe", stderr: "pipe" }),
+      ).toThrow(/DD-9 canary self-test failed/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("enforce mode with a PASSING canary launches normally (real canary, no mocking)", async () => {
+    const sandbox = new MacosSbplSandbox();
+    const profile = baseProfile({ mode: "enforce" });
+    const proc = sandbox.spawn(["/bin/echo", "hi"], profile, {
+      env: {},
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(0);
+    expect(sandbox.canaryResult?.passed).toBe(true);
+  }, 15_000);
+
+  test("acceptance: a §5 'stop' (read-only-dir write, F6) IS denied end-to-end via the real class, under a locally-forced enforce", async () => {
+    // Goes through the REAL production call site — `MacosSbplSandbox.spawn()`
+    // with `mode: "enforce"` — rather than hand-driving `sandbox-exec`
+    // directly (as the dedicated "four stops" describe block above does with
+    // a homeDir-overridden fixture, since `spawn()` itself has no homeDir
+    // override and always resolves the real `$HOME`). `readOnly` is a
+    // profile-controlled fixture dir either way, so this is safe to run
+    // against the real class without touching the machine's real
+    // ~/.ssh/~/.config/metafactory/cortex.
+    const roDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-enforce-stop-ro-"));
+    writeFileSync(join(roDir, "f.txt"), "ro-content");
+    try {
+      const sandbox = new MacosSbplSandbox();
+      const profile = baseProfile({ mode: "enforce", readOnly: [roDir] });
+      // A shell redirect (not `tee`) — it never reads stdin at all, so the
+      // denied open() is the ENTIRE command; no stdin-lifecycle question.
+      const target = join(roDir, "f.txt");
+      const proc = sandbox.spawn(["/bin/sh", "-c", `echo attempted-write > ${target}`], profile, {
+        env: {},
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr = await readAllStdout(proc.stderr);
+      await proc.exited;
+      expect(sandbox.canaryResult?.passed).toBe(true); // enforce actually ran (didn't refuse to launch)
+      expect(stderr).toContain("Operation not permitted");
+    } finally {
+      rmSync(roDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});
+
+describe.skipIf(!isDarwin)("MacosSbplSandbox — denial observation end-to-end (real sandbox-exec + log stream)", () => {
+  test("a real denied read under audit mode is observed via denials()", async () => {
+    // realpathSync immediately — same E3-shaped `/var` → `/private/var`
+    // rationale as the fixtures above.
+    const fixtureHome = realpathSync(mkdtempSync(join(tmpdir(), "cortex-sbpl-denial-home-")));
+    mkdirSync(join(fixtureHome, ".ssh"), { recursive: true });
+    writeFileSync(join(fixtureHome, ".ssh", "id_ed25519"), "FAKE-KEY");
+    try {
+      const sandbox = new MacosSbplSandbox();
+      const profile = baseProfile({ mode: "audit" });
+      // Spawn a session that (after a short delay, to clear log-stream's
+      // measured ~1s startup latency — module doc) attempts to read the
+      // denied ~/.ssh fixture file, using the profile's OWN generated text
+      // by constructing the argv the way spawn() itself would, but with a
+      // homeDir override — spawn() doesn't take opts for homeDir, so this
+      // test drives generateMacosSbplProfile + sandbox-exec directly and
+      // asserts the PARSER against a live log-stream tail, rather than
+      // routing through spawn() (which always resolves $HOME for real).
+      const generated = generateMacosSbplProfile(profile, { homeDir: fixtureHome });
+      const profileDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-denial-profile-"));
+      const profilePath = join(profileDir, "denial.sb");
+      writeFileSync(profilePath, generated.text);
+
+      const target = join(fixtureHome, ".ssh", "id_ed25519");
+      // 2500ms — the module doc's measured ~1s `log stream` startup latency
+      // plus headroom. This test flaked at 1200ms under load (other tests'
+      // recently-spawned sandbox-exec/log processes appear to add jitter to
+      // unified-log delivery) — this is the SAME observability gap the
+      // module doc discloses, not a new one; the wider margin is a test
+      // robustness fix, not evidence the underlying enforcement is delayed
+      // (SBPL enforcement itself is not delayed — only the LOG ENTRY is).
+      const script = `setTimeout(() => { try { require("fs").readFileSync(${JSON.stringify(target)}); } catch (e) { } }, 2500);`;
+
+      const logProc = Bun.spawn(
+        ["sandbox-exec", "-f", profilePath, "bun", "-e", script],
+        { stdout: "ignore", stderr: "ignore" },
+      );
+
+      const observed: { path?: string; reason: string }[] = [];
+      const denialAbort = new AbortController();
+      const tail = (async () => {
+        const proc = Bun.spawn(
+          ["log", "stream", "--style", "ndjson", "--predicate", `eventMessage CONTAINS "(${logProc.pid}) deny"`],
+          { stdout: "pipe", stderr: "ignore" },
+        );
+        denialAbort.signal.addEventListener("abort", () => { try { proc.kill(); } catch { /* already exited */ } });
+        if (!proc.stdout || typeof proc.stdout === "number") return;
+        const reader = proc.stdout.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+            for (const line of lines) {
+              const denial = parseSandboxDenialLogLine(line, logProc.pid);
+              if (denial) observed.push(denial);
+            }
+          }
+        } catch { /* stream closed on abort — expected */ }
+      })();
+
+      await logProc.exited;
+      // Grace period AFTER the subject process has exited — the log entry
+      // for a denial that happened right before exit can still be in-flight
+      // through the unified-log pipeline (module doc's observability gap).
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      denialAbort.abort();
+      await tail;
+
+      expect(observed.length).toBeGreaterThan(0);
+      expect(observed[0]?.path).toContain("id_ed25519");
+      rmSync(profileDir, { recursive: true, force: true });
+    } finally {
+      rmSync(fixtureHome, { recursive: true, force: true });
+    }
+  }, 20_000);
+});

--- a/src/runner/__tests__/session-sandbox.test.ts
+++ b/src/runner/__tests__/session-sandbox.test.ts
@@ -1,7 +1,13 @@
 /**
  * EBH-2 (cortex#2344) — unit tests for the `SessionSandbox` choke point:
  * the `none` backend's pass-through + once-per-instance event, and the
- * boot capability probe's memoization + HARD-HOLD resolution.
+ * boot capability probe's memoization + resolution.
+ *
+ * EBH-3a (cortex#2345) updates the resolution tests: the HARD HOLD is
+ * LIFTED for macOS specifically (`resolveSandboxBackend` now resolves
+ * `"macos-sbpl"` on a Darwin probe with `sandboxExecAvailable: true`) and
+ * REMAINS for every other platform/container case (EBH-3b territory). See
+ * `resolveSandboxBackend`'s doc comment in `session-sandbox.ts`.
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
@@ -92,7 +98,7 @@ describe("NoneSandbox — the EBH-2 pass-through backend", () => {
   });
 });
 
-describe("resolveSandboxBackend — cortex#2344 HARD HOLD", () => {
+describe("resolveSandboxBackend — EBH-3a: macOS HARD HOLD lifted, Linux/container held", () => {
   const baseProbe: SandboxCapabilityProbe = {
     platform: "darwin",
     sandboxExecAvailable: false,
@@ -104,7 +110,17 @@ describe("resolveSandboxBackend — cortex#2344 HARD HOLD", () => {
     probedAt: new Date().toISOString(),
   };
 
-  test("always resolves to 'none', even when every capability is available", () => {
+  test("darwin + sandboxExecAvailable → resolves 'macos-sbpl'", () => {
+    expect(resolveSandboxBackend({ ...baseProbe, sandboxExecAvailable: true })).toBe(
+      "macos-sbpl",
+    );
+  });
+
+  test("darwin WITHOUT sandboxExecAvailable → resolves 'none' (E1 not proven viable)", () => {
+    expect(resolveSandboxBackend({ ...baseProbe, sandboxExecAvailable: false })).toBe("none");
+  });
+
+  test("darwin resolution ignores bwrap/landlock fields entirely", () => {
     expect(
       resolveSandboxBackend({
         ...baseProbe,
@@ -113,17 +129,31 @@ describe("resolveSandboxBackend — cortex#2344 HARD HOLD", () => {
         bwrapUnshareWorks: true,
         landlockAvailable: true,
       }),
+    ).toBe("macos-sbpl");
+  });
+
+  test("linux HARD HOLD still stands — 'none' even when bwrap fully viable (EBH-3b territory)", () => {
+    expect(
+      resolveSandboxBackend({
+        ...baseProbe,
+        platform: "linux",
+        sandboxExecAvailable: false,
+        bwrapAvailable: true,
+        bwrapUnshareWorks: true,
+        landlockAvailable: true,
+      }),
     ).toBe("none");
   });
 
-  test("always resolves to 'none' when every capability is unavailable", () => {
-    expect(resolveSandboxBackend(baseProbe)).toBe("none");
+  test("in-container HARD HOLD still stands — 'none' regardless of mount scoping (DD-8, EBH-3b)", () => {
+    expect(
+      resolveSandboxBackend({ ...baseProbe, platform: "linux", inContainer: true }),
+    ).toBe("none");
   });
 
-  test("resolution is independent of platform/container state", () => {
-    expect(resolveSandboxBackend({ ...baseProbe, platform: "linux", inContainer: true })).toBe(
-      "none",
-    );
+  test("every capability unavailable on any platform → 'none'", () => {
+    expect(resolveSandboxBackend(baseProbe)).toBe("none");
+    expect(resolveSandboxBackend({ ...baseProbe, platform: "linux" })).toBe("none");
   });
 });
 
@@ -150,9 +180,17 @@ describe("getSandboxCapabilityProbe — DD-7 boot probe caching", () => {
     expect(first).not.toBe(second);
   });
 
-  test("resolvedBackend on the live probe is 'none' (HARD HOLD, this build)", async () => {
+  test("resolvedBackend on the live probe matches resolveSandboxBackend(probe) — no drift between boot and the pure resolver", async () => {
     const probe = await getSandboxCapabilityProbe();
-    expect(probe.resolvedBackend).toBe("none");
+    // EBH-3a: on a real macOS host with a working sandbox-exec (this repo's
+    // dev/CI-adjacent machines), the live probe now legitimately resolves
+    // "macos-sbpl" — the OLD hardcoded 'none' assertion no longer reflects
+    // reality. What must ALWAYS hold, on every platform this runs on, is
+    // that the probe's own resolution never drifts from the pure resolver.
+    expect(probe.resolvedBackend).toBe(resolveSandboxBackend(probe));
+    if (probe.platform !== "darwin" || !probe.sandboxExecAvailable) {
+      expect(probe.resolvedBackend).toBe("none");
+    }
   });
 
   test("probe never throws and always returns booleans, on whatever platform CI runs", async () => {

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -26,6 +26,7 @@ import {
   type SandboxMode,
   type SandboxProfile,
   type SandboxUnavailableEvent,
+  type SandboxDenialEvent,
 } from "./session-sandbox";
 
 // Re-export for convenience
@@ -578,12 +579,15 @@ export class CCSession extends EventEmitter {
 
     // EBH-2 (cortex#2344, DD-2) — the choke point. Every `claude --print`
     // spawn in cortex funnels through `SessionSandbox.spawn`, not a direct
-    // `Bun.spawn`. This build ships exactly the `none` backend
-    // (`createSessionSandbox` — see session-sandbox.ts): it spawns
-    // byte-identically to the pre-EBH-2 call below and fires
-    // `onUnavailable` once (DD-4/DD-6) so an un-jailed host is never
-    // silent. The `mode` on the projected profile is advisory only in this
-    // build — `none` does not branch on it — see `CCSessionOpts.sandboxMode`.
+    // `Bun.spawn`. EBH-3a (cortex#2345) adds the real `macos-sbpl` backend
+    // — `createSessionSandbox` (session-sandbox.ts) resolves it from the
+    // BOOT-warmed capability probe's sync snapshot; a session spawned before
+    // boot warms the probe (or any test that never calls
+    // `getSandboxCapabilityProbe`) still gets `none`, byte-identical to
+    // EBH-2. The `mode` on the projected profile still defaults to `"off"`
+    // on every live dispatch path (`CCSessionOpts.sandboxMode`) — resolving
+    // a real backend class is not the same as enforcing anything; see
+    // `session-sandbox-macos.ts`'s class doc for the `mode` gate.
     const sandboxMode: SandboxMode = this.opts.sandboxMode ?? "off";
     const sandboxProfile = deriveSandboxProfile(this.opts, sandboxMode);
     const sandbox = createSessionSandbox({
@@ -594,8 +598,8 @@ export class CCSession extends EventEmitter {
         this.emit("security-event", event);
         process.stderr.write(
           `[cc-session] ${event.type} backend=${event.backend} mode=${event.mode} — ` +
-            `no kernel execution boundary is enforcing this session (EBH-2; EBH-3 lands ` +
-            `real backends). See docs/design-session-sandbox.md.\n`,
+            `no kernel execution boundary is enforcing this session (EBH-2; EBH-3a landed the ` +
+            `macos-sbpl backend). See docs/design-session-sandbox.md.\n`,
         );
       },
     });
@@ -607,12 +611,9 @@ export class CCSession extends EventEmitter {
     // assert an exact claude-spawn call count — passes through. Triggering
     // a real subprocess spawn from inside that choke point breaks those
     // counts (confirmed: cc-session-isolation.test.ts) and adds
-    // platform-dependent flakiness to every boot in the test suite. The
-    // probe itself is fully implemented and independently unit-tested
-    // (session-sandbox.test.ts); wiring its FIRST call into an actual boot
-    // path (`cortex.ts`'s `startCortex`, most likely) is left to a
-    // dedicated follow-up that can address the test-suite fan-out
-    // deliberately rather than as a side effect of this choke-point change.
+    // platform-dependent flakiness to every boot in the test suite. EBH-3a
+    // wires the FIRST call into `cortex.ts`'s `startCortex` instead (a
+    // one-time boot-path call, well away from this per-session choke point).
     try {
       this.proc = sandbox.spawn(["claude", ...args], sandboxProfile, {
         stdout: "pipe",
@@ -620,6 +621,43 @@ export class CCSession extends EventEmitter {
         env,
         cwd: this.opts.cwd,
       });
+
+      // EBH-3a (DD-6) — drain the backend's denial stream in the background
+      // for the lifetime of this session and surface each one the same way
+      // `onUnavailable` is surfaced above: a "security-event" EventEmitter
+      // payload (not yet a direct bus publish — same "future bus publisher"
+      // scoping as sandbox-unavailable) plus a stderr line. `none`'s
+      // `denials()` never yields (nothing enforced, nothing to deny), so
+      // this loop is a permanent no-op for every session until a real
+      // backend resolves AND its mode is audit/enforce — see
+      // `session-sandbox-macos.ts`.
+      void (async () => {
+        try {
+          for await (const denial of sandbox.denials()) {
+            const event: SandboxDenialEvent = {
+              type: "system.security.sandbox-denial",
+              backend: sandbox.backend,
+              mode: sandboxProfile.mode,
+              ...(denial.path && { path: denial.path }),
+              ...(denial.host && { host: denial.host }),
+              reason: denial.reason,
+              timestamp: denial.timestamp,
+            };
+            this.emit("security-event", event);
+            process.stderr.write(
+              `[cc-session] ${event.type} backend=${event.backend} mode=${event.mode} ` +
+                `path=${event.path ?? "-"} host=${event.host ?? "-"} reason="${event.reason}"\n`,
+            );
+          }
+        } catch (err) {
+          // A denial-stream failure (e.g. `log stream` itself crashed) must
+          // never take the session down with it — log and move on.
+          console.warn(
+            "cc-session: sandbox denial stream ended unexpectedly:",
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      })();
 
       // Start inactivity-based timeout (resets on every stream event)
       this.resetInactivityTimer();

--- a/src/runner/session-sandbox-macos.ts
+++ b/src/runner/session-sandbox-macos.ts
@@ -1,0 +1,674 @@
+/**
+ * EBH-3a (cortex#2345) — the `macos-sbpl` `SessionSandbox` backend.
+ *
+ * ## What this is
+ *
+ * Generates an SBPL (`.sb`) profile from a resolved {@link SandboxProfile}
+ * and runs the session under it via `sandbox-exec -f <profile>` (DD-4's
+ * macOS row). Posture is **DD-10 v1 `guarded`**: `(allow default)` plus
+ * explicit `deny` rules for the sensitive set — NOT strict `(deny default)`.
+ * E4 (`docs/design-session-sandbox-platforms.md` §2) measured that a strict
+ * deny-default profile `SIGABRT`s (exit 134) without extensive dyld/mach
+ * allowances the runtime doesn't have cataloged yet; denylist-first is the
+ * deliberate staged choice, not an oversight. `(deny default)`/v2 `strict`
+ * is future work once the compatibility contract (design doc §3/§5) is
+ * empirically pinned end-to-end.
+ *
+ * ## The E3 discipline (THE thing that must not go wrong)
+ *
+ * E3 measured that a deny rule authored against an UNRESOLVED symlink alias
+ * (`/tmp/x`, which is itself a symlink to `/private/tmp/x`) silently does
+ * NOTHING — the read succeeds. The identical rule authored against the
+ * REALPATH (`/private/tmp/x`) correctly denies. This module's own repro
+ * (2026-07-25, this host) reproduced that finding exactly: a deny rule
+ * written as `/tmp/<marker>` failed to deny a read via `/tmp/<marker>`,
+ * while the same rule written as the resolved `/private/tmp/<marker>`
+ * denied correctly — see the canary below, which exercises this EXACT shape
+ * every session.
+ *
+ * Every path that enters {@link generateMacosSbplProfile} is resolved with
+ * {@link resolveProspectiveRealpath} (`path-containment.ts`, EBH-1's
+ * already-hardened realpath discipline — reused, not re-implemented) BEFORE
+ * it is written into the profile text. A path that fails to resolve is
+ * EXCLUDED and reported in `unresolved` — fail closed, never silently
+ * dropped from tracking, never silently trusted unresolved.
+ *
+ * ## What v1 `guarded` denies (the "sensitive set")
+ *
+ * `(allow default)` means everything NOT explicitly denied stays allowed —
+ * so this posture protects the enumerated set that matters most (secrets,
+ * tokens, self-modification), not universal allowedDirs-only confinement.
+ * That fuller boundary (deny everything outside `allowedDirs`) is v2
+ * `strict`'s job (DD-10) and needs deny-default, which E4 rules out for
+ * this slice. Denied here:
+ *
+ *   - `~/.config/metafactory/cortex/**` (config dir — CONFIG IMMUTABILITY, F1)
+ *   - `~/.ssh`, `~/.aws` (arbitrary-secret read, F1)
+ *   - `~/.claude/settings.json` — WRITE only (self-modification)
+ *   - `~/.claude/hooks/**` — WRITE only (self-modification; READ+EXEC stays
+ *     allowed — the compatibility contract requires it)
+ *   - every `readOnly` dir on the profile — WRITE only (F6)
+ *   - any caller-supplied `extraDenyPaths` (read+write) — the generic escape
+ *     hatch a caller (a test, or a future "other stacks" enumeration) uses to
+ *     deny an out-of-scope root this module doesn't know about by name.
+ *
+ * ## Denial observability (DD-6)
+ *
+ * `sandbox-exec` execs the target IN PLACE (execve replaces the process
+ * image; `Bun.spawn`'s returned pid IS the pid the kernel logs against —
+ * verified empirically, 2026-07-25, this host). macOS's unified log records
+ * every denial as `Sandbox: NAME(PID) deny(N) OPERATION PATH` (verified via
+ * `log stream --style ndjson`, both `file-read-data` and `file-write-create`
+ * operations). `MacosSbplSandbox.denials()` tails `log stream` scoped to the
+ * spawned pid and parses that exact line shape.
+ *
+ * **Known observability gap (measured, not assumed):** `log stream` has
+ * roughly ~1s of startup latency before it reliably delivers events (spot-
+ * checked on this host: a denial triggered before the stream had been
+ * running ~1s did not appear). SBPL enforcement itself is NOT delayed — a
+ * denial in the first second of a session is still denied — but its LOG
+ * ENTRY, and therefore the `system.security.sandbox-denial` event, may be
+ * missed. Acceptable for `audit`/`enforce`'s observability purpose (session
+ * lifetimes are seconds-to-minutes); flagged here rather than assumed away.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import type { Subprocess } from "bun";
+import { resolveProspectiveRealpath } from "../common/path-containment";
+import type {
+  SandboxDenial,
+  SandboxProfile,
+  SandboxSpawnOpts,
+  SessionSandbox,
+} from "./session-sandbox";
+
+// -----------------------------------------------------------------------------
+// SBPL text generation
+// -----------------------------------------------------------------------------
+
+/** Escape a resolved path for embedding in an SBPL string literal. Paths on
+ *  a real deployment never legitimately contain `"`/`\`, but a profile
+ *  generator that trusted that without escaping would be exactly the kind
+ *  of "looks safe, isn't" gap this epic exists to close. */
+function sbplQuote(path: string): string {
+  return path.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/** One `(deny …)` clause's inputs — kept structured (not pre-stringified)
+ *  so {@link generateMacosSbplProfile} can report exactly which INPUT path
+ *  produced which resolved deny, for `unresolved` reporting. */
+interface DenyEntry {
+  input: string;
+  op: "file-read*" | "file-write*";
+}
+
+export interface MacosSbplProfileOpts {
+  /**
+   * Additional roots to deny read+write, beyond the built-in sensitive set.
+   * The generic escape hatch for "out-of-scope" roots this module doesn't
+   * know by name (another stack's repo, a test fixture proving the
+   * mechanism generalizes past the three hardcoded categories). Real
+   * "enumerate every other stack" wiring is follow-up work — deriving that
+   * list needs a stacks registry `deriveSandboxProfile`/this module doesn't
+   * have access to today; this parameter is the seam that wiring lands in.
+   */
+  extraDenyPaths?: string[];
+  /** Override `$HOME` (tests). Defaults to `os.homedir()`. */
+  homeDir?: string;
+}
+
+export interface MacosSbplProfile {
+  /** The compiled SBPL text — write verbatim to a `.sb` file. */
+  text: string;
+  /** Every input path that failed to realpath-resolve, and why. FAIL CLOSED:
+   *  none of these made it into `text` — an unresolvable sensitive-set path
+   *  is not silently trusted, but it's also not fatal (e.g. `~/.aws` simply
+   *  doesn't exist on a host with no AWS credentials configured — nothing to
+   *  protect there either). Surfaced so a caller can decide whether to log. */
+  unresolved: { input: string; reason: string }[];
+  /** The resolved (realpath'd) roots actually denied — for tests/logging. */
+  resolvedDenyPaths: string[];
+}
+
+/**
+ * Build the built-in sensitive-set deny entries (design-session-sandbox.md
+ * §3, -platforms.md §5, DD-10 v1). Split out so tests can assert on the
+ * SET independent of SBPL string formatting.
+ */
+function builtinSensitiveDenyEntries(profile: SandboxProfile, homeDir: string): DenyEntry[] {
+  const entries: DenyEntry[] = [
+    // CONFIG IMMUTABILITY (F1) — the whole tree, read AND write. Simpler and
+    // STRONGER than trying to enumerate "other stacks" individually: this
+    // session's OWN stack config is denied too (least privilege — a session
+    // has no legitimate need to read its own stack's tokens off disk).
+    { input: join(homeDir, ".config", "metafactory", "cortex"), op: "file-read*" },
+    { input: join(homeDir, ".config", "metafactory", "cortex"), op: "file-write*" },
+    // Arbitrary-secret read (F1).
+    { input: join(homeDir, ".ssh"), op: "file-read*" },
+    { input: join(homeDir, ".ssh"), op: "file-write*" },
+    { input: join(homeDir, ".aws"), op: "file-read*" },
+    { input: join(homeDir, ".aws"), op: "file-write*" },
+    // Self-modification — WRITE only. Read+exec of hooks is a compatibility-
+    // contract REQUIREMENT (design doc §3), so hooks are not read-denied.
+    { input: join(homeDir, ".claude", "settings.json"), op: "file-write*" },
+    { input: join(homeDir, ".claude", "hooks"), op: "file-write*" },
+  ];
+  // F6 — a readOnlyDir is read-only at the kernel layer too, not just L1's
+  // path guard. Write-deny only; read stays allowed via (allow default).
+  for (const dir of profile.readOnly) {
+    entries.push({ input: dir, op: "file-write*" });
+  }
+  return entries;
+}
+
+/**
+ * EBH-3a — generate the DD-10 v1 `guarded` SBPL profile for `profile`.
+ * Every deny root is realpath-resolved via {@link resolveProspectiveRealpath}
+ * BEFORE being written into the profile text — the E3 discipline (module
+ * doc). `readWrite`/`execAllow`/`egressAllow` are NOT projected into the
+ * profile: under `(allow default)` they are already permitted (nothing to
+ * allow-list explicitly); they're carried on `SandboxProfile` for v2
+ * `strict`'s eventual deny-default + explicit-allow posture, unused here.
+ */
+export function generateMacosSbplProfile(
+  profile: SandboxProfile,
+  opts: MacosSbplProfileOpts = {},
+): MacosSbplProfile {
+  const homeDir = opts.homeDir ?? homedir();
+  const entries: DenyEntry[] = [
+    ...builtinSensitiveDenyEntries(profile, homeDir),
+    ...(opts.extraDenyPaths ?? []).flatMap(
+      (p): DenyEntry[] => [
+        { input: p, op: "file-read*" },
+        { input: p, op: "file-write*" },
+      ],
+    ),
+  ];
+
+  const unresolved: { input: string; reason: string }[] = [];
+  const resolvedDenyPaths = new Set<string>();
+  const lines: string[] = ["(version 1)", "(allow default)"];
+
+  for (const entry of entries) {
+    const resolution = resolveProspectiveRealpath(entry.input);
+    if (!resolution.ok) {
+      unresolved.push({ input: entry.input, reason: resolution.reason });
+      continue;
+    }
+    resolvedDenyPaths.add(resolution.real);
+    lines.push(`(deny ${entry.op} (subpath "${sbplQuote(resolution.real)}"))`);
+  }
+
+  return {
+    text: lines.join("\n") + "\n",
+    unresolved,
+    resolvedDenyPaths: [...resolvedDenyPaths],
+  };
+}
+
+// -----------------------------------------------------------------------------
+// DD-9 canary self-test — proves the E3 failure specifically, every session
+// -----------------------------------------------------------------------------
+
+export interface CanaryResult {
+  passed: boolean;
+  detail: string;
+}
+
+/**
+ * The child script run UNDER the canary's sandbox-exec wrapper. Reads the
+ * canary file via `fs.readFileSync` and prints a machine-parseable line —
+ * deliberately NOT shelling out to `cat` and parsing its stderr text (E2
+ * already proved bun's own `readFileSync` surfaces `EPERM` directly; using
+ * the SAME runtime the real session uses is also more representative than a
+ * coreutils proxy).
+ */
+const CANARY_READ_SCRIPT =
+  'try { require("fs").readFileSync(process.argv[1]); console.log("READ_OK"); } ' +
+  'catch (e) { console.log("ERR:" + (e && e.code ? e.code : "UNKNOWN")); }';
+
+interface CanaryFixture {
+  unresolvedFile: string;
+  resolvedReal: string;
+  isRealShape: boolean;
+  profilePath: string;
+  cleanup: () => void;
+}
+
+type CanaryFixtureResult = { ok: true; fixture: CanaryFixture } | { ok: false; result: CanaryResult };
+
+/**
+ * Shared setup for {@link runMacosCanarySelfTest} (async) and its
+ * synchronous sibling used at `spawn()`'s synchronous call site — creates
+ * the `/tmp`-aliased fixture file, resolves its realpath, and writes the
+ * deny-by-realpath `.sb` profile. Kept as ONE function so the fixture
+ * shape, the `/tmp` choice (§ module doc), and the realpath discipline can
+ * never drift between the two call sites — only "how do we wait for the
+ * subprocess" (sync vs async) differs at the two call sites.
+ */
+function prepareCanaryFixture(): CanaryFixtureResult {
+  const marker = `cortex-sbpl-canary-${randomUUID()}`;
+  // `/tmp` is used deliberately (not `os.tmpdir()`, which on macOS is
+  // typically a per-user `/var/folders/.../T/` path with NO symlink
+  // indirection) — `/tmp` IS the well-known symlink to `/private/tmp` that
+  // E3 measured failing, so this is the real E3 shape, not a proxy for it.
+  const unresolvedDir = join("/tmp", marker);
+  const unresolvedFile = join(unresolvedDir, "canary.txt");
+  let profileDir: string | undefined;
+
+  const cleanupAll = (): void => {
+    try {
+      rmSync(unresolvedDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup — a leftover canary temp dir is not a
+      // correctness issue, only tidiness, and must never mask the result.
+    }
+    if (profileDir) {
+      try {
+        rmSync(profileDir, { recursive: true, force: true });
+      } catch {
+        // Same rationale.
+      }
+    }
+  };
+
+  try {
+    mkdirSync(unresolvedDir, { recursive: true });
+    writeFileSync(unresolvedFile, "canary-do-not-read");
+
+    const resolution = resolveProspectiveRealpath(unresolvedDir);
+    if (!resolution.ok) {
+      cleanupAll();
+      return {
+        ok: false,
+        result: {
+          passed: false,
+          detail: `canary setup could not realpath-resolve its own fixture dir: ${resolution.reason}`,
+        },
+      };
+    }
+    // Sanity: the whole point of this canary is that resolvedDir DIFFERS
+    // from unresolvedDir (that's the E3 shape). On a host where /tmp is NOT
+    // a symlink (not macOS, or a future macOS that changes this), the two
+    // would be equal and the canary degrades to a same-path check — still a
+    // meaningful (if less pointed) proof, so it isn't refused, but is noted.
+    const isRealShape = resolution.real !== unresolvedDir;
+
+    profileDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-canary-profile-"));
+    const profilePath = join(profileDir, "canary.sb");
+    writeFileSync(
+      profilePath,
+      "(version 1)\n(allow default)\n" +
+        `(deny file-read* (subpath "${sbplQuote(resolution.real)}"))\n`,
+    );
+
+    return {
+      ok: true,
+      fixture: {
+        unresolvedFile,
+        resolvedReal: resolution.real,
+        isRealShape,
+        profilePath,
+        cleanup: cleanupAll,
+      },
+    };
+  } catch (err) {
+    cleanupAll();
+    return {
+      ok: false,
+      result: {
+        passed: false,
+        detail: `canary self-test threw during setup: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    };
+  }
+}
+
+/**
+ * Shared interpretation of the canary child's stdout — the DD-9 pass/fail
+ * logic (§4 "require an EXPLICIT EPERM… not sufficient evidence" — see
+ * {@link runMacosCanarySelfTest}'s doc for the full rationale). Both call
+ * sites (sync and async) feed this the SAME classification, so a change to
+ * what counts as "passed" can't drift between them.
+ */
+function interpretCanaryOutput(trimmed: string, fixture: CanaryFixture): CanaryResult {
+  if (trimmed === "ERR:EPERM") {
+    return {
+      passed: true,
+      detail:
+        `canary correctly denied (EPERM) reading the unresolved alias "${fixture.unresolvedFile}" ` +
+        `under a deny rule authored against the resolved "${fixture.resolvedReal}"` +
+        (fixture.isRealShape
+          ? ""
+          : " (NOTE: host's /tmp is not a symlink — degraded, same-path proof)"),
+    };
+  }
+  if (trimmed === "READ_OK") {
+    return {
+      passed: false,
+      detail:
+        "CRITICAL (E3): the canary read via the UNRESOLVED alias SUCCEEDED even though the " +
+        `deny rule targets its resolved realpath ("${fixture.resolvedReal}") — the sandbox is ` +
+        "silently inert for symlink-aliased paths on this host/build.",
+    };
+  }
+  return {
+    passed: false,
+    detail: `canary produced an unexpected result (not READ_OK or ERR:EPERM): "${trimmed}"`,
+  };
+}
+
+/**
+ * DD-9 — run the canary self-test that proves symlink-aware deny matching
+ * held for THIS host, THIS session (design-session-sandbox-platforms.md
+ * §4 DD-9, and this repo's own -platforms.md doc's "must exercise the
+ * symlink-alias failure, not a proxy for it"). Exact required shape:
+ *
+ *   1. author the deny rule against the RESOLVED path (`/private/tmp/<marker>`)
+ *   2. attempt the read via the UNRESOLVED alias (`/tmp/<marker>`)
+ *   3. require an EXPLICIT `EPERM` — "the read did not succeed" alone is not
+ *      sufficient evidence (a missing file also fails that way).
+ *
+ * ASYNC entry point — used by tests and any future async caller. `spawn()`
+ * itself (synchronous, per the `SessionSandbox` interface) calls
+ * {@link runMacosCanarySelfTestSync} instead; both share
+ * {@link prepareCanaryFixture}/{@link interpretCanaryOutput} so the fixture
+ * shape and pass/fail logic cannot drift between them.
+ */
+export async function runMacosCanarySelfTest(): Promise<CanaryResult> {
+  const prepared = prepareCanaryFixture();
+  if (!prepared.ok) return prepared.result;
+  const { fixture } = prepared;
+  try {
+    const proc = Bun.spawn(
+      ["sandbox-exec", "-f", fixture.profilePath, "bun", "-e", CANARY_READ_SCRIPT, fixture.unresolvedFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    return interpretCanaryOutput(stdout.trim(), fixture);
+  } catch (err) {
+    return {
+      passed: false,
+      detail: `canary self-test threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  } finally {
+    fixture.cleanup();
+  }
+}
+
+/**
+ * Synchronous sibling of {@link runMacosCanarySelfTest} for `spawn()`'s
+ * synchronous call site — `Bun.spawnSync` gives a blocking subprocess
+ * primitive. Shares the SAME fixture setup and result interpretation as the
+ * async version (see those functions); only the "wait for the subprocess"
+ * step differs.
+ */
+function runMacosCanarySelfTestSync(): CanaryResult {
+  const prepared = prepareCanaryFixture();
+  if (!prepared.ok) return prepared.result;
+  const { fixture } = prepared;
+  try {
+    const result = Bun.spawnSync(
+      ["sandbox-exec", "-f", fixture.profilePath, "bun", "-e", CANARY_READ_SCRIPT, fixture.unresolvedFile],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    return interpretCanaryOutput(result.stdout.toString().trim(), fixture);
+  } catch (err) {
+    return {
+      passed: false,
+      detail: `canary self-test threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  } finally {
+    fixture.cleanup();
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Denial observation — tail the unified log for THIS session's pid
+// -----------------------------------------------------------------------------
+
+/** `Sandbox: NAME(PID) deny(N) OPERATION RESOURCE` — verified against this
+ *  host's actual `log stream --style ndjson` output (both `file-read-data`
+ *  and `file-write-create` operations), 2026-07-25. `RESOURCE` is a path for
+ *  file operations; kept as a generic capture group since a future operation
+ *  class (e.g. `mach-lookup`) reads the same shape with a service name
+ *  instead of a path. */
+const SANDBOX_DENIAL_RE = /^Sandbox: (\S+)\((\d+)\) deny\((\d+)\) (\S+) (.*)$/;
+
+interface LogStreamEventMessage {
+  eventMessage?: string;
+  timestamp?: string;
+}
+
+/**
+ * Parse one `log stream --style ndjson` line into a {@link SandboxDenial},
+ * or `undefined` if the line isn't a denial for `pid` (noise, a different
+ * process's denial, or a malformed/non-JSON line — `log stream` occasionally
+ * emits a non-JSON preamble line ("Filtering the log data using…") which
+ * must not throw). Exported for unit tests — this is the part that doesn't
+ * need a real `log stream` subprocess to verify.
+ */
+export function parseSandboxDenialLogLine(line: string, pid: number): SandboxDenial | undefined {
+  let parsed: LogStreamEventMessage;
+  try {
+    parsed = JSON.parse(line) as LogStreamEventMessage;
+  } catch {
+    return undefined;
+  }
+  const message = parsed.eventMessage;
+  if (typeof message !== "string") return undefined;
+
+  const match = SANDBOX_DENIAL_RE.exec(message);
+  if (!match) return undefined;
+  const [, , pidStr, , op, resource] = match;
+  if (Number(pidStr) !== pid) return undefined;
+
+  return {
+    path: resource,
+    reason: `${op} denied`,
+    timestamp: parsed.timestamp ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * Tail `log stream` for denials attributed to `pid`, yielding a
+ * {@link SandboxDenial} per matching line. The predicate is scoped to the
+ * pid at the log-query layer (`eventMessage CONTAINS "(<pid>) deny"`) so we
+ * only pay JSON-parse cost for lines that are at least plausibly ours — a
+ * pid is a cortex-controlled integer here (from `Bun.spawn`), never
+ * attacker-influenced, so string-interpolating it into the predicate is
+ * safe. See the module doc's "Known observability gap" for the ~1s
+ * startup-latency caveat this was empirically measured against.
+ */
+async function* tailSandboxDenials(pid: number, signal: AbortSignal): AsyncIterable<SandboxDenial> {
+  const proc = Bun.spawn(
+    [
+      "log",
+      "stream",
+      "--style",
+      "ndjson",
+      "--predicate",
+      `eventMessage CONTAINS "(${pid}) deny"`,
+    ],
+    { stdout: "pipe", stderr: "ignore" },
+  );
+
+  const onAbort = (): void => {
+    try {
+      proc.kill();
+    } catch {
+      // Already exited — nothing to clean up.
+    }
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    // `stdout: "pipe"` above statically narrows `proc.stdout` to a
+    // `ReadableStream` (never the `number`/fd-passthrough arm) — no runtime
+    // check needed, unlike a caller that accepts caller-supplied spawn opts
+    // (e.g. `cc-session.ts`'s `pipeStdout`, which does need the check).
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const denial = parseSandboxDenialLogLine(line, pid);
+          if (denial) yield denial;
+        }
+      }
+    } catch (_err) {
+      // Stream closed (process killed on abort, or `log stream` itself
+      // exited) — expected, not an error to surface.
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    try {
+      proc.kill();
+    } catch {
+      // Already exited.
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// MacosSbplSandbox — the SessionSandbox implementation
+// -----------------------------------------------------------------------------
+
+/**
+ * EBH-3a's real macOS backend. `mode`-gated (design doc DD-5):
+ *
+ *   - `"off"`   — byte-identical `Bun.spawn(argv, opts)` pass-through. No
+ *     `.sb` profile is generated, no canary runs, no `log stream` starts.
+ *     This is what makes resolving a REAL backend here safe even though
+ *     `SandboxProfile.mode` defaults to `"off"` on every live dispatch path
+ *     today — resolving `macos-sbpl` is not the same as enforcing anything.
+ *   - `"audit"` — the v1 `guarded` profile IS applied for real (SBPL has no
+ *     genuine report-only primitive — see the module doc's posture
+ *     rationale). The DD-9 canary runs; on failure this is LOGGED (a
+ *     possibly-inert profile this run) but the session still launches — no
+ *     worse than `"off"`. Denials are observed and reported via `denials()`.
+ *   - `"enforce"` — same as `"audit"`, EXCEPT a failed canary REFUSES to
+ *     launch (throws) — DD-9's fail-closed requirement. Built and tested per
+ *     the cortex#2345 HARD HOLD ("wire the mechanism… do not enable it") —
+ *     no live caller ever sets `mode: "enforce"` in this build.
+ */
+export class MacosSbplSandbox implements SessionSandbox {
+  readonly backend = "macos-sbpl" as const;
+
+  private denialAbort: AbortController | undefined;
+  /** Set once `spawn()` decides to apply a profile, so `denials()` (called
+   *  separately, per the `SessionSandbox` interface) knows whether there is
+   *  anything to observe. `undefined` (never spawned, or spawned in `"off"`
+   *  mode) → `denials()` yields nothing, matching `NoneSandbox`. */
+  private denialSource: AsyncIterable<SandboxDenial> | undefined;
+  /** The most recent DD-9 canary result — `undefined` until `spawn()` has
+   *  run one (i.e. before any `"audit"`/`"enforce"` spawn). */
+  private lastCanary: CanaryResult | undefined;
+
+  /** The most recent canary result, exposed for callers (tests, future
+   *  status surfaces) that want to know whether THIS session's profile was
+   *  proven non-inert. `undefined` before any `"audit"`/`"enforce"` spawn. */
+  get canaryResult(): CanaryResult | undefined {
+    return this.lastCanary;
+  }
+
+  spawn(argv: string[], profile: SandboxProfile, opts: SandboxSpawnOpts): Subprocess {
+    if (profile.mode === "off") {
+      // Byte-identical pass-through — see the class doc. No profile, no
+      // canary, no log-stream watcher: a resolved-but-off backend must cost
+      // nothing and change nothing, exactly like NoneSandbox.
+      return Bun.spawn(argv, opts);
+    }
+
+    // Synchronous canary gate. DD-9 requires the canary to run "every
+    // session" before that session's profile is trusted — spawn() is
+    // synchronous (the whole `SessionSandbox` interface is), so this uses
+    // Bun's synchronous spawn-and-wait primitive rather than restructuring
+    // the choke point to be async. `Bun.spawnSync` mirrors `Bun.spawn`'s
+    // exec semantics; the canary's own implementation is exercised
+    // end-to-end (including its async path) by the dedicated canary tests —
+    // this call site only needs pass/fail, synchronously.
+    const canary = runMacosCanarySelfTestSync();
+    this.lastCanary = canary;
+
+    if (!canary.passed) {
+      if (profile.mode === "enforce") {
+        // DD-9 fail-closed — HELD (cortex#2345): no live caller sets
+        // `mode: "enforce"`, but the mechanism must exist and be correct
+        // for the day EBH-3's rollout (design doc §6 step 3) flips it.
+        throw new Error(
+          `[session-sandbox-macos] refusing to launch under enforce: DD-9 canary self-test ` +
+            `failed — ${canary.detail}`,
+        );
+      }
+      // audit — log loudly, but do not block. A possibly-inert profile in
+      // audit mode is no worse than "off"; refusing to launch here would
+      // make audit strictly more disruptive than the mode it exists to
+      // de-risk (design doc §6).
+      process.stderr.write(
+        `[session-sandbox-macos] WARNING: DD-9 canary self-test failed in audit mode — this ` +
+          `session's sandbox profile may be silently inert. ${canary.detail}\n`,
+      );
+    }
+
+    const generated = generateMacosSbplProfile(profile);
+    if (generated.unresolved.length > 0) {
+      process.stderr.write(
+        `[session-sandbox-macos] ${generated.unresolved.length} sensitive-set path(s) could ` +
+          `not be realpath-resolved and are NOT denied this session (fail-closed exclusion, ` +
+          `not a fail-open grant): ` +
+          generated.unresolved.map((u) => `"${u.input}" (${u.reason})`).join("; ") +
+          "\n",
+      );
+    }
+
+    const profileDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-"));
+    const profilePath = join(profileDir, "session.sb");
+    writeFileSync(profilePath, generated.text);
+
+    const proc = Bun.spawn(["sandbox-exec", "-f", profilePath, ...argv], opts);
+
+    // Profile file cleanup — needed only until sandbox-exec has read it
+    // (it's read once, at exec time), but kept alive until process exit for
+    // debuggability (a principal inspecting a hung/misbehaving session can
+    // read the exact profile it launched under).
+    void proc.exited.finally(() => {
+      try {
+        rmSync(profileDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort — a leftover temp profile is tidiness, not correctness.
+      }
+      this.denialAbort?.abort();
+    });
+
+    this.denialAbort = new AbortController();
+    this.denialSource = tailSandboxDenials(proc.pid, this.denialAbort.signal);
+
+    return proc;
+  }
+
+  async *denials(): AsyncIterable<SandboxDenial> {
+    if (!this.denialSource) return; // "off" mode, or spawn() never called
+    for await (const denial of this.denialSource) {
+      yield denial;
+    }
+  }
+}
+
+// Re-exported so a future status surface (`cortex stack list`, per
+// -platforms.md §6.5) can check "does this file even exist / is /tmp a
+// symlink on this host" without re-deriving the check. Not currently
+// consumed outside this module + its tests.
+export function isPathLikelyResolvable(path: string): boolean {
+  return existsSync(path);
+}

--- a/src/runner/session-sandbox.ts
+++ b/src/runner/session-sandbox.ts
@@ -1,5 +1,11 @@
 /**
  * EBH-2 (cortex#2344) — `SessionSandbox` choke point + the `none` backend.
+ * EBH-3a (cortex#2345) — lifts the HARD HOLD for macOS: {@link resolveSandboxBackend}
+ * now resolves `"macos-sbpl"` when the boot probe proves it viable. The real
+ * implementation lives in `session-sandbox-macos.ts` (kept out of this file
+ * so the interfaces/probe/none-backend stay the small, stable core EBH-2
+ * shipped — see that module's doc comment for the profile-generation,
+ * canary, and denial-observation design).
  *
  * ## What this closes
  *
@@ -9,28 +15,44 @@
  * child, because EBH-1's six adversarial rounds proved a **string-parsing**
  * guard can be made fail-closed but never sound (TOCTOU, coverage drift —
  * see -platforms.md §1). This module is that jail's *shape* — the
- * `SessionSandbox` interface every real backend (EBH-3: `macos-sbpl`,
- * `linux-bwrap`, `container-delegated`) will implement — plus the ONE
- * backend EBH-2 actually ships: `none`.
+ * `SessionSandbox` interface every real backend (`macos-sbpl`, EBH-3b's
+ * `linux-bwrap`/`container-delegated`) implements — plus the `none` backend
+ * (EBH-2) and the resolution wiring (EBH-3a) that picks between them.
  *
  * `none` spawns byte-identically to the pre-EBH-2 code (no kernel
  * enforcement — that's what "none" means) and loudly records that fact
  * (DD-4/DD-6/DD-7) so an unsandboxed host is never silent. It exists so
  * `cc-session.ts`'s spawn call has exactly ONE shape regardless of backend,
- * and so `macos-sbpl`/`linux-bwrap` (EBH-3) drop in without touching the
- * choke point (`cc-session.ts`'s `start()`) at all.
+ * and so `macos-sbpl` (this slice) and `linux-bwrap`/`container-delegated`
+ * (EBH-3b) drop in without touching the choke point (`cc-session.ts`'s
+ * `start()`) at all.
  *
- * ## HARD HOLD (cortex#2344 — this is EBH-2, not EBH-3)
+ * ## HARD HOLD — REMAINING SCOPE (EBH-3a is macOS-only; EBH-3b is not this slice)
  *
- * `macos-sbpl` and `linux-bwrap` are NOT implemented here. The boot
- * capability probe below (DD-7) detects whether their prerequisites are
- * present and records that for EBH-3 to consume, but {@link resolveSandboxBackend}
- * ALWAYS resolves to `"none"` in this build, regardless of what the probe
- * finds — there is no enforcement backend yet to resolve to.
+ * `linux-bwrap` and `container-delegated` are NOT implemented here — DD-8b's
+ * real-topology acceptance gate (E5: `bwrap` fails even as root inside a
+ * container's default seccomp/userns policy) needs its own dedicated slice.
+ * {@link resolveSandboxBackend} resolves `"macos-sbpl"` on a Darwin host
+ * where the probe proved `sandbox-exec` viable (E1/E2); every Linux/container
+ * probe result still resolves to `"none"`, exactly as EBH-2 shipped.
+ *
+ * The **`mode` default is unaffected by this change** — {@link SandboxMode}
+ * still defaults to `"off"` everywhere (`CCSessionOpts.sandboxMode`), and no
+ * dispatch path threads a config-resolved `"audit"`/`"enforce"` value through
+ * yet. Resolving a real `macos-sbpl` `SessionSandbox` instance is not the
+ * same as ENFORCING anything: with `mode: "off"` (the only value any live
+ * caller sets), `MacosSbplSandbox.spawn()` is a byte-identical pass-through,
+ * identical to `NoneSandbox` — see `session-sandbox-macos.ts`.
  */
 
 import { existsSync, readFileSync } from "fs";
 import type { Subprocess } from "bun";
+// EBH-3a — the real macOS backend. Kept in its own module (profile
+// generation, the DD-9 canary, and unified-log denial parsing are
+// substantial enough to want their own file); `session-sandbox-macos.ts`
+// imports ONLY types back from this module (never a runtime value), so this
+// is a one-directional runtime edge, not a circular import.
+import { MacosSbplSandbox } from "./session-sandbox-macos";
 
 // -----------------------------------------------------------------------------
 // SandboxProfile — DD-1's kernel-level projection of the resolved policy
@@ -107,8 +129,10 @@ export const SANDBOX_EGRESS_ALLOW_SEED: readonly string[] = Object.freeze([
 
 /** One denied access, surfaced by a real backend's kernel/audit log (DD-6).
  *  The `none` backend's {@link SessionSandbox.denials} never yields one —
- *  it enforces nothing, so nothing can be denied — but the shape exists now
- *  so EBH-3 doesn't change the `SessionSandbox` interface to add it. */
+ *  it enforces nothing, so nothing can be denied. `macos-sbpl` (EBH-3a,
+ *  `session-sandbox-macos.ts`) parses macOS unified-log `Sandbox: NAME(PID)
+ *  deny(N) OPERATION PATH` lines scoped to the spawned child's pid — see that
+ *  module for the empirically-verified log shape. */
 export interface SandboxDenial {
   path?: string;
   host?: string;
@@ -152,6 +176,25 @@ export interface SandboxUnavailableEvent {
   type: "system.security.sandbox-unavailable";
   backend: "none";
   mode: SandboxMode;
+  timestamp: string;
+}
+
+/**
+ * `system.security.sandbox-denial` observability payload (DD-6, EBH-3a) —
+ * the bus-event projection of a {@link SandboxDenial} a real backend
+ * observed. Same hyphenated-leaf discipline as {@link SandboxUnavailableEvent}
+ * (cortex#1935's regression gate) and the same "not yet a myelin wire
+ * envelope, plain EventEmitter payload for now" scoping: see that type's doc
+ * comment — it applies here verbatim. Emitted by `CCSession` (`cc-session.ts`)
+ * as it drains `SessionSandbox.denials()`, one event per observed denial.
+ */
+export interface SandboxDenialEvent {
+  type: "system.security.sandbox-denial";
+  backend: SandboxBackendId;
+  mode: SandboxMode;
+  path?: string;
+  host?: string;
+  reason: string;
   timestamp: string;
 }
 
@@ -217,16 +260,27 @@ export class NoneSandbox implements SessionSandbox {
 }
 
 /**
- * Construct the resolved `SessionSandbox` for a spawn. EBH-2 ships exactly
- * one backend, so this is currently a thin (but real) seam: EBH-3 extends
- * the switch, not the call sites that call this function.
+ * Construct the resolved `SessionSandbox` for a spawn.
+ *
+ * EBH-3a (cortex#2345) — now a REAL switch: when the boot probe has been
+ * warmed (see {@link getCachedSandboxCapabilityProbeSync}) and resolves to
+ * `"macos-sbpl"`, this constructs the real backend (`session-sandbox-macos.ts`).
+ * Every other case — probe not yet warmed, resolves to `"none"`, or any
+ * EBH-3b backend not yet implemented — falls back to `NoneSandbox`, BYTE-
+ * IDENTICAL to EBH-2. This is a synchronous function (called from
+ * `CCSession.start()`, itself synchronous) so it can only ever consult the
+ * SYNC snapshot, never the async probe directly — see that getter's doc for
+ * why an un-warmed probe is a safe, deliberate no-op fallback rather than a
+ * blocking wait.
  */
 export function createSessionSandbox(opts?: {
   onUnavailable?: (event: SandboxUnavailableEvent) => void;
 }): SessionSandbox {
-  // `resolveSandboxBackend` is intentionally NOT consulted here yet — every
-  // resolution collapses to `"none"` until EBH-3 adds a real implementation
-  // to construct. Once it does, this factory is where the switch lives.
+  const probe = getCachedSandboxCapabilityProbeSync();
+  const backend = probe ? resolveSandboxBackend(probe) : "none";
+  if (backend === "macos-sbpl") {
+    return new MacosSbplSandbox();
+  }
   return new NoneSandbox(opts?.onUnavailable);
 }
 
@@ -347,16 +401,56 @@ function checkInContainer(): boolean {
 
 /**
  * Resolve the backend this build will construct, given a capability probe.
- * HARD-PINNED to `"none"` (cortex#2344 HARD HOLD — see the module doc).
  * Takes the probe as a parameter (rather than reading the cache itself) so
- * it stays a pure, directly-testable function; EBH-3 is expected to grow
- * real branches here keyed on the probe's fields.
+ * it stays a pure, directly-testable function.
+ *
+ * EBH-3a (cortex#2345) lifts the EBH-2 HARD HOLD for macOS ONLY: a Darwin
+ * probe that proved `sandbox-exec` viable (E1/E2 — {@link
+ * SandboxCapabilityProbe.sandboxExecAvailable}) resolves to `"macos-sbpl"`.
+ * Every other case — non-Darwin, or Darwin without a viable `sandbox-exec` —
+ * still resolves to `"none"`, exactly as EBH-2 shipped. `linux-bwrap` and
+ * `container-delegated` remain UNRESOLVABLE (never returned) until EBH-3b
+ * lands DD-8b's real-topology acceptance gate — that HARD HOLD is unchanged
+ * by this slice.
+ *
+ * Resolving `"macos-sbpl"` here is NOT the same as enforcing anything: the
+ * constructed `MacosSbplSandbox`'s behaviour is gated on `SandboxProfile.mode`
+ * (still defaulted to `"off"` everywhere a real dispatch path sets it) — see
+ * `session-sandbox-macos.ts`.
  */
-export function resolveSandboxBackend(_probe: SandboxCapabilityProbe): SandboxBackendId {
+export function resolveSandboxBackend(probe: SandboxCapabilityProbe): SandboxBackendId {
+  if (probe.platform === "darwin" && probe.sandboxExecAvailable) return "macos-sbpl";
   return "none";
 }
 
 let cachedProbe: Promise<SandboxCapabilityProbe> | undefined;
+
+/**
+ * A SYNCHRONOUS snapshot of the boot probe, set the instant {@link
+ * runSandboxCapabilityProbe}'s promise settles (EBH-3a). Exists ONLY so
+ * {@link createSessionSandbox} — called from `CCSession.start()`, a
+ * synchronous method — can pick a real backend without awaiting anything.
+ *
+ * `undefined` until the FIRST `getSandboxCapabilityProbe()` call resolves —
+ * `createSessionSandbox` treats that as "not yet warmed" and falls back to
+ * `none`, so a session spawned before boot has warmed the probe (or in any
+ * test that never calls `getSandboxCapabilityProbe`) behaves EXACTLY as
+ * EBH-2 shipped. This is what keeps `cc-session-isolation.test.ts`'s exact
+ * `Bun.spawn` call-count assertions green: those tests construct `CCSession`
+ * directly and never warm the probe, so `createSessionSandbox` always
+ * resolves `NoneSandbox` for them, on every platform, in CI and locally.
+ */
+let syncProbeCache: SandboxCapabilityProbe | undefined;
+
+/**
+ * Synchronous read of the memoized probe, or `undefined` if it hasn't been
+ * warmed (or has been reset — see {@link resetSandboxCapabilityProbeForTests}).
+ * Exported for `createSessionSandbox` and for tests that want to assert on
+ * the sync-cache boundary directly without racing the async probe.
+ */
+export function getCachedSandboxCapabilityProbeSync(): SandboxCapabilityProbe | undefined {
+  return syncProbeCache;
+}
 
 async function runSandboxCapabilityProbe(): Promise<SandboxCapabilityProbe> {
   const sandboxExecAvailable = await checkSandboxExec();
@@ -406,7 +500,13 @@ async function runSandboxCapabilityProbe(): Promise<SandboxCapabilityProbe> {
  * concurrent first-callers still only trigger one probe.
  */
 export function getSandboxCapabilityProbe(): Promise<SandboxCapabilityProbe> {
-  cachedProbe ??= runSandboxCapabilityProbe();
+  cachedProbe ??= runSandboxCapabilityProbe().then((probe) => {
+    // EBH-3a — populate the sync snapshot the instant the async probe
+    // settles, so `createSessionSandbox` (a synchronous call from
+    // `CCSession.start()`) can read a resolved backend without awaiting.
+    syncProbeCache = probe;
+    return probe;
+  });
   return cachedProbe;
 }
 
@@ -419,4 +519,5 @@ export function getSandboxCapabilityProbe(): Promise<SandboxCapabilityProbe> {
  */
 export function resetSandboxCapabilityProbeForTests(): void {
   cachedProbe = undefined;
+  syncProbeCache = undefined;
 }


### PR DESCRIPTION
Closes #2345. Second slice of L2 (see #2341). **Enforcement remains off** — `sandboxMode`
defaults to `"off"` everywhere and no caller sets otherwise. This ships the *capability*.

## What lands

- `src/runner/session-sandbox-macos.ts` — `generateMacosSbplProfile()` builds a DD-10 v1
  `guarded` SBPL profile; `MacosSbplSandbox` wraps the spawn in `sandbox-exec`.
- `resolveSandboxBackend` selects `macos-sbpl` on darwin when `sandbox-exec` is present.
  Linux/container untouched (`none`, EBH-3b).
- Denials drained from the macOS unified log into `system.security.sandbox-denial`
  (hyphenated leaf — cortex#1935).
- DD-9 canary runs before every `audit`/`enforce` spawn.

## Independent verification (mine, not the branch's own tests)

I re-measured against real kernel behaviour rather than trusting the branch's assertions —
EBH-1f shipped a regression test that derived its expected values from the function under
test, so it could not fail. Everything below was run against the **generated** profile.

**E3 (the headline risk) — re-measured and sharper than recorded:**

| Rule authored on | Read via | Result |
|---|---|---|
| unresolved `/var/folders/…` | unresolved | **rc=0, contents returned — profile INERT** |
| resolved `/private/var/folders/…` | unresolved alias | rc=1 `Operation not permitted` |
| resolved | resolved | rc=1 `Operation not permitted` |

The kernel canonicalises the *access* and matches it against the literal rule text, so a rule
authored on the resolved path catches **either** name — and one authored on the unresolved path
catches nothing, silently, with no diagnostic. Confirmed the generator emits only resolved
paths (`/private/tmp/…`, never bare `/tmp/…`) and **fails closed** on paths it cannot resolve.

**The four §5 stops, on real paths, asserting explicit `EPERM`:**

| Stop | Result |
|---|---|
| read `~/.ssh` (40 real files present) | denied, `EPERM` |
| read cortex config tree | denied, `EPERM` |
| write `settings.json` / `hooks/` **through the `~/.claude` symlink** | denied; content intact |
| write into a `readOnly` dir (F6) | denied, `EPERM` |

Compatibility held: unrelated reads, `settings.json` **reads**, and read-only-dir reads all
still succeed.

**Also probed:** `subpath` applied to a *file* does deny, and it blocks atomic replace
(`write temp; mv over target`) too — no silent no-op there.

**`mode: "off"` is byte-identical pass-through** — verified in code (`Bun.spawn(argv, opts)`,
no profile, no canary, no log watcher) and by the unchanged spawn-count assertions.

## Adversarial finding — filed as #2409, and a claim corrected here

The posture is `(allow default)` + an enumerated denylist. Probing the generated profile on a
real host, **11 common secret-bearing stores were readable straight through it** (GPG keyring,
Docker config, `gh` host config, OS keychain files, git config, shell histories, assorted agent
state). Only `~/.ssh`, `~/.aws` and the cortex config tree are denied.

This is **not a live vulnerability** (nothing is enforced), and it is *by design* for v1 — E4
measured that strict `(deny default)` SIGABRTs. But it means the plan's claim that L2 fixes
"F1, F6 **by construction**" was wrong, so this PR corrects it: v1 `guarded` closes F6 by
construction and F1 **only for the enumerated set**; v2 `strict` closes F1 by construction.

The structural point, recorded in the plan: **a denylist cannot be completed by adding
entries.** More entries raise the attacker's cost; they never establish a boundary. So
**L2 v1 does not mean "the session is jailed"** — it means "these specific secrets are
protected, and read-only means read-only." Getting that distinction wrong is precisely the
declared-but-not-real failure this epic exists to fix.

## Residuals disclosed, not hidden

- **OQ-2 not discharged.** `fs_usage`/`dtruss` need root and this host has no passwordless
  `sudo`, so the syscall-level touched-path map was not produced. Substituted a real
  end-to-end test (genuine `claude --print`, then a genuine `--resume`, both under the real
  backend in `audit`) asserting zero denials — adequate for a narrow denylist, **not** a
  substitute for OQ-2 proper.
- `extraDenyPaths` exists as a seam but no production caller populates it.
- One transient extra failure appeared in 1 of 5 full-suite runs and did not reproduce in the
  other 4; unattributed.

## Tests

Baseline `origin/main` 10933 pass / 12 fail → branch 10968 pass / 12 fail, **identical failing
test names**. New: 31 tests + 1 real e2e session test, macOS-gated so ubuntu CI no-ops.
