### PR TITLE
feat(runner): EBH-4 — egress allowlist proxy, deny-by-default, enforcement off (#2346)

### DIFF
--- a/docs/design-session-sandbox.md
+++ b/docs/design-session-sandbox.md
@@ -7,6 +7,43 @@
 
 ---
 
+## 0. Implementation status — EBH-4 (cortex#2346, epic #2341)
+
+**§4.3's Layer-3 egress design is now implemented — `src/runner/egress-proxy.ts`
+— with one deliberate scope narrowing worth stating plainly (claim hygiene,
+per the epic's own §"three times now" lesson):**
+
+- **Built:** a per-session, deny-by-default HTTP `CONNECT` filtering proxy.
+  `SandboxProfile.egressAllow` (seeded since EBH-2) is now genuinely
+  enforced: `mode: "audit"` observes+logs denials without blocking
+  (`system.security.egress-denial`), `mode: "enforce"` blocks them. Fail-
+  closed on ambiguity (a malformed/unparseable proxy request is denied in
+  EVERY mode, never just `enforce`). Ships with the SAME HARD HOLD as every
+  prior EBH-2/3a slice: `mode: "off"` everywhere by default, no template/
+  example/dispatch path flips it.
+- **NOT built (this slice):** the §4.3 "physically unable to reach anything
+  but the proxy" story — no Linux network-namespace, no macOS PF anchor.
+  Building either needs root and/or the `linux-bwrap` topology, both
+  explicitly out of scope for EBH-4 (no Linux-specific dependency; macOS-only
+  target). **What actually ships is a cooperating-client proxy**: it works
+  because `cc-session.ts` points the child at it via `HTTP_PROXY`/
+  `HTTPS_PROXY` env vars, and because well-behaved HTTP clients honor those
+  vars. **A process that opens a raw socket and ignores the proxy env vars
+  bypasses this completely** — there is no kernel rule forcing egress
+  through it. Do not read "egress-denial events exist" as "egress is
+  contained" without that qualifier. Full rationale + the exact bypass
+  surface: the module doc at the top of `src/runner/egress-proxy.ts`.
+- This is the SAME shape as every other layer in this epic: FS confinement
+  (L1) is a string-parsing guard that can be made fail-closed but not sound;
+  L2 is a real kernel boundary on macOS but denylist-posture (v1 `guarded`,
+  not deny-default) and PF-anchor-less on the network side; L3 (this doc)
+  is deny-by-default on the hosts it filters, but only for traffic that
+  goes through it in the first place. Defense in depth, not a single
+  silver-bullet boundary — see §5 below, which this note extends rather
+  than replaces.
+
+---
+
 ## 1. Problem statement
 
 Cortex drives `claude --print` child processes from **untrusted inbound content** (Discord messages, GitHub events). Today the filesystem/exec/network boundary for those sessions is:

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -114,7 +114,8 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
     // EBH-2 (cortex#2344) — same `.default()`-but-required-on-output story
     // as `execution`/`plugins` above: `SandboxConfigSchema` fills defaults
     // after parse, so a hand-built `CortexConfig` fixture must include it.
-    sandbox: { mode: "off", backend: "auto" },
+    // EBH-4 (cortex#2346) added `egressAllow` to the same schema.
+    sandbox: { mode: "off", backend: "auto", egressAllow: [] },
     inference: { providers: {}, profiles: {} },
     plugins: { external: false },
     github: {

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -37,6 +37,7 @@ import {
   PolicyFederatedSchema,
   PolicyPublicSchema,
   PolicySchema,
+  SandboxConfigSchema,
   RendererSchema,
   WebhookOutRendererSchema,
   isFederatedSubjectInOwnScope,
@@ -1703,6 +1704,39 @@ describe("PolicySchema — sovereignty.enforce (EBH-6b, cortex#2380)", () => {
   test("policy.sovereignty.enforce: false parses false", () => {
     const parsed = PolicySchema.parse({ sovereignty: { enforce: false } });
     expect(parsed.sovereignty?.enforce).toBe(false);
+  });
+});
+
+/**
+ * EBH-4 (cortex#2346) — `SandboxConfigSchema.egressAllow`. Same
+ * default-off/default-empty, posture-visibility-not-a-flip discipline as
+ * EBH-6b's `sovereignty.enforce` tests above: an absent/empty block parses
+ * to the safe "seed-only allowlist" default, and the field is present and
+ * settable so a `system.yaml` CAN declare additional hosts — with the
+ * dispatch-path wiring deliberately still deferred (see the schema's own
+ * doc comment in `cortex-config.ts`).
+ */
+describe("SandboxConfigSchema — egressAllow (EBH-4, cortex#2346)", () => {
+  test("absent block ⇒ mode off, backend auto, egressAllow empty", () => {
+    const parsed = SandboxConfigSchema.parse({});
+    expect(parsed.mode).toBe("off");
+    expect(parsed.backend).toBe("auto");
+    expect(parsed.egressAllow).toEqual([]);
+  });
+
+  test("egressAllow declared with extra hosts parses through unchanged", () => {
+    const parsed = SandboxConfigSchema.parse({ egressAllow: ["extra.example.com", "another.example.org"] });
+    expect(parsed.egressAllow).toEqual(["extra.example.com", "another.example.org"]);
+  });
+
+  test("egressAllow does not require mode/backend to also be set", () => {
+    const parsed = SandboxConfigSchema.parse({ egressAllow: ["extra.example.com"] });
+    expect(parsed.mode).toBe("off");
+    expect(parsed.backend).toBe("auto");
+  });
+
+  test("non-string entries in egressAllow are rejected (fail closed on malformed config)", () => {
+    expect(() => SandboxConfigSchema.parse({ egressAllow: [123] })).toThrow();
   });
 });
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1686,12 +1686,31 @@ export type ExecutionConfig = z.infer<typeof ExecutionConfigSchema>;
  * accepted by the schema (so a `system.yaml` written against the FUTURE
  * shape doesn't fail to parse today) but has NO effect yet — EBH-3 is what
  * makes `resolveSandboxBackend` branch on it.
+ *
+ * EBH-4 (cortex#2346) adds `egressAllow` — extra hostnames for the L3
+ * egress-filtering proxy (`src/runner/egress-proxy.ts`), ON TOP OF the
+ * static compatibility-contract seed (`SANDBOX_EGRESS_ALLOW_SEED`,
+ * `session-sandbox.ts`: `api.anthropic.com`, `github.com`, …) every session
+ * already carries. **Posture-visibility, not a posture flip — mirrors
+ * EBH-6b's `policy.sovereignty.enforce` pattern** (`PolicySchema.sovereignty`
+ * below): the schema exists and is parseable so a `system.yaml` CAN declare
+ * additional allowed hosts, but — exactly like `mode`/`backend` above —
+ * **no live dispatch path threads this config block into
+ * `CCSessionOpts`/`deriveSandboxProfile` yet.** `deriveSandboxProfile`
+ * currently reads `CCSessionOpts.egressAllow` (a per-call override, e.g. for
+ * tests or a future dispatch-path wiring), never this config field directly.
+ * Wiring `system.sandbox.egressAllow` (and `mode`) from a loaded config into
+ * a live `CCSessionOpts` is the SAME deferred step EBH-3a already deferred
+ * for `mode`/`backend` — a principal decision, not an agent-authored default
+ * (design-session-sandbox.md §6 rollout). `default([])` keeps an absent/
+ * empty block byte-identical to "seed-only allowlist", the safe default.
  */
 export const SandboxConfigSchema = z.object({
   mode: z.enum(["off", "audit", "enforce"]).default("off"),
   backend: z
     .enum(["auto", "macos-sbpl", "linux-bwrap", "container-delegated", "none"])
     .default("auto"),
+  egressAllow: z.array(z.string()).default([]),
 });
 
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;

--- a/src/runner/__tests__/cc-session.test.ts
+++ b/src/runner/__tests__/cc-session.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, spyOn } from "bun:test";
 import { CCSession, type CCSessionOpts, resolvePathGuardEnv, deriveSandboxProfile } from "../cc-session";
 import { resetSandboxCapabilityProbeForTests } from "../session-sandbox";
 import { testClaude } from "../../common/test-utils";
@@ -221,6 +221,29 @@ describe("deriveSandboxProfile — EBH-2 policy → SandboxProfile projection (c
     expect(deriveSandboxProfile({}, "audit").mode).toBe("audit");
     expect(deriveSandboxProfile({}, "enforce").mode).toBe("enforce");
   });
+
+  /**
+   * EBH-4 (cortex#2346) — `opts.egressAllow` extends, never replaces, the
+   * static seed. This is the "wire egressAllow from the profile through to
+   * the proxy" contract's INPUT half — `egress-proxy.ts`'s tests cover the
+   * enforcement half.
+   */
+  test("opts.egressAllow is MERGED with the static seed, not a replacement", () => {
+    const profile = deriveSandboxProfile({ egressAllow: ["extra.example.com"] }, "audit");
+    expect(profile.egressAllow).toContain("api.anthropic.com"); // seed survives
+    expect(profile.egressAllow).toContain("extra.example.com"); // caller addition present
+  });
+
+  test("no opts.egressAllow ⇒ exactly the static seed, no duplication with itself", () => {
+    const profile = deriveSandboxProfile({}, "audit");
+    expect(profile.egressAllow).toEqual([...new Set(profile.egressAllow)]); // no dupes
+    expect(profile.egressAllow.length).toBeGreaterThan(0);
+  });
+
+  test("a duplicate of a seed entry in opts.egressAllow is deduplicated", () => {
+    const profile = deriveSandboxProfile({ egressAllow: ["api.anthropic.com"] }, "audit");
+    expect(profile.egressAllow.filter((h) => h === "api.anthropic.com")).toHaveLength(1);
+  });
 });
 
 /**
@@ -263,4 +286,121 @@ describe("CCSession — EBH-2 SessionSandbox routing", () => {
       backend: "none",
     });
   }, 60_000);
+});
+
+/**
+ * EBH-4 (cortex#2346) — proves `CCSession.start()` actually wires a spawned
+ * child through the `EgressProxy`: env vars set when `sandboxMode` is
+ * `"audit"`/`"enforce"`, absent when it's `"off"` (the HARD HOLD default,
+ * byte-identical to every session that exists today). Uses the same
+ * intercept-`Bun.spawn`-and-throw strategy as `cc-session-isolation.test.ts`
+ * — no real `claude` binary needed, deterministic, CI-safe. The REAL
+ * `EgressProxy` still binds a REAL ephemeral port in the "audit"/"enforce"
+ * cases (this is what proves the wiring, not a mock of it); the outer catch
+ * path (`egressProxy?.stop()`) tears it down when the intercepted spawn
+ * throws, so no port leaks across tests.
+ */
+describe("CCSession — EBH-4 egress proxy env wiring", () => {
+  interface Captured {
+    env: Record<string, string>;
+  }
+
+  function captureSpawn(): { calls: Captured[]; restore: () => void } {
+    const calls: Captured[] = [];
+    const spy = spyOn(Bun, "spawn").mockImplementation(((
+      _cmd: string[],
+      opts: { env: Record<string, string> },
+    ) => {
+      calls.push({ env: opts.env });
+      throw new Error("spawn intercepted by test");
+    }) as unknown as typeof Bun.spawn);
+    return { calls, restore: () => spy.mockRestore() };
+  }
+
+  test("mode 'off' (default) — no proxy env vars, byte-identical to pre-EBH-4", () => {
+    resetSandboxCapabilityProbeForTests();
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({ prompt: "hi", channel: "test" });
+      session.on("error", () => {/* expected — spawn intercepted */});
+      session.start();
+
+      expect(calls).toHaveLength(1);
+      const env = calls[0]!.env;
+      expect(env.HTTP_PROXY).toBeUndefined();
+      expect(env.HTTPS_PROXY).toBeUndefined();
+      expect(env.http_proxy).toBeUndefined();
+      expect(env.https_proxy).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("mode 'audit' — HTTP_PROXY/HTTPS_PROXY point at a real local proxy port, NO_PROXY stripped", () => {
+    resetSandboxCapabilityProbeForTests();
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        sandboxMode: "audit",
+      });
+      session.on("error", () => {/* expected — spawn intercepted */});
+      session.start();
+
+      expect(calls).toHaveLength(1);
+      const env = calls[0]!.env;
+      expect(env.HTTP_PROXY).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+      expect(env.HTTPS_PROXY).toBe(env.HTTP_PROXY);
+      expect(env.http_proxy).toBe(env.HTTP_PROXY);
+      expect(env.https_proxy).toBe(env.HTTP_PROXY);
+      expect(env.NO_PROXY).toBeUndefined();
+      expect(env.no_proxy).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("mode 'enforce' — same env wiring as audit", () => {
+    resetSandboxCapabilityProbeForTests();
+    const { calls, restore } = captureSpawn();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        sandboxMode: "enforce",
+      });
+      session.on("error", () => {/* expected — spawn intercepted */});
+      session.start();
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.env.HTTP_PROXY).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    } finally {
+      restore();
+    }
+  });
+
+  test("a NO_PROXY set on the parent env does not survive into a mode 'enforce' child (bypass-escape-hatch closed)", () => {
+    resetSandboxCapabilityProbeForTests();
+    const { calls, restore } = captureSpawn();
+    const priorNoProxy = process.env.NO_PROXY;
+    process.env.NO_PROXY = "*";
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        channel: "test",
+        sandboxMode: "enforce",
+        settingsIsolation: false, // inherits process.env as the base env
+      });
+      session.on("error", () => {/* expected — spawn intercepted */});
+      session.start();
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.env.NO_PROXY).toBeUndefined();
+    } finally {
+      if (priorNoProxy === undefined) delete process.env.NO_PROXY;
+      else process.env.NO_PROXY = priorNoProxy;
+      restore();
+    }
+  });
 });

--- a/src/runner/__tests__/egress-proxy.test.ts
+++ b/src/runner/__tests__/egress-proxy.test.ts
@@ -1,0 +1,332 @@
+/**
+ * EBH-4 (cortex#2346) — tests for the L3 egress-filtering `CONNECT` proxy.
+ *
+ * These are REAL socket tests (no mocking of `Bun.listen`/`Bun.connect`):
+ * a real destination TCP server, a real `EgressProxy` bound to
+ * `127.0.0.1:<ephemeral>`, and a real raw client socket speaking the
+ * `CONNECT` protocol — because the entire point of this module is that it
+ * genuinely tunnels/denies real bytes, not a simulation of doing so. Every
+ * test is 127.0.0.1-only; nothing here touches the network.
+ *
+ * Acceptance shape the design/EBH-4 brief calls for explicitly: "allowlisted
+ * destination succeeds, non-allowlisted is denied" — both directions are
+ * covered, plus the fail-closed-on-ambiguity discipline (a malformed
+ * request denies in EVERY mode, not just `enforce`) and the `audit` mode's
+ * report-only semantics (denies are observed but the connection still goes
+ * through).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  EgressProxy,
+  isHostAllowed,
+  tryParseConnect,
+  type EgressDenial,
+} from "../egress-proxy";
+
+// -----------------------------------------------------------------------------
+// Pure-function tests — no sockets involved
+// -----------------------------------------------------------------------------
+
+describe("isHostAllowed — exact, case-insensitive, no wildcards", () => {
+  test("exact match allowed", () => {
+    expect(isHostAllowed("api.anthropic.com", new Set(["api.anthropic.com"]))).toBe(true);
+  });
+
+  test("case-insensitive", () => {
+    expect(isHostAllowed("API.Anthropic.COM", new Set(["api.anthropic.com"]))).toBe(true);
+  });
+
+  test("trailing-dot FQDN normalizes the same as without", () => {
+    expect(isHostAllowed("api.anthropic.com.", new Set(["api.anthropic.com"]))).toBe(true);
+  });
+
+  test("host not in allowlist is denied", () => {
+    expect(isHostAllowed("evil.example", new Set(["api.anthropic.com"]))).toBe(false);
+  });
+
+  test("no suffix/wildcard matching — a subdomain of an allowed host is NOT allowed", () => {
+    expect(isHostAllowed("evil.api.anthropic.com", new Set(["api.anthropic.com"]))).toBe(false);
+    expect(isHostAllowed("anthropic.com", new Set(["api.anthropic.com"]))).toBe(false);
+  });
+
+  test("empty allowlist denies everything", () => {
+    expect(isHostAllowed("api.anthropic.com", new Set())).toBe(false);
+  });
+});
+
+describe("tryParseConnect — pure parser", () => {
+  const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+  test("incomplete header (no terminator yet) returns undefined", () => {
+    expect(tryParseConnect(enc("CONNECT api.anthropic.com:443 HTTP/1.1\r\n"))).toBeUndefined();
+  });
+
+  test("well-formed CONNECT parses host/port and captures trailing bytes", () => {
+    const result = tryParseConnect(
+      enc("CONNECT api.anthropic.com:443 HTTP/1.1\r\nHost: api.anthropic.com:443\r\n\r\nTRAILING"),
+    );
+    expect(result?.ok).toBe(true);
+    if (result?.ok) {
+      expect(result.host).toBe("api.anthropic.com");
+      expect(result.port).toBe(443);
+      expect(new TextDecoder().decode(result.trailing)).toBe("TRAILING");
+    }
+  });
+
+  test("non-CONNECT verb is a parse failure (plain-HTTP forward-proxying is out of scope)", () => {
+    const result = tryParseConnect(enc("GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n"));
+    expect(result?.ok).toBe(false);
+  });
+
+  test("non-numeric / out-of-range port is a parse failure", () => {
+    expect(tryParseConnect(enc("CONNECT example.com:notaport HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
+    expect(tryParseConnect(enc("CONNECT example.com:70000 HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
+    expect(tryParseConnect(enc("CONNECT example.com:0 HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
+  });
+
+  test("garbage before the terminator is a parse failure, not a crash", () => {
+    expect(tryParseConnect(enc("\x00\x01\x02 not http at all\r\n\r\n"))?.ok).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Real-socket integration tests
+// -----------------------------------------------------------------------------
+
+/** A trivial echo server: whatever a client sends, it sends back. Used as
+ *  the "allowed destination" the proxy tunnels to. */
+function startEchoServer(): { port: number; connections: number; stop: () => void } {
+  let connections = 0;
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open() {
+        connections += 1;
+      },
+      data(socket, chunk) {
+        socket.write(chunk);
+      },
+      close() {},
+      error() {},
+    },
+  });
+  return {
+    port: listener.port,
+    get connections() {
+      return connections;
+    },
+    stop: () => listener.stop(true),
+  };
+}
+
+/** Raw client that speaks the proxy protocol directly — mirrors the
+ *  `connectRaw` helper pattern in `daemon-socket-auth.test.ts`. */
+async function connectToProxy(proxyPort: number): Promise<{
+  write: (s: string | Uint8Array) => void;
+  received: () => string;
+  close: () => void;
+}> {
+  let buf = "";
+  const sock = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: proxyPort,
+    socket: {
+      data(_socket, chunk: Uint8Array) {
+        buf += new TextDecoder().decode(chunk);
+      },
+      error() {},
+      close() {},
+    },
+  });
+  return {
+    write: (s) => void sock.write(s),
+    received: () => buf,
+    close: () => sock.end(),
+  };
+}
+
+/** Poll until `cond()` is true or throw after `timeoutMs` — same shape as
+ *  `daemon-socket-auth.test.ts`'s `until()`. */
+async function until(cond: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error(`until() timed out waiting for condition`);
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** Drain the first N denials off an EgressProxy without blocking forever. */
+async function collectDenials(proxy: EgressProxy, count: number, timeoutMs = 2000): Promise<EgressDenial[]> {
+  const out: EgressDenial[] = [];
+  const iterator = proxy.denials()[Symbol.asyncIterator]();
+  const deadline = Date.now() + timeoutMs;
+  while (out.length < count) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw new Error(`collectDenials() timed out with ${out.length}/${count} collected`);
+    const result = await Promise.race([
+      iterator.next(),
+      new Promise<{ done: true; value: undefined }>((r) =>
+        setTimeout(() => r({ done: true, value: undefined }), remaining),
+      ),
+    ]);
+    if (result.done) break;
+    out.push(result.value);
+  }
+  return out;
+}
+
+let activeProxies: EgressProxy[] = [];
+let activeServers: { stop: () => void }[] = [];
+
+afterEach(() => {
+  for (const proxy of activeProxies) proxy.stop();
+  for (const server of activeServers) server.stop();
+  activeProxies = [];
+  activeServers = [];
+});
+
+describe("EgressProxy — allowlisted destination (enforce mode)", () => {
+  test("CONNECT to an allowed host succeeds and tunnels real bytes both ways", async () => {
+    const echo = startEchoServer();
+    activeServers.push(echo);
+
+    const proxy = new EgressProxy(["127.0.0.1"], "enforce");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const client = await connectToProxy(port);
+    client.write(`CONNECT 127.0.0.1:${echo.port} HTTP/1.1\r\nHost: 127.0.0.1:${echo.port}\r\n\r\n`);
+    await until(() => client.received().includes("200"));
+    expect(client.received()).toContain("HTTP/1.1 200 Connection Established");
+
+    client.write("ping-through-tunnel");
+    await until(() => client.received().includes("ping-through-tunnel"));
+    expect(client.received()).toContain("ping-through-tunnel");
+    expect(echo.connections).toBe(1);
+
+    client.close();
+  });
+});
+
+describe("EgressProxy — non-allowlisted destination (enforce mode)", () => {
+  test("CONNECT to a denied host is refused with 403 and NEVER reaches the destination", async () => {
+    const echo = startEchoServer();
+    activeServers.push(echo);
+
+    // Allowlist names some OTHER host — 127.0.0.1 (the echo server) is not on it.
+    const proxy = new EgressProxy(["allowed.example"], "enforce");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const denialsPromise = collectDenials(proxy, 1);
+
+    const client = await connectToProxy(port);
+    client.write(`CONNECT 127.0.0.1:${echo.port} HTTP/1.1\r\nHost: 127.0.0.1:${echo.port}\r\n\r\n`);
+    await until(() => client.received().length > 0);
+    expect(client.received()).toContain("403");
+    expect(client.received()).not.toContain("200");
+
+    const denials = await denialsPromise;
+    expect(denials).toHaveLength(1);
+    expect(denials[0]?.blocked).toBe(true);
+    expect(denials[0]?.host).toBe("127.0.0.1");
+
+    // The whole point: a blocked CONNECT never dials the destination at all.
+    expect(echo.connections).toBe(0);
+
+    client.close();
+  });
+});
+
+describe("EgressProxy — audit mode (DD-5 report-only)", () => {
+  test("a would-be-denied host is still connected through, and the denial is observed as NOT blocked", async () => {
+    const echo = startEchoServer();
+    activeServers.push(echo);
+
+    const proxy = new EgressProxy(["allowed.example"], "audit");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const denialsPromise = collectDenials(proxy, 1);
+
+    const client = await connectToProxy(port);
+    client.write(`CONNECT 127.0.0.1:${echo.port} HTTP/1.1\r\nHost: 127.0.0.1:${echo.port}\r\n\r\n`);
+    await until(() => client.received().includes("200"));
+    expect(client.received()).toContain("HTTP/1.1 200 Connection Established");
+
+    const denials = await denialsPromise;
+    expect(denials).toHaveLength(1);
+    expect(denials[0]?.blocked).toBe(false);
+
+    // Audit really does let it through — the destination sees the connection.
+    await until(() => echo.connections === 1);
+
+    client.close();
+  });
+});
+
+describe("EgressProxy — fail-closed on ambiguity, in EVERY mode", () => {
+  test("a malformed (non-CONNECT) request is denied even in audit mode", async () => {
+    const proxy = new EgressProxy(["anything.example"], "audit");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const denialsPromise = collectDenials(proxy, 1);
+
+    const client = await connectToProxy(port);
+    client.write("GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n");
+    await until(() => client.received().length > 0);
+    expect(client.received()).toContain("400");
+
+    const denials = await denialsPromise;
+    expect(denials).toHaveLength(1);
+    // Fail-closed discipline: malformed requests are ALWAYS blocked, even
+    // though this proxy is running in "audit" (which for a RECOGNIZED-but-
+    // disallowed host would have let the connection through).
+    expect(denials[0]?.blocked).toBe(true);
+
+    client.close();
+  });
+
+  test("a malformed request is denied in enforce mode too", async () => {
+    const proxy = new EgressProxy(["anything.example"], "enforce");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const client = await connectToProxy(port);
+    client.write("not even an HTTP request\r\n\r\n");
+    await until(() => client.received().length > 0);
+    expect(client.received()).toContain("400");
+
+    client.close();
+  });
+});
+
+describe("EgressProxy — lifecycle", () => {
+  test("start() twice on the same instance throws", () => {
+    const proxy = new EgressProxy([], "enforce");
+    activeProxies.push(proxy);
+    proxy.start();
+    expect(() => proxy.start()).toThrow();
+  });
+
+  test("stop() closes the listener — a new connection attempt is refused", async () => {
+    const proxy = new EgressProxy([], "enforce");
+    const { port } = proxy.start();
+    proxy.stop();
+
+    let refused = false;
+    try {
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port,
+        socket: { data() {}, error() { refused = true; }, close() {} },
+      });
+    } catch {
+      refused = true;
+    }
+    expect(refused).toBe(true);
+  });
+});

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -28,6 +28,7 @@ import {
   type SandboxUnavailableEvent,
   type SandboxDenialEvent,
 } from "./session-sandbox";
+import { EgressProxy, type EgressDenialEvent } from "./egress-proxy";
 
 // Re-export for convenience
 export type { UsageStats, StreamEvent };
@@ -75,6 +76,18 @@ export interface CCSessionOpts {
    * enforces it (EBH-3).
    */
   sandboxMode?: SandboxMode;
+  /**
+   * EBH-4 (cortex#2346) — additional egress hostnames for THIS session, on
+   * top of {@link SANDBOX_EGRESS_ALLOW_SEED}'s static seed (the compat-
+   * ibility-contract hosts every session needs: the model API, GitHub).
+   * Merged into {@link SandboxProfile.egressAllow} by {@link
+   * deriveSandboxProfile} — see that function's doc for the merge shape.
+   * Undefined/empty behaves exactly like today (seed-only allowlist).
+   * UNENFORCED unless `sandboxMode` is `"audit"`/`"enforce"` — see
+   * `egress-proxy.ts`'s module doc for what "enforced" means here (a
+   * cooperating-client proxy, not a kernel boundary).
+   */
+  egressAllow?: string[];
   timeoutMs?: number;
   cwd?: string;
   additionalArgs?: string[];
@@ -359,12 +372,15 @@ function splitGuardDirs(
  * for the identical reason it resolves to read-only in
  * `CORTEX_PATH_GUARD` (the safe default, EBH-1b).
  *
- * `execAllow`/`egressAllow` are NOT derived from `opts` — they're the
- * static compatibility-contract seed (see `session-sandbox.ts`), unenforced
- * until a real backend exists (EBH-3/EBH-4).
+ * `execAllow` is NOT derived from `opts` — it's the static compatibility-
+ * contract seed (see `session-sandbox.ts`), unenforced until a real exec
+ * jail exists (no backend enforces it yet). `egressAllow` IS now enforced
+ * (EBH-4, `egress-proxy.ts`) — it's the seed PLUS `opts.egressAllow`
+ * (deduplicated), so a caller can extend the allowlist per session without
+ * touching the static compatibility-contract list.
  */
 export function deriveSandboxProfile(
-  opts: Pick<CCSessionOpts, "allowedDirs" | "readOnlyDirs">,
+  opts: Pick<CCSessionOpts, "allowedDirs" | "readOnlyDirs" | "egressAllow">,
   mode: SandboxMode,
 ): SandboxProfile {
   const { allowedDirs, readOnlyDirs } = splitGuardDirs(opts);
@@ -372,7 +388,7 @@ export function deriveSandboxProfile(
     readWrite: allowedDirs,
     readOnly: readOnlyDirs,
     execAllow: [...SANDBOX_EXEC_ALLOW_SEED],
-    egressAllow: [...SANDBOX_EGRESS_ALLOW_SEED],
+    egressAllow: [...new Set([...SANDBOX_EGRESS_ALLOW_SEED, ...(opts.egressAllow ?? [])])],
     mode,
   };
 }
@@ -614,13 +630,111 @@ export class CCSession extends EventEmitter {
     // platform-dependent flakiness to every boot in the test suite. EBH-3a
     // wires the FIRST call into `cortex.ts`'s `startCortex` instead (a
     // one-time boot-path call, well away from this per-session choke point).
+    // EBH-4 (cortex#2346) — the L3 egress allowlist. Declared at function
+    // scope (not inside the try block below) so the `catch` can tear a
+    // successfully-started proxy back down if `sandbox.spawn` itself throws
+    // after the proxy bound its port — see `egress-proxy.ts` for the
+    // mechanism and its claim-hygiene doc (cooperating-client proxy, NOT a
+    // kernel boundary).
+    let egressProxy: EgressProxy | undefined;
     try {
+      // `mode: "off"` (the only value any live dispatch path sets —
+      // `sandboxMode` HARD HOLD, same as the FS backend) never constructs an
+      // `EgressProxy` at all: zero behaviour change, no listening socket, no
+      // env mutation. Only `audit`/`enforce` reach this branch.
+      if (sandboxProfile.mode !== "off") {
+        try {
+          egressProxy = new EgressProxy(sandboxProfile.egressAllow, sandboxProfile.mode);
+          const bound = egressProxy.start();
+          // Force the child through the proxy. Written UNCONDITIONALLY
+          // (upper+lowercase — different tools honor different casing) —
+          // same "cortex is the authoritative writer" discipline as
+          // CORTEX_BASH_GUARD/CORTEX_PATH_GUARD above. A NO_PROXY the parent
+          // env carried is deleted: leaving it would hand a cooperating
+          // client an explicit, config-driven bypass of the very proxy we
+          // just stood up (see egress-proxy.ts's module doc for the OTHER,
+          // non-cooperating bypass this does NOT close).
+          env.HTTP_PROXY = bound.proxyUrl;
+          env.HTTPS_PROXY = bound.proxyUrl;
+          env.http_proxy = bound.proxyUrl;
+          env.https_proxy = bound.proxyUrl;
+          delete env.NO_PROXY;
+          delete env.no_proxy;
+        } catch (proxyErr) {
+          const message = proxyErr instanceof Error ? proxyErr.message : String(proxyErr);
+          egressProxy = undefined;
+          if (sandboxProfile.mode === "enforce") {
+            // Fail closed (repo hard constraint) — "proxy unavailable while
+            // enabled" denies, it never silently launches with unfiltered
+            // egress. Thrown here so the outer catch's existing
+            // cleanupSettings + emit("error")/emit("exit") path handles it
+            // identically to a spawn failure.
+            throw new Error(
+              `[cc-session] EBH-4 egress proxy failed to start under mode "enforce" — refusing ` +
+                `to launch (fail-closed): ${message}`,
+              { cause: proxyErr },
+            );
+          }
+          // audit — no worse than "off" (mirrors MacosSbplSandbox's
+          // audit-canary-fail precedent): warn loudly, launch anyway,
+          // WITHOUT proxy env vars, so this run simply has no egress
+          // observability rather than a broken/inconsistent proxy config.
+          process.stderr.write(
+            `[cc-session] WARNING: EBH-4 egress proxy failed to start in audit mode (${message}) — ` +
+              `this session launches WITHOUT egress filtering or observability this run. ` +
+              `See docs/design-session-sandbox.md §4.3.\n`,
+          );
+        }
+      }
+
       this.proc = sandbox.spawn(["claude", ...args], sandboxProfile, {
         stdout: "pipe",
         stderr: "pipe",
         env,
         cwd: this.opts.cwd,
       });
+
+      if (egressProxy) {
+        const proxy = egressProxy;
+        // Tear the proxy down with the session — a listener left running
+        // past the child's exit is a leaked local port, not a security
+        // issue (127.0.0.1-only, deny-by-default even while orphaned), but
+        // leaking it is still sloppy and would eventually exhaust ephemeral
+        // ports on a long-lived daemon.
+        void this.proc.exited.finally(() => {
+          proxy.stop();
+        });
+        // EBH-4 (DD-6-style observability) — drain the proxy's denial
+        // stream for the lifetime of this session, mirroring EXACTLY the
+        // `SessionSandbox.denials()` loop below (same AsyncIterable
+        // consumption shape, same "security-event" EventEmitter payload,
+        // same never-let-the-drain-loop-crash-the-session discipline).
+        void (async () => {
+          try {
+            for await (const denial of proxy.denials()) {
+              const event: EgressDenialEvent = {
+                type: "system.security.egress-denial",
+                mode: sandboxProfile.mode as "audit" | "enforce",
+                host: denial.host,
+                port: denial.port,
+                reason: denial.reason,
+                blocked: denial.blocked,
+                timestamp: denial.timestamp,
+              };
+              this.emit("security-event", event);
+              process.stderr.write(
+                `[cc-session] ${event.type} mode=${event.mode} host=${event.host} ` +
+                  `port=${event.port} blocked=${event.blocked} reason="${event.reason}"\n`,
+              );
+            }
+          } catch (err) {
+            console.warn(
+              "cc-session: egress-proxy denial stream ended unexpectedly:",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+        })();
+      }
 
       // EBH-3a (DD-6) — drain the backend's denial stream in the background
       // for the lifetime of this session and surface each one the same way
@@ -674,8 +788,12 @@ export class CCSession extends EventEmitter {
       void this.wireExit();
     } catch (error) {
       // Spawn failed before the process existed — clean up the curated
-      // settings temp dir we just created (cortex#701).
+      // settings temp dir we just created (cortex#701), and any EBH-4
+      // egress proxy that bound its port before the failure (whether the
+      // failure WAS the proxy — the enforce fail-closed throw above — or a
+      // later `sandbox.spawn` failure with a proxy already listening).
       this.cleanupSettings();
+      egressProxy?.stop();
       const err = error instanceof Error ? error : new Error(String(error));
       this.emit("error", err);
       this.emit("exit", 1);

--- a/src/runner/egress-proxy.ts
+++ b/src/runner/egress-proxy.ts
@@ -1,0 +1,557 @@
+/**
+ * EBH-4 (cortex#2346, epic #2341) — the L3 **egress allowlist**: a local,
+ * deny-by-default HTTP `CONNECT` filtering proxy.
+ *
+ * ## What this closes
+ *
+ * `docs/design-session-sandbox.md` §4.3 and `docs/design-session-sandbox-platforms.md`
+ * name Layer 3 directly: even a session whose filesystem confinement (L1/L2)
+ * holds can still **exfiltrate** anything it legitimately read, over the
+ * network, to an attacker-controlled host — unless egress itself is bounded.
+ * `SandboxProfile.egressAllow` (`session-sandbox.ts`) has carried that
+ * allowlist since EBH-2, seeded but **unenforced**. This module is what
+ * finally reads it: every hostname a session's child process may reach,
+ * enumerated, everything else denied by default.
+ *
+ * ## THE central claim-hygiene point — read this before trusting the boundary
+ *
+ * **This is a cooperating-client proxy, not a kernel boundary.** It works
+ * ONLY because `cc-session.ts` points the spawned `claude` child at it via
+ * `HTTP_PROXY`/`HTTPS_PROXY` env vars, and because well-behaved HTTP clients
+ * (the `claude` CLI's own networking, `git`, `gh`, `curl` with default
+ * behavior, Node/Bun's `fetch`/`undici` when the env vars are honored)
+ * respect those variables. **A process that ignores `HTTP_PROXY`/`HTTPS_PROXY`
+ * and opens a raw TCP/TLS socket directly bypasses this proxy completely** —
+ * there is no OS-level rule forcing egress through it. That is a REAL,
+ * documented gap, not an oversight:
+ *
+ *   - **macOS** (this build's only target platform — see the module's HARD
+ *     HOLD below): no PF anchor, no per-uid firewall rule is installed.
+ *     Doing that requires root and is explicitly out of scope
+ *     (`docs/design-session-sandbox-platforms.md` calls this the same
+ *     "weaker than Linux" limitation for the FS backend's own posture).
+ *   - **Linux network-namespace containment** (the design doc's stronger
+ *     "physically unable to reach anything but the proxy" story, §4.3) is
+ *     NOT built here — that needs `unshare`/veth plumbing, which is
+ *     `linux-bwrap`/EBH-3b territory and explicitly excluded by this repo's
+ *     "no Linux-specific dependency" constraint for this slice.
+ *
+ * So: **what this DOES stop** — a cooperating child (the `claude` CLI itself,
+ * and any subprocess that inherits/honors the proxy env vars) from reaching
+ * a host outside the allowlist; every such attempt is denied and observable
+ * (`system.security.egress-denial`). **What this does NOT stop** — a
+ * deliberately adversarial process inside the session that opens its own
+ * socket (e.g. `python -c "import socket; …"`, a raw `nc`, a custom binary)
+ * ignoring the proxy env entirely. Do not describe this as "egress is
+ * contained" without that qualifier — it is "egress is contained for
+ * proxy-respecting clients." Closing the raw-socket gap needs either a
+ * kernel-level filter (PF anchor / netns, deferred) or an L1-style
+ * exec-time block on raw-socket-capable interpreters, neither of which is
+ * this slice.
+ *
+ * ## Mechanism
+ *
+ * A per-session `Bun.listen` TCP server on `127.0.0.1:0` (OS-assigned
+ * ephemeral port — never a fixed/predictable port). It speaks exactly ONE
+ * proxy verb: HTTP `CONNECT host:port HTTP/1.1`. On a well-formed CONNECT
+ * whose `host` is on the allowlist (exact, case-insensitive match — see
+ * "no wildcards" below), it dials the target and becomes a raw byte tunnel
+ * (the standard forward-proxy shape every HTTPS-over-proxy client expects).
+ * Anything else — a host not on the allowlist, or a request this parser
+ * cannot make sense of — is a deny.
+ *
+ * **No wildcard/suffix matching, deliberately.** `api.anthropic.com` matches
+ * only `api.anthropic.com`, never `*.anthropic.com`. This is the SAFER
+ * simple choice for a deny-by-default allowlist: a suffix rule is one typo
+ * away from silently admitting an attacker-registered look-alike
+ * (`anthropic.com.evil.example` would NOT match a suffix check written
+ * carelessly, but `evil-anthropic.com` style abuse of a naive `.includes()`
+ * check is exactly the kind of bug this avoids by only ever doing an exact
+ * `Set.has()` lookup). A config that needs a subdomain lists it explicitly.
+ *
+ * ## Fail-closed discipline (repo CLAUDE.md hard constraint)
+ *
+ *   - A CONNECT line this parser cannot understand (bad syntax, non-numeric
+ *     port, out-of-range port, or any non-CONNECT proxy verb — plain-HTTP
+ *     forward-proxying is NOT implemented in this slice) is **always
+ *     denied**, in EVERY mode including `audit`. "We could not determine
+ *     the destination" is ambiguity, and ambiguity denies — it is never
+ *     treated as "well, let it through, we're only auditing."
+ *   - A host recognized but NOT on the allowlist follows {@link SandboxMode}:
+ *     `audit` logs the would-be-denial and STILL connects through (DD-5's
+ *     report-only semantics — unlike the macOS FS backend, this mechanism
+ *     genuinely CAN report without blocking, so it does); `enforce` blocks
+ *     with `403` and never dials the target.
+ *   - If the proxy itself fails to bind, the caller (`cc-session.ts`)
+ *     decides: `enforce` refuses to launch the session at all (fail closed);
+ *     `audit` logs a loud warning and launches WITHOUT the proxy (no worse
+ *     than `mode: "off"` — matches `MacosSbplSandbox`'s audit-canary-fail
+ *     precedent).
+ *
+ * ## HARD HOLD (mirrors EBH-2/EBH-3a's posture — cortex#2346)
+ *
+ * This module is reachable ONLY when a caller passes `mode: "audit"` or
+ * `mode: "enforce"` — and, exactly like `system.sandbox.mode`
+ * (`cortex-config.ts`), **no live dispatch path threads a config-resolved
+ * mode into `CCSessionOpts.sandboxMode` yet**. The default everywhere is
+ * `"off"`, under which `cc-session.ts` never constructs an `EgressProxy` at
+ * all — zero behaviour change for every session that exists today. Flipping
+ * that default is a principal decision (design doc §6 rollout), not
+ * something this slice does.
+ */
+
+import type { Socket, TCPSocketListener } from "bun";
+import type { SandboxMode } from "./session-sandbox";
+
+/** The two modes an {@link EgressProxy} can actually be constructed under —
+ *  `"off"` never reaches this module (see the HARD HOLD above): `cc-session.ts`
+ *  does not construct an `EgressProxy` at all when the resolved
+ *  `SandboxProfile.mode` is `"off"`. */
+export type EgressProxyMode = Exclude<SandboxMode, "off">;
+
+/** One observed egress decision worth surfacing (DD-6-style observability —
+ *  mirrors {@link SandboxDenial}'s shape). `blocked: false` means this was an
+ *  `audit`-mode "would have denied" — the connection was still allowed
+ *  through; `blocked: true` means the connection was actually refused
+ *  (either a real `enforce` denial, or a fail-closed malformed-request
+ *  refusal, which is `blocked: true` in EVERY mode — see the module doc's
+ *  fail-closed discipline). */
+export interface EgressDenial {
+  host: string;
+  port: number;
+  reason: string;
+  blocked: boolean;
+  timestamp: string;
+}
+
+/** `system.security.egress-denial` — HYPHEN, not underscore, in the leaf
+ *  (cortex#1935's regression gate, `src/bus/__tests__/envelope-type-no-underscore.test.ts`,
+ *  scans every non-test source file for exactly this mistake). Mirrors
+ *  {@link SandboxDenialEvent}'s shape/naming discipline (`session-sandbox.ts`)
+ *  but is its own event type — a proxy-layer denial is a distinct
+ *  observation from a kernel FS denial, and conflating the two types would
+ *  make "which layer caught this" unrecoverable from the event alone. Not
+ *  yet a myelin wire envelope — same "plain EventEmitter payload for now,
+ *  a future bus publisher upgrades this" scoping as `SandboxDenialEvent`
+ *  (see that type's doc comment; applies here verbatim). Emitted by
+ *  `CCSession` as it drains {@link EgressProxy.denials}. */
+export interface EgressDenialEvent {
+  type: "system.security.egress-denial";
+  mode: EgressProxyMode;
+  host: string;
+  port: number;
+  reason: string;
+  blocked: boolean;
+  timestamp: string;
+}
+
+// -----------------------------------------------------------------------------
+// Host matching — exact, case-insensitive, no wildcards (see module doc)
+// -----------------------------------------------------------------------------
+
+/** Lowercase + strip a single trailing dot (`"Example.com."` and
+ *  `"example.com"` are the same DNS name — an authored allowlist entry
+ *  should not silently fail to match because of that cosmetic difference). */
+function normalizeHost(host: string): string {
+  const trimmed = host.trim().toLowerCase();
+  return trimmed.endsWith(".") ? trimmed.slice(0, -1) : trimmed;
+}
+
+/** Exported for unit tests — pure, no proxy/socket machinery required. */
+export function isHostAllowed(host: string, allow: ReadonlySet<string>): boolean {
+  return allow.has(normalizeHost(host));
+}
+
+// -----------------------------------------------------------------------------
+// Denial observability — a small pull-based async queue bridging the
+// synchronous Bun socket callbacks to the AsyncIterable shape `cc-session.ts`
+// already drains for SessionSandbox denials (same consumption pattern).
+// -----------------------------------------------------------------------------
+
+class DenialQueue implements AsyncIterable<EgressDenial> {
+  private items: EgressDenial[] = [];
+  private waiters: ((result: IteratorResult<EgressDenial>) => void)[] = [];
+  private closed = false;
+
+  push(item: EgressDenial): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ value: item, done: false });
+    } else {
+      this.items.push(item);
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    while (this.waiters.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length-checked above
+      const waiter = this.waiters.shift()!;
+      waiter({ value: undefined, done: true } as IteratorResult<EgressDenial>);
+    }
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<EgressDenial> {
+    for (;;) {
+      const next = this.items.shift();
+      if (next) {
+        yield next;
+        continue;
+      }
+      if (this.closed) return;
+      const result = await new Promise<IteratorResult<EgressDenial>>((resolve) => {
+        this.waiters.push(resolve);
+      });
+      if (result.done) return;
+      yield result.value;
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// CONNECT parsing
+// -----------------------------------------------------------------------------
+
+/** `CONNECT host:port HTTP/1.1` — the ONE proxy verb this module speaks.
+ *  Anything else (a plain-HTTP forward-proxy `GET http://…` request, an
+ *  unrecognized verb, malformed syntax) does not match and is fail-closed
+ *  denied by the caller — see the module doc's fail-closed discipline. */
+const CONNECT_LINE_RE = /^CONNECT\s+([^\s:/]+):(\d{1,5})\s+HTTP\/\d\.\d\s*$/i;
+
+/** Hard cap on buffered pre-CONNECT header bytes — a client that never
+ *  sends a terminating `\r\n\r\n` (or sends an absurdly long "header")
+ *  is fail-closed denied rather than buffered forever. Generous for a
+ *  CONNECT request (which is normally under 200 bytes) while still bounding
+ *  memory per connection. */
+const MAX_HEADER_BYTES = 8192;
+
+interface ParsedConnect {
+  ok: true;
+  host: string;
+  port: number;
+  /** Bytes received AFTER the `\r\n\r\n` header terminator, if the client
+   *  pipelined tunnel payload ahead of the "200 Connection Established"
+   *  response (unusual for CONNECT but not disallowed) — queued and
+   *  forwarded once the target connection is up. */
+  trailing: Uint8Array;
+}
+interface ParsedConnectFailure {
+  ok: false;
+  /** Best-effort host for the denial event — "?" when not even that much
+   *  could be extracted from the malformed request. */
+  host: string;
+  port: number;
+  reason: string;
+}
+
+/** Pure parse function — exported for unit tests. Returns `undefined` when
+ *  the header terminator hasn't arrived yet (caller should keep buffering,
+ *  up to {@link MAX_HEADER_BYTES}). */
+export function tryParseConnect(buffered: Uint8Array): ParsedConnect | ParsedConnectFailure | undefined {
+  const buf = Buffer.from(buffered.buffer, buffered.byteOffset, buffered.byteLength);
+  const terminatorIdx = buf.indexOf("\r\n\r\n");
+  if (terminatorIdx === -1) return undefined;
+
+  const headerText = buf.subarray(0, terminatorIdx).toString("utf8");
+  const firstLine = (headerText.split("\r\n")[0] ?? "").trim();
+  const match = CONNECT_LINE_RE.exec(firstLine);
+  if (!match) {
+    return {
+      ok: false,
+      host: "?",
+      port: 0,
+      reason: `unparseable proxy request (only CONNECT is supported): "${firstLine.slice(0, 120)}"`,
+    };
+  }
+
+  const host = match[1] ?? "";
+  const portNum = Number(match[2]);
+  if (host.length === 0 || !Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+    return {
+      ok: false,
+      host: host || "?",
+      port: Number.isFinite(portNum) ? portNum : 0,
+      reason: `malformed CONNECT target ("${firstLine.slice(0, 120)}")`,
+    };
+  }
+
+  return {
+    ok: true,
+    host,
+    port: portNum,
+    trailing: new Uint8Array(buf.subarray(terminatorIdx + 4)),
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Per-connection state
+// -----------------------------------------------------------------------------
+
+interface ConnState {
+  /** Raw bytes buffered until the CONNECT header terminator arrives. */
+  headerChunks: Uint8Array[];
+  headerLength: number;
+  /** Set once the CONNECT line has been parsed (successfully or not) — no
+   *  further header parsing happens on this connection past that point. */
+  resolved: boolean;
+  /** The upstream target socket, once dialed. `undefined` before the dial
+   *  resolves (or if the request was denied and no dial was attempted). */
+  target: Socket | undefined;
+  /** Client bytes that arrived before {@link target} finished connecting —
+   *  flushed to the target the moment it's up. */
+  preTunnelQueue: Uint8Array[];
+  /** Set by `teardown()` when the CLIENT side has already closed. A target
+   *  dial can still be in flight at that point (network latency); when it
+   *  resolves, its `open` handler checks this flag and closes the now-
+   *  orphaned upstream connection immediately instead of wiring up a tunnel
+   *  nothing will ever read from — otherwise a client that disconnects
+   *  mid-dial would leak a live upstream socket for the life of that
+   *  connection. */
+  clientClosed: boolean;
+}
+
+function newConnState(): ConnState {
+  return {
+    headerChunks: [],
+    headerLength: 0,
+    resolved: false,
+    target: undefined,
+    preTunnelQueue: [],
+    clientClosed: false,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// EgressProxy
+// -----------------------------------------------------------------------------
+
+const CONNECTION_ESTABLISHED = "HTTP/1.1 200 Connection Established\r\n\r\n";
+const FORBIDDEN = "HTTP/1.1 403 Forbidden\r\n\r\n";
+const BAD_REQUEST = "HTTP/1.1 400 Bad Request\r\n\r\n";
+const BAD_GATEWAY = "HTTP/1.1 502 Bad Gateway\r\n\r\n";
+
+/**
+ * A per-session deny-by-default CONNECT proxy. One instance per spawned
+ * session (`cc-session.ts` constructs and tears one down per `CCSession`,
+ * mirroring `MacosSbplSandbox`'s per-session `.sb` profile lifecycle) — never
+ * shared across sessions, so one session's allowlist can never leak into
+ * another's traffic.
+ */
+export class EgressProxy {
+  private readonly allowSet: ReadonlySet<string>;
+  private readonly mode: EgressProxyMode;
+  private readonly queue = new DenialQueue();
+  private readonly sockets = new Set<Socket<ConnState>>();
+  private listener: TCPSocketListener<ConnState> | undefined;
+
+  constructor(allow: readonly string[], mode: EgressProxyMode) {
+    this.allowSet = new Set(allow.map(normalizeHost));
+    this.mode = mode;
+  }
+
+  /**
+   * Bind on `127.0.0.1:<ephemeral>`. Synchronous — `Bun.listen` resolves
+   * the bind immediately, which matters because `cc-session.ts`'s
+   * `CCSession.start()` (the whole `SessionSandbox`/spawn choke point) is
+   * itself synchronous; this mirrors that constraint the same way
+   * `MacosSbplSandbox.spawn()` does for its own synchronous canary gate.
+   * Throws on a genuine bind failure (fail-closed handling is the caller's
+   * responsibility — see the module doc's "proxy fails to bind" branch).
+   */
+  start(): { port: number; proxyUrl: string } {
+    if (this.listener) {
+      throw new Error("[egress-proxy] start() called twice on the same EgressProxy instance");
+    }
+    this.listener = Bun.listen<ConnState>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open: (socket) => {
+          socket.data = newConnState();
+          this.sockets.add(socket);
+        },
+        data: (socket, chunk) => {
+          this.onClientData(socket, chunk);
+        },
+        close: (socket) => {
+          this.teardown(socket);
+        },
+        error: (socket, err) => {
+          process.stderr.write(`[egress-proxy] client socket error: ${err.message}\n`);
+          this.teardown(socket);
+        },
+      },
+    });
+    return { port: this.listener.port, proxyUrl: `http://127.0.0.1:${this.listener.port}` };
+  }
+
+  /** Close the listener and every live connection (client + dialed target).
+   *  Idempotent — safe to call more than once (e.g. once from the session's
+   *  `proc.exited.finally`, and again from an error-path cleanup). */
+  stop(): void {
+    for (const socket of this.sockets) {
+      const state = socket.data;
+      if (state.target) this.closeSafely(state.target);
+      this.closeSafely(socket);
+    }
+    this.sockets.clear();
+    this.listener?.stop(true);
+    this.listener = undefined;
+    this.queue.close();
+  }
+
+  /** Stream of egress decisions worth surfacing — mirrors
+   *  `SessionSandbox.denials()`'s AsyncIterable shape so `cc-session.ts`
+   *  drains both with the identical `for await` pattern. */
+  denials(): AsyncIterable<EgressDenial> {
+    return this.queue;
+  }
+
+  private onClientData(socket: Socket<ConnState>, chunk: Uint8Array): void {
+    const state = socket.data;
+    if (!state.resolved) {
+      state.headerChunks.push(chunk);
+      state.headerLength += chunk.length;
+      if (state.headerLength > MAX_HEADER_BYTES) {
+        this.denyFailClosed(socket, "?", 0, "CONNECT header exceeded size limit without a terminator");
+        return;
+      }
+      const buffered =
+        state.headerChunks.length === 1
+          ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length-checked above (=== 1)
+            state.headerChunks[0]!
+          : concatChunks(state.headerChunks, state.headerLength);
+      const parsed = tryParseConnect(buffered);
+      if (parsed === undefined) return; // header not complete yet — keep buffering
+      state.resolved = true;
+      state.headerChunks = [];
+
+      if (!parsed.ok) {
+        // Fail-closed discipline: an unparseable request is ALWAYS denied,
+        // in every mode — see the module doc. There is no destination to
+        // even evaluate against the allowlist.
+        this.denyFailClosed(socket, parsed.host, parsed.port, parsed.reason);
+        return;
+      }
+
+      if (parsed.trailing.length > 0) state.preTunnelQueue.push(parsed.trailing);
+      this.handleConnect(socket, state, parsed.host, parsed.port);
+      return;
+    }
+
+    // Header already resolved — this is post-CONNECT tunnel payload.
+    if (state.target) {
+      this.writeSafely(state.target, chunk);
+    } else {
+      // Target dial still in flight (or the request was already denied and
+      // the socket is on its way down) — queue; flushed on connect, dropped
+      // on teardown.
+      state.preTunnelQueue.push(chunk);
+    }
+  }
+
+  private handleConnect(socket: Socket<ConnState>, state: ConnState, host: string, port: number): void {
+    const allowed = isHostAllowed(host, this.allowSet);
+    if (!allowed) {
+      const blocked = this.mode === "enforce";
+      this.queue.push({
+        host,
+        port,
+        reason: `host not on egress allowlist (mode=${this.mode})`,
+        blocked,
+        timestamp: new Date().toISOString(),
+      });
+      if (blocked) {
+        this.writeSafely(socket, FORBIDDEN);
+        this.closeSafely(socket);
+        return;
+      }
+      // audit — DD-5 report-only: log the would-be-denial, still connect
+      // through, so a burn-in window measures real traffic without breaking it.
+    }
+
+    void Bun.connect({
+      hostname: host,
+      port,
+      socket: {
+        open: (targetSocket) => {
+          if (state.clientClosed) {
+            // The client disconnected while this dial was still in flight —
+            // wiring up a tunnel now would just leak an upstream connection
+            // nothing will ever read from. Close it immediately instead.
+            this.closeSafely(targetSocket);
+            return;
+          }
+          state.target = targetSocket;
+          this.writeSafely(socket, CONNECTION_ESTABLISHED);
+          for (const queued of state.preTunnelQueue) this.writeSafely(targetSocket, queued);
+          state.preTunnelQueue = [];
+        },
+        data: (_targetSocket, chunk) => {
+          this.writeSafely(socket, chunk);
+        },
+        close: () => {
+          this.closeSafely(socket);
+        },
+        error: (_targetSocket, err) => {
+          process.stderr.write(`[egress-proxy] target socket error (${host}:${port}): ${err.message}\n`);
+          this.closeSafely(socket);
+        },
+      },
+    }).catch((err: unknown) => {
+      // The target refused/was unreachable — a connectivity failure, NOT a
+      // security denial (the host WAS allowed; the network just failed), so
+      // this is not pushed onto the denial queue. Respond 502 like any real
+      // forward proxy would.
+      process.stderr.write(
+        `[egress-proxy] failed to connect upstream ${host}:${port}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      this.writeSafely(socket, BAD_GATEWAY);
+      this.closeSafely(socket);
+    });
+  }
+
+  private denyFailClosed(socket: Socket<ConnState>, host: string, port: number, reason: string): void {
+    this.queue.push({ host, port, reason, blocked: true, timestamp: new Date().toISOString() });
+    this.writeSafely(socket, BAD_REQUEST);
+    this.closeSafely(socket);
+  }
+
+  private teardown(socket: Socket<ConnState>): void {
+    const state = socket.data;
+    state.clientClosed = true;
+    if (state.target) this.closeSafely(state.target);
+    this.sockets.delete(socket);
+  }
+
+  private writeSafely(socket: Socket<ConnState> | Socket, data: string | Uint8Array): void {
+    try {
+      socket.write(data);
+    } catch {
+      // The peer is already gone (closed/reset mid-write) — nothing to
+      // recover; the corresponding close()/error() handler cleans up state.
+    }
+  }
+
+  private closeSafely(socket: Socket<ConnState> | Socket): void {
+    try {
+      socket.end();
+    } catch {
+      // Already closed — end() on a dead socket is a no-op we don't need to
+      // observe.
+    }
+  }
+}
+
+function concatChunks(chunks: Uint8Array[], totalLength: number): Uint8Array {
+  const out = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #2346. L3 of the ladder (#2341). **Enforcement remains off** — no dispatch path sets `sandboxMode` to anything but `off`, so no proxy is ever constructed in production today.

## What lands
Per-session `CONNECT`-only proxy on `127.0.0.1:<ephemeral>` (`src/runner/egress-proxy.ts`). `CCSession.start()` points the child at it via `HTTP_PROXY`/`HTTPS_PROXY` (both casings) and **deletes any inherited `NO_PROXY`**, closing the trivial opt-out. Denials surface as `system.security.egress-denial` (hyphenated — see below).

## Verified independently (raw sockets against the real proxy, no curl, no mocks)

| Scenario | Result |
|---|---|
| allowlisted CONNECT (enforce) | `200 Connection Established` |
| non-allowlisted (enforce) | `403` + denial logged |
| `localhost` when only `127.0.0.1` allowed | `403` — exact-match confirmed |
| malformed, **enforce AND audit** | `400` in both — fail-closed in *every* mode |
| empty allowlist | `403` — deny-by-default |
| non-allowlisted (audit) | connects through, denial logged `blocked=false` |

The audit row is the one that's easy to invert: audit must observe *without* blocking, and it does.

Also checked: binds **loopback only** (`127.0.0.1:0`) — no open-proxy exposure, my first concern with any new listener. `mode: "off"` constructs no proxy, opens no socket, mutates no env. A proxy failure under `enforce` **fails closed** rather than launching with unfiltered egress.

## The boundary, stated plainly
**This is a cooperating-client proxy, not a kernel boundary.** A process that ignores the proxy env vars and opens a raw socket defeats it entirely — the builder demonstrated this rather than describing it away, and it is documented in the module doc and design doc. Forcing traffic through it needs a PF anchor (root) or a network namespace (Linux topology), both out of scope here and gated on EBH-3b.

Same discipline as #2410: do not describe this as "egress is contained". It is *egress is contained for cooperating clients*.

## Residuals (disclosed, not hidden)
- Raw-socket bypass — real, unclosed, above.
- Exact-match hosts only, no wildcards — deliberate (no suffix-match footgun), but an operational sharp edge; documented.
- `system.sandbox.*` config → dispatch wiring still deferred, matching the same gap EBH-3a left for `mode`/`backend`.
- `CONNECT` tunneling only; plain-HTTP forward-proxying is treated as fail-closed-malformed.
- OQ-3 (does `--output-format stream-json` tolerate an HTTPS proxy without breaking SSE) **not verified** against a real dispatched session — flagged as unverified rather than assumed.

## Note on the issue text
#2346 names the event `system.security.egress_denied` — **underscored**, which is exactly the cortex#1935 anti-pattern: it publishes without error and is then silently dropped by every subscriber, because `validateEnvelope` runs subscriber-side. Implemented as `system.security.egress-denial`. The issue text should be corrected.

## Tests
Baseline `cb6cf854` 10968 pass / 12 fail → 10997 / 12, **same 12 failing names** (pre-existing on main). +29 tests. `tsc --noEmit` clean; lint 0 errors.