### PR TITLE
fix(purge): report ~/.claude/relay+events as intentionally-kept shared state (#2420)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -314,8 +314,15 @@ scripts:
 #     own review, `~/.claude` is Claude-Code-hook territory another hook or
 #     package could also write into (events-path.ts explicitly calls
 #     `~/.claude/events/raw` the "hook-substrate boundary" that stays put
-#     across every XDG wave for exactly this reason). Left out with this note
-#     rather than guessed at.
+#     across every XDG wave for exactly this reason; and `~/.claude/relay`  # xdg-audit:allow(prose naming the kept relay dir, not a code path — cortex#2420)
+#     holds relay-policy.yaml, CONFIG that even cortex's own state migration
+#     keeps in place — migrate-state-dir.ts moves only relay.pid out). Left
+#     out with this note rather than guessed at. cortex#2420: because a field
+#     tester who runs `arc purge cortex` and then finds these still on disk
+#     can't tell "kept on purpose" from "purge missed it", scripts/purge.sh
+#     now NAMES them at purge time (report_intentionally_kept_shared_state in
+#     scripts/lib/purge-supervision.sh) — the reporting complement to leaving
+#     them undeclared here.
 #
 # The per-stack DATA dir (`~/.local/share/metafactory/cortex`,
 # src/common/data-path.ts) is ALSO entirely excluded from owns.config/state —

--- a/scripts/__tests__/manifest-owns-purge.test.ts
+++ b/scripts/__tests__/manifest-owns-purge.test.ts
@@ -140,4 +140,21 @@ describe("arc-manifest.yaml — scripts.purge (cortex#2338)", () => {
     expect(script).toContain("purge_systemd_instances");
     expect(script).toContain("purge_launchd_instances");
   });
+
+  test("scripts/purge.sh reports the intentionally-kept shared-substrate dirs (cortex#2420)", () => {
+    const script = readFileSync(join(REPO_ROOT, "scripts", "purge.sh"), "utf-8");
+    expect(script).toContain("report_intentionally_kept_shared_state");
+  });
+
+  test("purge-supervision.sh's report names each shared dir left out of owns (cortex#2420)", () => {
+    const lib = readFileSync(join(REPO_ROOT, "scripts", "lib", "purge-supervision.sh"), "utf-8");
+    // The reporting function exists...
+    expect(lib).toContain("report_intentionally_kept_shared_state()");
+    // ...and it names exactly the shared trees the owns: block deliberately
+    // leaves undeclared — so the purge log explains every leftover the
+    // field test (cortex#2420) found.
+    expect(lib).toContain(".claude/events");
+    expect(lib).toContain(".claude/relay");
+    expect(lib).toContain(".config/nats");
+  });
 });

--- a/scripts/__tests__/purge-supervision.sh
+++ b/scripts/__tests__/purge-supervision.sh
@@ -213,6 +213,58 @@ purge_launchd_instances "${LAUNCH_DIR}"
 assert_eq "Linux → zero launchctl calls" "0" "$(wc -l < "${LAUNCHCTL_LOG}" | tr -d ' ')"
 assert_file_exists "Linux → plist left untouched" "${LAUNCH_DIR}/ai.meta-factory.cortex.work.plist"
 
+# ─── Section 3: report_intentionally_kept_shared_state (cortex#2420) ─
+printf '\n=== report_intentionally_kept_shared_state ===\n'
+
+REPORT_HOME="${TMPHOME}/report-home"
+
+# All three shared dirs present → each is named as KEPT, with the "on purpose"
+# footer and NO "none present" line.
+rm -rf "${REPORT_HOME}"
+mkdir -p "${REPORT_HOME}/.claude/events" "${REPORT_HOME}/.claude/relay" "${REPORT_HOME}/.config/nats"
+REPORT_OUT="$(report_intentionally_kept_shared_state "${REPORT_HOME}")"
+assert_true "names ~/.claude/events as kept" \
+  grep -qF "${REPORT_HOME}/.claude/events" <<<"${REPORT_OUT}"
+assert_true "names ~/.claude/relay as kept" \
+  grep -qF "${REPORT_HOME}/.claude/relay" <<<"${REPORT_OUT}"
+assert_true "names ~/.config/nats as kept" \
+  grep -qF "${REPORT_HOME}/.config/nats" <<<"${REPORT_OUT}"
+assert_true "prints the intentionally-KEPT header" \
+  grep -qF "Intentionally KEPT" <<<"${REPORT_OUT}"
+assert_true "prints the on-purpose footer when dirs are present" \
+  grep -qF "Left in place on purpose" <<<"${REPORT_OUT}"
+assert_true "no 'none present' line when dirs exist" \
+  bash -c "! grep -qF 'none of the shared dirs' <<<\"\${1}\"" _ "${REPORT_OUT}"
+
+# Only one of the three present → only that one is named; the absent two are
+# silently skipped (report only reflects reality on this host).
+rm -rf "${REPORT_HOME}"
+mkdir -p "${REPORT_HOME}/.claude/events"
+REPORT_OUT="$(report_intentionally_kept_shared_state "${REPORT_HOME}")"
+assert_true "names the one present dir" \
+  grep -qF "${REPORT_HOME}/.claude/events" <<<"${REPORT_OUT}"
+assert_true "does NOT name an absent dir (relay)" \
+  bash -c "! grep -qF '.claude/relay' <<<\"\${1}\"" _ "${REPORT_OUT}"
+
+# None present → the "nothing kept" line, and NO bullet paths.
+rm -rf "${REPORT_HOME}"
+mkdir -p "${REPORT_HOME}"
+REPORT_OUT="$(report_intentionally_kept_shared_state "${REPORT_HOME}")"
+assert_true "prints the 'none present' line when no shared dir exists" \
+  grep -qF "none of the shared dirs are present" <<<"${REPORT_OUT}"
+assert_true "prints no bullet path when nothing is kept" \
+  bash -c "! grep -qF '    • ' <<<\"\${1}\"" _ "${REPORT_OUT}"
+
+# A `set -e` caller survives the report call (best-effort, never aborts purge).
+REPORT_SETE_OUT="$(mktemp)"
+set +e
+bash -c "set -e; source '${SCRIPT_DIR}/lib/purge-supervision.sh'; report_intentionally_kept_shared_state '${REPORT_HOME}'; echo REPORT_COMPLETED" > "${REPORT_SETE_OUT}" 2>&1
+REPORT_SETE_RC=$?
+set -e
+assert_eq "a 'set -e' caller completes past the report call" "0" "${REPORT_SETE_RC}"
+assert_true "the caller ran past the report call" grep -qF "REPORT_COMPLETED" "${REPORT_SETE_OUT}"
+rm -f "${REPORT_SETE_OUT}"
+
 # ─── Results ──────────────────────────────────────────────────────
 printf '\nResults: %d passed, %d failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" -eq 0 ]

--- a/scripts/lib/purge-supervision.sh
+++ b/scripts/lib/purge-supervision.sh
@@ -92,3 +92,54 @@ purge_launchd_instances() {
     echo "  ⊘ no cortex/nats launchd plists found in ${launch_dir} — nothing to purge"
   fi
 }
+
+# Report the shared-substrate dirs `arc purge cortex` DELIBERATELY leaves in
+# place (cortex#2420). cortex writes into each of these, but NONE is
+# cortex-exclusive, so a blanket delete on purge could take out a neighbor's
+# state:
+#
+#   ~/.claude/events  — the raw Claude-Code event buffer. events-path.ts calls
+#                       `~/.claude/events/raw` the "hook-substrate boundary"
+#                       that stays put across every XDG wave; ANY Claude Code
+#                       hook or package can write here, not just cortex.
+#   ~/.claude/relay   — the cortex-relay dir. Holds relay-policy.yaml, which is
+#                       CONFIG that STAYS (migrate-state-dir.ts moves only
+#                       relay.pid out — "relay-policy.yaml is CONFIG and stays
+#                       put"); ~/.claude is likewise shared hook territory.
+#   ~/.config/nats    — NATS identity. arc's OWN nats provisioning
+#                       (identity-provision.ts) writes signing seeds + creds
+#                       here independent of cortex; only the seed carries a
+#                       "cortex-" prefix, so a glob can't safely tell cortex's
+#                       files from a neighbor's.
+#
+# These are documented as intentionally NOT-declared in arc-manifest.yaml's
+# `owns:` block; this surfaces that same decision at purge time so the operator
+# knows they remain and why — the arc#359 purge log would otherwise leave the
+# leftover unexplained (the cortex#2420 field-test surprise).
+#
+# Args: $1 HOME_DIR — defaults to ${HOME} (overridable for tests).
+report_intentionally_kept_shared_state() {
+  local home_dir="${1:-${HOME}}"
+  # path|reason pairs — the reason is shown so the operator can judge the risk
+  # of removing it by hand.
+  local kept=(
+    "${home_dir}/.claude/events|raw Claude-Code event buffer — hook-substrate boundary, shared by any CC hook"  # xdg-audit:allow(the hook-substrate boundary this reports as INTENTIONALLY KEPT — naming it is the point, cortex#2420)
+    "${home_dir}/.claude/relay|cortex-relay dir — holds relay-policy.yaml (config that stays) beside the pidfile"  # xdg-audit:allow(shared relay dir this reports as INTENTIONALLY KEPT — naming it is the point, cortex#2420)
+    "${home_dir}/.config/nats|NATS identity — arc's own nats provisioning writes signing seeds/creds here too"
+  )
+  echo "  Intentionally KEPT (shared state, not cortex-exclusive — see arc-manifest.yaml owns: note, cortex#2420):"
+  local entry path desc present=0
+  for entry in "${kept[@]}"; do
+    path="${entry%%|*}"
+    desc="${entry#*|}"
+    if [ -e "${path}" ]; then
+      present=1
+      echo "    • ${path} — ${desc}"
+    fi
+  done
+  if [ "${present}" -eq 0 ]; then
+    echo "    (none of the shared dirs are present on this host — nothing kept)"
+  else
+    echo "    Left in place on purpose. Remove by hand only if no other stack/hook/relay uses them."
+  fi
+}

--- a/scripts/purge.sh
+++ b/scripts/purge.sh
@@ -26,4 +26,9 @@ source "${SCRIPT_DIR}/lib/purge-supervision.sh"
 echo "Running Cortex purge..."
 purge_systemd_instances
 purge_launchd_instances
+# cortex#2420: name the shared-substrate dirs purge deliberately leaves behind
+# (~/.claude/{events,relay}, ~/.config/nats) so a field tester who finds them
+# still on disk knows they were KEPT on purpose, not missed — closing the
+# arc#359 "purge left leftovers" surprise without deleting a neighbor's state.
+report_intentionally_kept_shared_state
 echo "✓ Cortex purge complete"


### PR DESCRIPTION
`arc purge cortex` left `~/.claude/relay` + `~/.claude/events` with no explanation (field test).

## Investigation → decision
Both are **shared substrate, not cortex-owned** (evidence: `events-path.ts:23-24` — raw buffer is the hook-substrate boundary, any CC hook writes there; `state-path.ts:183-187` + `migrate-state-dir.ts:316` — relay holds `relay-policy.yaml` CONFIG that even state migration leaves put). An existing test (`manifest-owns-purge.test.ts:111-118`) actively forbids declaring them in owns.

So: NOT added to owns (deleting a neighbor's spool/seeds is the wrong default). Instead purge now **reports** them as intentionally-kept shared state, closing the leftover-with-no-explanation surprise.

## Changes
`purge-supervision.sh` gains `report_intentionally_kept_shared_state()` (names `~/.claude/{events,relay}` + `~/.config/nats`, present-only, set-e-safe); `purge.sh` calls it; tests +6 (32/32) and the owns test asserts the reporter is invoked. tsc + gates pass.

Closes #2420.

Generated with Claude Code
