### PR TITLE
fix(runner): #2409 part 1 — extend the L2 v1 guarded sensitive-set (cost-raising, not a boundary)

### DIFF
--- a/src/runner/__tests__/session-sandbox-macos.test.ts
+++ b/src/runner/__tests__/session-sandbox-macos.test.ts
@@ -109,6 +109,54 @@ describe("generateMacosSbplProfile", () => {
     expect(generated.text).toContain(`(deny file-write* (subpath "${aws}"))`);
   });
 
+  test("cortex#2409 — denies read+write on every extended sensitive-set entry (except Keychains, see next test)", () => {
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    const extended = [
+      join(fixtureHome, ".gnupg"),
+      join(fixtureHome, ".docker", "config.json"),
+      join(fixtureHome, ".config", "gh", "hosts.yml"),
+      join(fixtureHome, ".netrc"),
+      join(fixtureHome, ".git-credentials"),
+      join(fixtureHome, ".kube", "config"),
+      join(fixtureHome, ".npmrc"),
+      join(fixtureHome, ".pypirc"),
+      join(fixtureHome, ".cargo", "credentials.toml"),
+      join(fixtureHome, ".config", "op"),
+    ];
+    for (const p of extended) {
+      expect(generated.text).toContain(`(deny file-read* (subpath "${p}"))`);
+      expect(generated.text).toContain(`(deny file-write* (subpath "${p}"))`);
+    }
+  });
+
+  test("cortex#2409 — ~/Library/Keychains denies WRITE only, read stays open (empirically forced — see module doc's two-round story)", () => {
+    // Measured on a real host, TWICE: a real `claude --print` session both
+    // stats the keychain (file-read-metadata) AND reads its login-
+    // credential DATA (file-read-data) on every start — `claude` itself
+    // uses the OS keychain for auth state. `file-read*` broke a real
+    // session outright; even the narrower `file-read-data` still broke
+    // login ("Not logged in · Please run /login"). Read must stay fully
+    // open here; only WRITE (tamper) is denied. See the module doc + the
+    // real end-to-end acceptance test (cc-session-macos-sandbox-e2e).
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    const keychains = join(fixtureHome, "Library", "Keychains");
+    expect(generated.text).toContain(`(deny file-write* (subpath "${keychains}"))`);
+    expect(generated.text).not.toContain(`(deny file-read* (subpath "${keychains}"))`);
+    expect(generated.text).not.toContain(`(deny file-read-data (subpath "${keychains}"))`);
+  });
+
+  test("cortex#2409 — deliberately does NOT deny ~/.gitconfig or shell histories (see module doc rationale)", () => {
+    const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+    const excluded = [
+      join(fixtureHome, ".gitconfig"),
+      join(fixtureHome, ".zsh_history"),
+      join(fixtureHome, ".bash_history"),
+    ];
+    for (const p of excluded) {
+      expect(generated.text).not.toContain(`(subpath "${p}")`);
+    }
+  });
+
   test("denies WRITE (not read) on settings.json and hooks/ — self-modification, compat contract needs hook read+exec", () => {
     const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
     const settings = join(fixtureHome, ".claude", "settings.json");
@@ -447,6 +495,118 @@ describe.skipIf(!isDarwin)("The four §5 'stops' — real sandbox-exec, fixture 
     expect(r.stdout).toContain("ro-content");
   });
 });
+
+describe.skipIf(!isDarwin)(
+  "cortex#2409 — sensitive-set extension, real sandbox-exec against a fixture $HOME",
+  () => {
+    let fixtureHome: string;
+
+    beforeEach(() => {
+      // Same realpathSync-immediately discipline as the other fixture blocks
+      // above (E3 shape under macOS's /var → /private/var symlink).
+      fixtureHome = realpathSync(mkdtempSync(join(tmpdir(), "cortex-sbpl-2409-home-")));
+    });
+
+    afterEach(() => {
+      rmSync(fixtureHome, { recursive: true, force: true });
+    });
+
+    function runProbe(relPath: string[], content: string, argv: (target: string) => string[]) {
+      const dir = join(fixtureHome, ...relPath.slice(0, -1));
+      mkdirSync(dir, { recursive: true });
+      const target = join(fixtureHome, ...relPath);
+      writeFileSync(target, content);
+
+      const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+      const profileDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-2409-profile-"));
+      try {
+        const profilePath = join(profileDir, "probe.sb");
+        writeFileSync(profilePath, generated.text);
+        const result = Bun.spawnSync(["sandbox-exec", "-f", profilePath, ...argv(target)], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        return {
+          exitCode: result.exitCode,
+          stdout: result.stdout.toString(),
+          stderr: result.stderr.toString(),
+        };
+      } finally {
+        rmSync(profileDir, { recursive: true, force: true });
+      }
+    }
+
+    const readDenyCases: { name: string; relPath: string[] }[] = [
+      { name: "~/.gnupg", relPath: [".gnupg", "secring.gpg"] },
+      { name: "~/.docker/config.json", relPath: [".docker", "config.json"] },
+      { name: "~/.config/gh/hosts.yml", relPath: [".config", "gh", "hosts.yml"] },
+      { name: "~/.netrc", relPath: [".netrc"] },
+      { name: "~/.git-credentials", relPath: [".git-credentials"] },
+      { name: "~/.kube/config", relPath: [".kube", "config"] },
+      { name: "~/.npmrc", relPath: [".npmrc"] },
+      { name: "~/.pypirc", relPath: [".pypirc"] },
+      { name: "~/.cargo/credentials.toml", relPath: [".cargo", "credentials.toml"] },
+      { name: "~/.config/op", relPath: [".config", "op", "session.json"] },
+    ];
+
+    for (const c of readDenyCases) {
+      test(`${c.name} read is denied — explicit EPERM ("Operation not permitted"), no content leak`, () => {
+        const marker = `SECRET-${c.name}`;
+        const r = runProbe(c.relPath, marker, (target) => ["/bin/cat", target]);
+        expect(r.exitCode).not.toBe(0);
+        expect(r.stderr).toContain("Operation not permitted");
+        expect(r.stdout).not.toContain(marker);
+      });
+    }
+
+    test("~/Library/Keychains WRITE is denied — explicit EPERM", () => {
+      // Read is deliberately NOT tested as denied here — see the module doc
+      // + the unit test above: read must stay open (empirically forced,
+      // twice) for a real session's `claude` login-state check to work.
+      const target = join(fixtureHome, "Library", "Keychains", "login.keychain-db");
+      mkdirSync(join(fixtureHome, "Library", "Keychains"), { recursive: true });
+      writeFileSync(target, "not-a-real-keychain");
+      const generated = generateMacosSbplProfile(baseProfile(), { homeDir: fixtureHome });
+      const profileDir = mkdtempSync(join(tmpdir(), "cortex-sbpl-2409-profile-"));
+      try {
+        const profilePath = join(profileDir, "probe.sb");
+        writeFileSync(profilePath, generated.text);
+        // A shell redirect (not `tee`) — it never reads stdin, so the
+        // denied open() is the entire command; no stdin-lifecycle question
+        // (same pattern as the "stop 4" / "enforce" write-deny tests above).
+        const result = Bun.spawnSync(
+          ["sandbox-exec", "-f", profilePath, "/bin/sh", "-c", `echo appended >> ${target}`],
+          { stdout: "pipe", stderr: "pipe" },
+        );
+        expect(result.stderr.toString()).toContain("Operation not permitted");
+      } finally {
+        rmSync(profileDir, { recursive: true, force: true });
+      }
+    });
+
+    test("control — ~/Library/Keychains READ stays allowed (empirically forced compat exception)", () => {
+      const r = runProbe(
+        ["Library", "Keychains", "login.keychain-db"],
+        "not-a-real-keychain",
+        (target) => ["/bin/cat", target],
+      );
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("not-a-real-keychain");
+    });
+
+    test("control — ~/.gitconfig stays readable (deliberately NOT in the deny set)", () => {
+      const r = runProbe([".gitconfig"], "[user]\n\tname = fixture\n", (target) => ["/bin/cat", target]);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("[user]");
+    });
+
+    test("control — an ordinary workspace file stays readable ((allow default) still holds)", () => {
+      const r = runProbe(["project", "README.md"], "hello world", (target) => ["/bin/cat", target]);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("hello world");
+    });
+  },
+);
 
 describe.skipIf(!isDarwin)("MacosSbplSandbox — spawn() mode gating", () => {
   test("mode 'off' — byte-identical Bun.spawn pass-through, no .sb profile, no canary", () => {

--- a/src/runner/session-sandbox-macos.ts
+++ b/src/runner/session-sandbox-macos.ts
@@ -44,6 +44,17 @@
  *
  *   - `~/.config/metafactory/cortex/**` (config dir — CONFIG IMMUTABILITY, F1)
  *   - `~/.ssh`, `~/.aws` (arbitrary-secret read, F1)
+ *   - `~/.gnupg`, `~/.docker/config.json`, `~/.config/gh/hosts.yml`,
+ *     `~/.netrc`, `~/.git-credentials`, `~/.kube/config`, `~/.npmrc`,
+ *     `~/.pypirc`, `~/.cargo/credentials.toml`, `~/.config/op` (cortex#2409
+ *     sensitive-set extension — read+write)
+ *   - `~/Library/Keychains` (cortex#2409) — WRITE only, unlike every other
+ *     entry above: a real session both stats the keychain AND reads its
+ *     login-credential DATA on every start (`claude` itself uses the OS
+ *     keychain for auth state) — ANY read-deny here broke a real session
+ *     empirically (see {@link builtinSensitiveDenyEntries} for the full,
+ *     two-round story). Read stays open; this is a known, disclosed gap
+ *     in the set, not an oversight.
  *   - `~/.claude/settings.json` — WRITE only (self-modification)
  *   - `~/.claude/hooks/**` — WRITE only (self-modification; READ+EXEC stays
  *     allowed — the compatibility contract requires it)
@@ -51,6 +62,36 @@
  *   - any caller-supplied `extraDenyPaths` (read+write) — the generic escape
  *     hatch a caller (a test, or a future "other stacks" enumeration) uses to
  *     deny an out-of-scope root this module doesn't know about by name.
+ *
+ * **cortex#2409 is cost-raising, NOT a fix.** A denylist cannot be completed
+ * — the next unenumerated credential store is always available; adding
+ * entries raises the attacker's cost, it never establishes a boundary. The
+ * real fix is v2 `strict` (deny-default + explicit allow), where the
+ * property holds by construction. See `docs/security/hardening-plan.md`
+ * §"What L2 v1 does NOT close" — do not describe this set, however long it
+ * gets, as closing F1.
+ *
+ * Deliberately NOT in the set (considered and rejected, cortex#2409):
+ *
+ *   - `~/.gitconfig` — read constantly by ordinary `git` usage (identity for
+ *     every commit, `core.*`, aliases) that this harness itself performs
+ *     routinely (CLAUDE.md's own workflow is git-commit-heavy). Denying it
+ *     would break everyday sessions, not just hostile ones. It rarely holds
+ *     a literal secret itself — at most a pointer to a credential helper —
+ *     and the credential STORES those helpers actually use
+ *     (`~/.git-credentials`, `gh`'s `hosts.yml`, and `~/Library/Keychains`
+ *     for tamper via WRITE) are already denied above.
+ *   - `~/.zsh_history`, `~/.bash_history` — secret-adjacent (a pasted token
+ *     or password can land in history) but this module cannot verify from
+ *     cortex's own source what shell mode the `claude` binary's own Bash
+ *     tool invokes internally (interactive vs. non-interactive changes
+ *     whether a shell reads/appends these files at all). A wrong WRITE-deny
+ *     here risks the exact failure mode this issue warns against — a
+ *     silent, session-breaking regression in ordinary Bash-tool use — for a
+ *     class of secret exposure that requires a prior unsafe practice
+ *     (typing a raw credential on a command line) rather than an at-rest
+ *     store by design. Left out until that shell-mode question is measured
+ *     directly against the real binary, not guessed at.
  *
  * ## Denial observability (DD-6)
  *
@@ -151,6 +192,84 @@ function builtinSensitiveDenyEntries(profile: SandboxProfile, homeDir: string): 
     { input: join(homeDir, ".ssh"), op: "file-write*" },
     { input: join(homeDir, ".aws"), op: "file-read*" },
     { input: join(homeDir, ".aws"), op: "file-write*" },
+
+    // ---------------------------------------------------------------------
+    // cortex#2409 sensitive-set extension. Probing a generated profile on a
+    // real host found 11 credential/state stores readable straight through
+    // the original set above. Every entry below is a CREDENTIAL STORE the
+    // harness itself never needs to read to function (unlike hooks/ below,
+    // there is no compat-contract reason to leave read open), so each
+    // follows the ~/.ssh / ~/.aws precedent: deny BOTH read (secret
+    // exposure) and write (tamper — e.g. a planted malicious docker
+    // credential helper, a kube config repointed at an attacker-controlled
+    // API server, an injected GPG key). THIS IS STILL AN ENUMERATED
+    // DENYLIST (module doc) — it raises the attacker's cost, it does not
+    // close F1; the next unenumerated store is always available. See the
+    // module doc's "Deliberately NOT in the set" for the two candidates
+    // (`~/.gitconfig`, shell histories) considered and rejected.
+    // ---------------------------------------------------------------------
+
+    // GPG secret keyring + trustdb — private keys and signing material.
+    { input: join(homeDir, ".gnupg"), op: "file-read*" },
+    { input: join(homeDir, ".gnupg"), op: "file-write*" },
+    // Docker registry auth (base64-encoded or a credsStore pointer).
+    { input: join(homeDir, ".docker", "config.json"), op: "file-read*" },
+    { input: join(homeDir, ".docker", "config.json"), op: "file-write*" },
+    // gh CLI's stored OAuth token.
+    { input: join(homeDir, ".config", "gh", "hosts.yml"), op: "file-read*" },
+    { input: join(homeDir, ".config", "gh", "hosts.yml"), op: "file-write*" },
+    // Plaintext machine/login/password entries (curl, ftp, and others).
+    { input: join(homeDir, ".netrc"), op: "file-read*" },
+    { input: join(homeDir, ".netrc"), op: "file-write*" },
+    // git's plaintext credential-store helper output.
+    { input: join(homeDir, ".git-credentials"), op: "file-read*" },
+    { input: join(homeDir, ".git-credentials"), op: "file-write*" },
+    // macOS keychain databases — WRITE only, unlike every other entry in
+    // this set. TWO ROUNDS of empirical correction (cortex#2409, this
+    // host), both caught by the real end-to-end acceptance test
+    // (`cc-session-macos-sandbox-e2e.test.ts`), NOT reasoned out in
+    // advance:
+    //   1. The original `file-read*` version broke a real session with
+    //      spurious denials — a real `claude --print` session performs a
+    //      `file-read-metadata` (stat/access) against the keychain on
+    //      every start.
+    //   2. Narrowing to `file-read-data` (deny content reads, allow
+    //      metadata) was STILL wrong: the real session then failed
+    //      authentication outright ("Not logged in · Please run /login",
+    //      `success: false`) — `claude`'s own login-state check reads the
+    //      keychain's actual DATA, not just its metadata. This module's
+    //      earlier assumption (that keychain access is exclusively
+    //      securityd/XPC-mediated and therefore untouched by ANY read-deny
+    //      here) was wrong on both counts.
+    // So read access — data AND metadata — must stay allowed, same
+    // compatibility-contract reasoning as `.claude/hooks` below (self-
+    // modification is denied via write; the mechanism the harness itself
+    // depends on stays open). This still closes the WRITE/tamper vector
+    // (a planted or corrupted keychain entry); it does NOT close the
+    // offline-copy read vector for Keychains specifically — a real, known
+    // gap in this enumerated set, consistent with the module doc's "cannot
+    // be completed by adding entries" framing.
+    { input: join(homeDir, "Library", "Keychains"), op: "file-write*" },
+    // kubectl cluster/user credentials (tokens, client certs).
+    { input: join(homeDir, ".kube", "config"), op: "file-read*" },
+    { input: join(homeDir, ".kube", "config"), op: "file-write*" },
+    // May embed a registry `_authToken`. Same accepted trade-off as ~/.aws
+    // above: a session that legitimately needs an authenticated npm install
+    // loses that ability, same as one that legitimately needs AWS already
+    // does — least privilege over convenience for an untrusted-content-
+    // driven session.
+    { input: join(homeDir, ".npmrc"), op: "file-read*" },
+    { input: join(homeDir, ".npmrc"), op: "file-write*" },
+    // PyPI upload (twine) credentials.
+    { input: join(homeDir, ".pypirc"), op: "file-read*" },
+    { input: join(homeDir, ".pypirc"), op: "file-write*" },
+    // crates.io publish token. Not needed for ordinary `cargo build`/`test`.
+    { input: join(homeDir, ".cargo", "credentials.toml"), op: "file-read*" },
+    { input: join(homeDir, ".cargo", "credentials.toml"), op: "file-write*" },
+    // 1Password CLI session/cache state.
+    { input: join(homeDir, ".config", "op"), op: "file-read*" },
+    { input: join(homeDir, ".config", "op"), op: "file-write*" },
+
     // Self-modification — WRITE only. Read+exec of hooks is a compatibility-
     // contract REQUIREMENT (design doc §3), so hooks are not read-denied.
     { input: join(homeDir, ".claude", "settings.json"), op: "file-write*" },


### PR DESCRIPTION
Part 1 of #2409. Adds 10 read+write denies and 1 write-only. **Explicitly not a fix** — see below.

## Verified independently (fixture $HOME, real `sandbox-exec`)

All 10 refuse reads with explicit `EPERM`, zero content leaked, nothing unresolved:
`~/.gnupg` · `~/.docker/config.json` · `~/.config/gh/hosts.yml` · `~/.netrc` · `~/.git-credentials` · `~/.kube/config` · `~/.npmrc` · `~/.pypirc` · `~/.cargo/credentials.toml` · `~/.config/op`

Must-stay-open controls both correct: `~/Library/Keychains` **read** open, `~/.gitconfig` open.

## The Keychains finding — a permanent limit, not an oversight

The builder's first pass denied Keychains read. A **real** `claude --print` under that profile returned `Not logged in · Please run /login`. Narrowing to `file-read-data` still broke it. I reproduced this myself:

| Profile | Real session result |
|---|---|
| Keychains **read** denied | `Not logged in · Please run /login` |
| Keychains **write** denied (shipped) | `ok` |

`claude` authenticates via the OS keychain, so **any sandbox that lets a session run must let it read the keychain.** This layer can never close that. Shipped as write-only (tamper protection); the offline-copy read vector stays open and is documented as a known gap.

This also corrects my own earlier report: the "11 exposed stores" figure from the #2410 review was wrong. It is **10 closable + Keychains, which is structurally not closable here.**

## Deliberate exclusions, with reasoning
- **`~/.gitconfig`** — read constantly by ordinary git work; denying breaks everyday sessions, and the actual secret stores a helper would use are already denied.
- **shell histories** — secret-adjacent, but we cannot determine from cortex's source what shell mode the `claude` binary's Bash tool uses internally, so a wrong call breaks real sessions. Left out rather than guessed — the Keychains episode is exactly why.

## Framing unchanged
This raises the attacker's cost; it does **not** establish a boundary. A denylist cannot be completed by adding entries — the next unenumerated path is always available. `hardening-plan.md` already says so and was deliberately left alone so nothing reads as "closed". The boundary arrives with v2 `strict` (part 2).

## Tests
Baseline 10967 pass / 13 fail → branch 10985 pass / 12 fail. The 2 that disappeared are `(live)` NATS network tests (flaky, unrelated). No sandbox/session test fails. `tsc --noEmit` clean; lint clean bar one pre-existing warning also present on main. `sandboxMode` still defaults `off`; no caller touched.