### PR TITLE
feat(adapters): EBH-5 — plugin bundle signature verification (#2347, signing half only)

### DIFF
--- a/docs/config-layout/system/system.yaml
+++ b/docs/config-layout/system/system.yaml
@@ -274,8 +274,32 @@ paths:
 # surface outage behind a flag nobody flipped. `external` keeps its real job
 # of gating genuinely THIRD-party plugins — nothing cortex itself declares as
 # a first-party adapter bundle by name.
+#
+# `signing` (cortex#2347, EBH-5, ADR-0024 D4 "named future escalation:
+# registry signing") — staged posture gating bundle SIGNATURE verification,
+# INDEPENDENT of `external` above (it applies to every bundle the loader
+# considers, first-party or not — an ADDITIONAL gate, never a replacement
+# for the org-trust/first-party checks). Mirrors `security.signing` exactly:
+#   off        — (default) byte-identical to pre-EBH-5 behaviour; no bundle
+#                is ever read for a signature file.
+#   permissive — verify every bundle's `cortex-plugin.sig` and log the
+#                outcome, but NEVER refuse a bundle on a bad/missing
+#                signature. The shadow rung — prove verification against
+#                real installed bundles before gating anything.
+#   enforce    — refuse to load any bundle whose `cortex-plugin.sig` is
+#                missing, malformed, tampered, or signed by a key outside
+#                the in-tree trust root (`src/adapters/plugin-signing.ts`
+#                PLUGIN_TRUST_ROOT).
+# As of this writing PLUGIN_TRUST_ROOT ships EMPTY — no bundle in the
+# ecosystem is signed yet, so `enforce` refuses everything and `permissive`
+# logs a verify-failed warning for everything. Flipping either away from
+# `off` before a production trust root is populated is a no-op at best
+# (permissive) or a self-inflicted outage (enforce, refuses every bundle).
+# See that module's doc header for the open question this leaves for a
+# principal decision (who holds the signing key, how bundles get signed).
 plugins:
   external: false
+  signing: off
 
 # =============================================================================
 # nats — M2 transport. THE SINGLE PLACE SUBJECT OVERRIDES LIVE (IAW CFG.b.2)

--- a/docs/design-plugin-isolation.md
+++ b/docs/design-plugin-isolation.md
@@ -1,0 +1,100 @@
+# Plugin Process Isolation — Design Note (deferred half of EBH-5)
+
+**Status:** Draft (design only — no implementation)
+**Author:** Luna (with Andreas), cortex#2347 (EBH-5, epic #2341 "execution-boundary hardening")
+**Companion:** registry signing (cortex#2347's OTHER half — implemented alongside this note, `src/adapters/plugin-signing.ts`)
+**Refs:** [ADR-0024](adr/0024-pluggable-surface-adapters.md) D4 ("Plugins run in-process with full daemon authority; risk accepted for v1 with mitigations" — names *"separate-process-over-IPC if a real trust boundary is ever required"* as the escalation this note designs), `docs/security/hardening-plan.md` §2 L4, `src/adapters/loader.ts`
+
+---
+
+## 0. Why this is a design note, not a build
+
+cortex#2347 (EBH-5) is **trigger-gated**: build nothing here until *first non-first-party bundle loaded* (`system.plugins.external` flips on for a bundle outside the org's own first-party set) OR *first federated deployment* (cross-principal bus). Neither has happened. ADR-0024 D4 is an **accepted** decision — every bundle today is first-party, reviewed at the same CI bar as cortex itself, and process isolation is real, non-trivial engineering (a supervision layer, an IPC serialization boundary on the hot inbound/outbound dispatch path, per-adapter lifecycle management) that ADR-0024's own "Alternatives considered" section explicitly rejected for v1 on that cost, while naming it as the retained escalation path. Building it now would be scope creep past an accepted architectural decision, done without the trigger that would justify revisiting it, and without an ADR amendment recording why v1's cost-benefit calculus changed. This note exists so that when the trigger fires, the decision is fast — not "start from zero."
+
+Registry signing (the other half of this issue, landed in the same PR as this note) is **not** a substitute for isolation and does not reduce the urgency of this design. Signing answers *"is this the bundle a trusted publisher produced"* — a supply-chain question, checked once at load time. Isolation answers *"what can this bundle do once it's running"* — a runtime blast-radius question. A validly-signed bundle can still be compromised after publication (a maintainer's account is phished, a dependency is poisoned, a bug is exploited at runtime) or simply buggy in a way that reaches for something it shouldn't. Signing narrows *which* code you trust enough to run; isolation bounds *what happens* if that trust was misplaced. Both matter; neither implies the other. See §5 for how they compose once both exist.
+
+---
+
+## 1. Problem statement (recap — full detail in ADR-0024 D4)
+
+A surface plugin (adapter or renderer) loaded by `src/adapters/loader.ts` runs **in-process**, with the daemon's **full authority**: the stack NKey seed (can sign as the stack), config secrets, CC-session spawn, bash, filesystem. `await import()` executes arbitrary plugin code at load — there is no sandbox between "the loader decided to trust this bundle" and "this bundle's top-level module code is now running with everything the daemon can do." A malicious or compromised plugin is a full stack compromise. The load-time gates (org-trust, first-party exemption, compat check, duplicate-id, entry containment, and now signature verification) are all **load-time**; none of them constrain what an already-imported, already-registered plugin's `createAdapter`/`createRenderer`/`start`/`render` methods can do once the daemon calls them.
+
+This is explicitly **not** covered by the session sandbox (EBH-2..4, `docs/design-session-sandbox.md`): that sandbox wraps `claude --print` child processes — sessions, not the daemon. A plugin runs inside the daemon process itself; wrapping sessions in a kernel jail does nothing for it.
+
+---
+
+## 2. Options considered
+
+### Option A — Separate process per bundle, narrow IPC surface (ADR-0024's named escalation)
+
+Each loaded bundle runs in its own OS process (`Bun.spawn` a small host runtime that `import()`s the bundle and exposes only the `AdapterPlugin`/`RendererPlugin` SDK surface over IPC — likely a JSON-over-pipe or Unix-domain-socket RPC, not raw `postMessage`/shared memory). The daemon process calls into the plugin only through the same `PlatformAdapter`/`Renderer` method signatures it uses today, marshaled over IPC instead of a direct in-process call.
+
+**What this buys:** a compromised bundle's arbitrary-code-execution is confined to *its own process* — it cannot read the daemon's heap (other plugins' loaded state, in-flight message content it wasn't handed, the stack's NKey seed unless explicitly passed to it), cannot forge a call into another bundle, and can be killed/restarted independently without taking the daemon down. This is the acceptance-criteria shape the trigger-gated issue names: *"A bundle cannot read daemon memory / config / other bundles' state"* and *"bundle-to-daemon calls are limited to the declared SDK surface."*
+
+**Cost:** real. Every `PlatformAdapter`/`Renderer` method becomes an IPC round-trip instead of a function call — added latency on the hot inbound/outbound dispatch path (every Discord message, every render). Passing rich objects (envelopes, binding config with secrets, file attachments) across a process boundary needs a serialization contract, which is itself a new attack surface (a malformed IPC message from a compromised child) and a new place for the `secretFields`/binding-schema discipline to leak or be re-implemented incorrectly. Per-adapter lifecycle (spawn, health-check, crash-restart, graceful shutdown, log capture) is a supervision layer that doesn't exist today (`src/cortex.ts` has no `ProcessManager` — see repo CLAUDE.md's explicit "cortex does NOT have... process orchestration" rule, which this option would need to partially reverse or scope narrowly). The gateway's separate-process adapter path (cortex#524, `CONTEXT.md:181`) is real prior art for "adapters as their own process" but runs **unsigned** and is a *different* trust model (out-of-process by default, not as an isolation upgrade for the SAME in-tree loader) — it's a precedent that the architecture supports this shape, not a component this can directly reuse without its own review.
+
+**Verdict:** this is the real fix, and the one ADR-0024 D4 names. It is the option the trigger should cause to happen — engineered properly, at the point the trigger justifies the cost, not spec'd in more detail today (the SDK's exact method surface, and thus the IPC contract, may still shift before the trigger fires).
+
+### Option B — OS-level sandboxing of the whole daemon process (coarser than per-bundle)
+
+Instead of isolating each *bundle*, run the entire cortex daemon inside an OS sandbox (macOS `sandbox-exec`/Seatbelt profile, Linux `bwrap`/landlock/seccomp) — the same primitive family EBH-2/3 already use for session isolation (`docs/design-session-sandbox.md` §4.1's `SessionSandbox` interface / `macos-sbpl` / `linux-bwrap` backends).
+
+**What this buys:** a floor under EVERYTHING the daemon does, plugins included, with infrastructure this epic is already building for sessions — no new supervision layer, no IPC contract, reuses `SessionSandbox`'s profile-generation code.
+
+**Why it doesn't answer the acceptance criteria:** the daemon-level sandbox profile has to be **as permissive as the daemon's own legitimate needs** — NATS connectivity, config file I/O, the stack's own NKey seed, spawning CC sessions, disk access for events/logs. A plugin running inside that same process inherits the SAME permissive profile; it is not confined *relative to the daemon*, only relative to the *host OS* outside the daemon's own already-wide grant. This does not satisfy *"a bundle cannot read daemon memory / config / other bundles' state"* — memory and config are exactly what the daemon-scoped sandbox profile has to allow. **Rejected as the primary mechanism** for the SAME reason EBH-2 v1's `guarded` posture is documented as "narrowed, not closed" (`docs/security/hardening-plan.md` §L2 callout) — a coarse boundary around a process that legitimately needs broad access inside itself doesn't produce the per-plugin confinement this issue asks for. **Retained as defense-in-depth, not a substitute**: once the daemon itself runs under a sandbox profile (a separate, not-yet-scoped effort), a compromised plugin is still bounded by the HOST-level floor even where the per-bundle isolation (Option A) has a gap — the same "belt and suspenders, not either/or" logic already governing L1 vs L2 for sessions.
+
+### Option C — WASM/V8-isolate sandboxing of plugin code
+
+Compile or run plugin bundles inside a WebAssembly runtime or a V8 isolate with a narrow host-function import surface (similar in spirit to Cloudflare Workers' isolate model), rather than a full OS process.
+
+**What this buys:** potentially cheaper than a full process per bundle (no separate OS process, faster spawn, tighter memory isolation than same-process JS but without process-boundary IPC latency for every call — depending on the runtime, some isolate models support fast in-process host-function calls).
+
+**Cost / why not recommended for v1-of-the-escalation:** cortex's plugin SDK (`src/surface-sdk/`) is an ordinary TypeScript/Bun module contract today — `import()`ing a `.ts` file, calling async methods that themselves do real I/O (HTTP calls to Discord/Slack/Mattermost APIs, filesystem reads for attachments). Neither Bun nor Node ships a production-ready "run this TS module inside a V8 isolate with a host-function bridge" primitive the way Cloudflare Workers does — building one is a bigger and less-precedented lift than Option A, which reuses ordinary OS process primitives cortex already understands (`Bun.spawn`, already used for `arc list`, CC sessions, and the gateway's separate-process adapters). A bundle author would also need a materially different authoring model (no arbitrary `fs`/`net` access even for legitimate reasons, e.g. an adapter's own platform SDK making HTTP calls) unless the isolate is given broad host-function access anyway — which erodes the isolation benefit back toward Option A's IPC-surface problem without Option A's simpler mental model (OS process boundaries are well-understood; isolate escape classes are their own specialized field). **Rejected for v1 of the escalation** — worth revisiting only if Option A's per-process overhead proves prohibitive in practice, which requires actually building Option A first to measure.
+
+### Option D — Do nothing beyond load-time gates + signing (status quo + this PR)
+
+Keep the load-time-only trust model, now strengthened by signature verification, and accept D4's risk indefinitely.
+
+**Why this is the current, deliberate state, not a rejected option:** this is exactly what ADR-0024 D4 already decided for v1, and the trigger conditions exist precisely so this stays true UNTIL one of them fires. It is listed here for completeness, not as a live alternative being chosen — the epic's whole premise is that this stops being acceptable once a non-first-party bundle or federated deployment is real.
+
+---
+
+## 3. Recommended shape (for when the trigger fires)
+
+**Option A** (separate process per bundle, narrow IPC surface), engineered at that time against whatever `src/surface-sdk/` looks like then. Sketch of what "engineered properly" should include, so a future implementer starts from more than a blank page:
+
+- **One child process per LOADED bundle**, not per platform instance — matches today's `SurfacePluginRegistry` granularity (`(kind, id)`-keyed), so an adapter with multiple bound instances (e.g. two Discord bot tokens) still shares one process, same as it shares one in-process class today.
+- **IPC surface = the SDK, nothing else.** The child process's ONLY communication channel to the daemon is a request/response RPC whose method set is generated from (or manually kept in lock-step with) `PlatformAdapter`/`Renderer`'s method signatures. No shared filesystem access beyond what the bundle's own binding config grants it (e.g. attachment temp dirs, explicitly passed); no shared NKey seed (the daemon signs on the plugin's behalf when a signed action is needed, never hands the seed across the boundary); no arbitrary daemon-internal call.
+- **Crash isolation is already half-designed**: `loadExternalPlugins`'s existing "one bad bundle never takes down boot or another bundle" contract (ADR-0024 §3.3, D3) extends naturally to "one CRASHED child process never takes down the daemon or another bundle's child" — a supervision loop restarts a crashed plugin process the same way today's code isolates a bad `import()`.
+- **Secrets cross the boundary deliberately, not implicitly.** `AdapterPlugin.secretFields` already names which binding fields are secret (`src/adapters/registry.ts`) — the IPC transport should treat those the same way `bash-guard`/config loaders already treat secrets (never logged, redacted in any IPC-level tracing), and the daemon should hand a plugin process only the binding it needs, not the whole resolved `Surfaces` config.
+- **Ship staged**, mirroring every other control in this epic (`docs/security/hardening-plan.md`'s whole ladder, `SecurityPostureSchema.signing`'s off/permissive/enforce, `SessionSandbox`'s off/audit/enforce): an `audit` mode that runs plugins isolated but doesn't yet enforce the narrowed IPC surface (logs a would-have-been-refused call), then `enforce`. Building the isolation with an on/off switch from day one avoids the EBH-2 v1 lesson (a control that can't be tried in production before it's trusted is a control nobody dares turn on).
+
+None of this is being built now — it is recorded so the trigger-fired implementer has a starting sketch rather than a re-read of ADR-0024's one paragraph.
+
+---
+
+## 4. Trigger → action mapping
+
+| Trigger | What should happen |
+|---|---|
+| **First non-first-party bundle** about to load (`system.plugins.external` flips on for a stack that will load a bundle outside cortex's own `metafactory-cortex-adapter-*`/`metafactory-cortex-renderer-*` first-party set) | Before that stack goes live: (1) populate `PLUGIN_TRUST_ROOT` (`src/adapters/plugin-signing.ts`) with a real production key and require that bundle to be signed under `system.plugins.signing: enforce` — signing is buildable TODAY and should gate this immediately; (2) open the Option-A implementation as its own epic/issue, scoped against the then-current `src/surface-sdk/`, and treat that stack's exposure between "bundle loads" and "isolation ships" as a tracked, time-boxed risk acceptance, not a silent gap. |
+| **First federated deployment** (cross-principal bus) | Same as above — federation raises the stakes because a compromised plugin now has reach into cross-principal trust material (leaf secrets, admission state), not just a single-principal stack. Isolation should land BEFORE the first federated stack also runs a non-first-party bundle; a federated stack running only first-party, signed bundles is a smaller, still-nonzero risk (ADR-0024 D4's mitigations 1-3 all still apply to first-party bundles) that the epic's principal can consciously accept per-deployment. |
+| **Neither trigger** (today) | No isolation work. Registry signing (this PR) is the standing, non-trigger-gated improvement — it does not wait for either trigger because it is cheap, additive, and directly named by ADR-0024 D4 as part of the mitigation set. |
+
+---
+
+## 5. How signing and isolation compose once both exist
+
+They are independent, layered controls, not sequential steps:
+
+- **Signing without isolation** (this PR's state): raises the bar for "which code gets a chance to run" but a validly-signed, compromised-after-signing, or simply buggy bundle still has full daemon authority once it runs. This is where cortex is after this PR.
+- **Isolation without signing**: any bundle that clears the org-trust/first-party gates can run, confined to its own process — bounds the blast radius of a bug or compromise, but admits a wider set of code in the first place (no cryptographic provenance check).
+- **Both**: only signed-and-trusted code runs, AND it runs confined. This is the target state once the trigger fires and Option A ships. Neither control should be described as making the other unnecessary — a reviewer reading only one of the two doc headers (`plugin-signing.ts` or this note) should come away with an accurate, not overstated, picture of what's actually enforced.
+
+---
+
+## 6. Non-goals of this note
+
+- No implementation, no interface code, no IPC wire format spec — that is the trigger-fired implementer's job, informed by §3's sketch.
+- No ADR amendment. ADR-0024 D4 is unchanged by this note; §"Consequences" of this issue's parent PR states precisely what (nothing, on the isolation side) changed about what D4 asserts is true. If a future PR implements Option A, THAT PR should amend or supersede D4, not this design note.
+- No change to `system.plugins.external`'s default-off posture, the first-party exemption computation, or any existing load-time gate.

--- a/src/__tests__/cortex.plugin-signing-boot.test.ts
+++ b/src/__tests__/cortex.plugin-signing-boot.test.ts
@@ -1,0 +1,101 @@
+/**
+ * cortex#2347 (EBH-5 follow-up, adversarial review Finding 2 — availability)
+ * — boot-level proof that `system.plugins.signing: "enforce"` with an EMPTY
+ * plugin trust root REFUSES TO BOOT immediately, with a named/actionable
+ * error, rather than crashing several stages later at the renderer-coverage
+ * guard with an error that looks unrelated to `signing`.
+ *
+ * Modelled on `cortex.security-posture-boot.test.ts`'s
+ * "TC-1b: enforce + no stack identity → REFUSES TO BOOT" test (same
+ * `startCortex(...).rejects.toThrow(/REFUSING TO BOOT/i)` shape) — this is
+ * the SAME class of boot-time fail-fast guard, for the plugin-signing
+ * posture instead of the envelope-signing posture.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
+
+function minimalConfig(plugins?: AgentConfig["plugins"]): AgentConfig {
+  const base = AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-plugin-signing-posture-test-published" },
+  });
+  return plugins === undefined ? base : { ...base, plugins };
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  return {
+    enabled: false,
+    published,
+    onEnvelope(_handler: EnvelopeHandler) {
+      return { unregister: () => {} };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
+// Hermetic agents.d/ (R26 P1 PR hygiene, cortex#1371) — same rationale as
+// `cortex.security-posture-boot.test.ts`: never fall back to the
+// principal's LIVE `~/.config/cortex/agents.d/`.
+const HERMETIC_AGENTS_DIR = mkdtempSync(join(tmpdir(), "cortex-plugin-signing-posture-agents-hermetic-"));
+
+const COMMON_OPTS = {
+  disableConfigWatcher: true,
+  disableDashboard: true,
+  disableOutboundPoller: true,
+  principal: { id: "test-op" },
+  agentsDir: HERMETIC_AGENTS_DIR,
+} as const;
+
+describe("startCortex — system.plugins.signing boot guard (cortex#2347 follow-up, Finding 2)", () => {
+  test("enforce + EMPTY trust root → REFUSES TO BOOT immediately, naming plugins.signing (not a downstream coverage crash)", async () => {
+    const runtime = createRecordingRuntime();
+    const cfg = minimalConfig({ external: false, signing: "enforce" });
+
+    await expect(
+      startCortex(cfg, {
+        ...COMMON_OPTS,
+        injectRuntime: runtime,
+      }),
+    ).rejects.toThrow(/REFUSING TO BOOT.*system\.plugins\.signing="enforce".*trust root is EMPTY/is);
+  });
+
+  test("permissive + EMPTY trust root does NOT refuse to boot (never refuses a bundle, so no availability risk)", async () => {
+    const runtime = createRecordingRuntime();
+    const cfg = minimalConfig({ external: false, signing: "permissive" });
+
+    const handle = await startCortex(cfg, {
+      ...COMMON_OPTS,
+      injectRuntime: runtime,
+    });
+    await handle.stop();
+  });
+
+  test("off (default) + EMPTY trust root does NOT refuse to boot — byte-identical pre-EBH-5 behaviour", async () => {
+    const runtime = createRecordingRuntime();
+    const cfg = minimalConfig();
+
+    const handle = await startCortex(cfg, {
+      ...COMMON_OPTS,
+      injectRuntime: runtime,
+    });
+    await handle.stop();
+  });
+});

--- a/src/adapters/__tests__/loader.signing.test.ts
+++ b/src/adapters/__tests__/loader.signing.test.ts
@@ -13,12 +13,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createUser } from "nkeys.js";
 
-import { loadExternalPlugins, type ArcListRunResult } from "../loader";
+import { discoverPluginBundles, loadExternalPlugins, reimportRendererPlugin, type ArcListRunResult } from "../loader";
 import {
   computeBundleDigest,
   PLUGIN_SIGNATURE_FILENAME,
@@ -362,6 +362,246 @@ describe("loadExternalPlugins — system.plugins.signing (cortex#2347, EBH-5)", 
       expect(result.loaded).toEqual([]);
       expect(result.failed).toEqual([]);
       expect(result.skipped.map((s) => s.bundleName)).toEqual(["no-external-bundle"]);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+// =============================================================================
+// reimportRendererPlugin — reload re-verification (cortex#2347 follow-up,
+// adversarial review DO-NOT-MERGE finding: a bundle that verified once at
+// boot must NOT get a lifetime pass — `reimportRendererPlugin` is a SECOND,
+// independent `import()` call site and must re-verify from CURRENT on-disk
+// bytes at reload time, not trust whatever verified at boot).
+// =============================================================================
+
+/** Renderer entry whose top-level code has a real, observable, EXECUTION
+ *  side effect (an `appendFileSync` at MODULE-EVALUATION time, not inside
+ *  any function) — so a test can prove "this code ran" by checking the
+ *  sentinel file's CONTENT, not merely "no error was thrown". `marker` is
+ *  embedded in the appended line so the ORIGINAL and TAMPERED versions of
+ *  the same file are trivially distinguishable in the sentinel's content. */
+function rendererIndexWithExecutionMarker(id: string, sentinelPath: string, marker: string): string {
+  return [
+    "import { appendFileSync } from \"fs\";",
+    // Runs at IMPORT time — this is the exact statement that must never
+    // execute for a bundle refused before `import()`.
+    `appendFileSync(${JSON.stringify(sentinelPath)}, ${JSON.stringify(marker)} + "\\n");`,
+    "const plugin = {",
+    "  kind: \"renderer\",",
+    `  id: ${JSON.stringify(id)},`,
+    `  rendererKind: ${JSON.stringify(id)},`,
+    "  configSchema: { safeParse: (v) => ({ success: true, data: v }) },",
+    "  createRenderer: (config) => ({",
+    `    kind: ${JSON.stringify(id)},`,
+    `    id: ${JSON.stringify(id)},`,
+    "    subjects: [\"local.andreas.>\"],",
+    "    async start() {},",
+    "    async stop() {},",
+    "    get surfaceConfig() { return { id: this.id, subjects: this.subjects, render: () => this.render() }; },",
+    "    async render() {},",
+    "  }),",
+    "};",
+    "export default plugin;",
+    "",
+  ].join("\n");
+}
+
+describe("reimportRendererPlugin — reload re-verification (cortex#2347 follow-up)", () => {
+  test("a bundle that verified at BOOT but is TAMPERED before RELOAD is refused, and the tampered code NEVER EXECUTES", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-reload-tamper-"));
+    const sentinelPath = join(pkgRoot, "executed.marker");
+    try {
+      const signer = freshKeypair();
+      const dir = join(pkgRoot, "reload-bundle");
+      const { mkdirSync } = await import("fs");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "cortex-plugin.yaml"),
+        "kind: renderer\nid: reload-fixture\nentry: ./index.ts\nsdkRange: \"^1\"\n",
+      );
+      writeFileSync(join(dir, "index.ts"), rendererIndexWithExecutionMarker("reload-fixture", sentinelPath, "ORIGINAL"));
+
+      // Sign the ORIGINAL content.
+      const digestResult = computeBundleDigest(dir);
+      if (!digestResult.ok) throw new Error(`test setup: digest failed: ${digestResult.reason}`);
+      const signature = await signBundleDigest(signer.seed, digestResult.digest);
+      writeFileSync(
+        join(dir, PLUGIN_SIGNATURE_FILENAME),
+        renderSignatureFile({
+          version: 1,
+          algorithm: "ed25519",
+          signer: signer.pubkey,
+          digest: digestResult.digest,
+          signature,
+        }),
+      );
+
+      const pkg: ArcPackage = {
+        name: "reload-bundle",
+        version: "0.0.0",
+        type: "component",
+        status: "active",
+        tier: "community",
+        repoUrl: TRUSTED_REPO,
+        installPath: dir,
+      };
+      const trustedSigners = new Set([signer.pubkey]);
+
+      // 1. BOOT — loads under enforce; the ORIGINAL code legitimately runs
+      //    once (proves the harness itself is sound, not just the refusal).
+      const registry = new SurfacePluginRegistry();
+      const bootResult = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "enforce",
+        pluginTrustedSigners: trustedSigners,
+      });
+      expect(bootResult.failed).toEqual([]);
+      expect(bootResult.loaded.map((l) => l.id)).toEqual(["reload-fixture"]);
+      expect(existsSync(sentinelPath)).toBe(true);
+      expect(readFileSync(sentinelPath, "utf-8")).toBe("ORIGINAL\n");
+
+      // 2. TAMPER — mutate the entry file ON DISK after boot. The signature
+      //    file is untouched, so it now names a STALE digest. Also swap the
+      //    marker so any execution would be unmistakable in the sentinel.
+      writeFileSync(join(dir, "index.ts"), rendererIndexWithExecutionMarker("reload-fixture", sentinelPath, "TAMPERED-EXECUTED"));
+
+      // 3. RELOAD — re-discover the SAME bundle (as `reloadLivePlugin` does)
+      //    and call `reimportRendererPlugin` with the SAME posture + trust
+      //    root the boot call used.
+      const { bundles } = await discoverPluginBundles({ pkgRoot, runner: runnerFor([pkg]) });
+      const bundle = bundles.find((b) => b.bundleName === "reload-bundle");
+      if (!bundle) throw new Error("test setup: bundle not discoverable for reload");
+
+      const reimportResult = await reimportRendererPlugin(bundle, {
+        bust: true,
+        pluginSigning: "enforce",
+        pluginTrustedSigners: trustedSigners,
+      });
+
+      // ASSERTION 1 — the reload is REFUSED (not merely "an error", the
+      // SPECIFIC signature-verify stage this fix adds).
+      expect(reimportResult.ok).toBe(false);
+      if (!reimportResult.ok) {
+        expect(reimportResult.stage).toBe("signature_verify:digest_mismatch");
+      }
+
+      // ASSERTION 2 — the tampered code NEVER EXECUTED. This is the sharp
+      // assertion the review specifically asked for: not "no plugin object
+      // was returned" (which a refusal-before-import trivially satisfies by
+      // construction) but "the file's top-level side effect never ran" —
+      // proof `import()` itself was never reached for the tampered bytes.
+      // If it HAD executed, the sentinel would now read
+      // "ORIGINAL\nTAMPERED-EXECUTED\n"; it must be UNCHANGED from step 1.
+      expect(readFileSync(sentinelPath, "utf-8")).toBe("ORIGINAL\n");
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("a bundle that is NOT tampered reloads fine under enforce (still loads the good one — same lesson as boot)", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-reload-good-"));
+    const sentinelPath = join(pkgRoot, "executed.marker");
+    try {
+      const signer = freshKeypair();
+      const dir = join(pkgRoot, "reload-bundle");
+      const { mkdirSync } = await import("fs");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "cortex-plugin.yaml"),
+        "kind: renderer\nid: reload-fixture-good\nentry: ./index.ts\nsdkRange: \"^1\"\n",
+      );
+      writeFileSync(
+        join(dir, "index.ts"),
+        rendererIndexWithExecutionMarker("reload-fixture-good", sentinelPath, "RUN"),
+      );
+      const digestResult = computeBundleDigest(dir);
+      if (!digestResult.ok) throw new Error(`test setup: digest failed: ${digestResult.reason}`);
+      const signature = await signBundleDigest(signer.seed, digestResult.digest);
+      writeFileSync(
+        join(dir, PLUGIN_SIGNATURE_FILENAME),
+        renderSignatureFile({
+          version: 1,
+          algorithm: "ed25519",
+          signer: signer.pubkey,
+          digest: digestResult.digest,
+          signature,
+        }),
+      );
+      const pkg: ArcPackage = {
+        name: "reload-bundle",
+        version: "0.0.0",
+        type: "component",
+        status: "active",
+        tier: "community",
+        repoUrl: TRUSTED_REPO,
+        installPath: dir,
+      };
+      const trustedSigners = new Set([signer.pubkey]);
+
+      const { bundles } = await discoverPluginBundles({ pkgRoot, runner: runnerFor([pkg]) });
+      const bundle = bundles.find((b) => b.bundleName === "reload-bundle");
+      if (!bundle) throw new Error("test setup: bundle not discoverable for reload");
+
+      const reimportResult = await reimportRendererPlugin(bundle, {
+        bust: true,
+        pluginSigning: "enforce",
+        pluginTrustedSigners: trustedSigners,
+      });
+
+      expect(reimportResult.ok).toBe(true);
+      if (reimportResult.ok) {
+        expect(reimportResult.plugin.id).toBe("reload-fixture-good");
+      }
+      // Executed exactly once — this reload's import.
+      expect(readFileSync(sentinelPath, "utf-8")).toBe("RUN\n");
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("reload with pluginSigning 'off' skips verification entirely (byte-identical pre-fix behaviour when posture is off)", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-reload-off-"));
+    try {
+      const dir = join(pkgRoot, "unsigned-reload-bundle");
+      const { mkdirSync } = await import("fs");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "cortex-plugin.yaml"),
+        "kind: renderer\nid: reload-fixture-off\nentry: ./index.ts\nsdkRange: \"^1\"\n",
+      );
+      writeFileSync(
+        join(dir, "index.ts"),
+        "const plugin = { kind: \"renderer\", id: \"reload-fixture-off\", rendererKind: \"reload-fixture-off\", " +
+          "configSchema: { safeParse: (v) => ({ success: true, data: v }) }, createRenderer: (c) => ({ " +
+          "kind: \"reload-fixture-off\", id: \"reload-fixture-off\", subjects: [], async start(){}, async stop(){}, " +
+          "get surfaceConfig(){return {id:this.id, subjects:this.subjects, render:()=>this.render()};}, async render(){} }) };\n" +
+          "export default plugin;\n",
+      );
+      const pkg: ArcPackage = {
+        name: "unsigned-reload-bundle",
+        version: "0.0.0",
+        type: "component",
+        status: "active",
+        tier: "community",
+        repoUrl: TRUSTED_REPO,
+        installPath: dir,
+      };
+      const { bundles } = await discoverPluginBundles({ pkgRoot, runner: runnerFor([pkg]) });
+      const bundle = bundles.find((b) => b.bundleName === "unsigned-reload-bundle");
+      if (!bundle) throw new Error("test setup: bundle not discoverable for reload");
+
+      // No cortex-plugin.sig anywhere — under any non-"off" posture this
+      // would refuse at signature_missing. Under "off" it must load fine.
+      const reimportResult = await reimportRendererPlugin(bundle, { bust: true, pluginSigning: "off" });
+      expect(reimportResult.ok).toBe(true);
+      if (reimportResult.ok) {
+        expect(reimportResult.plugin.id).toBe("reload-fixture-off");
+      }
     } finally {
       rmSync(pkgRoot, { recursive: true, force: true });
     }

--- a/src/adapters/__tests__/loader.signing.test.ts
+++ b/src/adapters/__tests__/loader.signing.test.ts
@@ -1,0 +1,369 @@
+/**
+ * cortex#2347 (EBH-5, ADR-0024 D4) — loader-pipeline integration tests for
+ * `system.plugins.signing`. Unit-level digest/signature-primitive tests
+ * live in `plugin-signing.test.ts`; this file proves the STAGED POSTURE
+ * composes correctly with the existing discover → gate → import → register
+ * pipeline: off is a byte-identical no-op, permissive verifies-and-logs
+ * without ever refusing, and enforce actually refuses a bad bundle while
+ * still loading a good one (a gate without a "still loads the good one"
+ * test is how a control silently dies — repo lesson, EBH task brief).
+ *
+ * No network: `arc list --json` is fully injected via `runner`, same
+ * convention as `loader.test.ts`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createUser } from "nkeys.js";
+
+import { loadExternalPlugins, type ArcListRunResult } from "../loader";
+import {
+  computeBundleDigest,
+  PLUGIN_SIGNATURE_FILENAME,
+  renderSignatureFile,
+  signBundleDigest,
+} from "../plugin-signing";
+import { SurfacePluginRegistry } from "../registry";
+import type { ArcPackage } from "../../common/types/plugin-manifest";
+
+const TRUSTED_REPO = "https://github.com/the-metafactory/metafactory-fixture-plugins";
+
+function freshKeypair(): { seed: string; pubkey: string } {
+  const kp = createUser();
+  return { seed: new TextDecoder().decode(kp.getSeed()), pubkey: kp.getPublicKey() };
+}
+
+function runnerFor(packages: ArcPackage[]): () => Promise<ArcListRunResult> {
+  return async () => ({ stdout: JSON.stringify({ packages }), stderr: "", exitCode: 0 });
+}
+
+/** Build a minimal, real renderer bundle directory (manifest + entry that
+ *  actually satisfies `RendererPlugin`'s shape) under `pkgRoot`, optionally
+ *  signed. Returns the ArcPackage record a fake `arc list --json` run would
+ *  report for it. */
+async function writeBundle(
+  pkgRoot: string,
+  dirName: string,
+  opts: { id: string; sign?: { seed: string; pubkey: string }; tamperAfterSigning?: boolean },
+): Promise<ArcPackage> {
+  const dir = join(pkgRoot, dirName);
+  const { mkdirSync } = await import("fs");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "cortex-plugin.yaml"),
+    `kind: renderer\nid: ${opts.id}\nentry: ./index.ts\nsdkRange: "^1"\n`,
+  );
+  // Deliberately ZERO external imports (no `zod`, no cortex-internal path) —
+  // these bundles are written under the OS tmpdir, outside the repo tree, so
+  // there is no `node_modules` for Bun to resolve a real dependency against.
+  // `configSchema` is a plain object exposing the one method the loader's
+  // `isRendererPluginShape` checks (`typeof configSchema.safeParse ===
+  // "function"`), mirroring `loader.test.ts`'s own `makeInTreeDiscordStub`
+  // stub-schema pattern.
+  writeFileSync(
+    join(dir, "index.ts"),
+    [
+      "const plugin = {",
+      "  kind: \"renderer\",",
+      `  id: ${JSON.stringify(opts.id)},`,
+      `  rendererKind: ${JSON.stringify(opts.id)},`,
+      "  configSchema: { safeParse: (v) => ({ success: true, data: v }) },",
+      "  createRenderer: (config) => ({",
+      `    kind: ${JSON.stringify(opts.id)},`,
+      `    id: ${JSON.stringify(opts.id)},`,
+      "    subjects: [\"local.andreas.>\"],",
+      "    async start() {},",
+      "    async stop() {},",
+      "    get surfaceConfig() { return { id: this.id, subjects: this.subjects, render: () => this.render() }; },",
+      "    async render() {},",
+      "  }),",
+      "};",
+      "export default plugin;",
+      "",
+    ].join("\n"),
+  );
+
+  if (opts.sign) {
+    const digestResult = computeBundleDigest(dir);
+    if (!digestResult.ok) throw new Error(`test setup: digest failed: ${digestResult.reason}`);
+    const signature = await signBundleDigest(opts.sign.seed, digestResult.digest);
+    writeFileSync(
+      join(dir, PLUGIN_SIGNATURE_FILENAME),
+      renderSignatureFile({
+        version: 1,
+        algorithm: "ed25519",
+        signer: opts.sign.pubkey,
+        digest: digestResult.digest,
+        signature,
+      }),
+    );
+  }
+
+  if (opts.tamperAfterSigning) {
+    writeFileSync(join(dir, "index.ts"), (await Bun.file(join(dir, "index.ts")).text()) + "// tampered\n");
+  }
+
+  return {
+    name: dirName,
+    version: "0.0.0",
+    type: "component",
+    status: "active",
+    tier: "community",
+    repoUrl: TRUSTED_REPO,
+    installPath: dir,
+  };
+}
+
+describe("loadExternalPlugins — system.plugins.signing (cortex#2347, EBH-5)", () => {
+  test("default (posture unset / 'off') loads an UNSIGNED bundle exactly as before — byte-identical no-op", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-off-"));
+    try {
+      const pkg = await writeBundle(pkgRoot, "unsigned-bundle", { id: "sig-fixture-off" });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        // pluginSigning intentionally omitted — must default to "off".
+      });
+      expect(result.failed).toEqual([]);
+      expect(result.loaded.map((l) => l.id)).toEqual(["sig-fixture-off"]);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("'off' loads a TAMPERED/mismatched bundle too — posture off never even reads the signature file", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-off-tamper-"));
+    try {
+      const signer = freshKeypair();
+      const pkg = await writeBundle(pkgRoot, "tampered-but-off", {
+        id: "sig-fixture-off-tamper",
+        sign: signer,
+        tamperAfterSigning: true,
+      });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "off",
+        pluginTrustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.failed).toEqual([]);
+      expect(result.loaded.map((l) => l.id)).toEqual(["sig-fixture-off-tamper"]);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("'enforce': a VALIDLY signed bundle from a trusted signer loads", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-enforce-good-"));
+    try {
+      const signer = freshKeypair();
+      const pkg = await writeBundle(pkgRoot, "good-signed-bundle", {
+        id: "sig-fixture-enforce-good",
+        sign: signer,
+      });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "enforce",
+        pluginTrustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.failed).toEqual([]);
+      expect(result.loaded.map((l) => l.id)).toEqual(["sig-fixture-enforce-good"]);
+      expect(registry.getRenderer("sig-fixture-enforce-good")).toBeDefined();
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("'enforce': an UNSIGNED bundle is refused BEFORE import — the good bundle in the SAME load still loads", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-enforce-mixed-"));
+    try {
+      const signer = freshKeypair();
+      const goodPkg = await writeBundle(pkgRoot, "good-signed-bundle", {
+        id: "sig-fixture-mixed-good",
+        sign: signer,
+      });
+      const unsignedPkg = await writeBundle(pkgRoot, "unsigned-bundle", { id: "sig-fixture-mixed-unsigned" });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([goodPkg, unsignedPkg]),
+        pluginSigning: "enforce",
+        pluginTrustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.loaded.map((l) => l.id).sort()).toEqual(["sig-fixture-mixed-good"]);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0]?.bundleName).toBe("unsigned-bundle");
+      expect(result.failed[0]?.stage).toBe("signature_verify:signature_missing");
+      // Proves it never even reached import: the OTHER bundle registered fine
+      // and there is no "import" stage failure recorded.
+      expect(registry.getRenderer("sig-fixture-mixed-good")).toBeDefined();
+      expect(registry.getRenderer("sig-fixture-mixed-unsigned")).toBeUndefined();
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("'enforce': a bundle tampered with AFTER signing is refused (digest_mismatch)", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-enforce-tamper-"));
+    try {
+      const signer = freshKeypair();
+      const pkg = await writeBundle(pkgRoot, "tampered-bundle", {
+        id: "sig-fixture-enforce-tamper",
+        sign: signer,
+        tamperAfterSigning: true,
+      });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "enforce",
+        pluginTrustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.loaded).toEqual([]);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0]?.stage).toBe("signature_verify:digest_mismatch");
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("'enforce': a well-signed bundle whose signer is NOT in the trust root is refused (signer_not_trusted)", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-enforce-untrusted-"));
+    try {
+      const signer = freshKeypair();
+      const someoneElse = freshKeypair();
+      const pkg = await writeBundle(pkgRoot, "wrong-signer-bundle", {
+        id: "sig-fixture-enforce-untrusted",
+        sign: signer,
+      });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "enforce",
+        pluginTrustedSigners: new Set([someoneElse.pubkey]),
+      });
+      expect(result.loaded).toEqual([]);
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0]?.stage).toBe("signature_verify:signer_not_trusted");
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("'permissive': an unsigned bundle still LOADS (verify + log, never refuse)", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-permissive-"));
+    try {
+      const pkg = await writeBundle(pkgRoot, "unsigned-bundle", { id: "sig-fixture-permissive" });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "permissive",
+        pluginTrustedSigners: new Set(),
+      });
+      expect(result.failed).toEqual([]);
+      expect(result.loaded.map((l) => l.id)).toEqual(["sig-fixture-permissive"]);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("'permissive': a TAMPERED bundle still LOADS (fail-open by design, unlike enforce)", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-permissive-tamper-"));
+    try {
+      const signer = freshKeypair();
+      const pkg = await writeBundle(pkgRoot, "tampered-bundle", {
+        id: "sig-fixture-permissive-tamper",
+        sign: signer,
+        tamperAfterSigning: true,
+      });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "permissive",
+        pluginTrustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.failed).toEqual([]);
+      expect(result.loaded.map((l) => l.id)).toEqual(["sig-fixture-permissive-tamper"]);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("org-trust gate still refuses a non-the-metafactory repo BEFORE signature verification runs, even under 'enforce'", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-org-trust-"));
+    try {
+      const signer = freshKeypair();
+      const pkg = await writeBundle(pkgRoot, "attacker-bundle", {
+        id: "sig-fixture-org-trust",
+        sign: signer,
+      });
+      pkg.repoUrl = "https://github.com/attacker/sig-fixture-org-trust";
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: true,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "enforce",
+        pluginTrustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.loaded).toEqual([]);
+      expect(result.failed).toHaveLength(1);
+      // Refused at org_trust, NOT at any signature_verify stage — proves
+      // signing composes with (never bypasses or is bypassed by) the
+      // existing gate ordering.
+      expect(result.failed[0]?.stage).toBe("org_trust");
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("external-flag gate still skips a non-first-party bundle BEFORE signature verification, even under 'enforce'", async () => {
+    const pkgRoot = mkdtempSync(join(tmpdir(), "cortex-signing-external-flag-"));
+    try {
+      const signer = freshKeypair();
+      // Deliberately UNSIGNED — if signature verification ran here it would
+      // FAIL (missing sig), which would show up as `failed`, not `skipped`.
+      const pkg = await writeBundle(pkgRoot, "no-external-bundle", { id: "sig-fixture-external-flag" });
+      const registry = new SurfacePluginRegistry();
+      const result = await loadExternalPlugins({
+        registry,
+        externalEnabled: false,
+        pkgRoot,
+        runner: runnerFor([pkg]),
+        pluginSigning: "enforce",
+        pluginTrustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.loaded).toEqual([]);
+      expect(result.failed).toEqual([]);
+      expect(result.skipped.map((s) => s.bundleName)).toEqual(["no-external-bundle"]);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/adapters/__tests__/plugin-signing.test.ts
+++ b/src/adapters/__tests__/plugin-signing.test.ts
@@ -17,6 +17,7 @@ import { join } from "path";
 import { createUser } from "nkeys.js";
 
 import {
+  assertPluginSigningTrustRootConfigured,
   computeBundleDigest,
   PLUGIN_SIGNATURE_FILENAME,
   renderSignatureFile,
@@ -304,5 +305,25 @@ describe("test-helper sanity", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("assertPluginSigningTrustRootConfigured (cortex#2347 follow-up, Finding 2 — availability)", () => {
+  test("throws when posture is 'enforce' and the trust root is empty", () => {
+    expect(() => assertPluginSigningTrustRootConfigured("enforce", new Set())).toThrow(
+      /REFUSING TO BOOT.*system\.plugins\.signing="enforce".*trust root is EMPTY/s,
+    );
+  });
+
+  test("does NOT throw when posture is 'enforce' and the trust root is non-empty", () => {
+    expect(() => assertPluginSigningTrustRootConfigured("enforce", new Set(["U" + "A".repeat(55)]))).not.toThrow();
+  });
+
+  test("does NOT throw for 'permissive' even with an empty trust root — permissive never refuses a bundle, so it cannot cause an availability outage", () => {
+    expect(() => assertPluginSigningTrustRootConfigured("permissive", new Set())).not.toThrow();
+  });
+
+  test("does NOT throw for 'off' even with an empty trust root — this module is never consulted under off", () => {
+    expect(() => assertPluginSigningTrustRootConfigured("off", new Set())).not.toThrow();
   });
 });

--- a/src/adapters/__tests__/plugin-signing.test.ts
+++ b/src/adapters/__tests__/plugin-signing.test.ts
@@ -1,0 +1,308 @@
+/**
+ * cortex#2347 (EBH-5, ADR-0024 D4) — unit tests for
+ * `src/adapters/plugin-signing.ts`: the bundle content digest and the
+ * signature-verification primitive, independent of the loader pipeline
+ * (loader-level integration tests live in `loader.signing.test.ts`).
+ *
+ * No network, no `arc list` — everything here operates on a throwaway
+ * temp directory + a freshly generated ed25519 keypair (via `nkeys.js`,
+ * the same library `src/bus/stack-provisioning.ts` uses for stack
+ * signing identities).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createUser } from "nkeys.js";
+
+import {
+  computeBundleDigest,
+  PLUGIN_SIGNATURE_FILENAME,
+  renderSignatureFile,
+  signBundleDigest,
+  verifyBundleSignature,
+} from "../plugin-signing";
+
+function freshKeypair(): { seed: string; pubkey: string } {
+  const kp = createUser();
+  return {
+    seed: new TextDecoder().decode(kp.getSeed()),
+    pubkey: kp.getPublicKey(),
+  };
+}
+
+function makeBundleDir(): string {
+  return mkdtempSync(join(tmpdir(), "cortex-plugin-signing-"));
+}
+
+/** Write a minimal two-file bundle (manifest + entry) and sign it with
+ *  `signer`. Returns the dir so the caller can further mutate it. */
+async function makeSignedBundle(
+  dir: string,
+  signer: { seed: string; pubkey: string },
+): Promise<void> {
+  writeFileSync(
+    join(dir, "cortex-plugin.yaml"),
+    "kind: renderer\nid: signing-fixture\nentry: ./index.ts\nsdkRange: \"^1\"\n",
+  );
+  writeFileSync(join(dir, "index.ts"), "export default { hello: 'world' };\n");
+  const digestResult = computeBundleDigest(dir);
+  if (!digestResult.ok) throw new Error(`test setup: digest failed: ${digestResult.reason}`);
+  const signature = await signBundleDigest(signer.seed, digestResult.digest);
+  writeFileSync(
+    join(dir, PLUGIN_SIGNATURE_FILENAME),
+    renderSignatureFile({
+      version: 1,
+      algorithm: "ed25519",
+      signer: signer.pubkey,
+      digest: digestResult.digest,
+      signature,
+    }),
+  );
+}
+
+describe("computeBundleDigest (cortex#2347)", () => {
+  test("is deterministic for identical content", () => {
+    const dir = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(dir, "index.ts"), "export default {};\n");
+      const a = computeBundleDigest(dir);
+      const b = computeBundleDigest(dir);
+      expect(a).toEqual(b);
+      expect(a.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("changes when any file's content changes", () => {
+    const dir = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(dir, "index.ts"), "export default {};\n");
+      const before = computeBundleDigest(dir);
+      writeFileSync(join(dir, "index.ts"), "export default { tampered: true };\n");
+      const after = computeBundleDigest(dir);
+      expect(before.ok && after.ok).toBe(true);
+      if (before.ok && after.ok) {
+        expect(before.digest).not.toBe(after.digest);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("changes when the MANIFEST changes (not just the entry file)", () => {
+    const dir = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(dir, "index.ts"), "export default {};\n");
+      const before = computeBundleDigest(dir);
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^2\"\n");
+      const after = computeBundleDigest(dir);
+      expect(before.ok && after.ok).toBe(true);
+      if (before.ok && after.ok) {
+        expect(before.digest).not.toBe(after.digest);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes the signature file itself from the digest", () => {
+    const dir = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(dir, "index.ts"), "export default {};\n");
+      const before = computeBundleDigest(dir);
+      writeFileSync(join(dir, PLUGIN_SIGNATURE_FILENAME), "version: 1\nalgorithm: ed25519\nsigner: whatever\ndigest: whatever\nsignature: whatever\n");
+      const after = computeBundleDigest(dir);
+      expect(before).toEqual(after);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses (fails closed) when the bundle contains a nested symlink", () => {
+    const dir = makeBundleDir();
+    const outside = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(outside, "sneaky.ts"), "export default {};\n");
+      symlinkSync(join(outside, "sneaky.ts"), join(dir, "index.ts"));
+      const result = computeBundleDigest(dir);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toMatch(/symlink/);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("verifyBundleSignature (cortex#2347) — both directions", () => {
+  test("a validly signed bundle from a TRUSTED signer verifies", async () => {
+    const dir = makeBundleDir();
+    try {
+      const signer = freshKeypair();
+      await makeSignedBundle(dir, signer);
+      const result = await verifyBundleSignature({
+        installPath: dir,
+        trustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result).toEqual({ ok: true, signer: signer.pubkey });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a bundle with NO signature file is refused (signature_missing)", async () => {
+    const dir = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(dir, "index.ts"), "export default {};\n");
+      const result = await verifyBundleSignature({ installPath: dir, trustedSigners: new Set() });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.stage).toBe("signature_missing");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a well-formed signature from a signer NOT in the trust root is refused (signer_not_trusted)", async () => {
+    const dir = makeBundleDir();
+    try {
+      const signer = freshKeypair();
+      const someoneElse = freshKeypair();
+      await makeSignedBundle(dir, signer);
+      const result = await verifyBundleSignature({
+        installPath: dir,
+        trustedSigners: new Set([someoneElse.pubkey]),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.stage).toBe("signer_not_trusted");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a bundle tampered with AFTER signing is refused (digest_mismatch), even though the signer is trusted", async () => {
+    const dir = makeBundleDir();
+    try {
+      const signer = freshKeypair();
+      await makeSignedBundle(dir, signer);
+      // Mutate content after signing — signature file is untouched, so it
+      // still names the OLD (now-stale) digest.
+      writeFileSync(join(dir, "index.ts"), "export default { tampered: true };\n");
+      const result = await verifyBundleSignature({
+        installPath: dir,
+        trustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.stage).toBe("digest_mismatch");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a corrupted signature (right digest, forged signature bytes) is refused (signature_invalid)", async () => {
+    const dir = makeBundleDir();
+    try {
+      const signer = freshKeypair();
+      await makeSignedBundle(dir, signer);
+      writeFileSync(
+        join(dir, PLUGIN_SIGNATURE_FILENAME),
+        renderSignatureFile({
+          version: 1,
+          algorithm: "ed25519",
+          signer: signer.pubkey,
+          digest: computeBundleDigest(dir).ok
+            ? (computeBundleDigest(dir) as { ok: true; digest: string }).digest
+            : "0".repeat(64),
+          // Well-formed base64, but not a valid signature over the digest.
+          signature: Buffer.alloc(64, 7).toString("base64"),
+        }),
+      );
+      const result = await verifyBundleSignature({
+        installPath: dir,
+        trustedSigners: new Set([signer.pubkey]),
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.stage).toBe("signature_invalid");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a malformed signature file (schema violation) is refused (signature_parse)", async () => {
+    const dir = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(dir, "index.ts"), "export default {};\n");
+      writeFileSync(join(dir, PLUGIN_SIGNATURE_FILENAME), "not: valid\nsignature: shape\n");
+      const result = await verifyBundleSignature({ installPath: dir, trustedSigners: new Set() });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.stage).toBe("signature_parse");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a symlinked signature file escaping the bundle directory is refused (signature_containment)", async () => {
+    const dir = makeBundleDir();
+    const outside = makeBundleDir();
+    try {
+      writeFileSync(join(dir, "cortex-plugin.yaml"), "kind: renderer\nid: x\nentry: ./index.ts\nsdkRange: \"^1\"\n");
+      writeFileSync(join(dir, "index.ts"), "export default {};\n");
+      const secretSig = join(outside, "not-really-a-sig.yaml");
+      writeFileSync(
+        secretSig,
+        "version: 1\nalgorithm: ed25519\nsigner: \"U0000000000000000000000000000000000000000000000000000\"\ndigest: \"" +
+          "0".repeat(64) +
+          "\"\nsignature: \"aaaa\"\n",
+      );
+      symlinkSync(secretSig, join(dir, PLUGIN_SIGNATURE_FILENAME));
+      const result = await verifyBundleSignature({ installPath: dir, trustedSigners: new Set() });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.stage).toBe("signature_containment");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test("verifying twice against an unmodified signed bundle is stable (no flakiness)", async () => {
+    const dir = makeBundleDir();
+    try {
+      const signer = freshKeypair();
+      await makeSignedBundle(dir, signer);
+      const trustedSigners = new Set([signer.pubkey]);
+      const first = await verifyBundleSignature({ installPath: dir, trustedSigners });
+      const second = await verifyBundleSignature({ installPath: dir, trustedSigners });
+      expect(first).toEqual(second);
+      expect(first.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Sanity: mkdirSync import is unused-otherwise; keep tree-shaking honest by
+// referencing it in a trivial smoke test rather than leaving an unused import
+// (the loader test file suite does the same pattern for its fixtures).
+describe("test-helper sanity", () => {
+  test("makeBundleDir + mkdirSync both usable for nested-fixture tests", () => {
+    const dir = makeBundleDir();
+    try {
+      mkdirSync(join(dir, "nested"));
+      const result = computeBundleDigest(dir);
+      expect(result.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/adapters/loader.ts
+++ b/src/adapters/loader.ts
@@ -89,6 +89,11 @@ import type {
   RendererPlugin,
   SurfacePluginRegistry,
 } from "./registry";
+import {
+  PLUGIN_TRUST_ROOT,
+  verifyBundleSignature,
+  type PluginSigningPosture,
+} from "./plugin-signing";
 
 // =============================================================================
 // arc subprocess driver — injectable for tests. Same "spawn, capture
@@ -833,6 +838,22 @@ export interface LoadPluginsOptions {
    * depending on (or mutating) the real file.
    */
   cortexManifestPath?: string;
+  /**
+   * cortex#2347 (EBH-5, ADR-0024 D4) — `system.plugins.signing` posture.
+   * Default `"off"` — byte-identical to pre-EBH-5 behaviour, no bundle is
+   * ever read for a signature file. `"permissive"` verifies and logs but
+   * never refuses; `"enforce"` refuses any bundle whose signature is
+   * missing, malformed, tampered, or signed outside the trust root. See
+   * `src/adapters/plugin-signing.ts` module doc for the full design.
+   */
+  pluginSigning?: PluginSigningPosture;
+  /**
+   * cortex#2347 (EBH-5) test seam — pre-resolved plugin-signing trust
+   * root (NKey pubkeys). Production callers never set this: it defaults
+   * to {@link PLUGIN_TRUST_ROOT}, the in-tree constant. Tests inject a
+   * throwaway keypair's pubkey here instead of mutating the real constant.
+   */
+  pluginTrustedSigners?: ReadonlySet<string>;
 }
 
 export interface LoadPluginsResult {
@@ -875,6 +896,25 @@ export async function loadExternalPlugins(
   const firstPartyRendererRepos =
     options.firstPartyRendererRepos ?? readCortexDeclaredRendererRepos(manifestPath);
 
+  // cortex#2347 (EBH-5) — resolve the signing posture + trust root ONCE per
+  // load, same treatment as the first-party allowlists above. Default `off`
+  // keeps every existing caller (and every existing test) byte-identical.
+  const pluginSigning = options.pluginSigning ?? "off";
+  const pluginTrustedSigners = options.pluginTrustedSigners ?? PLUGIN_TRUST_ROOT;
+  if (pluginSigning !== "off" && pluginTrustedSigners.size === 0) {
+    // Loud, non-fatal (the loader NEVER throws) heads-up: a posture was
+    // enabled with nothing to verify against. Under `enforce` this refuses
+    // EVERY bundle (fail-closed, not silent); under `permissive` every
+    // bundle logs a verify-failed warning. Either way this is very likely a
+    // misconfiguration, not an intentional state — surfaced once per load
+    // rather than buried in per-bundle stderr noise.
+    process.stderr.write(
+      `cortex plugin-loader: system.plugins.signing="${pluginSigning}" but the plugin trust root ` +
+        `is EMPTY — no bundle can verify. See src/adapters/plugin-signing.ts PLUGIN_TRUST_ROOT ` +
+        `(populating it is a deliberate open decision, not yet made — see that module's doc).\n`,
+    );
+  }
+
   const { bundles, issues: discoveryIssues } = await discoverPluginBundles({
     pkgRoot: options.pkgRoot,
     runner: options.runner,
@@ -893,6 +933,8 @@ export async function loadExternalPlugins(
         externalEnabled,
         firstPartyRendererRepos,
         firstPartyAdapterRepos,
+        pluginSigning,
+        pluginTrustedSigners,
         loaded,
         skipped,
         failed,
@@ -927,6 +969,10 @@ interface LoadOneBundleSinks {
   /** cortex#1794 (S9a) — pre-resolved once in {@link loadExternalPlugins},
    *  never re-read per bundle. */
   firstPartyAdapterRepos: ReadonlySet<string>;
+  /** cortex#2347 (EBH-5) — `system.plugins.signing` posture, resolved once. */
+  pluginSigning: PluginSigningPosture;
+  /** cortex#2347 (EBH-5) — plugin-signing trust root, resolved once. */
+  pluginTrustedSigners: ReadonlySet<string>;
   loaded: LoadedPluginInfo[];
   skipped: SkippedPluginInfo[];
   failed: FailedPluginInfo[];
@@ -1012,6 +1058,39 @@ async function loadOneBundle(bundle: DiscoveredBundle, sinks: LoadOneBundleSinks
       `a ${manifest.kind} plugin with id "${manifest.id}" is already registered (in-tree plugins and earlier-loaded bundles always win) — refusing to shadow it`,
     );
     return;
+  }
+
+  // (d.5) Signature verification — cortex#2347 (EBH-5, ADR-0024 D4). Gated
+  // by `system.plugins.signing` (default "off" — this whole block is a
+  // no-op then, byte-identical to pre-EBH-5 behaviour). Runs from bytes on
+  // disk ONLY — no `import()`, directly or indirectly — strictly BEFORE
+  // the entry module is ever loaded (stage (e) below). This is an
+  // ADDITIONAL, independent gate: it composes with (never replaces or
+  // widens) the org-trust gate (a) and the first-party exemption (b) —
+  // neither of those computations is touched here, and a bundle that
+  // failed either gate already returned above and never reaches this line.
+  if (sinks.pluginSigning !== "off") {
+    const sigResult = await verifyBundleSignature({
+      installPath,
+      trustedSigners: sinks.pluginTrustedSigners,
+    });
+    if (!sigResult.ok) {
+      if (sinks.pluginSigning === "enforce") {
+        fail(`signature_verify:${sigResult.stage}`, sigResult.reason);
+        return;
+      }
+      // permissive — verify + log, NEVER refuse. The shadow rung: prove
+      // verification against real installed bundles before gating.
+      process.stderr.write(
+        `cortex plugin-loader: ${bundleName} (${manifest.kind}:${manifest.id}) signature verification ` +
+          `FAILED (permissive — continuing) at ${sigResult.stage}: ${sigResult.reason}\n`,
+      );
+    } else {
+      process.stderr.write(
+        `cortex plugin-loader: ${bundleName} (${manifest.kind}:${manifest.id}) signature verified ` +
+          `(signer=${sigResult.signer.slice(0, 12)}…)\n`,
+      );
+    }
   }
 
   // (e) Entry containment + import.

--- a/src/adapters/loader.ts
+++ b/src/adapters/loader.ts
@@ -1267,6 +1267,22 @@ export type ReimportRendererResult =
  * boot, applied to the SAME bundle a second time, so a reload is held to the
  * identical trust bar as a fresh boot-time load — no relaxed re-import path.
  *
+ * **cortex#2347 (EBH-5 follow-up, adversarial review DO-NOT-MERGE finding)
+ * — this is the SECOND `import()` call site that loads plugin bundle code,
+ * and it RE-VERIFIES the signature every time, from CURRENT on-disk bytes.**
+ * A bundle that verified at boot does not get a lifetime pass: the file on
+ * disk may have changed since boot (that is the entire point of a reload
+ * command existing), so `opts.pluginSigning`/`opts.pluginTrustedSigners`
+ * are threaded through and checked via {@link verifyBundleSignature} BEFORE
+ * the entry module is imported below — same posture semantics as
+ * `loadOneBundle` (`off` no-ops, `permissive` verifies-and-logs-never-
+ * refuses, `enforce` refuses and the tampered code is never imported).
+ * `pluginSigning` is a REQUIRED param (no default) precisely so a caller
+ * cannot silently omit it the way this call site silently omitted
+ * verification entirely before this fix — see `src/adapters/plugin-signing.ts`'s
+ * module doc "Coverage" section for the full audit of both `import()` call
+ * sites.
+ *
  * Does NOT touch the {@link SurfacePluginRegistry} — the registry is a
  * `(kind, id)`-keyed CLASS registry (ADR-0024 D5), and a reload replaces a
  * live INSTANCE, not the class binding config-parsing resolves against. The
@@ -1292,7 +1308,20 @@ export type ReimportRendererResult =
  */
 export async function reimportRendererPlugin(
   bundle: DiscoveredBundle,
-  opts: { bust: boolean },
+  opts: {
+    bust: boolean;
+    /**
+     * cortex#2347 (EBH-5 follow-up) — `system.plugins.signing` posture.
+     * REQUIRED, no default: boot-time verification does not carry forward
+     * to a reload (this is a distinct `import()` call site), and every
+     * caller must make an explicit, visible choice rather than one that
+     * silently reintroduces the gap this fix closes.
+     */
+    pluginSigning: PluginSigningPosture;
+    /** Trust root override — defaults to {@link PLUGIN_TRUST_ROOT}, same
+     *  default {@link loadExternalPlugins} uses. */
+    pluginTrustedSigners?: ReadonlySet<string>;
+  },
 ): Promise<ReimportRendererResult> {
   const { manifest, bundleName } = bundle;
   const fail = (stage: string, reason: string): ReimportRendererResult => {
@@ -1304,6 +1333,32 @@ export async function reimportRendererPlugin(
 
   if (manifest.kind !== "renderer") {
     return fail("kind_check", `reimportRendererPlugin only supports renderer bundles; "${bundleName}" is kind "${manifest.kind}"`);
+  }
+
+  // Signature re-verification — cortex#2347 (EBH-5 follow-up). From CURRENT
+  // on-disk bytes, every reload, strictly BEFORE the entry module is
+  // imported below. See this function's doc + `plugin-signing.ts`'s
+  // "Coverage" section.
+  if (opts.pluginSigning !== "off") {
+    const trustedSigners = opts.pluginTrustedSigners ?? PLUGIN_TRUST_ROOT;
+    const sigResult = await verifyBundleSignature({
+      installPath: bundle.installPath,
+      trustedSigners,
+    });
+    if (!sigResult.ok) {
+      if (opts.pluginSigning === "enforce") {
+        return fail(`signature_verify:${sigResult.stage}`, sigResult.reason);
+      }
+      process.stderr.write(
+        `cortex plugin-loader: reload of ${bundleName} (renderer:${manifest.id}) signature verification ` +
+          `FAILED (permissive — continuing) at ${sigResult.stage}: ${sigResult.reason}\n`,
+      );
+    } else {
+      process.stderr.write(
+        `cortex plugin-loader: reload of ${bundleName} (renderer:${manifest.id}) signature verified ` +
+          `(signer=${sigResult.signer.slice(0, 12)}…)\n`,
+      );
+    }
   }
 
   const resolved = resolveEntryWithinBundle(bundle.installPath, manifest.entry);

--- a/src/adapters/plugin-signing.ts
+++ b/src/adapters/plugin-signing.ts
@@ -90,10 +90,18 @@
  * signed (an `arc publish` pipeline step? a manual `cortex plugin sign`
  * CLI, not built here?) — is an ecosystem/operational decision, not a
  * cortex-code decision, and is out of scope for this slice. Shipping
- * with an empty trust root is safe BECAUSE verification is default-off
- * (`system.plugins.signing: "off"`, see `PluginsConfigSchema`) and
- * verification-enabled is itself an explicit opt-in — an empty trust
- * root cannot brick a deployment that never opts in.
+ * with an empty trust root is safe under `off` (the default) and
+ * `permissive` (verify-and-log, never refuses). It is NOT automatically
+ * safe under `enforce` — an empty trust root there refuses every bundle,
+ * including a FIRST-PARTY one a stack may depend on for the ADR-0024
+ * §OQ9 renderer-coverage floor (see `docs/security/hardening-plan.md`),
+ * which downstream surfaces as an unrelated-looking boot crash at the
+ * coverage guard. {@link assertPluginSigningTrustRootConfigured} is the
+ * boot-time guard that catches this BEFORE it reaches that point — see
+ * its own doc for why this is a "make the failure loud and immediate,"
+ * not a "prevent the failure" fix (`enforce` with nothing to verify
+ * against genuinely cannot safely proceed; that refusal is correct, not
+ * a bug — only its confusing, three-layers-downstream presentation was).
  *
  * ## Posture (mirrors `security.signing`, `src/common/types/config.ts`)
  *
@@ -102,9 +110,43 @@
  * (verify + log, NEVER refuse — the shadow rung to prove verification
  * against live bundles before gating) · `enforce` (refuse any bundle
  * whose signature is missing, malformed, tampered, or signed by a key
- * outside {@link PLUGIN_TRUST_ROOT}). The posture read + branch lives in
- * `loader.ts`'s `loadOneBundle`; this module only ever answers "does
- * this bundle verify", never "what should happen if it doesn't".
+ * outside {@link PLUGIN_TRUST_ROOT}). This module only ever answers
+ * "does this bundle verify right now", never "what should happen if it
+ * doesn't" — that branch lives at EVERY call site listed in "Coverage"
+ * below, independently, because each is a distinct point where plugin
+ * code is about to execute.
+ *
+ * ## Coverage — every `import()` call site that loads plugin bundle code
+ *
+ * There are exactly two, both in `loader.ts`, both verified (audited
+ * cortex#2347 follow-up, adversarial-review finding — a bundle that
+ * verified once must NOT get a lifetime pass):
+ *
+ *   1. **Boot** — `loadOneBundle` (called from `loadExternalPlugins`).
+ *      Verifies once, at first load, before that bundle's entry module
+ *      is ever imported for this daemon process's lifetime.
+ *   2. **Reload** — `reimportRendererPlugin` (called from
+ *      `src/gateway/plugin-runtime.ts`'s `reloadLivePlugin`/
+ *      `loadLivePlugin`, reachable via the `system.plugin.control-request`
+ *      bus subject and the `cortex plugin reload`/`load` CLI). This is a
+ *      SEPARATE, later `import()` of the SAME bundle's entry module — the
+ *      file on disk may have changed since boot (that is the entire point
+ *      of a reload command). It therefore RE-VERIFIES from CURRENT on-disk
+ *      bytes, every time, using the same posture + trust root as boot —
+ *      never "trusts" a boot-time result that has gone stale. A bundle
+ *      tampered with after boot is refused at reload under `enforce`, and
+ *      its (tampered) code is never imported.
+ *
+ * Every other `import()`/`require()`/`eval()`-shaped call in the codebase
+ * (audited alongside this fix — `grep -rn "await import(" src/` minus
+ * `__tests__`) loads a static npm dependency (`@metafactory/content-filter`,
+ * `bun`, `fs`, `fs/promises`) or an internal cortex module by literal
+ * path — never third-party bundle code reached through the plugin loader.
+ * If a THIRD call site is ever added (a future runtime-adapter-reload verb,
+ * cortex#1896's tracked follow-up, is the most likely candidate), it MUST
+ * verify through this module before importing, and this list MUST grow to
+ * three — a call site missing from this list is the bug class this note
+ * exists to prevent recurring.
  *
  * ## What this module does NOT do
  *
@@ -114,7 +156,11 @@
  * still runs in-process with full daemon authority (ADR-0024 D4
  * unchanged). Signature verification answers "is this the bundle a
  * trusted publisher produced", not "what can this bundle do once it
- * runs".
+ * runs". It does NOT protect against a bundle that re-signs itself with
+ * a DIFFERENT, still-trusted key between boot and reload — that is not a
+ * gap, it is the system working as designed (a trusted publisher legally
+ * re-publishing); what it defends against is untrusted or tampered bytes
+ * being imported, at every point bytes are about to become code.
  */
 
 import { createHash } from "node:crypto";
@@ -152,6 +198,64 @@ export type PluginSigningPosture = "off" | "permissive" | "enforce";
 export const PLUGIN_TRUST_ROOT: ReadonlySet<string> = new Set([
   // INTENTIONALLY EMPTY — see module doc header.
 ]);
+
+/**
+ * cortex#2347 (EBH-5 follow-up, adversarial review Finding 2 — availability)
+ * — boot-time precondition: `system.plugins.signing === "enforce"` with an
+ * EMPTY effective trust root cannot deliver a working boot. Under `enforce`
+ * EVERY bundle fails to verify (there is nothing to verify against),
+ * including a FIRST-PARTY bundle a stack may depend on for the ADR-0024
+ * §OQ9 renderer-coverage floor (today: `metafactory-cortex-renderer-pagerduty`
+ * — see `docs/security/hardening-plan.md`). Left unchecked, THIS function's
+ * absence is exactly how that surfaces: several boot-stages later, as an
+ * uncaught `RendererCoverageInstallStateError` (`src/renderers/coverage.ts`)
+ * that names a coverage shortfall, not the `signing` flag that actually
+ * caused it — a confusing, accidental-looking outage from a config change
+ * that was one field, in one place, days or commits away from the crash.
+ *
+ * This function turns that into an IMMEDIATE, NAMED, actionable refusal,
+ * called from `src/cortex.ts` BEFORE `loadExternalPlugins` even runs — the
+ * earliest point the boot sequence can know both facts (the resolved
+ * posture, and the trust root it will verify against). It deliberately does
+ * NOT:
+ *   - weaken `enforce`'s semantics (a stack genuinely cannot safely verify
+ *     anything against an empty trust root — refusing to boot IS correct;
+ *     only the previous failure's presentation was the bug), or
+ *   - auto-exempt first-party bundles from signature verification (that
+ *     would be exactly the "solve availability by widening trust" shape
+ *     this review explicitly forbids — see `plugin-signing.ts`'s own
+ *     "Coverage" section: EVERY bundle verifies, first-party included).
+ * It only makes the SAME necessary refusal loud and immediate instead of
+ * an accidental-looking crash three layers downstream.
+ *
+ * `permissive` is deliberately EXEMPT from this hard-fail: it never refuses
+ * a bundle (verify-and-log only), so an empty trust root under `permissive`
+ * cannot cause an availability outage — `loadExternalPlugins` already logs
+ * a one-line heads-up for that case (see its own "empty trust root" check).
+ * `off` is exempt because this module is never consulted under `off`.
+ *
+ * @throws a plain `Error` (matching this codebase's `bootVerifierSelfCheck`
+ *   "REFUSING TO BOOT" convention, `src/bus/verifier-self-check.ts`) when
+ *   `posture === "enforce"` and `trustedSigners.size === 0`. Never throws
+ *   otherwise.
+ */
+export function assertPluginSigningTrustRootConfigured(
+  posture: PluginSigningPosture,
+  trustedSigners: ReadonlySet<string>,
+): void {
+  if (posture !== "enforce") return;
+  if (trustedSigners.size > 0) return;
+  throw new Error(
+    `cortex plugin-loader: REFUSING TO BOOT — system.plugins.signing="enforce" but the plugin ` +
+      `trust root is EMPTY (src/adapters/plugin-signing.ts PLUGIN_TRUST_ROOT has zero entries). ` +
+      `Every bundle's signature would fail to verify, INCLUDING first-party bundles this stack may ` +
+      `depend on for ADR-0024 §OQ9 renderer coverage (e.g. metafactory-cortex-renderer-pagerduty) — ` +
+      `left unchecked this crashes several boot-stages later at the renderer-coverage guard with an ` +
+      `error that looks unrelated to this setting. Populate PLUGIN_TRUST_ROOT with a real production ` +
+      `signing key before enabling enforce, or set system.plugins.signing to "off" or "permissive" ` +
+      `until one is provisioned. See plugin-signing.ts's module doc "Open question" section.`,
+  );
+}
 
 // =============================================================================
 // Signature file schema

--- a/src/adapters/plugin-signing.ts
+++ b/src/adapters/plugin-signing.ts
@@ -1,0 +1,469 @@
+/**
+ * cortex#2347 (EBH-5, ADR-0024 D4 "named future escalation: registry
+ * signing") — cryptographic signature verification for surface-plugin
+ * bundles, at load time, from bytes on disk.
+ *
+ * ## Why this exists
+ *
+ * `loader.ts`'s org-trust gate (`isTrustedOrgRepo`) and first-party
+ * exemption (`isFirstPartyBundle`) both rest on `arc list --json`'s
+ * self-reported `repoUrl` — a fact `loader.ts` itself flags as
+ * un-independently-verifiable (see its `readCortexDeclaredAdapterRepos`
+ * doc, "Threat-model note"): if arc ever recorded a `repoUrl` decoupled
+ * from the package's real clone source, both gates would fall together.
+ * ADR-0024 D4 names the fix directly: **"registry signing … mirrors
+ * ADR-0018/0023"**. This module is that mechanism: an independent,
+ * additive gate that verifies a bundle's on-disk content was signed by a
+ * key on cortex's trust root, checked from bytes on disk BEFORE the
+ * bundle's entry module is ever `import()`-ed.
+ *
+ * **This does NOT replace the org-trust/first-party gates.** Composing
+ * ADD (this module ANDs with the existing gates, never substitutes for
+ * them) is deliberate: no production bundle in the ecosystem is signed
+ * yet (see "Open question" below), so making signature-based trust the
+ * SOLE gate today would either refuse every bundle (under `enforce`) or
+ * do nothing (under `off`) — neither improves on today. What changes is
+ * additive: once a publisher signs, `enforce` gives cortex a real,
+ * checkable fact to gate on, on top of the assumption that already
+ * existed. `isFirstPartyBundle` / `isFirstPartyAdapterBundle` /
+ * `isFirstPartyRendererBundle` / `readCortexDeclaredAdapterRepos` /
+ * `readCortexDeclaredRendererRepos` are UNTOUCHED by this module.
+ *
+ * ## Format
+ *
+ * A bundle's install directory MAY carry a sibling signature file,
+ * {@link PLUGIN_SIGNATURE_FILENAME} (`cortex-plugin.sig`), alongside
+ * `cortex-plugin.yaml`:
+ *
+ * ```yaml
+ * version: 1
+ * algorithm: ed25519
+ * signer: "U..."          # NKey public key (matches agent.nkey_pub / stack.nkey_pub format)
+ * digest: "<64-hex sha256>"  # see computeBundleDigest
+ * signature: "<base64 64-byte ed25519 signature>"
+ * ```
+ *
+ * The signer identifies itself by NKey (the same `U`-prefixed base32
+ * encoding cortex already uses for agent and stack signing identities —
+ * `src/common/types/nkey.ts`), not a bare base64 pubkey, so a plugin
+ * publisher's key can be generated, stored, and reasoned about with the
+ * exact same tooling (`nk`, `generateStackIdentity`) cortex already
+ * documents for every other signing identity in the system.
+ *
+ * `digest` is a deterministic content digest over the ENTIRE bundle
+ * tree (every regular file under `installPath`, sorted by relative
+ * path, EXCLUDING the signature file itself) — see
+ * {@link computeBundleDigest}. Signing only the manifest (or only the
+ * declared `entry` file) would leave a hole: `entry` can import sibling
+ * files the signature would then not cover. Signing the whole tree
+ * closes that — any file changed after signing invalidates the
+ * signature, including the manifest.
+ *
+ * `signature` covers a domain-separated message
+ * (`SIGNATURE_DOMAIN_PREFIX + digest`), not the raw digest bytes —
+ * ordinary signing hygiene so a plugin-bundle signature can never be
+ * replayed as a signature over an unrelated protocol that happens to
+ * sign the same 64 hex characters.
+ *
+ * ## Trust root — where it lives and why
+ *
+ * {@link PLUGIN_TRUST_ROOT} is an in-tree, PR-reviewed `ReadonlySet`
+ * of NKey public keys — the SAME shape of anchor as
+ * `TRUSTED_ORG_REPO_RE` and the original `FIRST_PARTY_RENDERER_REPOS`
+ * in `loader.ts`: changeable only by a reviewed cortex source change +
+ * release, never by bundle-author-controlled or deployment-mutable
+ * data. This is deliberate, not incidental — a trust root that lived in
+ * a deployment config file (`~/.config/metafactory/cortex/...`) would
+ * be *editable by anything with the daemon's own filesystem access*,
+ * which under ADR-0024 D4's accepted full-authority model includes an
+ * already-loaded plugin (the exact self-rewrite risk `loader.ts`'s
+ * `readCortexDeclaredAdapterRepos` doc already records for
+ * `arc-manifest.yaml`). An in-tree constant requires a REBUILD to
+ * change, which is a strictly higher bar.
+ *
+ * **Open question this module deliberately does NOT resolve (flagged,
+ * not silently decided):** {@link PLUGIN_TRUST_ROOT} ships EMPTY. No
+ * bundle in the ecosystem is signed today, and there is no arc/CI
+ * pipeline that produces a `cortex-plugin.sig` for a published bundle.
+ * Populating the trust root with a real production key — and deciding
+ * WHO holds the corresponding private seed and HOW/WHEN a bundle gets
+ * signed (an `arc publish` pipeline step? a manual `cortex plugin sign`
+ * CLI, not built here?) — is an ecosystem/operational decision, not a
+ * cortex-code decision, and is out of scope for this slice. Shipping
+ * with an empty trust root is safe BECAUSE verification is default-off
+ * (`system.plugins.signing: "off"`, see `PluginsConfigSchema`) and
+ * verification-enabled is itself an explicit opt-in — an empty trust
+ * root cannot brick a deployment that never opts in.
+ *
+ * ## Posture (mirrors `security.signing`, `src/common/types/config.ts`)
+ *
+ * `system.plugins.signing`: `off` (default, byte-identical to
+ * pre-EBH-5 behaviour — this module is never consulted) · `permissive`
+ * (verify + log, NEVER refuse — the shadow rung to prove verification
+ * against live bundles before gating) · `enforce` (refuse any bundle
+ * whose signature is missing, malformed, tampered, or signed by a key
+ * outside {@link PLUGIN_TRUST_ROOT}). The posture read + branch lives in
+ * `loader.ts`'s `loadOneBundle`; this module only ever answers "does
+ * this bundle verify", never "what should happen if it doesn't".
+ *
+ * ## What this module does NOT do
+ *
+ * It does not sandbox or isolate plugin execution — that is the
+ * trigger-gated, deferred half of cortex#2347 (EBH-5), designed but not
+ * built at `docs/design-plugin-isolation.md`. A validly-signed bundle
+ * still runs in-process with full daemon authority (ADR-0024 D4
+ * unchanged). Signature verification answers "is this the bundle a
+ * trusted publisher produced", not "what can this bundle do once it
+ * runs".
+ */
+
+import { createHash } from "node:crypto";
+import { lstatSync, readdirSync, readFileSync, realpathSync } from "fs";
+import { join, relative, sep } from "path";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod/v4";
+
+import { NKEY_PUBKEY_ERROR_MESSAGE, NKEY_PUBKEY_REGEX } from "../common/types/nkey";
+import { verifyEd25519 } from "../common/registry/signing";
+import { nkeyToBase64Pubkey } from "../bus/verify-signed-by-chain";
+import { signClaimWithSeed } from "../bus/stack-provisioning";
+
+/**
+ * The three settable `system.plugins.signing` postures — re-exported here
+ * (mirroring `SigningPosture` in `src/bus/verifier-self-check.ts`) so
+ * `loader.ts` can import the type from the module that owns the
+ * verification semantics rather than re-declaring the literal union.
+ */
+export type PluginSigningPosture = "off" | "permissive" | "enforce";
+
+// =============================================================================
+// Trust root
+// =============================================================================
+
+/**
+ * cortex#2347 (EBH-5) — the plugin-bundle signing trust root. See the
+ * module doc "Open question" section: INTENTIONALLY EMPTY until a
+ * production signing key is provisioned and the principal decides who
+ * holds it. Populating this set is a plain cortex source PR, exactly
+ * like `FIRST_PARTY_RENDERER_REPOS` in `loader.ts` — never a config
+ * change, never derived from anything a bundle or its manifest can
+ * influence.
+ */
+export const PLUGIN_TRUST_ROOT: ReadonlySet<string> = new Set([
+  // INTENTIONALLY EMPTY — see module doc header.
+]);
+
+// =============================================================================
+// Signature file schema
+// =============================================================================
+
+/** Sibling file to `cortex-plugin.yaml` inside a bundle's install dir. */
+export const PLUGIN_SIGNATURE_FILENAME = "cortex-plugin.sig";
+
+/** Domain separator prepended to the digest before signing/verifying —
+ *  ordinary signing hygiene so a plugin-bundle signature can't be replayed
+ *  as a signature over an unrelated protocol. */
+const SIGNATURE_DOMAIN_PREFIX = "cortex-plugin-bundle-v1\0";
+
+function signedMessage(digestHex: string): Uint8Array {
+  return new TextEncoder().encode(SIGNATURE_DOMAIN_PREFIX + digestHex);
+}
+
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+export const PluginSignatureSchema = z
+  .object({
+    version: z.literal(1),
+    algorithm: z.literal("ed25519"),
+    /** NKey public key — same `U`-prefixed base32 encoding as
+     *  `agent.nkey_pub` / `stack.nkey_pub`. */
+    signer: z.string().regex(NKEY_PUBKEY_REGEX, NKEY_PUBKEY_ERROR_MESSAGE),
+    /** sha256 hex digest of the bundle tree — see {@link computeBundleDigest}. */
+    digest: z
+      .string()
+      .regex(SHA256_HEX_RE, "digest must be a 64-char lowercase sha256 hex digest"),
+    /** base64-encoded 64-byte ed25519 signature over the domain-separated digest. */
+    signature: z.string().min(1, "signature is required"),
+  })
+  .strict();
+
+export type PluginSignature = z.infer<typeof PluginSignatureSchema>;
+
+// =============================================================================
+// Bundle content digest
+// =============================================================================
+
+export type BundleDigestResult = { ok: true; digest: string } | { ok: false; reason: string };
+
+/**
+ * Recursively collect every REGULAR file under `dir` (relative to `root`),
+ * refusing on any symlink or unexpected entry type. Returns an error
+ * string on failure, `undefined` on success; entries are pushed into
+ * `out` as `"<relPath>\0<sha256hex>"` in no particular order — the caller
+ * sorts the full collection before hashing, so traversal order never
+ * affects the result.
+ *
+ * Symlinks are refused, not silently skipped or dereferenced: a nested
+ * symlink inside an already-contained bundle directory could point
+ * outside it (mirrors the `cortex-plugin.yaml`/`entry` symlink defenses
+ * in `loader.ts`) and be swapped without changing this digest if we
+ * either ignored it or hashed only its target string. A legitimate
+ * bundle has no reason to ship one.
+ */
+function collectFileHashes(
+  dir: string,
+  root: string,
+  exclude: ReadonlySet<string>,
+  out: string[],
+): string | undefined {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    return `failed to read directory "${dir}": ${err instanceof Error ? err.message : String(err)}`;
+  }
+  for (const entry of entries) {
+    const abs = join(dir, entry.name);
+    const rel = relative(root, abs).split(sep).join("/");
+    if (exclude.has(rel)) continue;
+
+    let stat;
+    try {
+      stat = lstatSync(abs);
+    } catch (err) {
+      return `failed to stat "${rel}": ${err instanceof Error ? err.message : String(err)}`;
+    }
+
+    if (stat.isSymbolicLink()) {
+      return `bundle contains a symlink at "${rel}" — refusing to compute a digest over an untrusted symlink`;
+    }
+    if (stat.isDirectory()) {
+      const err = collectFileHashes(abs, root, exclude, out);
+      if (err !== undefined) return err;
+      continue;
+    }
+    if (!stat.isFile()) {
+      return `unexpected filesystem entry type at "${rel}" (not a regular file, directory, or symlink)`;
+    }
+
+    let content: Buffer;
+    try {
+      content = readFileSync(abs);
+    } catch (err) {
+      return `failed to read "${rel}": ${err instanceof Error ? err.message : String(err)}`;
+    }
+    const fileHash = createHash("sha256").update(content).digest("hex");
+    out.push(`${rel}\0${fileHash}`);
+  }
+  return undefined;
+}
+
+/**
+ * Compute a deterministic sha256 digest over the ENTIRE bundle tree
+ * rooted at `installPath` (every regular file, sorted by relative path),
+ * excluding {@link PLUGIN_SIGNATURE_FILENAME} at the ROOT (it can't sign
+ * itself). `cortex-plugin.yaml` is INCLUDED — tampering with the manifest
+ * after signing must invalidate the signature too.
+ *
+ * Never throws: any read/stat failure, or a nested symlink, is returned
+ * as `{ ok: false, reason }` — a failed digest computation is treated by
+ * the caller as a verification failure, never as "no opinion".
+ */
+export function computeBundleDigest(installPath: string): BundleDigestResult {
+  const exclude = new Set<string>([PLUGIN_SIGNATURE_FILENAME]);
+  const out: string[] = [];
+  const err = collectFileHashes(installPath, installPath, exclude, out);
+  if (err !== undefined) return { ok: false, reason: err };
+  out.sort();
+  const digest = createHash("sha256").update(out.join("\n")).digest("hex");
+  return { ok: true, digest };
+}
+
+// =============================================================================
+// Verification
+// =============================================================================
+
+export type VerifyBundleSignatureResult =
+  | { ok: true; signer: string }
+  | { ok: false; stage: string; reason: string };
+
+export interface VerifyBundleSignatureOptions {
+  /** Realpath'd, containment-verified bundle install directory (the SAME
+   *  value `loader.ts`'s `DiscoveredBundle.installPath` carries). */
+  installPath: string;
+  /** The trust root to check the signer against. Production callers pass
+   *  {@link PLUGIN_TRUST_ROOT}; tests inject their own throwaway keypair's
+   *  pubkey. No internal default — explicit only, mirroring
+   *  `isFirstPartyAdapterBundle`'s no-default convention in `loader.ts`. */
+  trustedSigners: ReadonlySet<string>;
+}
+
+/**
+ * Verify a bundle's {@link PLUGIN_SIGNATURE_FILENAME} against
+ * `opts.trustedSigners`, entirely from bytes on disk — no `import()`,
+ * directly or indirectly. Never throws.
+ *
+ * Failure stages (all refuse; the caller decides what "refuse" means for
+ * the active posture — see `loader.ts`):
+ *   - `signature_missing` — no `cortex-plugin.sig` in the bundle.
+ *   - `signature_containment` — the sig file is a symlink escaping the
+ *     bundle directory (mirrors the manifest-file defense in `loader.ts`).
+ *   - `signature_parse` — the file isn't valid YAML matching
+ *     {@link PluginSignatureSchema}.
+ *   - `signer_not_trusted` — the file parses fine but `signer` is not in
+ *     `trustedSigners`.
+ *   - `digest_compute` — {@link computeBundleDigest} failed (unreadable
+ *     file, nested symlink, …).
+ *   - `digest_mismatch` — the bundle's current content digest does not
+ *     match the signed `digest` — content changed since signing.
+ *   - `signer_malformed` — `signer` is a well-formed NKey string but could
+ *     not be decoded to a raw ed25519 pubkey (defensive; the regex should
+ *     already prevent this).
+ *   - `signature_invalid` — the ed25519 signature does not verify against
+ *     the claimed signer's pubkey over the domain-separated digest.
+ */
+export async function verifyBundleSignature(
+  opts: VerifyBundleSignatureOptions,
+): Promise<VerifyBundleSignatureResult> {
+  const { installPath, trustedSigners } = opts;
+
+  // Realpath the install dir itself before comparing containment — the
+  // production caller (`loader.ts`'s `DiscoveredBundle.installPath`) has
+  // ALREADY realpath'd this, but this function is defensive regardless
+  // (and on macOS, `/var` is itself a symlink to `/private/var`, so even
+  // an already-"resolved" tmp path can still differ from its OWN realpath
+  // by that prefix — comparing two un-normalized strings would false-flag).
+  let realInstallPath: string;
+  try {
+    realInstallPath = realpathSync(installPath);
+  } catch (err) {
+    return {
+      ok: false,
+      stage: "install_path_unreadable",
+      reason: `bundle install path "${installPath}" does not resolve: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const sigPath = join(realInstallPath, PLUGIN_SIGNATURE_FILENAME);
+
+  let realSigPath: string;
+  try {
+    realSigPath = realpathSync(sigPath);
+  } catch {
+    return {
+      ok: false,
+      stage: "signature_missing",
+      reason: `no ${PLUGIN_SIGNATURE_FILENAME} found in the bundle`,
+    };
+  }
+
+  // Symlinked-signature-file defense — mirrors `loader.ts` discovery's
+  // symlinked-manifest defense: the install DIRECTORY is already
+  // realpath'd + containment-verified by the caller, but the signature
+  // FILE inside it could itself be a symlink pointing outside.
+  const contained = realSigPath === realInstallPath || realSigPath.startsWith(realInstallPath + sep);
+  if (!contained) {
+    return {
+      ok: false,
+      stage: "signature_containment",
+      reason: `${PLUGIN_SIGNATURE_FILENAME} (resolved: "${realSigPath}") escapes the trusted bundle directory "${realInstallPath}" — refused`,
+    };
+  }
+
+  let raw: unknown;
+  try {
+    const text = readFileSync(realSigPath, "utf-8");
+    raw = parseYaml(text);
+  } catch (err) {
+    return {
+      ok: false,
+      stage: "signature_parse",
+      reason: `${PLUGIN_SIGNATURE_FILENAME} could not be read/parsed as YAML: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const parsed = PluginSignatureSchema.safeParse(raw);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      stage: "signature_parse",
+      reason: `${PLUGIN_SIGNATURE_FILENAME} is invalid: ${parsed.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ")}`,
+    };
+  }
+  const sig = parsed.data;
+
+  if (!trustedSigners.has(sig.signer)) {
+    return {
+      ok: false,
+      stage: "signer_not_trusted",
+      reason: `signer "${sig.signer.slice(0, 12)}…" is not in the plugin trust root`,
+    };
+  }
+
+  const digestResult = computeBundleDigest(realInstallPath);
+  if (!digestResult.ok) {
+    return { ok: false, stage: "digest_compute", reason: digestResult.reason };
+  }
+  if (digestResult.digest !== sig.digest) {
+    return {
+      ok: false,
+      stage: "digest_mismatch",
+      reason:
+        "bundle content digest does not match the signed digest — the bundle has been modified since signing (or this signature belongs to a different bundle)",
+    };
+  }
+
+  const pubkeyB64 = nkeyToBase64Pubkey(sig.signer);
+  if (pubkeyB64 === undefined) {
+    return {
+      ok: false,
+      stage: "signer_malformed",
+      reason: `signer NKey "${sig.signer.slice(0, 12)}…" could not be decoded to a raw ed25519 pubkey`,
+    };
+  }
+
+  const verified = await verifyEd25519(pubkeyB64, sig.signature, signedMessage(sig.digest));
+  if (!verified) {
+    return {
+      ok: false,
+      stage: "signature_invalid",
+      reason: "ed25519 signature verification failed — signature does not match the digest under the claimed signer key",
+    };
+  }
+
+  return { ok: true, signer: sig.signer };
+}
+
+// =============================================================================
+// Authoring helper (test / future-tooling use — NOT wired into any CLI here)
+// =============================================================================
+
+/**
+ * Sign a bundle digest with an NKey seed (`SU…`). Pairs with
+ * {@link verifyBundleSignature} / {@link computeBundleDigest} to build a
+ * {@link PLUGIN_SIGNATURE_FILENAME}'s `signature` field.
+ *
+ * NOT wired into any CLI or production caller in this slice — production
+ * bundle signing (an `arc publish` pipeline step, or a future
+ * `cortex plugin sign` command) is the operational/ecosystem decision
+ * flagged in the module doc "Open question" section, out of scope here.
+ * Exists so tests (and, later, whatever tooling implements that decision)
+ * have a single correct implementation of "what does signing a bundle
+ * digest mean" rather than each reinventing the domain-separation +
+ * NKey-seed bridge.
+ */
+export async function signBundleDigest(seed: string, digestHex: string): Promise<string> {
+  return signClaimWithSeed(seed, signedMessage(digestHex));
+}
+
+/** Render a {@link PluginSignature} as the YAML text `cortex-plugin.sig`
+ *  expects. Authoring helper — see {@link signBundleDigest}'s doc. */
+export function renderSignatureFile(sig: PluginSignature): string {
+  return (
+    `version: ${String(sig.version)}\n` +
+    `algorithm: ${sig.algorithm}\n` +
+    `signer: "${sig.signer}"\n` +
+    `digest: "${sig.digest}"\n` +
+    `signature: "${sig.signature}"\n`
+  );
+}

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -117,7 +117,7 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
     // EBH-4 (cortex#2346) added `egressAllow` to the same schema.
     sandbox: { mode: "off", backend: "auto", egressAllow: [] },
     inference: { providers: {}, profiles: {} },
-    plugins: { external: false },
+    plugins: { external: false, signing: "off" },
     github: {
       webhookSecret: "",
       repos: [],

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -94,6 +94,7 @@ const TEST_CONFIG: AgentConfig = {
   },
   plugins: {
     external: false,
+    signing: "off",
   },
   github: {
     webhookSecret: "",

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -748,12 +748,22 @@ export const AgentConfigSchema = z.object({
    *  `CortexConfigSchema.plugins`/`PluginsConfigSchema` in `./cortex-config.ts`
    *  for the full rationale (first-party-renderer exemption, etc). Drop
    *  both on 7.2e. Explicit object default (not `emptyDefault()`) so an
-   *  absent `plugins:` block yields `{external: false}`, not `{}` — see
-   *  `cortex-config.ts`'s `emptyDefault` docstring for the Zod v4 quirk
-   *  this sidesteps. */
+   *  absent `plugins:` block yields `{external: false, signing: "off"}`,
+   *  not `{}` — see `cortex-config.ts`'s `emptyDefault` docstring for the
+   *  Zod v4 quirk this sidesteps.
+   *
+   *  cortex#2347 (EBH-5) — `signing` MIRRORS
+   *  `PluginsConfigSchema.signing` (`./cortex-config.ts`) field-for-field.
+   *  Without it here, `AgentConfigSchema.parse(merged)` (the cortex-shape
+   *  synthesis path, `src/common/config/loader.ts`) would silently STRIP
+   *  a principal-declared `plugins.signing` off the merged object (Zod
+   *  drops unknown keys by default) — the exact "passthrough must mirror
+   *  the field" trap the `security`/`mc`/`plugins.external` comments in
+   *  `loader.ts`'s `loadCortexShape` already warn about for this file. */
   plugins: z.object({
     external: z.boolean().default(false),
-  }).default({ external: false }),
+    signing: z.enum(["off", "permissive", "enforce"]).default("off"),
+  }).default({ external: false, signing: "off" }),
 
   /** G-203b: GitHub webhook ingestion */
   github: z.object({

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1784,9 +1784,27 @@ export type {
  * this flag is off, because "don't load third-party code" (secure for
  * adapters) is fail-open for a paging sink (a stack with an uninstalled or
  * unloaded pager silently never pages).
+ *
+ * cortex#2347 (EBH-5, ADR-0024 D4 "named future escalation: registry
+ * signing") — `signing` is the staged posture gating bundle SIGNATURE
+ * verification (`src/adapters/plugin-signing.ts`), mirroring
+ * `SecurityPostureSchema.signing` (`./config.ts`) exactly: `off` (default —
+ * byte-identical to pre-EBH-5 behaviour, `plugin-signing.ts` is never
+ * consulted) · `permissive` (verify + log every outcome, NEVER refuse a
+ * bundle on a bad/missing signature — the shadow rung to prove
+ * verification against real installed bundles before gating anything) ·
+ * `enforce` (refuse to load any bundle whose `cortex-plugin.sig` is
+ * missing, malformed, tampered, or signed by a key outside the in-tree
+ * trust root). This is INDEPENDENT of `external`: signature verification
+ * (when non-`off`) applies to every bundle the loader considers, first-
+ * party or not — it is an ADDITIONAL gate layered on top of the existing
+ * org-trust / first-party checks, never a replacement for them, and never
+ * a new way to GRANT the first-party exemption (`isFirstPartyBundle` and
+ * its allowlist readers are untouched by this field).
  */
 export const PluginsConfigSchema = z.object({
   external: z.boolean().default(false),
+  signing: z.enum(["off", "permissive", "enforce"]).default("off"),
 });
 
 export type PluginsConfig = z.infer<typeof PluginsConfigSchema>;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3331,6 +3331,11 @@ export async function startCortex(
   const pluginLoadResult = await loadExternalPlugins({
     registry: surfacePluginRegistry,
     externalEnabled: config.plugins.external,
+    // cortex#2347 (EBH-5, ADR-0024 D4) — `system.plugins.signing` posture.
+    // Default "off" (the schema default) keeps this call byte-identical to
+    // pre-EBH-5 boot; `pluginTrustedSigners` is left unset so the loader
+    // reads its own in-tree `PLUGIN_TRUST_ROOT` constant.
+    pluginSigning: config.plugins.signing,
   });
   // cortex#1792 — ONE stderr line per outcome, not two: `loadOneBundle`
   // (`src/adapters/loader.ts`) already writes a `cortex plugin-loader: …`

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -145,6 +145,7 @@ import {
   type SurfacePluginRegistry,
 } from "./adapters/registry";
 import { loadExternalPlugins } from "./adapters/loader";
+import { assertPluginSigningTrustRootConfigured, PLUGIN_TRUST_ROOT } from "./adapters/plugin-signing";
 import { createSystemPluginLoadFailedEvent, createSystemPluginLoadedEvent } from "./bus/system-events";
 import { startPluginControlServer } from "./gateway/plugin-control-server";
 import type { PluginRuntimeDeps, RendererHandle } from "./gateway/plugin-runtime";
@@ -3328,14 +3329,28 @@ export async function startCortex(
   // runtime-hard-fail half of OQ9 (does `system.>` coverage still hold two
   // classes after this?) is cortex#1893, a separate issue; this loop only
   // SURFACES what loaded so that check has something to read.
+  // cortex#2347 (EBH-5 follow-up, adversarial review Finding 2 —
+  // availability) — REFUSE TO BOOT immediately, with a named/actionable
+  // error, if `enforce` is on with nothing to verify against. Left
+  // unchecked, this exact misconfiguration crashes several boot-stages
+  // later at the renderer-coverage guard below with an error that looks
+  // unrelated to `signing` — see `assertPluginSigningTrustRootConfigured`'s
+  // own doc. Must run BEFORE `loadExternalPlugins` — no point discovering
+  // and gating bundles this posture is guaranteed to refuse anyway.
+  assertPluginSigningTrustRootConfigured(config.plugins.signing, PLUGIN_TRUST_ROOT);
+
   const pluginLoadResult = await loadExternalPlugins({
     registry: surfacePluginRegistry,
     externalEnabled: config.plugins.external,
     // cortex#2347 (EBH-5, ADR-0024 D4) — `system.plugins.signing` posture.
     // Default "off" (the schema default) keeps this call byte-identical to
-    // pre-EBH-5 boot; `pluginTrustedSigners` is left unset so the loader
-    // reads its own in-tree `PLUGIN_TRUST_ROOT` constant.
+    // pre-EBH-5 boot. `pluginTrustedSigners` is passed explicitly (not left
+    // to the loader's internal default) so this call and `pluginRuntimeDeps`
+    // below (which reload/load thread to `reimportRendererPlugin`) provably
+    // share the exact SAME trust-root reference — boot and reload are held
+    // to the identical trust bar, not two independently-resolved ones.
     pluginSigning: config.plugins.signing,
+    pluginTrustedSigners: PLUGIN_TRUST_ROOT,
   });
   // cortex#1792 — ONE stderr line per outcome, not two: `loadOneBundle`
   // (`src/adapters/loader.ts`) already writes a `cortex plugin-loader: …`
@@ -5979,6 +5994,12 @@ export async function startCortex(
     ...(gw !== undefined && { gateway: gw }),
     skippedRendererConfigs,
     registry: surfacePluginRegistry,
+    // cortex#2347 (EBH-5 follow-up) — the SAME posture + trust root the
+    // boot-time `loadExternalPlugins` call above used, so `reload`/`load`
+    // (which re-`import()` a bundle's entry module a SECOND time via
+    // `reimportRendererPlugin`) are held to the identical trust bar as boot.
+    pluginSigning: config.plugins.signing,
+    pluginTrustedSigners: PLUGIN_TRUST_ROOT,
   };
   const pluginControlServer = await startPluginControlServer(runtime, pluginRuntimeDeps, systemEventSource);
 

--- a/src/gateway/__tests__/plugin-runtime.test.ts
+++ b/src/gateway/__tests__/plugin-runtime.test.ts
@@ -101,6 +101,12 @@ function baseDeps(overrides: Partial<PluginRuntimeDeps> = {}): PluginRuntimeDeps
     router: makeRouter(),
     skippedRendererConfigs: new Map(),
     registry: new SurfacePluginRegistry(),
+    // cortex#2347 (EBH-5 follow-up) — "off" reproduces this file's pre-fix
+    // behaviour (`reimportRenderer` is a fully injected fake in every test
+    // here, so the real signature-verification branch never engages
+    // regardless of posture); tests that specifically want to exercise the
+    // posture override it explicitly.
+    pluginSigning: "off",
     ...overrides,
   };
 }

--- a/src/gateway/plugin-runtime.ts
+++ b/src/gateway/plugin-runtime.ts
@@ -37,6 +37,14 @@
  *     entry cortex.ts retained is reused verbatim, so `load` constructs
  *     EXACTLY what boot would have. Refused for adapters (same #1896
  *     rationale as reload).
+ *
+ * cortex#2347 (EBH-5 follow-up, adversarial review DO-NOT-MERGE finding) —
+ * BOTH `reload` and `load` re-`import()` a bundle's entry module (via
+ * `reimportRendererPlugin`), which is a SECOND, independent signature-
+ * verification point (`src/adapters/plugin-signing.ts`), not a reuse of
+ * whatever verified at boot. `PluginRuntimeDeps.pluginSigning` (REQUIRED,
+ * no default) is threaded to every `reimportRendererPlugin` call in this
+ * file for exactly that reason — see that field's own doc.
  */
 
 import type { PlatformAdapter } from "../adapters/types";
@@ -48,6 +56,7 @@ import {
   type ReimportRendererResult,
 } from "../adapters/loader";
 import type { RendererPlugin, SurfacePluginRegistry } from "../adapters/registry";
+import type { PluginSigningPosture } from "../adapters/plugin-signing";
 import type { Renderer } from "../renderers/types";
 import type { SurfaceGateway } from "./surface-gateway";
 
@@ -130,6 +139,22 @@ export interface PluginRuntimeDeps {
   /** Forwarded to `discoverPluginBundles`/tests; `undefined` = arc's real
    *  install root. */
   pkgRoot?: string;
+  /**
+   * cortex#2347 (EBH-5 follow-up, adversarial review DO-NOT-MERGE finding)
+   * — `system.plugins.signing` posture, threaded to `reimportRendererPlugin`
+   * for BOTH `reload` and `load` (both re-`import()` a bundle's entry
+   * module — see `src/adapters/plugin-signing.ts`'s "Coverage" section).
+   * REQUIRED, no default: `src/cortex.ts` sets this from the SAME
+   * `config.plugins.signing` the boot-time loader uses, so reload is held
+   * to the identical posture as boot, always — a caller cannot construct
+   * `PluginRuntimeDeps` without deciding this.
+   */
+  pluginSigning: PluginSigningPosture;
+  /** Trust root override — defaults to `PLUGIN_TRUST_ROOT`
+   *  (`src/adapters/plugin-signing.ts`), same default the boot-time loader
+   *  uses. Production callers never set this; tests inject a throwaway
+   *  keypair's pubkey. */
+  pluginTrustedSigners?: ReadonlySet<string>;
   /** Test seam — defaults to the real `discoverPluginBundles`. Production
    *  callers never set this. */
   discoverBundles?: (opts: {
@@ -139,7 +164,11 @@ export interface PluginRuntimeDeps {
    *  callers never set this. */
   reimportRenderer?: (
     bundle: DiscoveredBundle,
-    opts: { bust: boolean },
+    opts: {
+      bust: boolean;
+      pluginSigning: PluginSigningPosture;
+      pluginTrustedSigners?: ReadonlySet<string>;
+    },
   ) => Promise<ReimportRendererResult>;
 }
 
@@ -256,7 +285,11 @@ export async function reloadLivePlugin(
   }
 
   const reimportRenderer = deps.reimportRenderer ?? reimportRendererPlugin;
-  const reimport = await reimportRenderer(bundle, { bust: true });
+  const reimport = await reimportRenderer(bundle, {
+    bust: true,
+    pluginSigning: deps.pluginSigning,
+    ...(deps.pluginTrustedSigners !== undefined && { pluginTrustedSigners: deps.pluginTrustedSigners }),
+  });
   if (!reimport.ok) {
     return {
       ok: false,
@@ -315,7 +348,11 @@ export async function loadLivePlugin(
   }
 
   const reimportRenderer = deps.reimportRenderer ?? reimportRendererPlugin;
-  const reimport = await reimportRenderer(bundle, { bust: false });
+  const reimport = await reimportRenderer(bundle, {
+    bust: false,
+    pluginSigning: deps.pluginSigning,
+    ...(deps.pluginTrustedSigners !== undefined && { pluginTrustedSigners: deps.pluginTrustedSigners }),
+  });
   if (!reimport.ok) {
     return { ok: false, detail: `load failed at ${reimport.stage}: ${reimport.reason}` };
   }


### PR DESCRIPTION
Part of #2347 / epic #2341. **Signing half only** — process isolation stays trigger-gated (neither trigger has fired) and would need an ADR-0024 D4 amendment; a design note ships instead.

Default `off`; `permissive` verifies+logs; `enforce` refuses. Verification runs from bytes on disk **before** `await import()`. Trust root is an in-tree `ReadonlySet` of NKey pubkeys — changeable only by reviewed source PR, never by deployment config (config is what a compromised plugin could rewrite). Ships **EMPTY** pending a principal decision on who holds the signing key.

## Adversarial review found a real bypass — fixed, then re-verified

First pass got **DO-NOT-MERGE**: `reimportRendererPlugin` (behind `cortex plugin reload` and the bus reload action) never verified. Reproduced end-to-end — bundle verifies at boot under `enforce`, tampered on disk, reloaded, `ok:true`, **tampered code executed**. A bundle that verified once had a lifetime pass.

Now fixed and confirmed by real test output:
```
reload of reload-bundle refused at signature_verify:digest_mismatch
reload of reload-bundle (reload-fixture-good) signature verified (signer=UBKWBFOQM4WO…)
```
The regression test asserts the tampered code's **side effect never ran** (sentinel file unchanged), not merely that an error returned.

**Call-site audit — independently confirmed by me.** The only dynamic imports of non-literal paths in `src/` are `loader.ts:1105` (boot) and `loader.ts:1374` (reload); both verify. All other `await import()` calls are static npm packages or node builtins. This was the coverage-completeness class that took nine rounds on the bash guard, so I checked it rather than accepting the claim.

## Attacks that failed (real fixture bundles + throwaway keys, not a code read)
Untrusted bundle · file added post-signing (digest recomputed from current disk bytes every time) · cross-bundle signature replay · first-party-exemption bypass (signing runs unconditionally *after* the exemption) · empty signature · algorithm/version downgrade (`z.literal`) · NKey type confusion (U-prefix + CRC) · symlink escapes · domain separation (`cortex-plugin-bundle-v1\0`) · `off` as byte-identical no-op. Tests confirmed **not** self-referential.

## Availability finding — also fixed
Empty trust root + `enforce` on a stack using the first-party pagerduty renderer would refuse it, drop `system.>` coverage below ADR-0024 §OQ9, and throw uncaught in `startCortex` — **boot never completes**. Now a named preflight error (`assertPluginSigningTrustRootConfigured`) fires before `loadExternalPlugins`. Not fixed by weakening the coverage guard or auto-exempting first-party from signing.

## First-party exemption
Unchanged — verified: the exemption functions and the #1942 anti-spoof anchors (`ADAPTER_BUNDLE_DEP_NAME_RE`/`RENDERER_BUNDLE_DEP_NAME_RE`) are untouched.

## Tests
34 new. Full suite 11067 pass / 14 fail — the 14 are 12 long-standing failures plus 2 real-process-spawn tests that fail from **account quota exhaustion** (see below), reproducing identically on a pristine `cb2acca8`. `tsc --noEmit` and lint clean.

## Residual for the principal
**Trust root population** — who holds the production signing seed and how bundles get signed. Deliberately not decided here.