### PR TITLE
docs(security): test specs for NWS adversarial round 2 + Linux field validation

### DIFF
--- a/docs/design-test-spec-linux-field.md
+++ b/docs/design-test-spec-linux-field.md
@@ -1,0 +1,166 @@
+# Test Spec — Linux field validation of the execution-boundary hardening
+
+**Status:** Draft for review
+**Tester:** Vincent Zontini (fresh-install / bring-up, Debian/Linux)
+**Author:** Luna (with Andreas)
+**Refs:** epic [cortex#2341](https://github.com/the-metafactory/cortex/issues/2341) · [vision#4 §4](https://github.com/the-metafactory/vision/issues/4) (trust & hardening) · [cortex#2424](https://github.com/the-metafactory/cortex/issues/2424) (Phase-0 field-test hardening) · `docs/design-session-sandbox-platforms.md` · `docs/security/hardening-plan.md`
+
+---
+
+## 1. Problem
+
+Seven slices of execution-boundary hardening landed between 2026-07-24 and 2026-07-26 (see §Appendix). **All of it was built and verified on macOS.** The Linux half is undischarged, and one specific gate cannot be answered from a Mac at all:
+
+> **DD-8b — does a kernel-level sandbox actually work in the real Linux deployment topology?**
+
+Measured on this developer machine (`-platforms.md` E5/E6): `bubblewrap` **fails inside a container even as root**, and works only where user namespaces are permitted. A Docker probe established the dependency but ran on a VM kernel, so it explicitly does **not** discharge the gate. Until a real Debian host answers it, the Linux sandbox backend (EBH-3b) is unstartable — we do not know which backend to build.
+
+**This spec asks a Linux field tester to answer that**, alongside the normal install/bring-up walkthrough.
+
+### What this spec does NOT ask for
+
+Vincent is a **usability and bring-up** tester, not a security reviewer. Nothing here requires security expertise, exploit-writing, or adversarial thinking. The adversarial re-test is a **separate** engagement for Rob Chuvala (NWS), scheduled in vision#4 §4 as *"second NWS swarm attack round after EBH-1 + audit-mode backends land"*.
+
+---
+
+## 2. Design decision
+
+**DD-TS1 — the hardening ships OFF; this test validates that it stays invisible.**
+
+Every boundary built in #2341 is **disabled by default**: `sandboxMode` defaults `"off"`, `sandboxPosture` defaults `"guarded"`, `plugins.signing` defaults `"off"`, `sovereignty.enforce` defaults `false`. No caller sets any of them.
+
+So the **primary success criterion is a non-event**: a fresh Linux install must behave exactly as it did before this work. A tester noticing *anything* is a finding.
+
+The secondary criterion is **capability reporting** — what the host *could* enforce, which is the input EBH-3b needs.
+
+---
+
+## 3. Test classes
+
+| Class | Question | Needs security expertise? |
+|---|---|---|
+| **A — Regression** | Did the hardening break the normal install/bring-up path? | No |
+| **B — Capability** | What sandbox primitives does this host actually support? | No |
+| **C — Observability** | Does cortex correctly *report* that no boundary is enforced? | No |
+
+Class B is the one that unblocks EBH-3b.
+
+---
+
+## 4. Harness contract
+
+- **Run on a real Debian/Linux host**, not a container, unless a scenario says otherwise. Containerisation is the variable under test in T-B3.
+- **Read-only and reversible.** No scenario asks you to enable enforcement, edit live config, or run anything destructive. If a step seems to want that, stop and say so — that is a spec bug.
+- **Report what you observe, not what you conclude.** "Command X printed Y" is worth more than "the sandbox works". If something is ambiguous, say it was ambiguous.
+- **A failure is a result.** T-B1 returning "not supported" is a *successful test* — it tells us which backend to build. There is no wrong answer.
+- Paste actual command output. Exit codes matter; so does stderr.
+
+---
+
+## 5. Scenarios
+
+### Class A — Regression (does it still just work?)
+
+**T-A1 — Fresh install.** Install cortex on a clean Debian host per the standard onboarding SOP. Record any step that differs from your previous runs (#1678, #1737, #2331), any new prompt, warning, or delay.
+*Pass:* install completes as before, no new friction.
+
+**T-A2 — First boot.** Start the stack. Capture full boot output.
+*Pass:* boots to healthy. **Any hard failure mentioning `plugin`, `signing`, `renderer coverage`, or `sandbox` is a priority finding** — those are new code paths and they are supposed to be inert.
+
+**T-A3 — Normal session.** Run whatever your usual bring-up smoke test is (dispatch a message, get a response).
+*Pass:* unchanged behaviour, no new latency.
+
+**T-A4 — Uninstall/reinstall.** Per #2424's install/uninstall path.
+*Pass:* clean, as before.
+
+### Class B — Capability (the EBH-3b gate — the valuable part)
+
+Run these directly in a shell. They are diagnostics, not cortex commands.
+
+**T-B1 — Is `bubblewrap` available and functional?**
+```bash
+which bwrap || echo "NOT INSTALLED"
+bwrap --ro-bind / / --dev /dev true 2>&1; echo "exit=$?"
+```
+Report both. If not installed, also report `apt-cache policy bubblewrap`.
+
+**T-B2 — Are unprivileged user namespaces permitted?**
+```bash
+cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null || echo "(knob absent)"
+cat /proc/sys/user/max_user_namespaces
+unshare --user --map-root-user true 2>&1; echo "exit=$?"
+```
+
+**T-B3 — Same three commands, inside a container**, if you can run one (`docker run -it debian` or equivalent). This is the case that failed on the developer's machine; we need to know whether that reproduces on a real host.
+
+**T-B4 — Is Landlock present?**
+```bash
+uname -r
+grep -i landlock /boot/config-$(uname -r) 2>/dev/null || echo "(no config file)"
+```
+
+**T-B5 — systemd hardening.** If running cortex under systemd:
+```bash
+systemd-analyze security cortex@<your-stack>.service 2>&1 | head -30
+```
+Report the overall exposure score and any directive listed as unsafe.
+
+### Class C — Observability
+
+**T-C1 — Does cortex say it has no boundary?** With the stack running, search the boot log for `sandbox-unavailable`.
+*Pass:* a line appears stating no kernel boundary is enforcing the session, naming backend `none`.
+*This is the correct and expected state on Linux today* — the macOS backend exists, the Linux one does not yet. We are verifying cortex is **honest about it** rather than silently pretending to be protected.
+
+---
+
+## 6. SOP
+
+1. Work from a clean Debian host at the current cortex release.
+2. Run Class A first — if install is broken, stop and report; B and C need a working install (except T-B1..B4, which are pure shell and can run regardless).
+3. File one issue per finding against `the-metafactory/cortex`, labelled `bug` + `now`, referencing this file.
+4. Post a single summary comment on **#2341** with the Class B results table — that is the EBH-3b input.
+
+---
+
+## 7. Non-goals
+
+- **Not a security assessment.** No exploit attempts, no adversarial probing. That is Rob's engagement.
+- **Not a test of enforcement.** Nothing is enabled; there is nothing to enforce yet.
+- **Not a performance benchmark.**
+- **Not macOS.** Covered already.
+
+---
+
+## 8. Open questions (each with a recommendation)
+
+**OQ-TS1 — Should Vincent run T-B3 (container case) at all, given the added setup?**
+*Recommendation: yes, but mark it optional.* It is the single most informative result — it decides whether the Linux backend can be `linux-bwrap` or must be `container-delegated` (DD-8, delegate-don't-nest). If it costs him more than ~15 minutes, skip it and we accept a slower EBH-3b.
+
+**OQ-TS2 — Should this spec wait for the next cortex release?**
+*Recommendation: yes.* v2 `strict` (`8ed20b62`) is currently unreleased, and one egress fix is in flight. Testing a version that isn't a release makes findings hard to attribute. Cut the release first, then hand this over.
+
+**OQ-TS3 — Is `systemd-analyze security` (T-B5) meaningful given the unit hardening merged in OQ-5?**
+*Recommendation: yes, and record the score as a baseline.* We applied `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only` and traced `ReadWritePaths` — but only ever validated them in CI, never on a real Debian host under a real workload.
+
+---
+
+## 9. Delivery
+
+- **Deliverable from Vincent:** the Class B results table on #2341, plus one issue per Class A/C finding.
+- **What it unblocks:** EBH-3b (Linux backend) — currently unstartable.
+- **Estimated effort:** ~45 min for Classes A + C alongside a normal bring-up run; ~15 min for Class B; +15 min if T-B3 is attempted.
+
+---
+
+## Appendix — what landed (for context only; no action required)
+
+| Slice | What | Default |
+|---|---|---|
+| EBH-1 (×8 rounds) | Path guard for file tools + Bash read paths | **live** |
+| EBH-2 | Session-sandbox choke point | off |
+| EBH-3a | macOS `sandbox-exec` backend | off |
+| EBH-4 | Egress allowlist proxy | off |
+| #2409 pt1/pt2 | Sensitive set + deny-default `strict` posture | off |
+| EBH-5 | Plugin bundle signature verification | off |
+| EBH-6/6b | Sovereignty posture made configurable | off (audit-only) |
+| #2386 | Persona `allowedTools` enforced at dispatch | **live** |

--- a/docs/design-test-spec-nws-round-2.md
+++ b/docs/design-test-spec-nws-round-2.md
@@ -1,0 +1,121 @@
+# Test Spec — NWS adversarial round 2 (response to the 2026-07-23 review)
+
+**Status:** Draft for review
+**Reviewer:** Robert Chuvala — NorthWoods Sentinel Labs
+**Author:** Luna (with Andreas)
+**Refs:** [`reviews/2026-07-23-nws-security-review.md`](security/reviews/2026-07-23-nws-security-review.md) · [`hardening-plan.md`](security/hardening-plan.md) · epic [cortex#2341](https://github.com/the-metafactory/cortex/issues/2341) · [vision#4 §4](https://github.com/the-metafactory/vision/issues/4)
+
+---
+
+## 1. Purpose
+
+Round 1 produced one diagnosis under every finding:
+
+> **Cortex enforces at the gate, not at execution.** Boundaries were declared at load-time and prompt-time, but once an agent driven by untrusted content was running, most boundaries were *an instruction the model was asked to obey*, not a wall that stopped it.
+
+Seven slices have since landed. This round asks whether that is actually true now, or whether we have merely built a more convincing description of a boundary.
+
+**The most useful thing you can do is prove a claim in §4 false.** Those are our load-bearing assertions. We would rather learn they are wrong from you than from an incident.
+
+---
+
+## 2. Read this before you start — what ships OFF
+
+This matters more than anything else in the spec, and it will shape what a runtime probe finds.
+
+**Almost all of the new enforcement is disabled by default.** `sandboxMode` defaults `"off"`, `sandboxPosture` defaults `"guarded"`, `plugins.signing` defaults `"off"`, `sovereignty.enforce` defaults `false`. **No caller sets any of them.** This was deliberate: build the boundary, verify it, enable it as a separate decision with a separate blast radius.
+
+Consequence: **a black-box probe of a default deployment will find roughly what you found in round 1**, because at runtime little has changed. That is not a finding — it is the documented posture.
+
+Two things *are* live and worth attacking directly:
+
+| Live control | What it does |
+|---|---|
+| **L1 path guard** (`src/runner/hooks/path-guard.hook.ts`, `bash-guard.hook.ts`) | Cortex-owned `PreToolUse` containment for file tools **and** Bash read-command paths |
+| **Persona `allowedTools`** (`src/bus/dispatch-handler.ts`) | A declared tool allowlist is now enforced at dispatch |
+
+Everything else should be assessed as **code review of a boundary that is not yet switched on** — which is exactly the moment it is cheapest to fix.
+
+---
+
+## 3. What changed, mapped to your findings
+
+| Your finding | What landed | Default | Where |
+|---|---|---|---|
+| **F1** file tools have no `PreToolUse` hook | Cortex-owned path guard; **nine** adversarial rounds (see §5) | **live** | `path-guard.hook.ts`, `bash-guard.hook.ts` |
+| **F1** (kernel) | macOS `sandbox-exec` backend; `guarded` (denylist) + `strict` (deny-default) postures | off | `session-sandbox-macos.ts` |
+| **F6** `readOnlyDirs` is a preamble sentence | Wired through the dispatch seam; read-only enforced at the kernel layer | live (L1) / off (L2) | `cc-session.ts` |
+| **F3** sovereignty audit-only, unreachable | Promoted to a real config key, threaded to both consumers | off — still audit-only | `policy.sovereignty.enforce` |
+| **F4** principal-DM disables the Bash guard | Path containment now applies in guard-off sessions (lenient mode) | live | `bash-guard.hook.ts` |
+| **F2** plugins at full daemon authority | Bundle signature verification before `import()`; `off`/`permissive`/`enforce` | off | `plugin-signing.ts`, `loader.ts` |
+| — (new) | L3 egress allowlist proxy, deny-by-default | off | `egress-proxy.ts` |
+| **#1758** web-gateway bypasses `DispatchHandler` | **Still open.** Documented, not fixed | — | `bus-inbound-sink.ts:186` |
+
+---
+
+## 4. Claims we are making — please try to refute these
+
+Each is a specific, falsifiable assertion. Breaking any one is a high-value finding.
+
+**C1 — L1 containment has no remaining bypass.** Nine rounds closed: blacklist→whitelist inversion, `~user` expansion, brace expansion, bare-relative flag values, `git diff --no-index` arbitrary-file dump, `gh --body-file` remote exfil, `file -flist`, coverage-drift via an opt-in command list, and the guard-off residual. We believe the class is closed. *We think this is the claim most likely to be false.*
+
+**C2 — L2 `strict` denies out-of-scope reads by construction, not enumeration.** Under `(deny default)`, a path is denied because nothing allows it. Verified: out-of-scope file, read-only-dir write, and `~/.ssh/id_ed25519` all refused with `EPERM` while no rule names any of them.
+
+**C3 — L2 `guarded` is NOT a boundary and we do not claim it is.** It is `(allow default)` + a denylist. Eleven secret-bearing stores read straight through it before we extended the set. *A denylist cannot be completed by adding entries.* If you find our docs anywhere implying otherwise, that is a finding.
+
+**C4 — The plugin signing gate cannot be bypassed.** Verification runs from bytes on disk before `await import()`. Our own adversarial pass found and fixed a complete bypass via `cortex plugin reload` (a second `import()` site that skipped verification). We audited for a third; we may have missed one.
+
+**C5 — L3 egress holds only for cooperating clients.** A process that ignores proxy env vars and opens a raw socket defeats it. We state this rather than claiming containment.
+
+**C6 — The keychain cannot be protected from the session.** Denying `~/Library/Keychains` read kills the session (`Not logged in`). `claude` authenticates through it. We believe this is permanent; if you see a way around it, we want to know.
+
+**C7 — `mode: off` is a byte-identical no-op.** All the new machinery is genuinely inert by default.
+
+---
+
+## 5. Where we think we are weakest
+
+Offered honestly, so you can spend effort where it counts rather than rediscovering what we already know.
+
+- **#1758 — the web-gateway path bypasses `DispatchHandler` entirely**, so per-agent tool policy is inert for web-bound agents. Known, open, documented. The persona `allowedTools` work inherits this hole.
+- **Coverage completeness.** Twice now we fixed a control at the call site in front of us and left a second one open (L1's nine rounds; plugin reload). **Assume there is a third.**
+- **TOCTOU at L1.** Unfixable there — cortex does not control the `open()`; Claude Code's tools re-open the path. L2 is the real answer.
+- **Plugin process isolation (F2) is NOT built.** ADR-0024 D4 still stands as an accepted risk. Signing narrows *which* code loads; it does nothing about what loaded code can do.
+- **Linux is unvalidated.** All of L2 is macOS-only. The Linux backend is unstartable pending a capability gate (see the companion Linux field-test spec).
+- **The `strict` real-session e2e could not be re-run at merge** (account quota). It passed during development. Treat `strict`'s real-world compatibility as *asserted, not currently re-verified*.
+
+---
+
+## 6. Suggested method
+
+1. **Code review over black-box probing**, for the reasons in §2 — most controls are off, so runtime probing under-tests them.
+2. **Attack the claims in §4 directly.** A refutation with a reproduction beats a broad sweep.
+3. **For the live controls (L1, persona tools), black-box is fair game** and welcome.
+4. If you want to assess enforcement behaviour, enable it explicitly in a **throwaway** deployment — `sandboxMode: "audit"`, then `"enforce"`. Please do not enable on anything real; these paths have never run in production.
+5. The nine L1 rounds are in `EBH-HARDENING-LEDGER.md` with the bypass and the fix for each — useful for finding round ten.
+
+---
+
+## 7. Non-goals
+
+- Not a re-audit of what round 1 already covered and we did not touch.
+- Not a performance or availability assessment.
+- Not the paid behavioural/intent-fidelity work — that remains a separate proposal.
+
+---
+
+## 8. Open questions for you
+
+**OQ-N1 — Is "build it, verify it, ship it off" the right posture?** We chose it to separate correctness risk from availability risk. The cost is that little is enforced today. Would you rather see audit mode enabled by default?
+
+**OQ-N2 — Is the enumerated sensitive set worth maintaining at all**, given a denylist cannot be completed? Or should we go straight to `strict` everywhere and delete `guarded`?
+
+**OQ-N3 — Does the swarm-posture structural check** (`docs/security/swarm-posture/`) measure anything you consider meaningful, or is it security theatre?
+
+---
+
+## 9. Delivery
+
+- **Format:** whatever suits you; round 1's review document worked well.
+- **Filing:** findings as issues on `the-metafactory/cortex` referencing #2341, or one document — your preference.
+- **What we will do with it:** the same as round 1 — verify every claim against source before planning, and tell you which ones did not survive verification.


### PR DESCRIPTION
Two companion test specs closing out epic #2341, in the format of the test-bench spec (#2273). Docs only.

## `design-test-spec-nws-round-2.md` — Robert Chuvala (NWS)

The adversarial re-test [vision#4 §4](https://github.com/the-metafactory/vision/issues/4) schedules for *"after EBH-1 + audit-mode backends land"*.

It leads with the thing that most affects his time: **almost everything ships OFF** (`sandboxMode` `"off"`, `sandboxPosture` `"guarded"`, `plugins.signing` `"off"`, `sovereignty.enforce` `false`, no caller sets any). So a black-box probe of a default deployment will find roughly what round 1 found — **that is documented posture, not a finding**, and saying so up front stops him spending a day rediscovering it. Only the L1 path guard and persona `allowedTools` are live.

The core of it is **seven falsifiable claims (C1–C7) with an invitation to break them** — including which one we think is most likely to be false (C1, "L1 has no remaining bypass"). An adversarial reviewer is most valuable aimed at specific assertions rather than sweeping.

§5 lists where we think we are weakest, offered so he doesn't rediscover known gaps: #1758 still open; TOCTOU unfixable at L1; plugin process isolation not built (ADR-0024 D4 stands); Linux unvalidated; the `strict` real-session e2e asserted-but-not-currently-re-verified (quota). It states plainly that **we assume a third un-audited `import()`-style call site exists**, having twice fixed one control and missed a second.

## `design-test-spec-linux-field.md` — Vincent Zontini

For a **bring-up tester, not a security reviewer** — no security expertise required, and it says so, since the adversarial round is Rob's separate engagement.

Its real purpose is the **DD-8b capability gate that EBH-3b is blocked on**. All of L2 was built and verified on macOS; the Linux backend is unstartable until someone answers whether `bubblewrap` and unprivileged user namespaces work on a real Debian host — *including inside a container*, which failed on the developer machine even as root. Five shell diagnostics answer it.

Because the hardening ships off, the regression criterion is a **non-event**: a fresh install must behave exactly as before, and noticing anything is a finding. It states explicitly that a "not supported" result is a **successful test** — there is no wrong answer.

## Recommendation recorded in both

**Hand these over after the next release.** v2 `strict` (`8ed20b62`) is currently unreleased and an egress fix is in flight; testing a moving `main` makes findings hard to attribute to a version.
