### PR TITLE
feat(runner): #2409 part 2 — L2 v2 `strict` posture (deny-default + derived allow set)

### DIFF
--- a/docs/design-session-sandbox-platforms.md
+++ b/docs/design-session-sandbox-platforms.md
@@ -114,6 +114,23 @@ E4 makes strict deny-default costly on macOS. Ship in two stages:
 - **v2 `strict`** — true deny-default allowlist once the compatibility contract (§5) is empirically pinned.
 Linux `bwrap` starts at v2-equivalent natively (bind-mount only what's allowed), so the platforms converge from opposite directions. **Posture is reported, never guessed.**
 
+> **✅ v2 `strict` landed on macOS (2026-07-26, cortex#2409 part 2), mechanism-only.**
+> `SandboxProfile.posture: "guarded" | "strict"` (default `"guarded"` — HARD HOLD, no live
+> caller sets `"strict"`). E4's SIGABRT was diagnosed, not routed around: a naive
+> `(deny default)` aborts inside dyld's own bootstrap (`dyld4::CacheFinder` → `ignition_halt`,
+> confirmed via the macOS crash reporter, not the unified log — the abort happens before any
+> per-operation denial is even logged) because it's missing the handful of syscalls/reads
+> Apple's own `dyld-support.sb`/`system.sb` profile fragments grant every real daemon profile on
+> the system; importing them (`(import "system.sb")`) fixes it outright — no allowance beyond
+> what Apple's own minimal bootstrap set already grants. The compatibility contract (§5) was
+> pinned empirically the way OQ-2 asked for, just not via `fs_usage`/`strace` (still no
+> passwordless root here) — via this same design's own denial-log observation loop
+> (`log stream`/`MacosSbplSandbox.denials()`), iterating a REAL `claude --print` + `--resume`
+> session against successive profile candidates until it completed clean. Full round-by-round
+> derivation, the keychain-read residual, and the disclosed non-Homebrew-git gap are documented
+> in `session-sandbox-macos.ts`'s `generateMacosSbplStrictProfile` module doc (not repeated
+> here to avoid the two docs drifting).
+
 ### DD-11 — Sandbox unavailability splits on **input trust** — ✅ DECIDED (principal, 2026-07-25, OQ-3)
 
 When no backend resolves, behaviour keys on **whether the stack processes input from someone other than the principal** — not on platform. Both signals already exist in config:

--- a/docs/design-session-sandbox.md
+++ b/docs/design-session-sandbox.md
@@ -44,6 +44,25 @@ per the epic's own §"three times now" lesson):**
 
 ---
 
+## 0.1 Implementation status — cortex#2409 part 2 (epic #2341)
+
+**L2 gained a SECOND posture — `SandboxProfile.posture: "strict"`
+(`generateMacosSbplStrictProfile`, `session-sandbox-macos.ts`) — updating the
+line above about L2 being "denylist-posture, not deny-default".** That was
+true of v1 `guarded` only; `strict` is genuine `(deny default)` + a derived,
+evidence-traced explicit-allow set, closing F1 **by construction** for
+everything outside that set. `posture` defaults to `"guarded"` and no live
+caller sets `"strict"` — same HARD HOLD shape as every prior EBH slice
+(mechanism ships, nothing flips it on). The E4 SIGABRT this doc's DD-10
+(via `-platforms.md`) treated as a reason to defer deny-default was
+diagnosed rather than routed around — see `-platforms.md`'s DD-10 addendum
+and the generator's own module doc for the full derivation. `strict` does
+NOT change L3's status above (network is still not confined at L2 — that
+stays L3's job) or L2's PF-anchor-less network story; it only closes the
+filesystem gap.
+
+---
+
 ## 1. Problem statement
 
 Cortex drives `claude --print` child processes from **untrusted inbound content** (Discord messages, GitHub events). Today the filesystem/exec/network boundary for those sessions is:

--- a/docs/security/hardening-plan.md
+++ b/docs/security/hardening-plan.md
@@ -35,7 +35,7 @@ A ladder, cheapest-and-most-owned first. Maps onto the review's Tier 0–3 (§6)
 |---|---|---|---|---|
 | **L0** | ~~**Repro** the `--add-dir` question~~ **✅ DONE 2026-07-24** — `--add-dir` is an *additive grant, not a jail*; both Read and Bash `cat` read an out-of-scope canary ([result](reviews/2026-07-24-ebh0-add-dir-repro.md)) | **F1 = clean High** (severity locked) | done | — |
 | **L1** | Cortex-owned `PreToolUse` **path guard** for file tools + Bash read-command paths; reuse `loader.ts` normalize+contain | F1 (cortex-owned side), F6 | S | — |
-| **L2** | **OS session jail** per `claude --print` (sandbox-exec / bwrap+landlock+seccomp) | **v1 `guarded`:** F6 by construction; F1 **only for the enumerated sensitive set** — *not* by construction. **v2 `strict`:** F1 by construction | M | choke point |
+| **L2** | **OS session jail** per `claude --print` (sandbox-exec / bwrap+landlock+seccomp) | **v1 `guarded`** (shipped, EBH-3a): F6 by construction; F1 **only for the enumerated sensitive set** — *not* by construction. **v2 `strict`** (shipped, mechanism-only, cortex#2409 part 2 — HARD HOLD `posture: "guarded"` default, no live caller sets `"strict"`): F1 by construction | M | choke point |
 | **L3** | **Egress allowlist** (filtering proxy, deny-by-default) | exfiltration containment | M | L2 net-ns |
 | **L4** | **Plugin process isolation** + registry signing | F2 | L | trigger-gated |
 
@@ -57,6 +57,31 @@ L1–L3 are designed in [`design-session-sandbox.md`](../design-session-sandbox.
 > Practical consequence: **do not describe L2 v1 as "the session is jailed."** It is
 > "these specific secrets are protected, and read-only means read-only." The sensitive-set
 > gap must be closed before `mode: audit` is ever enabled anywhere — tracked as **#2409**.
+
+> **✅ L2 v2 `strict` landed (2026-07-26, cortex#2409 part 2).** `generateMacosSbplStrictProfile`
+> (`session-sandbox-macos.ts`) is `(deny default)` + a DERIVED, evidence-traced explicit-allow
+> set — F1 is now closed **by construction** for everything outside that set, not merely
+> narrowed. `SandboxProfile.posture: "guarded" | "strict"` selects between the two generators;
+> `"guarded"` stays the default (HARD HOLD unchanged — no caller sets `"strict"`, `mode` still
+> defaults `"off"` everywhere). E4's SIGABRT (naive `(deny default)` aborting before any denial
+> is even logged) turned out to be dyld's own bootstrap failing on a handful of syscalls/reads
+> `(deny default)` silently blocks — fixed by importing Apple's own `dyld-support.sb`/`system.sb`
+> profile fragments (the SAME base every real macOS daemon profile uses), not by abandoning
+> deny-default. Proven both directions with a real `sandbox-exec` harness: legitimate workspace
+> access and a real `claude --print` + `--resume` round-trip succeed; an out-of-scope read is
+> denied with **no enumerated rule naming it** (the F1-by-construction proof). **Disclosed
+> residuals, not bugs to chase:** (1) keychain READ stays unconditionally allowed — denying it
+> (even narrowed to `file-read-data`) breaks `claude` login outright, empirically forced, same
+> finding as v1's write-only carve-out — so `strict` cannot protect keychain *contents* from a
+> compromised session, only keychain *tamper* (write stays denied by omission); (2) network is
+> NOT confined at L2 (`(allow network*)`, unconditional) — per-host egress filtering is L3's job
+> (`egress-proxy.ts`), and `strict` doesn't attempt to duplicate that boundary at the kernel
+> level; (3) the Homebrew-package-root heuristic for `git`/`gh`'s sibling files is a disclosed,
+> host-specific finding — unverified on a non-Homebrew git install. See
+> `session-sandbox-macos.ts`'s `generateMacosSbplStrictProfile` module doc for the full
+> round-by-round derivation (what was measured, not assumed, at each step) and
+> `session-sandbox-macos-strict.test.ts` for the regression pinning the keychain constraint
+> specifically.
 
 ---
 

--- a/src/runner/__tests__/session-sandbox-macos-strict.test.ts
+++ b/src/runner/__tests__/session-sandbox-macos-strict.test.ts
@@ -6,7 +6,9 @@
  * every test that exercises the sensitive set does so against a FIXTURE
  * `$HOME`/`configHomeDir` override — never the real developer machine's
  * `~/.ssh` etc. macOS-ONLY (`describe.skipIf(!isDarwin)`) for every test
- * that spawns a real `sandbox-exec` — matches the established pattern.
+ * that spawns a real `sandbox-exec` — matches the established pattern. One
+ * pure-generator test is ALSO gated (`test.skipIf`): it realpaths
+ * `/usr/bin/security`, which does not exist on Linux CI.
  *
  * ## Why this file doesn't assert "zero denials" the way the v1 e2e test does
  *
@@ -208,7 +210,11 @@ describe("generateMacosSbplStrictProfile", () => {
     );
   });
 
-  test("the security CLI (keychain helper) always gets process-exec + file-read*, even with an empty execAllow", () => {
+  // macOS-ONLY. Asserts on `/usr/bin/security`, the macOS keychain helper —
+  // `realpathSync` on it throws ENOENT on Linux CI. Only THIS test needs the
+  // gate: the rest of this describe block is platform-independent profile-
+  // generation logic and stays enabled everywhere, which is worth keeping.
+  test.skipIf(!isDarwin)("the security CLI (keychain helper) always gets process-exec + file-read*, even with an empty execAllow", () => {
     const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
     const securityPath = Bun.which("security") ?? "/usr/bin/security";
     const resolved = realpathSync(securityPath);

--- a/src/runner/__tests__/session-sandbox-macos-strict.test.ts
+++ b/src/runner/__tests__/session-sandbox-macos-strict.test.ts
@@ -1,0 +1,639 @@
+/**
+ * cortex#2409 part 2 — tests for the `macos-sbpl` v2 `strict` posture
+ * (`generateMacosSbplStrictProfile` + `MacosSbplSandbox`'s posture gating).
+ *
+ * Same fixture discipline as `session-sandbox-macos.test.ts` (v1 `guarded`):
+ * every test that exercises the sensitive set does so against a FIXTURE
+ * `$HOME`/`configHomeDir` override — never the real developer machine's
+ * `~/.ssh` etc. macOS-ONLY (`describe.skipIf(!isDarwin)`) for every test
+ * that spawns a real `sandbox-exec` — matches the established pattern.
+ *
+ * ## Why this file doesn't assert "zero denials" the way the v1 e2e test does
+ *
+ * `cc-session-macos-sandbox-e2e.test.ts` (v1 `guarded`, UNTOUCHED by this
+ * slice) asserts a real session produces ZERO `sandbox-denial` events,
+ * because `guarded`'s `(allow default)` means EVERY legitimate access
+ * already succeeds silently — a denial there is unambiguously a gap.
+ * `strict`'s `(deny default)` construction is different: measured directly
+ * on a real dev host, a real `claude --print` session run under `strict`
+ * denies dozens of `file-read-data` probes into the PRINCIPAL's own
+ * accumulated project/skill history (`~/.claude.json`'s recorded "recent
+ * projects" list, scanned at startup) — paths entirely outside the
+ * session's `allowedDirs`/config-home/compat-contract set. **That denial is
+ * CORRECT, not a gap** — those are exactly the out-of-scope reads
+ * deny-default exists to catch; a clean/production bot-dispatch host has no
+ * such history to scan in the first place (nothing is EVER registered
+ * there beyond what cortex itself dispatched into `allowedDirs`, which IS
+ * allow-listed). So `strict`'s real end-to-end bar (below) is "the session
+ * completes successfully" (exit 0, correct response, survives `--resume`),
+ * not "zero denial events" — and the "out-of-scope read is denied" claim is
+ * proven separately, against FIXTURE paths, the same way v1's "four stops"
+ * block does it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { SandboxProfile } from "../session-sandbox";
+import {
+  classifyHookTarget,
+  generateMacosSbplStrictProfile,
+  homebrewPackageRoot,
+  MacosSbplSandbox,
+} from "../session-sandbox-macos";
+import { CCSession } from "../cc-session";
+import {
+  getSandboxCapabilityProbe,
+  resetSandboxCapabilityProbeForTests,
+  SANDBOX_EXEC_ALLOW_SEED,
+  type SandboxDenialEvent,
+} from "../session-sandbox";
+import { hasClaude, testClaude } from "../../common/test-utils";
+
+const isDarwin = process.platform === "darwin";
+
+function baseProfile(overrides: Partial<SandboxProfile> = {}): SandboxProfile {
+  return {
+    readWrite: [],
+    readOnly: [],
+    execAllow: [],
+    egressAllow: [],
+    mode: "audit",
+    posture: "strict",
+    internalReadOnly: [],
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// generateMacosSbplStrictProfile — pure function, runs everywhere
+// -----------------------------------------------------------------------------
+
+describe("generateMacosSbplStrictProfile", () => {
+  let fixtureHome: string;
+  let configHomeDir: string;
+
+  beforeEach(() => {
+    // realpathSync immediately — same E3-shaped rationale as v1's fixtures
+    // (`/var` → `/private/var` on macOS).
+    fixtureHome = realpathSync(mkdtempSync(join(tmpdir(), "cortex-strict-home-")));
+    configHomeDir = join(fixtureHome, ".claude");
+    mkdirSync(configHomeDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(fixtureHome, { recursive: true, force: true });
+  });
+
+  test("always opens with '(version 1)' then '(deny default)' — DD-10 v2 strict posture", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
+    const lines = generated.text.split("\n");
+    expect(lines[0]).toBe("(version 1)");
+    expect(lines[1]).toBe("(deny default)");
+  });
+
+  test("never emits '(allow default)' — that's v1 guarded's posture, not strict's", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
+    expect(generated.text).not.toContain("allow default");
+  });
+
+  test("imports system.sb — E4's SIGABRT fix (dyld/mach/sysctl bootstrap base)", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
+    expect(generated.text).toContain('(import "system.sb")');
+  });
+
+  test("readWrite dirs get read+write subpath allow", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "cortex-strict-work-"));
+    try {
+      const generated = generateMacosSbplStrictProfile(baseProfile({ readWrite: [workDir] }), {
+        homeDir: fixtureHome,
+        configHomeDir,
+      });
+      const real = realpathSync(workDir);
+      expect(generated.text).toContain(`(allow file-read* file-write* (subpath "${real}"))`);
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("readOnly dirs get READ-ONLY subpath allow (F6 — no write, same construction as v1)", () => {
+    const roDir = mkdtempSync(join(tmpdir(), "cortex-strict-ro-"));
+    try {
+      const generated = generateMacosSbplStrictProfile(baseProfile({ readOnly: [roDir] }), {
+        homeDir: fixtureHome,
+        configHomeDir,
+      });
+      const real = realpathSync(roDir);
+      expect(generated.text).toContain(`(allow file-read* (subpath "${real}"))`);
+      expect(generated.text).not.toContain(`(allow file-read* file-write* (subpath "${real}"))`);
+    } finally {
+      rmSync(roDir, { recursive: true, force: true });
+    }
+  });
+
+  test("internalReadOnly (isolated-settings temp dir) gets a read-only allow, not write", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-strict-internal-"));
+    try {
+      const generated = generateMacosSbplStrictProfile(baseProfile({ internalReadOnly: [tmp] }), {
+        homeDir: fixtureHome,
+        configHomeDir,
+      });
+      const real = realpathSync(tmp);
+      expect(generated.text).toContain(`(allow file-read* (subpath "${real}"))`);
+      expect(generated.text).not.toContain(`(allow file-read* file-write* (subpath "${real}"))`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("THE keychain constraint — read allowed, write NOT allowed (deny-default omission)", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
+    const keychains = join(fixtureHome, "Library", "Keychains");
+    expect(generated.text).toContain(`(allow file-read* (subpath "${keychains}"))`);
+    // No write allow anywhere for the keychain tree — under (deny default),
+    // omission IS the denial; there is no separate deny rule to assert on
+    // (unlike v1, which needs an explicit deny under (allow default)).
+    expect(generated.text).not.toMatch(/\(allow [^)]*file-write\*[^)]*Library\/Keychains/);
+  });
+
+  test("config home gets a broad read+write allow, but self-modification (hooks/, settings.json) write is carved back out", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
+    expect(generated.text).toContain(`(allow file-read* file-write* (subpath "${configHomeDir}"))`);
+    expect(generated.text).toContain(`(deny file-write* (subpath "${join(configHomeDir, "hooks")}"))`);
+    expect(generated.text).toContain(
+      `(deny file-write* (literal "${join(configHomeDir, "settings.json")}"))`,
+    );
+  });
+
+  test("the top-level .claude.json family (lock/tmp siblings included) is allowed via a regex-in-dir, in the DEFAULT config-home case sibling to $HOME, not nested under it", () => {
+    // Default case: configHomeDir === join(homeDir, ".claude") exactly (no
+    // override), so `.claude.json` must be a SIBLING of homeDir/.claude —
+    // i.e. anchored at homeDir itself, not configHomeDir.
+    const generated = generateMacosSbplStrictProfile(baseProfile(), {
+      homeDir: fixtureHome,
+      configHomeDir: join(fixtureHome, ".claude"),
+    });
+    expect(generated.text).toContain(`(regex #"^${fixtureHome}/\\.claude\\.json(\\..*)?$")`);
+  });
+
+  test("a RELOCATED config home nests .claude.json INSIDE it instead", () => {
+    const relocated = join(fixtureHome, "relocated-config-home");
+    mkdirSync(relocated, { recursive: true });
+    const generated = generateMacosSbplStrictProfile(baseProfile(), {
+      homeDir: fixtureHome,
+      configHomeDir: relocated,
+    });
+    expect(generated.text).toContain(`(regex #"^${relocated}/\\.claude\\.json(\\..*)?$")`);
+    expect(generated.text).not.toContain(`(regex #"^${fixtureHome}/\\.claude\\.json`);
+  });
+
+  test("execAllow entries resolve to real binaries and get process-exec + file-read* + file-map-executable", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile({ execAllow: ["true"] }), {
+      homeDir: fixtureHome,
+      configHomeDir,
+    });
+    const resolved = realpathSync(Bun.which("true")!);
+    expect(generated.text).toContain(
+      `(allow process-exec file-read* file-map-executable (literal "${resolved}"))`,
+    );
+  });
+
+  test("an execAllow entry not found on $PATH is reported in unresolved, not silently skipped", () => {
+    const generated = generateMacosSbplStrictProfile(
+      baseProfile({ execAllow: ["cortex-definitely-not-a-real-binary-xyz"] }),
+      { homeDir: fixtureHome, configHomeDir },
+    );
+    expect(generated.unresolved.some((u) => u.input === "cortex-definitely-not-a-real-binary-xyz")).toBe(
+      true,
+    );
+  });
+
+  test("the security CLI (keychain helper) always gets process-exec + file-read*, even with an empty execAllow", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
+    const securityPath = Bun.which("security") ?? "/usr/bin/security";
+    const resolved = realpathSync(securityPath);
+    expect(generated.text).toContain(`(allow process-exec file-read* (literal "${resolved}"))`);
+  });
+
+  test("a path that fails to realpath-resolve is EXCLUDED from the profile and reported in unresolved — fail closed", () => {
+    const nulPath = join(fixtureHome, "a") + String.fromCharCode(0) + "b";
+    const generated = generateMacosSbplStrictProfile(baseProfile({ readWrite: [nulPath] }), {
+      homeDir: fixtureHome,
+      configHomeDir,
+    });
+    expect(generated.text).not.toContain(String.fromCharCode(0));
+    expect(generated.unresolved.some((u) => u.input === nulPath)).toBe(true);
+  });
+
+  test("network* is allowed unconditionally — L2 strict is FS-only, not a network boundary (documented scope)", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile(), { homeDir: fixtureHome, configHomeDir });
+    expect(generated.text).toContain("(allow network*)");
+  });
+});
+
+describe("homebrewPackageRoot", () => {
+  test("extracts the package root from a Cellar-shaped path", () => {
+    expect(homebrewPackageRoot("/opt/homebrew/Cellar/git/2.49.0/bin/git")).toBe(
+      "/opt/homebrew/Cellar/git/2.49.0",
+    );
+  });
+
+  test("returns undefined for a non-Cellar path (disclosed residual for non-Homebrew hosts)", () => {
+    expect(homebrewPackageRoot("/usr/bin/git")).toBeUndefined();
+  });
+
+  test("returns undefined for a malformed/truncated Cellar path", () => {
+    expect(homebrewPackageRoot("/opt/homebrew/Cellar/git")).toBeUndefined();
+  });
+});
+
+describe("classifyHookTarget", () => {
+  test("a target under arc's package-repos root gets its whole repo checkout allow-listed (subpath)", () => {
+    const home = "/Users/fixture";
+    const result = classifyHookTarget(
+      join(home, ".local", "share", "metafactory", "arc", "repos", "cortex", "src", "runner", "hooks", "x.ts"),
+      home,
+    );
+    expect(result).toEqual({ subpath: join(home, ".local", "share", "metafactory", "arc", "repos", "cortex") });
+  });
+
+  test("a target OUTSIDE the arc root gets only its own literal file allow-listed", () => {
+    const home = "/Users/fixture";
+    const result = classifyHookTarget(join(home, "custom-hooks", "my-hook.ts"), home);
+    expect(result).toEqual({ literal: join(home, "custom-hooks", "my-hook.ts") });
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Real sandbox-exec — macOS only. Proves BOTH directions: legitimate access
+// still works, AND an out-of-scope read is denied BY CONSTRUCTION (no
+// enumerated deny rule needed — the whole point of deny-default).
+// -----------------------------------------------------------------------------
+
+describe.skipIf(!isDarwin)("strict — real sandbox-exec, both directions", () => {
+  let fixtureHome: string;
+  let configHomeDir: string;
+  let workDir: string;
+  let otherDir: string;
+
+  beforeEach(() => {
+    fixtureHome = realpathSync(mkdtempSync(join(tmpdir(), "cortex-strict-e2e-home-")));
+    configHomeDir = join(fixtureHome, ".claude");
+    mkdirSync(configHomeDir, { recursive: true });
+    workDir = mkdtempSync(join(tmpdir(), "cortex-strict-e2e-work-"));
+    writeFileSync(join(workDir, "file.txt"), "workspace-content");
+    // An out-of-scope secret — NOT in readWrite/readOnly/configHome/anything
+    // on the allow set. Under (deny default), this must be unreachable
+    // WITHOUT any explicit deny rule naming it.
+    otherDir = mkdtempSync(join(tmpdir(), "cortex-strict-e2e-secret-"));
+    mkdirSync(join(otherDir, ".ssh"), { recursive: true });
+    writeFileSync(join(otherDir, ".ssh", "id_ed25519"), "FAKE-PRIVATE-KEY");
+  });
+
+  afterEach(() => {
+    rmSync(fixtureHome, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+    rmSync(otherDir, { recursive: true, force: true });
+  });
+
+  function runUnderStrictProfile(argv: string[]): { exitCode: number; stdout: string; stderr: string } {
+    // execAllow carries the TEST DRIVER binaries this file's own real-
+    // sandbox-exec tests invoke (`cat`/`sh`/`tee`) — under strict,
+    // process-exec is deny-by-default too (unlike v1 guarded, where ANY
+    // exec succeeds via `(allow default)`), so a test spawning a plain
+    // `/bin/cat` needs it on the allow list the SAME way a real session's
+    // compat-contract binaries do, or the exec itself is denied and every
+    // assertion below would be testing "cat couldn't even launch" instead
+    // of the file-access question the test is actually about.
+    const profile = baseProfile({ readWrite: [workDir], execAllow: ["cat", "sh", "bash", "tee"] });
+    const generated = generateMacosSbplStrictProfile(profile, { homeDir: fixtureHome, configHomeDir });
+    const profileDir = mkdtempSync(join(tmpdir(), "cortex-strict-e2e-profile-"));
+    try {
+      const profilePath = join(profileDir, "strict.sb");
+      writeFileSync(profilePath, generated.text);
+      const result = Bun.spawnSync(["sandbox-exec", "-f", profilePath, ...argv], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return {
+        exitCode: result.exitCode,
+        stdout: result.stdout.toString(),
+        stderr: result.stderr.toString(),
+      };
+    } finally {
+      rmSync(profileDir, { recursive: true, force: true });
+    }
+  }
+
+  test("DIRECTION 1 — legitimate access: reading INSIDE the allowed workDir succeeds", () => {
+    const r = runUnderStrictProfile(["/bin/cat", join(workDir, "file.txt")]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("workspace-content");
+  });
+
+  test("DIRECTION 1 — legitimate access: writing INSIDE the allowed workDir succeeds", () => {
+    const target = join(workDir, "new.txt");
+    const r = runUnderStrictProfile(["/bin/sh", "-c", `echo written > ${target}`]);
+    expect(r.exitCode).toBe(0);
+    expect(readFileSync(target, "utf-8")).toContain("written");
+  });
+
+  test("DIRECTION 2 — F1 closed BY CONSTRUCTION: an out-of-scope read is denied with NO enumerated deny rule naming it", () => {
+    const generated = generateMacosSbplStrictProfile(baseProfile({ readWrite: [workDir] }), {
+      homeDir: fixtureHome,
+      configHomeDir,
+    });
+    // The profile text contains NO deny/mention of otherDir at all — proving
+    // the denial below is deny-default's OWN construction, not an
+    // enumerated rule (the v1-vs-v2 distinction this whole slice is about).
+    expect(generated.text).not.toContain(realpathSync(otherDir));
+
+    const target = join(otherDir, ".ssh", "id_ed25519");
+    const r = runUnderStrictProfile(["/bin/cat", target]);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("Operation not permitted");
+    expect(r.stdout).not.toContain("FAKE-PRIVATE-KEY");
+  });
+
+  test("DIRECTION 2 — F6: write into a readOnly dir is still denied under strict", () => {
+    const roDir = mkdtempSync(join(tmpdir(), "cortex-strict-e2e-ro-"));
+    writeFileSync(join(roDir, "f.txt"), "ro-content");
+    try {
+      const profile = baseProfile({
+        readWrite: [workDir],
+        readOnly: [roDir],
+        execAllow: ["cat", "sh", "bash"],
+      });
+      const generated = generateMacosSbplStrictProfile(profile, { homeDir: fixtureHome, configHomeDir });
+      const profileDir = mkdtempSync(join(tmpdir(), "cortex-strict-e2e-ro-profile-"));
+      try {
+        const profilePath = join(profileDir, "strict.sb");
+        writeFileSync(profilePath, generated.text);
+        const target = join(roDir, "f.txt");
+        const result = Bun.spawnSync(
+          ["sandbox-exec", "-f", profilePath, "/bin/sh", "-c", `echo x >> ${target}`],
+          { stdout: "pipe", stderr: "pipe" },
+        );
+        expect(result.stderr.toString()).toContain("Operation not permitted");
+        // Positive control — read still works.
+        const readResult = Bun.spawnSync(["sandbox-exec", "-f", profilePath, "/bin/cat", target], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        expect(readResult.exitCode).toBe(0);
+        expect(readResult.stdout.toString()).toContain("ro-content");
+      } finally {
+        rmSync(profileDir, { recursive: true, force: true });
+      }
+    } finally {
+      rmSync(roDir, { recursive: true, force: true });
+    }
+  });
+
+  test("THE keychain constraint, DIRECTION 1: keychain READ is allowed under strict", () => {
+    const keychainDir = join(fixtureHome, "Library", "Keychains");
+    mkdirSync(keychainDir, { recursive: true });
+    writeFileSync(join(keychainDir, "login.keychain-db"), "not-a-real-keychain");
+    const r = runUnderStrictProfile(["/bin/cat", join(keychainDir, "login.keychain-db")]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("not-a-real-keychain");
+  });
+
+  test("THE keychain constraint, DIRECTION 2: keychain WRITE is denied under strict (deny-default omission)", () => {
+    const keychainDir = join(fixtureHome, "Library", "Keychains");
+    mkdirSync(keychainDir, { recursive: true });
+    const target = join(keychainDir, "login.keychain-db");
+    writeFileSync(target, "not-a-real-keychain");
+    const r = runUnderStrictProfile(["/bin/sh", "-c", `echo tampered >> ${target}`]);
+    expect(r.stderr).toContain("Operation not permitted");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// THE keychain constraint's REGRESSION test — the documented REASON keychain
+// read is allowed: prove that DENYING it breaks a real `claude --print`
+// session outright. This is deliberately run against a hand-modified profile
+// (the real generator's own output with the keychain-read line stripped),
+// not a fixture $HOME — the auth/keychain state that breaks is the REAL
+// machine's, which is the whole point (this IS what E-KC measured).
+// -----------------------------------------------------------------------------
+
+describe.skipIf(!isDarwin || !hasClaude)(
+  "THE keychain constraint — regression: denying keychain READ breaks a real claude session",
+  () => {
+    testClaude(
+      "a strict profile with the keychain-read allow line stripped fails auth ('Not logged in')",
+      async () => {
+        const { homedir } = await import("os");
+        const homeDir = homedir();
+        // The REAL generator's own output — same code path a live session
+        // would use — with ONLY the keychain-read allow line removed. Every
+        // other allow (system.sb, .claude.json, config home, etc.) stays,
+        // so a failure here isolates the keychain-read line specifically.
+        const workDir = mkdtempSync(join(tmpdir(), "cortex-strict-kc-regress-work-"));
+        try {
+          const generated = generateMacosSbplStrictProfile(
+            baseProfile({ readWrite: [workDir], execAllow: [...SANDBOX_EXEC_ALLOW_SEED] }),
+          );
+          const keychainAllowLine = `(allow file-read* (subpath "${join(homeDir, "Library", "Keychains")}"))`;
+          expect(generated.text).toContain(keychainAllowLine); // sanity — the line exists to strip
+          const withoutKeychainRead = generated.text
+            .split("\n")
+            .filter((line) => line !== keychainAllowLine)
+            .join("\n");
+
+          const profileDir = mkdtempSync(join(tmpdir(), "cortex-strict-kc-regress-profile-"));
+          try {
+            const profilePath = join(profileDir, "no-keychain.sb");
+            writeFileSync(profilePath, withoutKeychainRead);
+            const claudeBin = realpathSync(Bun.which("claude")!);
+            const result = Bun.spawnSync(
+              ["sandbox-exec", "-f", profilePath, claudeBin, "--print", "-p", "say hi"],
+              { stdout: "pipe", stderr: "pipe", cwd: workDir, env: { ...process.env } },
+            );
+            const combined = result.stdout.toString() + result.stderr.toString();
+            // The DOCUMENTED failure mode (module doc, v1's own two-round
+            // story) — auth breaks outright when keychain read is denied.
+            expect(result.exitCode).not.toBe(0);
+            expect(combined).toMatch(/not logged in|please run \/login|EPERM|error/i);
+          } finally {
+            rmSync(profileDir, { recursive: true, force: true });
+          }
+        } finally {
+          rmSync(workDir, { recursive: true, force: true });
+        }
+      },
+      30_000,
+    );
+  },
+);
+
+// -----------------------------------------------------------------------------
+// MacosSbplSandbox — posture gating (mirrors v1's own "spawn() mode gating"
+// describe block, extended for posture)
+// -----------------------------------------------------------------------------
+
+describe.skipIf(!isDarwin)("MacosSbplSandbox — posture gating (guarded vs strict)", () => {
+  test("posture 'strict' + mode 'audit': a real session under a strict profile can still read its workDir", async () => {
+    const workDir = mkdtempSync(join(tmpdir(), "cortex-strict-spawn-work-"));
+    writeFileSync(join(workDir, "f.txt"), "hello");
+    try {
+      const sandbox = new MacosSbplSandbox();
+      const profile = baseProfile({
+        mode: "audit",
+        posture: "strict",
+        readWrite: [workDir],
+        execAllow: ["cat"],
+      });
+      const proc = sandbox.spawn(["/bin/cat", join(workDir, "f.txt")], profile, {
+        env: {},
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stdout =
+        typeof proc.stdout === "object" && proc.stdout !== null
+          ? await new Response(proc.stdout as ReadableStream<Uint8Array>).text()
+          : "";
+      const exitCode = await proc.exited;
+      expect(exitCode).toBe(0);
+      expect(stdout.trim()).toBe("hello");
+      expect(sandbox.canaryResult?.passed).toBe(true);
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("posture 'strict': an out-of-scope read is denied end-to-end via the real class", async () => {
+    const secretDir = mkdtempSync(join(tmpdir(), "cortex-strict-spawn-secret-"));
+    writeFileSync(join(secretDir, "secret.txt"), "TOP-SECRET");
+    try {
+      const sandbox = new MacosSbplSandbox();
+      // execAllow includes "cat" so a failure here is unambiguously the
+      // FILE READ being denied, not the exec of `cat` itself (also denied
+      // under strict by default, and also stringified as "Operation not
+      // permitted" — leaving it off would make this test pass for the
+      // wrong reason).
+      const profile = baseProfile({ mode: "audit", posture: "strict", readWrite: [], execAllow: ["cat"] });
+      const proc = sandbox.spawn(["/bin/cat", join(secretDir, "secret.txt")], profile, {
+        env: {},
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderr =
+        typeof proc.stderr === "object" && proc.stderr !== null
+          ? await new Response(proc.stderr as ReadableStream<Uint8Array>).text()
+          : "";
+      const exitCode = await proc.exited;
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("Operation not permitted");
+    } finally {
+      rmSync(secretDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  test("posture defaults to 'guarded' behavior when unset on the profile (HARD HOLD parity check)", async () => {
+    // A profile that OMITS posture entirely would fail TypeScript (the
+    // field is required) — this test instead pins that `deriveSandboxProfile`
+    // (cc-session.ts) is the ACTUAL default-setter, and that a profile built
+    // with posture "guarded" behaves exactly like pre-#2409 EBH-3a: an
+    // out-of-scope read SUCCEEDS (guarded's allow-default posture, unchanged).
+    const secretDir = mkdtempSync(join(tmpdir(), "cortex-guarded-spawn-secret-"));
+    writeFileSync(join(secretDir, "secret.txt"), "not-actually-secret-for-this-test");
+    try {
+      const sandbox = new MacosSbplSandbox();
+      const profile = baseProfile({ mode: "audit", posture: "guarded", readWrite: [] });
+      const proc = sandbox.spawn(["/bin/cat", join(secretDir, "secret.txt")], profile, {
+        env: {},
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const exitCode = await proc.exited;
+      expect(exitCode).toBe(0); // guarded's (allow default) — unchanged by this slice
+    } finally {
+      rmSync(secretDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});
+
+// -----------------------------------------------------------------------------
+// Real end-to-end acceptance — a full CCSession under strict/audit. Mirrors
+// cc-session-macos-sandbox-e2e.test.ts's shape (fresh session + --resume),
+// but asserts SUCCESS + response content rather than zero denials — see this
+// file's module doc for why that bar differs from v1 guarded's.
+// -----------------------------------------------------------------------------
+
+describe.skipIf(!isDarwin || !hasClaude)(
+  "EBH-2409-part-2 acceptance — real CCSession end-to-end under posture: 'strict' (macos-sbpl)",
+  () => {
+    let workDir: string;
+
+    beforeEach(async () => {
+      resetSandboxCapabilityProbeForTests();
+      const probe = await getSandboxCapabilityProbe();
+      expect(probe.resolvedBackend).toBe("macos-sbpl");
+      workDir = mkdtempSync(join(tmpdir(), "cortex-strict-cc-e2e-"));
+    });
+
+    afterEach(() => {
+      resetSandboxCapabilityProbeForTests();
+      rmSync(workDir, { recursive: true, force: true });
+    });
+
+    testClaude(
+      "fresh session + --resume of it BOTH complete successfully under strict",
+      async () => {
+        const denials: SandboxDenialEvent[] = [];
+
+        const first = new CCSession({
+          prompt: "Say just the word hi, nothing else",
+          channel: "test",
+          timeoutMs: 45_000,
+          sandboxMode: "audit",
+          sandboxPosture: "strict",
+          cwd: workDir,
+          allowedDirs: [workDir],
+        });
+        first.on("security-event", (event: unknown) => {
+          const e = event as { type: string };
+          if (e.type === "system.security.sandbox-denial") denials.push(event as SandboxDenialEvent);
+        });
+
+        const firstResult = await first.start().wait();
+        expect(firstResult.success).toBe(true);
+        expect(firstResult.exitCode).toBe(0);
+        expect(firstResult.sessionId).toBeDefined();
+        expect(firstResult.response.toLowerCase()).toContain("hi");
+
+        const second = new CCSession({
+          prompt: "Say just the word bye, nothing else",
+          channel: "test",
+          timeoutMs: 45_000,
+          sandboxMode: "audit",
+          sandboxPosture: "strict",
+          cwd: workDir,
+          allowedDirs: [workDir],
+          resumeSessionId: firstResult.sessionId,
+        });
+        second.on("security-event", (event: unknown) => {
+          const e = event as { type: string };
+          if (e.type === "system.security.sandbox-denial") denials.push(event as SandboxDenialEvent);
+        });
+
+        const secondResult = await second.start().wait();
+        expect(secondResult.success).toBe(true);
+        expect(secondResult.exitCode).toBe(0);
+        expect(secondResult.response.toLowerCase()).toContain("bye");
+
+        // A workspace write must have succeeded WITHOUT any denial on
+        // workDir itself (the legitimate-access half of the "both
+        // directions" bar) — denials targeting workDir specifically would
+        // mean the compat contract is broken, unlike the personal-history
+        // noise class this file's module doc documents as expected.
+        const workDirDenials = denials.filter((d) => d.path?.startsWith(workDir));
+        expect(workDirDenials).toHaveLength(0);
+      },
+      60_000,
+    );
+  },
+);

--- a/src/runner/__tests__/session-sandbox-macos-strict.test.ts
+++ b/src/runner/__tests__/session-sandbox-macos-strict.test.ts
@@ -46,7 +46,6 @@ import { CCSession } from "../cc-session";
 import {
   getSandboxCapabilityProbe,
   resetSandboxCapabilityProbeForTests,
-  SANDBOX_EXEC_ALLOW_SEED,
   type SandboxDenialEvent,
 } from "../session-sandbox";
 import { hasClaude, testClaude } from "../../common/test-utils";
@@ -419,55 +418,33 @@ describe.skipIf(!isDarwin)("strict — real sandbox-exec, both directions", () =
 // machine's, which is the whole point (this IS what E-KC measured).
 // -----------------------------------------------------------------------------
 
-describe.skipIf(!isDarwin || !hasClaude)(
-  "THE keychain constraint — regression: denying keychain READ breaks a real claude session",
-  () => {
-    testClaude(
-      "a strict profile with the keychain-read allow line stripped fails auth ('Not logged in')",
-      async () => {
-        const { homedir } = await import("os");
-        const homeDir = homedir();
-        // The REAL generator's own output — same code path a live session
-        // would use — with ONLY the keychain-read allow line removed. Every
-        // other allow (system.sb, .claude.json, config home, etc.) stays,
-        // so a failure here isolates the keychain-read line specifically.
-        const workDir = mkdtempSync(join(tmpdir(), "cortex-strict-kc-regress-work-"));
-        try {
-          const generated = generateMacosSbplStrictProfile(
-            baseProfile({ readWrite: [workDir], execAllow: [...SANDBOX_EXEC_ALLOW_SEED] }),
-          );
-          const keychainAllowLine = `(allow file-read* (subpath "${join(homeDir, "Library", "Keychains")}"))`;
-          expect(generated.text).toContain(keychainAllowLine); // sanity — the line exists to strip
-          const withoutKeychainRead = generated.text
-            .split("\n")
-            .filter((line) => line !== keychainAllowLine)
-            .join("\n");
-
-          const profileDir = mkdtempSync(join(tmpdir(), "cortex-strict-kc-regress-profile-"));
-          try {
-            const profilePath = join(profileDir, "no-keychain.sb");
-            writeFileSync(profilePath, withoutKeychainRead);
-            const claudeBin = realpathSync(Bun.which("claude")!);
-            const result = Bun.spawnSync(
-              ["sandbox-exec", "-f", profilePath, claudeBin, "--print", "-p", "say hi"],
-              { stdout: "pipe", stderr: "pipe", cwd: workDir, env: { ...process.env } },
-            );
-            const combined = result.stdout.toString() + result.stderr.toString();
-            // The DOCUMENTED failure mode (module doc, v1's own two-round
-            // story) — auth breaks outright when keychain read is denied.
-            expect(result.exitCode).not.toBe(0);
-            expect(combined).toMatch(/not logged in|please run \/login|EPERM|error/i);
-          } finally {
-            rmSync(profileDir, { recursive: true, force: true });
-          }
-        } finally {
-          rmSync(workDir, { recursive: true, force: true });
-        }
-      },
-      30_000,
-    );
-  },
-);
+// SAFETY NOTE (added after this test's live form was found to carry a real
+// risk): the original version of this block spawned a REAL `claude --print`
+// process, against this machine's REAL $HOME, under a profile with the
+// keychain-read allow line deliberately stripped — to reproduce the
+// documented "denying keychain read breaks login" finding end-to-end. That
+// is exactly what it did: it reliably reproduced "Not logged in". But it
+// does so by repeatedly forcing a REAL `claude` invocation through a failed
+// auth path against the REAL, SHARED, global `~/.claude.json`/keychain
+// state on the host — not a fixture. Unlike this file's other real-
+// sandbox-exec tests (which use a fixture `$HOME` or fixture keychain
+// files), this one had no way to avoid touching the real auth state,
+// because the whole point was proving the REAL login path breaks. Running
+// it repeatedly, on a shared dev host where an active, longer-lived Claude
+// Code session's own authentication may depend on the SAME `~/.claude.json`
+// state, is a real, demonstrated hazard — not a hypothetical one — and it
+// was pulled after that risk surfaced, rather than kept for coverage this
+// suite does not need: the underlying fact (denying keychain read breaks
+// `claude` login) is ALREADY independently established and documented —
+// see `generateMacosSbplStrictProfile`'s module doc's "THE keychain
+// constraint" section and `session-sandbox-macos.ts`'s v1 `guarded`
+// module doc's own two-round story (a PRIOR, independent measurement of
+// the identical fact). The safe, still-real-sandbox-exec regression for
+// THIS module lives above: "THE keychain constraint, DIRECTION 1/2" in the
+// "strict — real sandbox-exec, both directions" describe block — those
+// use a FIXTURE `$HOME`/keychain file, never the real one, and assert the
+// same read-allowed/write-denied shape without ever exercising `claude`'s
+// own real auth path.
 
 // -----------------------------------------------------------------------------
 // MacosSbplSandbox — posture gating (mirrors v1's own "spawn() mode gating"

--- a/src/runner/__tests__/session-sandbox-macos.test.ts
+++ b/src/runner/__tests__/session-sandbox-macos.test.ts
@@ -50,6 +50,8 @@ function baseProfile(overrides: Partial<SandboxProfile> = {}): SandboxProfile {
     execAllow: [],
     egressAllow: [],
     mode: "audit",
+    posture: "guarded",
+    internalReadOnly: [],
     ...overrides,
   };
 }

--- a/src/runner/__tests__/session-sandbox.test.ts
+++ b/src/runner/__tests__/session-sandbox.test.ts
@@ -28,6 +28,8 @@ const BASE_PROFILE: SandboxProfile = {
   execAllow: ["claude"],
   egressAllow: ["api.anthropic.com"],
   mode: "off",
+  posture: "guarded",
+  internalReadOnly: [],
 };
 
 afterEach(() => {

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -7,7 +7,7 @@
 
 import { EventEmitter } from "events";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join } from "path";
 import { parseStreamLine, StreamLineBuffer, type UsageStats, type StreamEvent } from "./stream-parser";
 import { buildClaudeArgs, type ClaudeInvocationOpts } from "./claude-invoker";
 import {
@@ -24,6 +24,7 @@ import {
   SANDBOX_EXEC_ALLOW_SEED,
   SANDBOX_EGRESS_ALLOW_SEED,
   type SandboxMode,
+  type SandboxPosture,
   type SandboxProfile,
   type SandboxUnavailableEvent,
   type SandboxDenialEvent,
@@ -76,6 +77,16 @@ export interface CCSessionOpts {
    * enforces it (EBH-3).
    */
   sandboxMode?: SandboxMode;
+  /**
+   * cortex#2409 part 2 — DD-10's filesystem posture (`"guarded"` v1's
+   * `(allow default)` + denylist, or `"strict"` v2's `(deny default)` +
+   * derived explicit-allow). Undefined behaves exactly like `"guarded"` —
+   * the HARD HOLD default, unchanged from every prior EBH slice: no live
+   * dispatch path sets `"strict"`. Orthogonal to {@link sandboxMode}: mode
+   * gates whether the profile enforces at all; posture gates what its
+   * default rule is. See `session-sandbox.ts`'s `SandboxPosture` doc.
+   */
+  sandboxPosture?: SandboxPosture;
   /**
    * EBH-4 (cortex#2346) — additional egress hostnames for THIS session, on
    * top of {@link SANDBOX_EGRESS_ALLOW_SEED}'s static seed (the compat-
@@ -380,8 +391,19 @@ function splitGuardDirs(
  * touching the static compatibility-contract list.
  */
 export function deriveSandboxProfile(
-  opts: Pick<CCSessionOpts, "allowedDirs" | "readOnlyDirs" | "egressAllow">,
+  opts: Pick<CCSessionOpts, "allowedDirs" | "readOnlyDirs" | "egressAllow" | "sandboxPosture">,
   mode: SandboxMode,
+  /**
+   * cortex#2409 part 2 — session-internal read-only paths ONLY the STRICT
+   * generator needs (see `SandboxProfile.internalReadOnly`'s doc): today,
+   * the per-session isolated-settings temp dir. A separate parameter
+   * (not folded into `opts`) because it is NOT part of the caller-facing
+   * policy `opts` represents — it's plumbing `CCSession.start()` computes
+   * for itself (`createIsolatedSettings`'s `settingsPath`) and threads
+   * through explicitly, so `deriveSandboxProfile` stays a pure function of
+   * its own inputs rather than reaching into session-construction state.
+   */
+  internalReadOnly: string[] = [],
 ): SandboxProfile {
   const { allowedDirs, readOnlyDirs } = splitGuardDirs(opts);
   return {
@@ -390,6 +412,11 @@ export function deriveSandboxProfile(
     execAllow: [...SANDBOX_EXEC_ALLOW_SEED],
     egressAllow: [...new Set([...SANDBOX_EGRESS_ALLOW_SEED, ...(opts.egressAllow ?? [])])],
     mode,
+    // cortex#2409 part 2 HARD HOLD — defaults to "guarded" (DD-10 v1,
+    // unchanged) whenever the caller doesn't set `sandboxPosture`, which is
+    // every live dispatch path today. See `SandboxPosture`'s doc.
+    posture: opts.sandboxPosture ?? "guarded",
+    internalReadOnly,
   };
 }
 
@@ -605,7 +632,20 @@ export class CCSession extends EventEmitter {
     // a real backend class is not the same as enforcing anything; see
     // `session-sandbox-macos.ts`'s class doc for the `mode` gate.
     const sandboxMode: SandboxMode = this.opts.sandboxMode ?? "off";
-    const sandboxProfile = deriveSandboxProfile(this.opts, sandboxMode);
+    // cortex#2409 part 2 — the isolated-settings temp dir (when isolating)
+    // is cortex-internal plumbing, not part of the caller's `allowedDirs`/
+    // `readOnlyDirs` policy, but the STRICT posture's `(deny default)` still
+    // needs an explicit allow for it (`claude` reads its own `--settings
+    // <path>` argument at startup) or every isolated session breaks under
+    // `strict`. `dirname`, not the file itself — the strict generator
+    // realpath-resolves + subpath-allows the directory (also covers the
+    // materialised skills plugin dir, cortex#990 A1, which lives alongside
+    // `settings.json` in the SAME temp dir).
+    const sandboxProfile = deriveSandboxProfile(
+      this.opts,
+      sandboxMode,
+      this.isolatedSettings ? [dirname(this.isolatedSettings.settingsPath)] : [],
+    );
     const sandbox = createSessionSandbox({
       onUnavailable: (event: SandboxUnavailableEvent) => {
         // Observable to any listener (a future bus publisher included) —

--- a/src/runner/session-sandbox-macos.ts
+++ b/src/runner/session-sandbox-macos.ts
@@ -113,12 +113,14 @@
  * lifetimes are seconds-to-minutes); flagged here rather than assumed away.
  */
 
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { randomUUID } from "crypto";
 import type { Subprocess } from "bun";
 import { resolveProspectiveRealpath } from "../common/path-containment";
+import { activeConfigHomeEnv } from "../common/substrates/config-home";
+import { resolveArcPackReposDir } from "../common/config/arc-pack-repos-dir";
 import type {
   SandboxDenial,
   SandboxProfile,
@@ -325,6 +327,532 @@ export function generateMacosSbplProfile(
     text: lines.join("\n") + "\n",
     unresolved,
     resolvedDenyPaths: [...resolvedDenyPaths],
+  };
+}
+
+// -----------------------------------------------------------------------------
+// v2 `strict` SBPL text generation (cortex#2409 part 2) — DD-10's deny-
+// default posture: `(deny default)` + a DERIVED, documented, minimal
+// explicit-allow set. This is the boundary that holds "by construction" —
+// everything NOT on the allow set below is denied, full stop, no enumeration
+// to complete.
+//
+// ## How this allow set was derived (the evidence trail the issue asked for)
+//
+// Every entry below was found by the SAME loop, run against this real host
+// (macOS 26.5.1, arm64, `sandbox-exec` present):
+//
+//   1. write a candidate `(deny default)` profile;
+//   2. spawn a REAL `claude --print` session under it (via `sandbox-exec -f`);
+//   3. read what the kernel denied from the macOS unified log (the SAME
+//      `Sandbox: NAME(PID) deny(N) OPERATION PATH` shape `session-sandbox-
+//      macos.ts`'s own `denials()`/`parseSandboxDenialLogLine` already parses
+//      — no `fs_usage`/`dtruss`, no root, exactly the EBH-3a-established
+//      observation mechanism);
+//   4. add the MINIMUM allow that resolves that denial;
+//   5. repeat until a full fresh-session + `--resume` round-trip completed
+//      with ZERO denials (the same bar EBH-3a's own e2e test holds `guarded`
+//      to).
+//
+// Round-by-round findings (each is what iteration on step 3 actually showed —
+// not reasoned out in advance):
+//
+//   - **Round 1 (E4's SIGABRT, exit 134).** A naive `(deny default)` with
+//     only a `process-exec` allow for the target binary SIGABRTs before any
+//     denial is even logged — the unified log shows NOTHING for the crash
+//     (verified: `log show` around the crash window is empty). The macOS
+//     crash reporter (`~/Library/Logs/DiagnosticReports/*.ips`) tells the
+//     real story: the fault is in `dyld4::CacheFinder::CacheFinder` →
+//     `ProcessConfig::DyldCache` → `ignition_halt`/`abort_with_reason` —
+//     dyld's OWN bootstrap (locating/validating the shared cache, resolving
+//     cryptex graft points) aborts when it can't complete a handful of
+//     specific syscalls/reads `(deny default)` blocks silently (no Seatbelt
+//     denial line is logged for whatever dyld's `ignition`/`libignition`
+//     layer hits — it aborts before the normal per-operation denial
+//     mechanism even applies). FIX: `(import "dyld-support.sb")` — Apple's
+//     OWN shipped profile fragment for exactly this
+//     (`/System/Library/Sandbox/Profiles/dyld-support.sb`, "Rules required to
+//     bootstrap a process with dyld"), used verbatim by Apple's real daemon
+//     profiles (`bsd.sb` imports `system.sb`, which imports this). Verified:
+//     `(deny default)(import "dyld-support.sb")(allow process-exec …)` runs
+//     `/usr/bin/true` to a clean exit 0, no crash, no denial.
+//   - **Round 2.** Importing the WIDER `system.sb` (which itself imports
+//     `dyld-support.sb`, plus grants `file-read-metadata`, `sysctl-read`,
+//     the standard `mach-lookup` set for cfprefsd/notification_center/
+//     opendirectoryd/trustd/logd, and the base `/System`, `/usr/lib`,
+//     `/usr/share` reads) took a real `claude --version` invocation from
+//     SIGABRT to a clean run with ZERO denials, once the target binary + its
+//     cwd were allow-listed. `system.sb` is the SAME base every real Apple
+//     daemon profile in `/System/Library/Sandbox/Profiles/` builds on
+//     (`bsd.sb`'s `(import "system.sb")` — inspected directly on this host);
+//     reusing it is "don't hand-roll dyld/mach bootstrap", the same
+//     philosophy as reusing `loader.ts`'s path-containment code elsewhere in
+//     this repo.
+//   - **Round 3 (a real `claude --print` prompt, not just `--version`).**
+//     Denials observed: `process-fork` + `posix_spawn 'security'` — `claude`
+//     shells out to macOS's `/usr/bin/security` CLI to query keychain state
+//     at startup. Then, once `security` could exec: `mach-lookup
+//     com.apple.securityd.xpc`, `mach-lookup com.apple.SecurityServer`,
+//     `user-preference-read kcfpreferencesanyapplication`/`com.apple.security`
+//     — `security`'s own keychain-query path. FIX: allow `process-fork`
+//     (matches Apple's own `application.sb` baseline for ordinary sandboxed
+//     apps — inspected directly), explicit exec+read allow for the resolved
+//     `security` binary, the two `mach-lookup` names, and a broad
+//     `user-preference-read` (matches `application.sb`'s own posture —
+//     preference reads are stat-adjacent metadata, not secret content).
+//   - **Round 4.** `process-exec* /bin/sh` denied — Claude Code's OWN Bash
+//     tool execs `/bin/sh` internally (measured directly: this denial fires
+//     the moment the Bash tool runs, with no cortex-side shell invocation of
+//     our own in the repro). FIX: added `"sh"` to the shared
+//     `SANDBOX_EXEC_ALLOW_SEED` (session-sandbox.ts) — a genuine
+//     compatibility-contract requirement, not strict-specific (the guarded
+//     posture never enforced `execAllow` at all, so this addition is
+//     previously-dead data becoming used, not a behavior change for
+//     `guarded`).
+//   - **Round 5.** Cortex's OWN hooks (`~/.claude/hooks/*.hook.ts`, or the
+//     equivalent under a relocated config home) carry a `#!/usr/bin/env bun`
+//     shebang (verified: `head -1` on this repo's installed hooks). The
+//     kernel-level exec chain for EVERY hook invocation is therefore `env` →
+//     `bun`, not just `bun` — `/usr/bin/env` itself needs `process-exec`.
+//     FIX: added `"env"` to the same seed.
+//   - **Round 6.** `file-read-data` denied on the bare `$HOME` and `/Users`
+//     directories (not their contents — the literal directory entries
+//     themselves; something in `claude`'s startup enumerates its own home's
+//     top level). FIX: a narrow, NON-recursive `(literal …)` allow (not
+//     `subpath`) for exactly those two paths — lists directory NAMES one
+//     level deep, not file contents; the lowest-risk grant that resolved the
+//     denial.
+//   - **Round 7.** `/private/etc/ssl/cert.pem` (TLS root bundle) and
+//     `/Library/Preferences/com.apple.networkd.plist` denied once the
+//     session reached actual network I/O. FIX: explicit reads for both —
+//     baseline OS/TLS plumbing every networked process needs, not session-
+//     specific.
+//   - **Git/gh.** The compatibility contract (design-session-sandbox.md §3,
+//     -platforms.md §5) explicitly requires `git`/`gh` to keep working.
+//     `execAllow`'s entries are resolved via `Bun.which` (the SAME `$PATH`
+//     the spawned child inherits — `session-settings.ts` preserves `PATH`
+//     unchanged for isolated sessions, so parent-side resolution and child-
+//     side resolution agree) then realpath'd. On THIS host both are Homebrew
+//     installs (`/opt/homebrew/bin/{git,gh}` → `Cellar/{git,gh}/<ver>/bin/…`)
+//     — resolved binaries under a `/Cellar/<pkg>/<ver>/` tree get that whole
+//     package root allow-listed too (read + map-executable), since Homebrew
+//     binaries commonly dlopen/reference sibling files (share/templates,
+//     libexec) within their OWN package tree. This is a DERIVED, HOST-
+//     SPECIFIC finding, not a general guarantee — a non-Homebrew git install
+//     (e.g. Xcode CLT's `/usr/bin/git`, or a bare-metal Linux-shaped install)
+//     is NOT covered by the Cellar heuristic and gets only its literal binary
+//     allow-listed; this is a disclosed residual (see the function doc)
+//     pending measurement on a non-Homebrew host.
+//
+// ## THE keychain constraint (do not "fix" this away)
+//
+// `~/Library/Keychains` READ is unconditionally allowed (`file-read*`, both
+// data and metadata) — `claude` authenticates via the OS keychain, and E-KC
+// (measured on a real host, this epic) found that denying keychain reads —
+// even narrowed to `file-read-data` alone — breaks login outright ("Not
+// logged in · Please run /login"). This is the IDENTICAL empirical finding
+// `builtinSensitiveDenyEntries` (v1 `guarded`) already documents for its own
+// WRITE-only keychain carve-out; `strict` inherits the SAME constraint in
+// allow-set form: keychain read is unconditionally on the allow list, write
+// is NOT (omitted from every allow rule ⇒ denied by `(deny default)`,
+// exactly like every other unlisted operation). **`strict` therefore cannot
+// protect keychain CONTENTS from a compromised session** — an injected
+// prompt that gets the agent to read+exfiltrate its own keychain data still
+// succeeds at the FS layer (the egress-proxy/L3 layer is the only thing that
+// could then contain exfiltration, and only for cooperating-client traffic).
+// This is a disclosed, permanent residual, not a bug to chase — see the
+// design doc's own residual list (§5) for the parallel `gh`/git-credential
+// finding this generalizes.
+//
+// ## Network — NOT this layer's job
+//
+// `(allow network*)` is unconditional here. `strict`'s whole point is
+// FILESYSTEM confinement (F1); per-host network filtering is Layer 3's job
+// (`egress-proxy.ts`'s cooperating-client HTTP CONNECT proxy) — SBPL's own
+// host-based network primitives are coarse/unreliable (design doc §4.3), and
+// `strict` does not attempt to duplicate that boundary at the kernel level.
+// This is the SAME scope split `guarded` (v1) already has (it also allows
+// all network via `(allow default)`) — `strict` is not a regression here,
+// only an improvement on the FS dimension.
+// -----------------------------------------------------------------------------
+
+export interface MacosSbplStrictProfileOpts {
+  /** Override `$HOME` (tests). Defaults to `os.homedir()`. */
+  homeDir?: string;
+  /**
+   * Override the resolved claude-code config home (hooks/settings/session-
+   * state/events dir). Defaults to the SAME resolution `cc-session.ts` uses
+   * for `skillSourceDir` — `activeConfigHomeEnv("claude-code")?.value ??
+   * join(homeDir, ".claude")` — so a deployment that relocated its config
+   * home (the `substrates:` block) gets the SAME directory allow-listed
+   * here that the session actually reads/writes. Tests override this
+   * directly rather than mutating the process-wide `activeConfigHomeEnv`
+   * singleton.
+   */
+  configHomeDir?: string;
+  /**
+   * Additional session-internal read-only paths (cortex#2409 part 2 — see
+   * `SandboxProfile.internalReadOnly`'s doc: today, the per-session
+   * isolated-settings temp dir). Named to mirror v1's `extraDenyPaths` —
+   * the generic escape hatch for "another path this generator doesn't know
+   * about by name".
+   */
+  internalReadOnlyPaths?: string[];
+}
+
+export interface MacosSbplStrictProfile {
+  /** The compiled SBPL text — write verbatim to a `.sb` file. */
+  text: string;
+  /** Every input path that failed to realpath-resolve, and why — FAIL
+   *  CLOSED: an unresolvable ALLOW input is excluded from `text` (never
+   *  silently trusted unresolved), exactly like v1's `unresolved` handling,
+   *  just mirrored for the opposite (allow, not deny) direction. */
+  unresolved: { input: string; reason: string }[];
+  /** Every resolved (realpath'd) root actually allowed — for tests/logging. */
+  resolvedAllowPaths: string[];
+}
+
+/** `.../Cellar/<pkg>/<version>/...` → `.../Cellar/<pkg>/<version>` — the
+ *  Homebrew package-root heuristic from Round "Git/gh" above. `undefined`
+ *  when `resolvedPath` isn't under a `/Cellar/` tree (a non-Homebrew
+ *  install) — the caller then allow-lists only the literal binary, a
+ *  disclosed residual for non-Homebrew hosts. Exported for unit tests. */
+export function homebrewPackageRoot(resolvedPath: string): string | undefined {
+  const marker = "/Cellar/";
+  const idx = resolvedPath.indexOf(marker);
+  if (idx === -1) return undefined;
+  const afterCellar = resolvedPath.slice(idx + marker.length);
+  const segments = afterCellar.split("/");
+  const pkg = segments[0];
+  const version = segments[1];
+  if (!pkg || !version) return undefined;
+  return resolvedPath.slice(0, idx + marker.length) + pkg + "/" + version;
+}
+
+/**
+ * Classify a hook file's realpath against arc's package-repos root
+ * (`resolveArcPackReposDir` — the SAME resolver `cortex.ts`'s exec-brain pack
+ * loader uses, reused rather than re-derived) — Round 5's discovery that
+ * cortex's own hooks are commonly symlinks INTO an arc-managed repo checkout
+ * (`~/.local/share/metafactory/arc/repos/<repo>/…`, verified on this host:
+ * `~/.claude/hooks/CortexBashGuard.hook.ts` → `…/arc/repos/cortex/src/runner/
+ * hooks/bash-guard.hook.ts`). A hook run via `bun <file>` needs its sibling
+ * source files too (bun resolves `import`s at the FILE level), so a symlink
+ * target under the arc root gets its WHOLE repo checkout allow-listed
+ * (read + map-executable, never write — self-modification of arc-managed
+ * source stays denied); a target that resolves OUTSIDE the arc root (a
+ * custom, non-arc-managed hook) gets only its own literal file allow-listed
+ * — least-privilege for the case this function can't generalize about.
+ * Exported for unit tests.
+ */
+export function classifyHookTarget(
+  resolvedTarget: string,
+  homeDir: string,
+): { subpath: string } | { literal: string } {
+  const arcRoot = resolveArcPackReposDir({ home: homeDir });
+  const arcRootWithSep = arcRoot.endsWith("/") ? arcRoot : arcRoot + "/";
+  if (resolvedTarget.startsWith(arcRootWithSep)) {
+    const rest = resolvedTarget.slice(arcRootWithSep.length);
+    const repo = rest.split("/")[0];
+    if (repo) return { subpath: join(arcRoot, repo) };
+  }
+  return { literal: resolvedTarget };
+}
+
+/** One allow rule's inputs, kept structured (like v1's `DenyEntry`) so
+ *  `generateMacosSbplStrictProfile` can report exactly which INPUT produced
+ *  which resolved allow, for `unresolved` reporting. `"regex-in-dir"` is
+ *  Round 8's addition: `input` is realpath-resolved as a DIRECTORY (the
+ *  SAME E3 discipline as `subpath`/`literal`), then `regexSuffix` is
+ *  appended after the escaped, resolved dir to match a whole FAMILY of
+ *  sibling files whose exact names aren't individually predictable (atomic-
+ *  write lockfile/tempfile siblings — see the `.claude.json` allow below). */
+interface AllowEntry {
+  input: string;
+  kind: "subpath" | "literal" | "regex-in-dir";
+  ops: readonly string[];
+  regexSuffix?: string;
+}
+
+function pushAllow(
+  entries: AllowEntry[],
+  input: string,
+  kind: "subpath" | "literal",
+  ops: readonly string[],
+): void {
+  entries.push({ input, kind, ops });
+}
+
+function pushRegexInDirAllow(
+  entries: AllowEntry[],
+  dir: string,
+  regexSuffix: string,
+  ops: readonly string[],
+): void {
+  entries.push({ input: dir, kind: "regex-in-dir", ops, regexSuffix });
+}
+
+/** Escape ERE metacharacters in a literal path so it can be embedded in an
+ *  SBPL `(regex #"…")` pattern as a LITERAL prefix (not reinterpreted as
+ *  regex syntax) — the path-side half of Round 8's `.claude.json` family
+ *  match. Applied BEFORE {@link sbplQuoteRegexLiteral} (the separate SBPL-
+ *  string-literal escaping for the resulting pattern text). */
+function regexEscapePathForSbpl(path: string): string {
+  return path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Escape a completed REGEX PATTERN string for embedding in an SBPL
+ * `(regex #"…")` literal. Deliberately NOT {@link sbplQuote}: measured
+ * directly on this host (`sandbox-exec`, two minimal profiles differing
+ * only in this) that SBPL's `#"…"` string literal does NOT process `\\` as
+ * a backslash-escape the way `sbplQuote` assumes for `subpath`/`literal`
+ * paths — doubling a pattern's regex backslashes (`\.` → `\\.`) makes the
+ * SBPL parser treat them as two LITERAL characters (`\` then `.`, i.e. an
+ * escaped backslash followed by a wildcard-any-char `.`), which no longer
+ * matches the intended literal dot and silently stops matching the target
+ * file at all — confirmed: a `(regex #"…a\\.txt$")` profile denied a read
+ * `(regex #"…a\.txt$")` correctly allowed, same file, same profile
+ * otherwise. Only `"` needs escaping here — a regex pattern built by THIS
+ * module never legitimately contains one (paths don't), but the discipline
+ * (never trust a segment to not need it) matches `sbplQuote`'s own stance
+ * on `"`. */
+function sbplQuoteRegexLiteral(pattern: string): string {
+  return pattern.replace(/"/g, '\\"');
+}
+
+/**
+ * EBH-3a follow-on, cortex#2409 part 2 — generate the DD-10 v2 `strict`
+ * SBPL profile: `(deny default)` + the derived explicit-allow set documented
+ * in this module's section doc above. Every allow root is realpath-resolved
+ * via {@link resolveProspectiveRealpath} BEFORE being written into the
+ * profile text — the SAME E3 discipline v1's generator applies to its DENY
+ * rules, mirrored here for ALLOW rules: under `(deny default)`, an allow
+ * authored against an unresolved symlink alias would silently fail to
+ * match — the analogous failure to E3, just inverted (a control that looks
+ * granted and isn't, instead of denied and isn't).
+ */
+export function generateMacosSbplStrictProfile(
+  profile: SandboxProfile,
+  opts: MacosSbplStrictProfileOpts = {},
+): MacosSbplStrictProfile {
+  const homeDir = opts.homeDir ?? homedir();
+  const defaultConfigHomeDir = join(homeDir, ".claude");
+  const configHomeDir = opts.configHomeDir ?? activeConfigHomeEnv("claude-code")?.value ?? defaultConfigHomeDir;
+
+  const entries: AllowEntry[] = [];
+
+  // --- claude-code top-level JSON state file (Round 8 — measured directly
+  //     on a real host): `claude` reads/writes a `.claude.json` (auth/
+  //     project-history bookkeeping) that is NOT a child of the config-home
+  //     DIRECTORY in the default case — it sits at `<homeDir>/.claude.json`,
+  //     a SIBLING of `<homeDir>/.claude/` (verified: file mtime updated by a
+  //     real session run against the default config home). When the config
+  //     home is RELOCATED (`CLAUDE_CONFIG_DIR`/`activeConfigHomeEnv`), the
+  //     json file moves WITH it, nested INSIDE the relocated dir instead
+  //     (verified the same way against a relocated config home on this
+  //     host: `<relocated-dir>/.claude.json`). Neither shape is a `subpath`
+  //     of `configHomeDir` in the default case, so this needs its own
+  //     explicit allow rather than falling out of the broad configHomeDir
+  //     grant below. `claude` ALSO writes this file via the standard
+  //     atomic-write idiom — a `.claude.json.lock` lockfile plus
+  //     `.claude.json.tmp.<pid>.<hash>` scratch files with unpredictable
+  //     names (both measured directly: denied on a real run) — so a single
+  //     `literal` allow for `.claude.json` itself is not enough; the whole
+  //     sibling FAMILY needs an allow, hence `regex-in-dir` rather than
+  //     `literal`.
+  const claudeJsonDir = configHomeDir === defaultConfigHomeDir ? homeDir : configHomeDir;
+  pushRegexInDirAllow(entries, claudeJsonDir, "/\\.claude\\.json(\\..*)?$", [
+    "file-read*",
+    "file-write*",
+  ]);
+
+  // --- per-project tool/MCP cache dir (Round 8) — `claude` creates
+  //     `~/Library/Caches/claude-cli-nodejs/<escaped-cwd>/` keyed by the
+  //     session's escaped absolute cwd; the exact per-project leaf name
+  //     isn't predictable without re-implementing claude's own escaping, so
+  //     the stable PARENT is allow-listed (cache data, not credentials —
+  //     same low-sensitivity class as `file-read-metadata`/network prefs
+  //     above).
+  pushAllow(
+    entries,
+    join(homeDir, "Library", "Caches", "claude-cli-nodejs"),
+    "subpath",
+    ["file-read*", "file-write*"],
+  );
+
+  // --- claude CLI's own version-lock dir (Round 8) — `~/.local/state/
+  //     claude/locks/<version>.lock`, written via the same atomic-write
+  //     idiom as `.claude.json` (an unpredictable `.lock.tmp.<hash>`
+  //     scratch file first — measured directly: denied on a real run).
+  //     Unlike `.claude.json` (a file with SIBLINGS in a shared directory
+  //     that must not be broadly opened up), this whole dir is claude's OWN
+  //     dedicated lock-file directory — a plain `subpath` allow is simpler
+  //     and just as correctly scoped.
+  pushAllow(
+    entries,
+    join(homeDir, ".local", "state", "claude", "locks"),
+    "subpath",
+    ["file-read*", "file-write*"],
+  );
+
+  // --- workspace: readWrite / readOnly / internalReadOnly (session policy) ---
+  for (const dir of profile.readWrite) {
+    pushAllow(entries, dir, "subpath", ["file-read*", "file-write*"]);
+  }
+  for (const dir of profile.readOnly) {
+    // F6, same construction as v1: read-only means read-only, no write allow.
+    pushAllow(entries, dir, "subpath", ["file-read*"]);
+  }
+  for (const dir of [...profile.internalReadOnly, ...(opts.internalReadOnlyPaths ?? [])]) {
+    pushAllow(entries, dir, "subpath", ["file-read*"]);
+  }
+
+  // --- claude-code config home: hooks / settings / session+resume state / events ---
+  pushAllow(entries, configHomeDir, "subpath", ["file-read*", "file-write*"]);
+
+  // --- execAllow: resolve each compat-contract binary via $PATH, then realpath ---
+  const execResolutions: { name: string; real: string }[] = [];
+  const unresolvedInputs: { input: string; reason: string }[] = [];
+  for (const name of profile.execAllow) {
+    const which = Bun.which(name);
+    if (which === null) {
+      unresolvedInputs.push({ input: name, reason: `"${name}" not found on $PATH` });
+      continue;
+    }
+    const resolved = resolveProspectiveRealpath(which);
+    if (!resolved.ok) {
+      unresolvedInputs.push({ input: which, reason: resolved.reason });
+      continue;
+    }
+    execResolutions.push({ name, real: resolved.real });
+    pushAllow(entries, resolved.real, "literal", ["process-exec", "file-read*", "file-map-executable"]);
+    const pkgRoot = homebrewPackageRoot(resolved.real);
+    if (pkgRoot) {
+      pushAllow(entries, pkgRoot, "subpath", ["file-read*", "file-map-executable"]);
+    }
+  }
+
+  // --- security CLI (keychain access helper `claude` shells out to, Round 3) ---
+  const securityWhich = Bun.which("security") ?? "/usr/bin/security";
+  const securityResolved = resolveProspectiveRealpath(securityWhich);
+  if (securityResolved.ok) {
+    pushAllow(entries, securityResolved.real, "literal", ["process-exec", "file-read*"]);
+  } else {
+    unresolvedInputs.push({ input: securityWhich, reason: securityResolved.reason });
+  }
+
+  // --- hooks: symlinked targets outside configHomeDir (Round 5) ---
+  const hooksDir = join(configHomeDir, "hooks");
+  let hookEntries: string[] = [];
+  try {
+    hookEntries = readdirSync(hooksDir);
+  } catch {
+    // No hooks dir (yet) — nothing to enumerate. Not a resolution failure;
+    // the broad configHomeDir allow above already covers hooksDir once it
+    // exists (a non-symlinked hook file is read straight from there).
+  }
+  const seenHookAllows = new Set<string>();
+  for (const name of hookEntries) {
+    const hookPath = join(hooksDir, name);
+    const resolved = resolveProspectiveRealpath(hookPath);
+    if (!resolved.ok) {
+      unresolvedInputs.push({ input: hookPath, reason: resolved.reason });
+      continue;
+    }
+    // Only symlink TARGETS that land OUTSIDE configHomeDir need a separate
+    // allow — a hook whose realpath is still under configHomeDir (a plain,
+    // non-symlinked file, or a symlink within the same tree) is already
+    // covered by the broad configHomeDir allow above.
+    const configHomeWithSep = configHomeDir.endsWith("/") ? configHomeDir : configHomeDir + "/";
+    if (resolved.real === configHomeDir || resolved.real.startsWith(configHomeWithSep)) continue;
+    const classified = classifyHookTarget(resolved.real, homeDir);
+    const key = "subpath" in classified ? classified.subpath : classified.literal;
+    if (seenHookAllows.has(key)) continue;
+    seenHookAllows.add(key);
+    if ("subpath" in classified) {
+      pushAllow(entries, classified.subpath, "subpath", ["file-read*", "file-map-executable"]);
+    } else {
+      pushAllow(entries, classified.literal, "literal", ["file-read*", "file-map-executable"]);
+    }
+  }
+
+  // --- keychain: READ only (THE keychain constraint — see section doc) ---
+  pushAllow(entries, join(homeDir, "Library", "Keychains"), "subpath", ["file-read*"]);
+
+  // --- realpath-resolve + emit every collected allow entry ---
+  const unresolved: { input: string; reason: string }[] = [...unresolvedInputs];
+  const resolvedAllowPaths = new Set<string>();
+  const bodyLines: string[] = [];
+  for (const entry of entries) {
+    const resolution = resolveProspectiveRealpath(entry.input);
+    if (!resolution.ok) {
+      unresolved.push({ input: entry.input, reason: resolution.reason });
+      continue;
+    }
+    resolvedAllowPaths.add(resolution.real);
+    if (entry.kind === "regex-in-dir") {
+      const pattern =
+        "^" + regexEscapePathForSbpl(resolution.real) + (entry.regexSuffix ?? "");
+      bodyLines.push(`(allow ${entry.ops.join(" ")} (regex #"${sbplQuoteRegexLiteral(pattern)}"))`);
+      continue;
+    }
+    const matcher = entry.kind === "subpath" ? "subpath" : "literal";
+    bodyLines.push(
+      `(allow ${entry.ops.join(" ")} (${matcher} "${sbplQuote(resolution.real)}"))`,
+    );
+  }
+
+  // --- self-modification carve-out WITHIN the allowed config home (parity
+  //     with v1's F6/self-mod deny — a narrower deny still wins over a
+  //     broader allow that precedes it in SBPL's rule evaluation, the same
+  //     mechanism v1 relies on for its readOnly-dir write-denies) ---
+  const configHomeReal = resolveProspectiveRealpath(configHomeDir);
+  const selfModDenyLines: string[] = [];
+  if (configHomeReal.ok) {
+    selfModDenyLines.push(
+      `(deny file-write* (subpath "${sbplQuote(join(configHomeReal.real, "hooks"))}"))`,
+      `(deny file-write* (literal "${sbplQuote(join(configHomeReal.real, "settings.json"))}"))`,
+    );
+  }
+
+  const lines: string[] = [
+    "(version 1)",
+    "(deny default)",
+    '(import "system.sb")', // Round 1/2 — fixes E4's SIGABRT; dyld/mach/sysctl bootstrap base.
+    "(allow file-read-metadata)", // matches application.sb/bsd.sb baseline — stat-only, not content.
+    "(allow process-fork)", // matches application.sb baseline — needed for security/git/env/bun.
+    "(allow network*)", // NOT this layer's job — see section doc "Network".
+    "(allow user-preference-read)", // Round 3 — security's keychain-query preference reads.
+    '(allow mach-lookup (global-name "com.apple.securityd.xpc") (global-name "com.apple.SecurityServer"))', // Round 3
+    `(allow file-read-data (literal "${sbplQuote(homeDir)}") (literal "/Users"))`, // Round 6 — bare-dir listing only, non-recursive.
+    '(allow file-read* (subpath "/private/etc/ssl"))', // Round 7 — TLS root bundle.
+    '(allow file-read* (literal "/Library/Preferences/com.apple.networkd.plist"))', // Round 7
+    '(allow file-read* (literal "/private/etc/hosts"))',
+    '(allow file-read* (literal "/private/etc/resolv.conf"))',
+    '(allow file-ioctl (literal "/dev/null"))', // Round 8 — a tty-check-shaped ioctl on /dev/null, denied on a real run.
+    '(allow process-exec file-read* (literal "/bin/ps"))', // Round 8 — claude's own process-tree probing at startup.
+    // Round 9 — `/bin/sh` on this macOS (26.5.1) is a small ~100KB "variant
+    // selector" stub that internally re-execs a FIXED system path
+    // (`/bin/bash`) for a shell invocation shape a real Bash-tool command
+    // uses — NOT whatever `bash` resolves to on $PATH (measured directly:
+    // this dev host's $PATH resolves `bash` to a Homebrew install via
+    // `execAllow`'s normal Bun.which resolution, which does NOT satisfy the
+    // OS's internal fixed-path re-exec — `sandbox-exec` reported "Failed to
+    // exec /bin/bash as variant for /bin/sh" even with Homebrew's bash
+    // allow-listed). So the SYSTEM `/bin/sh` and `/bin/bash` are allow-
+    // listed here as fixed literals, unconditionally — independent of
+    // whatever `execAllow`'s "sh"/"bash" entries resolve to via $PATH.
+    '(allow process-exec file-read* (literal "/bin/sh"))',
+    '(allow process-exec file-read* (literal "/bin/bash"))',
+    ...bodyLines,
+    ...selfModDenyLines,
+  ];
+
+  return {
+    text: lines.join("\n") + "\n",
+    unresolved,
+    resolvedAllowPaths: [...resolvedAllowPaths],
   };
 }
 
@@ -740,12 +1268,23 @@ export class MacosSbplSandbox implements SessionSandbox {
       );
     }
 
-    const generated = generateMacosSbplProfile(profile);
+    // cortex#2409 part 2 — DD-10's TWO postures. `profile.posture` defaults
+    // to `"guarded"` (deriveSandboxProfile's HARD HOLD) — only a caller that
+    // EXPLICITLY sets `sandboxPosture: "strict"` reaches the new generator.
+    const generated =
+      profile.posture === "strict"
+        ? generateMacosSbplStrictProfile(profile)
+        : generateMacosSbplProfile(profile);
     if (generated.unresolved.length > 0) {
+      const label = profile.posture === "strict" ? "allow-set" : "sensitive-set";
+      const consequence =
+        profile.posture === "strict"
+          ? "NOT allowed this session (fail-closed exclusion — an unresolvable ALLOW input is " +
+            "dropped, never silently trusted; the corresponding access is denied by (deny default))"
+          : "NOT denied this session (fail-closed exclusion, not a fail-open grant)";
       process.stderr.write(
-        `[session-sandbox-macos] ${generated.unresolved.length} sensitive-set path(s) could ` +
-          `not be realpath-resolved and are NOT denied this session (fail-closed exclusion, ` +
-          `not a fail-open grant): ` +
+        `[session-sandbox-macos] ${generated.unresolved.length} ${label} path(s) could not be ` +
+          `realpath-resolved and are ${consequence}: ` +
           generated.unresolved.map((u) => `"${u.input}" (${u.reason})`).join("; ") +
           "\n",
       );

--- a/src/runner/session-sandbox.ts
+++ b/src/runner/session-sandbox.ts
@@ -62,6 +62,29 @@ import { MacosSbplSandbox } from "./session-sandbox-macos";
  *  ONLY default this build ships — see the cortex#2344 HARD HOLD. */
 export type SandboxMode = "off" | "audit" | "enforce";
 
+/**
+ * cortex#2409 part 2 — DD-10's TWO filesystem postures, orthogonal to
+ * {@link SandboxMode} (mode gates WHETHER the profile is enforced; posture
+ * gates WHAT the profile's default rule is):
+ *
+ *   - `"guarded"` (DD-10 v1, EBH-3a) — `(allow default)` + an enumerated
+ *     denylist of the sensitive set. Raises attacker cost; does NOT
+ *     establish a boundary — the next unenumerated path is always
+ *     available. THE DEFAULT, and the only posture any live caller sets.
+ *   - `"strict"` (DD-10 v2, this slice) — `(deny default)` + a derived,
+ *     documented, minimal explicit-allow set. F1 closed BY CONSTRUCTION for
+ *     everything outside the allow set, not merely narrowed. See
+ *     `session-sandbox-macos.ts`'s `generateMacosSbplStrictProfile` doc for
+ *     the full allow-set derivation and its evidence trail.
+ *
+ * `"strict"` is additive — `"guarded"` keeps working unchanged, selected by
+ * config the same way `"guarded"` always has been. HARD HOLD (cortex#2409
+ * part 2, unchanged from every prior EBH slice): no caller in this build
+ * sets `"strict"`; `deriveSandboxProfile` defaults every profile to
+ * `"guarded"` when `CCSessionOpts.sandboxPosture` is unset.
+ */
+export type SandboxPosture = "guarded" | "strict";
+
 /** Every backend `SessionSandbox` can resolve to. Only `"none"` has an
  *  implementation in this build (EBH-2); the rest are EBH-3/DD-8. */
 export type SandboxBackendId =
@@ -98,6 +121,33 @@ export interface SandboxProfile {
    */
   egressAllow: string[];
   mode: SandboxMode;
+  /**
+   * cortex#2409 part 2 — DD-10's filesystem posture. Defaults to
+   * `"guarded"` (see {@link SandboxPosture}'s doc for the HARD HOLD).
+   * `generateMacosSbplProfile` (v1) ignores this field entirely — it is
+   * ALWAYS `(allow default)` regardless of what's here, so an accidental
+   * `"strict"` value reaching that generator can never silently upgrade
+   * enforcement; only `generateMacosSbplStrictProfile` reads it (and only
+   * `MacosSbplSandbox.spawn()`'s own posture branch decides which generator
+   * runs — this field is data, not itself a switch).
+   */
+  posture: SandboxPosture;
+  /**
+   * cortex#2409 part 2 — session-internal read-only paths the STRICT
+   * generator must allow that are neither the caller's `readWrite`/
+   * `readOnly` policy dirs nor part of the static compatibility-contract
+   * seed below: today, exactly the per-session isolated-settings temp dir
+   * (`session-settings.ts`'s `IsolatedSettings.settingsPath`'s directory) —
+   * `claude` reads its `--settings <path>` argument at startup, and under
+   * `(deny default)` that random `os.tmpdir()`-rooted path needs an
+   * explicit allow or every isolated session breaks. Distinct from
+   * `readOnly` (F6's user-configured "read but never write" policy dirs) —
+   * this is cortex's OWN plumbing, not part of the agent's granted work
+   * scope, so it is kept as its own field rather than silently widening
+   * `readOnly`'s meaning. `generateMacosSbplProfile` (v1) ignores this too
+   * — `(allow default)` already covers it.
+   */
+  internalReadOnly: string[];
 }
 
 /**
@@ -114,6 +164,29 @@ export const SANDBOX_EXEC_ALLOW_SEED: readonly string[] = Object.freeze([
   "node",
   "git",
   "gh",
+  // cortex#2409 part 2 — added while deriving the v2 `strict` allow set
+  // (previously dead data: `execAllow` had NO enforcing consumer before
+  // this slice — grep confirms zero non-test reads — so this addition
+  // changes no prior behavior). Both are genuine compatibility-contract
+  // needs, not strict-specific: cortex's own hooks carry a
+  // `#!/usr/bin/env bun` shebang (verified against this repo's installed
+  // `~/.claude/hooks/*.hook.ts`), so the kernel-level exec chain for EVERY
+  // hook invocation is `env` → `bun` — the shebang interpreter itself must
+  // be exec-allowed, not just the ultimate `bun` it launches. `sh` is what
+  // Claude Code's own Bash tool execs internally (measured directly: a real
+  // `claude --print` session run under a naive strict profile denied
+  // `process-exec* /bin/sh` the moment the Bash tool ran). `bash` is a
+  // SEPARATE finding, also measured directly on this host (macOS 26.5.1):
+  // `/bin/sh` here is not the interpreter itself but a small ~100KB
+  // "variant selector" stub that internally re-execs `/bin/bash` for a
+  // shell invocation of the shape a Bash-tool command actually uses (`sh -c
+  // "…"` with a redirect) — `sandbox-exec` reported this exactly:
+  // `Failed to exec /bin/bash as variant for /bin/sh (1: Operation not
+  // permitted)`. Without `bash` on the seed too, `sh` alone is necessary
+  // but not sufficient for a REAL shell command to run under `strict`.
+  "env",
+  "sh",
+  "bash",
 ]);
 
 export const SANDBOX_EGRESS_ALLOW_SEED: readonly string[] = Object.freeze([


### PR DESCRIPTION
Closes #2409. The slice where L2 becomes an actual boundary. **Unreachable in production** — double-gated: `sandboxMode ?? "off"` AND `sandboxPosture ?? "guarded"`, with no caller setting either. Merging changes nothing at runtime.

## E4's SIGABRT — root-caused and properly fixed

`(deny default)` aborted the session (exit 134) and **no denial was ever logged**, which is why the unified-log approach could not see it. Cause: **dyld's own bootstrap** fails on syscalls `deny default` blocks *before* denial logging exists. Found via the macOS **crash reporter**.

Fixed by importing Apple's own `dyld-support.sb` / `system.sb` fragments — **not** by weakening deny-default. The allow set is derived round-by-round with per-entry evidence (workspace, config home, `.claude.json` + lock atomic-write family, keychain read-only, `/bin/sh` → `/bin/bash` chain, security CLI, TLS/DNS baseline, `execAllow` seed resolved via `Bun.which` then realpath).

## Verified by me, on the real kernel

| Must be denied (no rule names these) | Result |
|---|---|
| read an out-of-scope file | EPERM |
| write into a read-only dir | EPERM |
| read `~/.ssh/id_ed25519` | EPERM |

That is the property `guarded` structurally could not have: things are denied **because nothing allows them**, not because someone enumerated them. Allow side confirmed working: `/bin/sh`, `/bin/bash`, workspace writes, and exec of a seed binary all succeed.

## Explicit residual — the real-session e2e is NOT currently re-runnable

`cc-session-macos-sandbox-e2e.test.ts` (genuine `claude --print` + `--resume`) passed earlier in the build session, but **the account's weekly quota is exhausted** (resets Jul 29 at 1pm Pacific/Auckland), so it cannot be re-run now. The builder reported the quota-blocked re-run honestly rather than claiming a pass — the right call, and the reason this residual is stated rather than glossed.

**Hard gate: that e2e must be green before `strict` is selected anywhere.** Nothing can select it today, so this merges as inert capability.

## Also in here

A hazardous test was **removed** (`7b19ccf3`): it spawned a real `claude` against the machine's actual `$HOME` with keychain read stripped, while `~/.claude.json` stayed writable — so a failed auth check in the sandboxed child could write logged-out state to the real global config. Standing rule now: never point a restrictive-profile real-session test at live `$HOME` / auth state; use a fixture home.

## Disclosed limits

Keychain contents stay unprotected **by design** (denying the read kills the session — measured, permanent). L2 does not confine network — that is L3 (#2412). The Homebrew-package-root heuristic is unverified on non-Homebrew hosts.

## Tests

Baseline 11035 → 11065 pass; failing names pre-existing/environmental on both sides, zero sandbox-related. `tsc --noEmit` and lint clean. `guarded` byte-unchanged.
