### PR TITLE
fix(runner): audit mode must not block — plain-HTTP forward-proxy support (#2346 follow-up)

### DIFF
--- a/src/runner/__tests__/egress-proxy.test.ts
+++ b/src/runner/__tests__/egress-proxy.test.ts
@@ -67,19 +67,14 @@ describe("tryParseConnect — pure parser", () => {
       enc("CONNECT api.anthropic.com:443 HTTP/1.1\r\nHost: api.anthropic.com:443\r\n\r\nTRAILING"),
     );
     expect(result?.ok).toBe(true);
-    if (result?.ok) {
+    if (result?.ok && result.kind === "connect") {
       expect(result.host).toBe("api.anthropic.com");
       expect(result.port).toBe(443);
       expect(new TextDecoder().decode(result.trailing)).toBe("TRAILING");
     }
   });
 
-  test("non-CONNECT verb is a parse failure (plain-HTTP forward-proxying is out of scope)", () => {
-    const result = tryParseConnect(enc("GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n"));
-    expect(result?.ok).toBe(false);
-  });
-
-  test("non-numeric / out-of-range port is a parse failure", () => {
+  test("non-numeric / out-of-range CONNECT port is a parse failure", () => {
     expect(tryParseConnect(enc("CONNECT example.com:notaport HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
     expect(tryParseConnect(enc("CONNECT example.com:70000 HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
     expect(tryParseConnect(enc("CONNECT example.com:0 HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
@@ -87,6 +82,96 @@ describe("tryParseConnect — pure parser", () => {
 
   test("garbage before the terminator is a parse failure, not a crash", () => {
     expect(tryParseConnect(enc("\x00\x01\x02 not http at all\r\n\r\n"))?.ok).toBe(false);
+  });
+
+  test("a verb this parser doesn't recognize at all is a parse failure", () => {
+    expect(tryParseConnect(enc("WHATEVER http://example.com/ HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// cortex#2412 follow-up — plain-HTTP absolute-URI forward-proxy parsing.
+// `HTTP_PROXY` clients (as opposed to `HTTPS_PROXY`) send this shape, not
+// CONNECT; before this fix it fell into the CONNECT parser's failure branch
+// and was fail-closed denied in EVERY mode, including `audit` — defeating
+// `audit`'s entire report-only purpose (see the module doc's "Fail-closed
+// discipline" section for the full rationale).
+// -----------------------------------------------------------------------------
+
+describe("tryParseConnect — plain-HTTP absolute-URI forward-proxy requests", () => {
+  const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+  const decode = (result: ReturnType<typeof tryParseConnect>): string => {
+    if (!result || !result.ok || result.kind !== "http-forward") {
+      throw new Error("expected a parsed http-forward result");
+    }
+    return new TextDecoder().decode(result.forwardBytes);
+  };
+
+  test("GET with an explicit port parses host/port and is no longer a failure", () => {
+    const result = tryParseConnect(enc("GET http://example.com:8080/path HTTP/1.1\r\nHost: example.com:8080\r\n\r\n"));
+    expect(result?.ok).toBe(true);
+    if (result?.ok) {
+      expect(result.kind).toBe("http-forward");
+      expect(result.host).toBe("example.com");
+      expect(result.port).toBe(8080);
+    }
+  });
+
+  test("no explicit port defaults to 80 (plain-HTTP default)", () => {
+    const result = tryParseConnect(enc("POST http://localhost/api/events/ingest HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.kind === "http-forward") {
+      expect(result.host).toBe("localhost");
+      expect(result.port).toBe(80);
+    }
+  });
+
+  test("rewrites the request line to origin-form (path only, no scheme/host)", () => {
+    const text = decode(
+      tryParseConnect(enc("POST http://localhost:8766/api/events/ingest HTTP/1.1\r\nHost: localhost:8766\r\n\r\n")),
+    );
+    expect(text.split("\r\n")[0]).toBe("POST /api/events/ingest HTTP/1.1");
+  });
+
+  test("preserves the client's Host header verbatim — does not duplicate it", () => {
+    const text = decode(
+      tryParseConnect(enc("POST http://localhost:8766/x HTTP/1.1\r\nHost: localhost:8766\r\nX-Foo: bar\r\n\r\n")),
+    );
+    const hostLines = text.split("\r\n").filter((l) => /^host:/i.test(l));
+    expect(hostLines).toHaveLength(1);
+    expect(hostLines[0]).toBe("Host: localhost:8766");
+    expect(text).toContain("X-Foo: bar");
+  });
+
+  test("synthesizes a Host header when the client didn't send one", () => {
+    const text = decode(tryParseConnect(enc("GET http://example.com:8080/path HTTP/1.1\r\n\r\n")));
+    expect(text).toContain("Host: example.com:8080\r\n");
+  });
+
+  test("synthesized Host header omits :80 for the default port", () => {
+    const text = decode(tryParseConnect(enc("GET http://example.com/path HTTP/1.1\r\n\r\n")));
+    expect(text).toContain("Host: example.com\r\n");
+    expect(text).not.toContain("Host: example.com:80");
+  });
+
+  test("no path defaults to origin-form \"/\"", () => {
+    const text = decode(tryParseConnect(enc("GET http://example.com HTTP/1.1\r\n\r\n")));
+    expect(text.split("\r\n")[0]).toBe("GET / HTTP/1.1");
+  });
+
+  test("body bytes already buffered past the terminator are appended after the rewritten headers", () => {
+    const result = tryParseConnect(
+      enc('POST http://localhost:8766/ingest HTTP/1.1\r\nHost: localhost:8766\r\nContent-Length: 11\r\n\r\n{"ok":true}'),
+    );
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.kind === "http-forward") {
+      const text = new TextDecoder().decode(result.forwardBytes);
+      expect(text.endsWith('{"ok":true}')).toBe(true);
+    }
+  });
+
+  test("malformed absolute-URI port is a parse failure", () => {
+    expect(tryParseConnect(enc("GET http://example.com:notaport/ HTTP/1.1\r\n\r\n"))?.ok).toBe(false);
   });
 });
 
@@ -114,6 +199,47 @@ function startEchoServer(): { port: number; connections: number; stop: () => voi
   });
   return {
     port: listener.port,
+    get connections() {
+      return connections;
+    },
+    stop: () => listener.stop(true),
+  };
+}
+
+/** A minimal real HTTP-ish server: captures the raw bytes of every request
+ *  it receives (so a test can assert the proxy rewrote the request line to
+ *  origin-form, added a Host header, etc.) and answers with a real,
+ *  well-formed HTTP/1.1 response. Used as the "destination" for the
+ *  plain-HTTP absolute-URI forward-proxy tests — the whole point of those
+ *  tests is that a REAL HTTP round trip completes, not merely that no error
+ *  came back. */
+function startCapturingHttpServer(): {
+  port: number;
+  requests: () => string[];
+  connections: number;
+  stop: () => void;
+} {
+  let connections = 0;
+  const requests: string[] = [];
+  const RESPONSE = "HTTP/1.1 200 OK\r\nContent-Length: 7\r\n\r\ngot-it!";
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open() {
+        connections += 1;
+      },
+      data(socket, chunk) {
+        requests.push(new TextDecoder().decode(chunk));
+        socket.write(RESPONSE);
+      },
+      close() {},
+      error() {},
+    },
+  });
+  return {
+    port: listener.port,
+    requests: () => requests,
     get connections() {
       return connections;
     },
@@ -267,8 +393,147 @@ describe("EgressProxy — audit mode (DD-5 report-only)", () => {
   });
 });
 
-describe("EgressProxy — fail-closed on ambiguity, in EVERY mode", () => {
-  test("a malformed (non-CONNECT) request is denied even in audit mode", async () => {
+// -----------------------------------------------------------------------------
+// cortex#2412 follow-up — plain-HTTP absolute-URI forward, real sockets.
+//
+// THE core regression: before this fix, `audit` mode responded to an
+// unparseable-to-the-old-parser plain-HTTP request with `400 Bad Request`
+// and closed the socket — for EVERY plain-HTTP request, allowlisted or not,
+// because the old parser never even got as far as evaluating the
+// allowlist. That is a `blocked=true` outcome from a mode whose entire
+// contract is "never terminates, never writes an error response." The
+// tests below assert the ACTUAL fix: a plain-HTTP request completes
+// end-to-end (real response bytes, not just "no error") in both the
+// allowed and NOT-allowed-under-audit cases, and is refused only where
+// `enforce` is supposed to refuse it.
+// -----------------------------------------------------------------------------
+
+describe("EgressProxy — plain-HTTP absolute-URI forward (allowlisted destination)", () => {
+  test("POST to an allowed host completes end-to-end: origin-form + Host header at the target, real response relayed to the client", async () => {
+    const target = startCapturingHttpServer();
+    activeServers.push(target);
+
+    const proxy = new EgressProxy(["127.0.0.1"], "enforce");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const client = await connectToProxy(port);
+    client.write(
+      `POST http://127.0.0.1:${target.port}/api/events/ingest HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${target.port}\r\n` +
+        `Content-Length: 2\r\n\r\nhi`,
+    );
+
+    // Real end-to-end proof: the client actually gets the target's real
+    // HTTP response body, not merely "no 400/403 came back".
+    await until(() => client.received().includes("got-it!"));
+    expect(client.received()).toContain("HTTP/1.1 200 OK");
+    expect(client.received()).toContain("got-it!");
+
+    await until(() => target.connections === 1);
+    const [request] = target.requests();
+    expect(request).toBeDefined();
+    // The target sees origin-form, not the absolute-URI the client sent.
+    expect(request?.startsWith("POST /api/events/ingest HTTP/1.1\r\n")).toBe(true);
+    expect(request).toContain(`Host: 127.0.0.1:${target.port}`);
+
+    client.close();
+  });
+});
+
+describe("EgressProxy — plain-HTTP absolute-URI forward, NOT-allowlisted destination, audit mode (the bug)", () => {
+  test("a plain-HTTP POST to a non-allowlisted host completes end-to-end under audit — no error response, no termination — and is recorded blocked:false", async () => {
+    const target = startCapturingHttpServer();
+    activeServers.push(target);
+
+    // Allowlist names some OTHER host — the target is not on it, so this is
+    // exactly the "would enforce deny this" case audit is supposed to
+    // observe WITHOUT acting on it.
+    const proxy = new EgressProxy(["allowed.example"], "audit");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const denialsPromise = collectDenials(proxy, 1);
+
+    const client = await connectToProxy(port);
+    client.write(
+      `POST http://127.0.0.1:${target.port}/api/events/ingest HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${target.port}\r\n` +
+        `Content-Length: 2\r\n\r\nhi`,
+    );
+
+    // THE assertion that would have failed before the fix: a REAL response
+    // from the REAL destination arrives — not a 400, not a closed socket
+    // with nothing on it.
+    await until(() => client.received().includes("got-it!"));
+    expect(client.received()).toContain("HTTP/1.1 200 OK");
+    expect(client.received()).not.toContain("400 Bad Request");
+    expect(client.received()).not.toContain("403 Forbidden");
+
+    // The destination genuinely saw the request — audit really let it
+    // through, exactly like it already does for CONNECT.
+    await until(() => target.connections === 1);
+    const [request] = target.requests();
+    expect(request?.startsWith("POST /api/events/ingest HTTP/1.1\r\n")).toBe(true);
+
+    const denials = await denialsPromise;
+    expect(denials).toHaveLength(1);
+    expect(denials[0]?.blocked).toBe(false);
+    expect(denials[0]?.host).toBe("127.0.0.1");
+
+    client.close();
+  });
+});
+
+describe("EgressProxy — plain-HTTP absolute-URI forward, NOT-allowlisted destination, enforce mode", () => {
+  test("a plain-HTTP POST to a non-allowlisted host is refused with 403 and NEVER reaches the destination", async () => {
+    const target = startCapturingHttpServer();
+    activeServers.push(target);
+
+    const proxy = new EgressProxy(["allowed.example"], "enforce");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const denialsPromise = collectDenials(proxy, 1);
+
+    const client = await connectToProxy(port);
+    client.write(
+      `POST http://127.0.0.1:${target.port}/api/events/ingest HTTP/1.1\r\n` +
+        `Host: 127.0.0.1:${target.port}\r\n` +
+        `Content-Length: 2\r\n\r\nhi`,
+    );
+    await until(() => client.received().length > 0);
+    expect(client.received()).toContain("403");
+    expect(client.received()).not.toContain("got-it!");
+
+    const denials = await denialsPromise;
+    expect(denials).toHaveLength(1);
+    expect(denials[0]?.blocked).toBe(true);
+
+    // The whole point: a blocked plain-HTTP request never dials the
+    // destination at all — identical guarantee to CONNECT's.
+    expect(target.connections).toBe(0);
+
+    client.close();
+  });
+});
+
+describe("EgressProxy — fail-closed on ambiguity (NO determinable destination), in EVERY mode", () => {
+  // cortex#2412 follow-up: this describe block used to send a well-formed
+  // `GET http://example.com/ HTTP/1.1` request as its "ambiguous" example —
+  // but that request is NOT ambiguous at all (it names a destination in the
+  // standard plain-HTTP forward-proxy shape); the OLD parser simply didn't
+  // understand that shape yet. Routing it into the no-destination fail-
+  // closed branch was exactly the bug: it made `audit` kill traffic (cortex's
+  // own event-ingest POSTs) that `enforce`, given the SAME allowlist,
+  // wouldn't necessarily have blocked either — `audit` was blocking
+  // *differently* from what `enforce` would do, not predicting it. Now that
+  // the parser understands the absolute-URI shape (see the
+  // "plain-HTTP absolute-URI forward" describe blocks below), these tests
+  // use input that is genuinely unparseable — no verb this parser
+  // recognizes in either shape, so there is truly no destination to dial in
+  // ANY mode.
+  test("a request with no recognizable verb/shape is denied even in audit mode", async () => {
     const proxy = new EgressProxy(["anything.example"], "audit");
     activeProxies.push(proxy);
     const { port } = proxy.start();
@@ -276,21 +541,41 @@ describe("EgressProxy — fail-closed on ambiguity, in EVERY mode", () => {
     const denialsPromise = collectDenials(proxy, 1);
 
     const client = await connectToProxy(port);
-    client.write("GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n");
+    client.write("not even an HTTP request\r\n\r\n");
     await until(() => client.received().length > 0);
     expect(client.received()).toContain("400");
 
     const denials = await denialsPromise;
     expect(denials).toHaveLength(1);
-    // Fail-closed discipline: malformed requests are ALWAYS blocked, even
-    // though this proxy is running in "audit" (which for a RECOGNIZED-but-
-    // disallowed host would have let the connection through).
+    // Fail-closed discipline: a request with NO destination is ALWAYS
+    // blocked, even though this proxy is running in "audit" (which for a
+    // RECOGNIZED-but-disallowed destination would have let the connection
+    // through — see the "plain-HTTP absolute-URI forward" tests below).
     expect(denials[0]?.blocked).toBe(true);
 
     client.close();
   });
 
-  test("a malformed request is denied in enforce mode too", async () => {
+  test("a malformed CONNECT (bad port) is denied even in audit mode", async () => {
+    const proxy = new EgressProxy(["anything.example"], "audit");
+    activeProxies.push(proxy);
+    const { port } = proxy.start();
+
+    const denialsPromise = collectDenials(proxy, 1);
+
+    const client = await connectToProxy(port);
+    client.write("CONNECT example.com:999999 HTTP/1.1\r\n\r\n");
+    await until(() => client.received().length > 0);
+    expect(client.received()).toContain("400");
+
+    const denials = await denialsPromise;
+    expect(denials).toHaveLength(1);
+    expect(denials[0]?.blocked).toBe(true);
+
+    client.close();
+  });
+
+  test("a request with no recognizable verb/shape is denied in enforce mode too", async () => {
     const proxy = new EgressProxy(["anything.example"], "enforce");
     activeProxies.push(proxy);
     const { port } = proxy.start();

--- a/src/runner/egress-proxy.ts
+++ b/src/runner/egress-proxy.ts
@@ -1,6 +1,8 @@
 /**
  * EBH-4 (cortex#2346, epic #2341) — the L3 **egress allowlist**: a local,
- * deny-by-default HTTP `CONNECT` filtering proxy.
+ * deny-by-default forward proxy filtering both HTTP `CONNECT` (TLS tunnels)
+ * and plain-HTTP absolute-URI requests (cortex#2412 follow-up — see the
+ * module doc's "Mechanism" section below).
  *
  * ## What this closes
  *
@@ -52,13 +54,32 @@
  * ## Mechanism
  *
  * A per-session `Bun.listen` TCP server on `127.0.0.1:0` (OS-assigned
- * ephemeral port — never a fixed/predictable port). It speaks exactly ONE
- * proxy verb: HTTP `CONNECT host:port HTTP/1.1`. On a well-formed CONNECT
- * whose `host` is on the allowlist (exact, case-insensitive match — see
- * "no wildcards" below), it dials the target and becomes a raw byte tunnel
- * (the standard forward-proxy shape every HTTPS-over-proxy client expects).
- * Anything else — a host not on the allowlist, or a request this parser
- * cannot make sense of — is a deny.
+ * ephemeral port — never a fixed/predictable port). It speaks TWO proxy
+ * shapes:
+ *
+ *   - HTTP `CONNECT host:port HTTP/1.1` — the TLS-tunnel form every
+ *     HTTPS-over-proxy client uses. On a well-formed CONNECT whose `host`
+ *     is on the allowlist (exact, case-insensitive match — see "no
+ *     wildcards" below), it dials the target and becomes a raw byte tunnel.
+ *   - The plain-HTTP absolute-URI forward-proxy form (`POST
+ *     http://host[:port]/path HTTP/1.1`, per RFC 7230 §5.3.2 — any of
+ *     `GET`/`POST`/`PUT`/`DELETE`/`PATCH`/`HEAD`/`OPTIONS`/`TRACE`). This
+ *     is what `HTTP_PROXY` (as opposed to `HTTPS_PROXY`) actually sends —
+ *     cortex's OWN hook telemetry (`event-logger.hook.ts` et al. POSTing to
+ *     `http://localhost:8766/...`) takes exactly this shape, not CONNECT
+ *     (cortex#2412 follow-up). On a well-formed request whose `host` is on
+ *     the allowlist, the proxy dials the target and forwards the request
+ *     rewritten to origin-form (path only, `Host` header added if the
+ *     client didn't send one — RFC 7230 §5.3.2's proxy obligation), then
+ *     relays the response back verbatim; no synthetic reply is sent to the
+ *     client the way CONNECT's "200 Connection Established" is, because the
+ *     client is expecting a real HTTP response from the target, not a
+ *     tunnel handshake.
+ *
+ * Both forms funnel through the SAME allow/deny-by-mode decision (see
+ * "Fail-closed discipline" below) — a host not on the allowlist, or a
+ * request this parser cannot make sense of at all (no verb it recognizes,
+ * no destination it can extract), is a deny.
  *
  * **No wildcard/suffix matching, deliberately.** `api.anthropic.com` matches
  * only `api.anthropic.com`, never `*.anthropic.com`. This is the SAFER
@@ -71,17 +92,34 @@
  *
  * ## Fail-closed discipline (repo CLAUDE.md hard constraint)
  *
- *   - A CONNECT line this parser cannot understand (bad syntax, non-numeric
- *     port, out-of-range port, or any non-CONNECT proxy verb — plain-HTTP
- *     forward-proxying is NOT implemented in this slice) is **always
- *     denied**, in EVERY mode including `audit`. "We could not determine
- *     the destination" is ambiguity, and ambiguity denies — it is never
- *     treated as "well, let it through, we're only auditing."
- *   - A host recognized but NOT on the allowlist follows {@link SandboxMode}:
- *     `audit` logs the would-be-denial and STILL connects through (DD-5's
- *     report-only semantics — unlike the macOS FS backend, this mechanism
- *     genuinely CAN report without blocking, so it does); `enforce` blocks
- *     with `403` and never dials the target.
+ * The dividing line is NOT "which mode" — it's "does this request have a
+ * destination at all":
+ *
+ *   - A request with **no determinable destination** — garbage bytes, a
+ *     verb this parser doesn't recognize in either shape above, a CONNECT
+ *     with a non-numeric/out-of-range port, an absolute-URI request with an
+ *     unparseable host/port, or a header that never terminates within
+ *     {@link MAX_HEADER_BYTES} — is **always denied, in EVERY mode
+ *     including `audit`**. This is NOT a policy choice `audit` could relax:
+ *     there is no host to dial, so there is no "traffic" for `audit` to
+ *     "let proceed." `enforce` would refuse this identically (an
+ *     unaddressable request isn't a destination *enforce* would reach
+ *     either), so `audit` denying it too is `audit` correctly PREDICTING
+ *     `enforce` — not a departure from DD-5's report-only contract, which
+ *     is specifically about mode-governed ALLOWLIST decisions, not about
+ *     requests with no destination to evaluate one against.
+ *   - A request WITH a determinable destination (CONNECT or the plain-HTTP
+ *     absolute-URI form) whose host is recognized but NOT on the allowlist
+ *     follows {@link SandboxMode}: `audit` logs the would-be-denial and
+ *     STILL connects/forwards through — no error response, no socket
+ *     termination (DD-5's report-only semantics — unlike the macOS FS
+ *     backend, this mechanism genuinely CAN report without blocking, so it
+ *     does); `enforce` blocks with `403`/`400` and never dials the target.
+ *     This is the ONLY axis `audit` vs `enforce` actually differ on — see
+ *     cortex#2412's follow-up fix, which closed a bug where an unparseable
+ *     plain-HTTP request (a shape this module simply didn't parse yet) was
+ *     wrongly routed into the no-destination branch above and killed even
+ *     under `audit`, defeating `audit`'s entire dry-run purpose.
  *   - If the proxy itself fails to bind, the caller (`cc-session.ts`)
  *     decides: `enforce` refuses to launch the session at all (fail closed);
  *     `audit` logs a loud warning and launches WITHOUT the proxy (no worse
@@ -211,24 +249,34 @@ class DenialQueue implements AsyncIterable<EgressDenial> {
 }
 
 // -----------------------------------------------------------------------------
-// CONNECT parsing
+// Proxy-request parsing — CONNECT (TLS tunnel) and plain-HTTP absolute-URI
+// forward-proxy requests (see the module doc's "Mechanism" section)
 // -----------------------------------------------------------------------------
 
-/** `CONNECT host:port HTTP/1.1` — the ONE proxy verb this module speaks.
- *  Anything else (a plain-HTTP forward-proxy `GET http://…` request, an
- *  unrecognized verb, malformed syntax) does not match and is fail-closed
- *  denied by the caller — see the module doc's fail-closed discipline. */
+/** `CONNECT host:port HTTP/1.1` — the TLS-tunnel proxy verb. */
 const CONNECT_LINE_RE = /^CONNECT\s+([^\s:/]+):(\d{1,5})\s+HTTP\/\d\.\d\s*$/i;
 
-/** Hard cap on buffered pre-CONNECT header bytes — a client that never
+/** The plain-HTTP absolute-URI forward-proxy form (RFC 7230 §5.3.2) —
+ *  `POST http://host[:port][/path] HTTP/1.1`. This is what `HTTP_PROXY`
+ *  clients send for non-TLS requests; `HTTPS_PROXY` clients send `CONNECT`
+ *  instead (see {@link CONNECT_LINE_RE}). `https://` absolute-URIs are
+ *  deliberately NOT matched here — a proxy-respecting client always
+ *  CONNECTs for TLS, never sends an `https://` absolute-URI in the request
+ *  line, so accepting one here would just be extra surface for no real
+ *  client to ever exercise. */
+const ABSOLUTE_HTTP_LINE_RE =
+  /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE)\s+http:\/\/([^\s:/]+)(?::(\d{1,5}))?(\/[^\s]*)?\s+HTTP\/\d\.\d\s*$/i;
+
+/** Hard cap on buffered pre-request header bytes — a client that never
  *  sends a terminating `\r\n\r\n` (or sends an absurdly long "header")
  *  is fail-closed denied rather than buffered forever. Generous for a
- *  CONNECT request (which is normally under 200 bytes) while still bounding
- *  memory per connection. */
+ *  CONNECT/small-request header (normally well under 1KB) while still
+ *  bounding memory per connection. */
 const MAX_HEADER_BYTES = 8192;
 
 interface ParsedConnect {
   ok: true;
+  kind: "connect";
   host: string;
   port: number;
   /** Bytes received AFTER the `\r\n\r\n` header terminator, if the client
@@ -236,6 +284,21 @@ interface ParsedConnect {
    *  response (unusual for CONNECT but not disallowed) — queued and
    *  forwarded once the target connection is up. */
   trailing: Uint8Array;
+}
+interface ParsedHttpForward {
+  ok: true;
+  kind: "http-forward";
+  host: string;
+  port: number;
+  /** The exact bytes to write to the freshly dialed target once its socket
+   *  opens — the request line rewritten to origin-form (RFC 7230 §5.3.2:
+   *  a proxy forwarding a request MUST NOT forward the absolute-URI form
+   *  to the origin server), the original header lines (a `Host` header
+   *  added if the client didn't send one), the terminator, and any body
+   *  bytes the client had already sent ahead of the terminator. Built once
+   *  at parse time (not re-derived per write) so `EgressProxy` never has to
+   *  re-parse or mutate headers in the hot path. */
+  forwardBytes: Uint8Array;
 }
 interface ParsedConnectFailure {
   ok: false;
@@ -248,41 +311,101 @@ interface ParsedConnectFailure {
 
 /** Pure parse function — exported for unit tests. Returns `undefined` when
  *  the header terminator hasn't arrived yet (caller should keep buffering,
- *  up to {@link MAX_HEADER_BYTES}). */
-export function tryParseConnect(buffered: Uint8Array): ParsedConnect | ParsedConnectFailure | undefined {
+ *  up to {@link MAX_HEADER_BYTES}). Tries the CONNECT shape first, then the
+ *  plain-HTTP absolute-URI shape; a request matching neither (or matching
+ *  one with an unusable host/port) is a parse failure — see the module
+ *  doc's fail-closed discipline for what that means per mode. */
+export function tryParseConnect(
+  buffered: Uint8Array,
+): ParsedConnect | ParsedHttpForward | ParsedConnectFailure | undefined {
   const buf = Buffer.from(buffered.buffer, buffered.byteOffset, buffered.byteLength);
   const terminatorIdx = buf.indexOf("\r\n\r\n");
   if (terminatorIdx === -1) return undefined;
 
   const headerText = buf.subarray(0, terminatorIdx).toString("utf8");
   const firstLine = (headerText.split("\r\n")[0] ?? "").trim();
-  const match = CONNECT_LINE_RE.exec(firstLine);
-  if (!match) {
+
+  const connectMatch = CONNECT_LINE_RE.exec(firstLine);
+  if (connectMatch) {
+    const host = connectMatch[1] ?? "";
+    const portNum = Number(connectMatch[2]);
+    if (host.length === 0 || !Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+      return {
+        ok: false,
+        host: host || "?",
+        port: Number.isFinite(portNum) ? portNum : 0,
+        reason: `malformed CONNECT target ("${firstLine.slice(0, 120)}")`,
+      };
+    }
     return {
-      ok: false,
-      host: "?",
-      port: 0,
-      reason: `unparseable proxy request (only CONNECT is supported): "${firstLine.slice(0, 120)}"`,
+      ok: true,
+      kind: "connect",
+      host,
+      port: portNum,
+      trailing: new Uint8Array(buf.subarray(terminatorIdx + 4)),
     };
   }
 
-  const host = match[1] ?? "";
-  const portNum = Number(match[2]);
-  if (host.length === 0 || !Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+  const httpMatch = ABSOLUTE_HTTP_LINE_RE.exec(firstLine);
+  if (httpMatch) {
+    const method = (httpMatch[1] ?? "").toUpperCase();
+    const host = httpMatch[2] ?? "";
+    const portStr = httpMatch[3];
+    const portNum = portStr ? Number(portStr) : 80; // absolute-URI http:// defaults to port 80
+    const path = httpMatch[4] ?? "/";
+    if (host.length === 0 || !Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+      return {
+        ok: false,
+        host: host || "?",
+        port: Number.isFinite(portNum) ? portNum : 0,
+        reason: `malformed absolute-URI target ("${firstLine.slice(0, 120)}")`,
+      };
+    }
+    const body = new Uint8Array(buf.subarray(terminatorIdx + 4));
     return {
-      ok: false,
-      host: host || "?",
-      port: Number.isFinite(portNum) ? portNum : 0,
-      reason: `malformed CONNECT target ("${firstLine.slice(0, 120)}")`,
+      ok: true,
+      kind: "http-forward",
+      host,
+      port: portNum,
+      forwardBytes: buildForwardRequest(headerText, method, path, host, portNum, body),
     };
   }
 
   return {
-    ok: true,
-    host,
-    port: portNum,
-    trailing: new Uint8Array(buf.subarray(terminatorIdx + 4)),
+    ok: false,
+    host: "?",
+    port: 0,
+    reason:
+      `unparseable proxy request (only CONNECT and plain-HTTP absolute-URI ` +
+      `requests are supported): "${firstLine.slice(0, 120)}"`,
   };
+}
+
+/** Rewrite a plain-HTTP absolute-URI request into the origin-form a real
+ *  origin server expects (RFC 7230 §5.3.2) — `POST http://host/path
+ *  HTTP/1.1` becomes `POST /path HTTP/1.1`, with every other header line
+ *  preserved verbatim and a `Host` header synthesized only if the client
+ *  didn't already send one. `body` is the raw bytes the client had already
+ *  sent past the header terminator (untouched, never decoded as text — it
+ *  may be arbitrary binary) and is appended after the rewritten headers. */
+function buildForwardRequest(
+  headerText: string,
+  method: string,
+  path: string,
+  host: string,
+  port: number,
+  body: Uint8Array,
+): Uint8Array {
+  const headerLines = headerText.split("\r\n");
+  const restHeaders = headerLines.slice(1);
+  const hasHostHeader = restHeaders.some((line) => /^host\s*:/i.test(line));
+  const rewrittenHeaders = hasHostHeader
+    ? restHeaders
+    : [`Host: ${port === 80 ? host : `${host}:${port}`}`, ...restHeaders];
+  const rewritten = [`${method} ${path} HTTP/1.1`, ...rewrittenHeaders, "", ""].join("\r\n");
+  const headBytes = new Uint8Array(Buffer.from(rewritten, "utf8"));
+  if (body.length === 0) return headBytes;
+  return concatChunks([headBytes, body], headBytes.length + body.length);
 }
 
 // -----------------------------------------------------------------------------
@@ -333,11 +456,12 @@ const BAD_REQUEST = "HTTP/1.1 400 Bad Request\r\n\r\n";
 const BAD_GATEWAY = "HTTP/1.1 502 Bad Gateway\r\n\r\n";
 
 /**
- * A per-session deny-by-default CONNECT proxy. One instance per spawned
- * session (`cc-session.ts` constructs and tears one down per `CCSession`,
- * mirroring `MacosSbplSandbox`'s per-session `.sb` profile lifecycle) — never
- * shared across sessions, so one session's allowlist can never leak into
- * another's traffic.
+ * A per-session deny-by-default forward proxy (CONNECT tunnel + plain-HTTP
+ * absolute-URI forwarding — see the module doc's "Mechanism" section). One
+ * instance per spawned session (`cc-session.ts` constructs and tears one
+ * down per `CCSession`, mirroring `MacosSbplSandbox`'s per-session `.sb`
+ * profile lifecycle) — never shared across sessions, so one session's
+ * allowlist can never leak into another's traffic.
  */
 export class EgressProxy {
   private readonly allowSet: ReadonlySet<string>;
@@ -415,7 +539,7 @@ export class EgressProxy {
       state.headerChunks.push(chunk);
       state.headerLength += chunk.length;
       if (state.headerLength > MAX_HEADER_BYTES) {
-        this.denyFailClosed(socket, "?", 0, "CONNECT header exceeded size limit without a terminator");
+        this.denyFailClosed(socket, "?", 0, "proxy request header exceeded size limit without a terminator");
         return;
       }
       const buffered =
@@ -436,8 +560,14 @@ export class EgressProxy {
         return;
       }
 
-      if (parsed.trailing.length > 0) state.preTunnelQueue.push(parsed.trailing);
-      this.handleConnect(socket, state, parsed.host, parsed.port);
+      // "connect"'s trailing bytes (TLS ClientHello pipelined ahead of the
+      // 200 response) still need queuing here; "http-forward"'s equivalent
+      // body-so-far is already folded into `parsed.forwardBytes` at parse
+      // time (see `buildForwardRequest`), so there is nothing to queue.
+      if (parsed.kind === "connect" && parsed.trailing.length > 0) {
+        state.preTunnelQueue.push(parsed.trailing);
+      }
+      this.handleConnect(socket, state, parsed);
       return;
     }
 
@@ -452,7 +582,15 @@ export class EgressProxy {
     }
   }
 
-  private handleConnect(socket: Socket<ConnState>, state: ConnState, host: string, port: number): void {
+  /**
+   * Common allow/deny-by-mode path for BOTH proxy shapes (CONNECT tunnel
+   * and plain-HTTP absolute-URI forward). `parsed` carries a `kind`
+   * discriminant that only affects what gets written once the target dial
+   * succeeds — see the `open` handler below — everything about the
+   * allowlist/mode decision itself is identical for both.
+   */
+  private handleConnect(socket: Socket<ConnState>, state: ConnState, parsed: ParsedConnect | ParsedHttpForward): void {
+    const { host, port } = parsed;
     const allowed = isHostAllowed(host, this.allowSet);
     if (!allowed) {
       const blocked = this.mode === "enforce";
@@ -469,7 +607,10 @@ export class EgressProxy {
         return;
       }
       // audit — DD-5 report-only: log the would-be-denial, still connect
-      // through, so a burn-in window measures real traffic without breaking it.
+      // through (and, for http-forward, still relay the request through to
+      // the target — see the `open` handler below), so a burn-in window
+      // measures real traffic without breaking it. No error response, no
+      // socket termination — that is the entire point of `audit`.
     }
 
     void Bun.connect({
@@ -485,7 +626,18 @@ export class EgressProxy {
             return;
           }
           state.target = targetSocket;
-          this.writeSafely(socket, CONNECTION_ESTABLISHED);
+          if (parsed.kind === "connect") {
+            // TLS-tunnel handshake: tell the client the tunnel is up before
+            // relaying anything — this IS the expected reply for CONNECT.
+            this.writeSafely(socket, CONNECTION_ESTABLISHED);
+          } else {
+            // Plain-HTTP forward: no synthetic reply to the client — it is
+            // expecting the target's real HTTP response, not a tunnel
+            // handshake. Write the rewritten request FIRST so it can never
+            // race behind response bytes the `data` handler below relays
+            // back to the client.
+            this.writeSafely(targetSocket, parsed.forwardBytes);
+          }
           for (const queued of state.preTunnelQueue) this.writeSafely(targetSocket, queued);
           state.preTunnelQueue = [];
         },
@@ -504,7 +656,8 @@ export class EgressProxy {
       // The target refused/was unreachable — a connectivity failure, NOT a
       // security denial (the host WAS allowed; the network just failed), so
       // this is not pushed onto the denial queue. Respond 502 like any real
-      // forward proxy would.
+      // forward proxy would (correct for both CONNECT and plain-HTTP
+      // clients — both understand a raw HTTP/1.1 status line reply here).
       process.stderr.write(
         `[egress-proxy] failed to connect upstream ${host}:${port}: ` +
           `${err instanceof Error ? err.message : String(err)}\n`,

--- a/src/runner/session-sandbox.ts
+++ b/src/runner/session-sandbox.ts
@@ -189,11 +189,59 @@ export const SANDBOX_EXEC_ALLOW_SEED: readonly string[] = Object.freeze([
   "bash",
 ]);
 
+/**
+ * cortex#2412 follow-up (the `egress-proxy.ts` audit-mode fix) — a real
+ * `audit`-mode run against this seed surfaced two hosts a hardened session
+ * actually reaches that weren't on it. Both calls below were made
+ * explicitly, not defaulted:
+ *
+ *   - `"mcp-proxy.anthropic.com"` — ADDED. claude.ai-connected MCP servers
+ *     (task list, Drive, and the rest of that family) route through this
+ *     host. Functional requirement, same tier as `"api.anthropic.com"`, not
+ *     a convenience: under `enforce`, denying it silently breaks every MCP
+ *     tool a session tries to use.
+ *   - `"http-intake.logs.us5.datadoghq.com"` (third-party telemetry) —
+ *     DELIBERATELY LEFT OUT. A hardened session has no functional need to
+ *     reach it, and the entire point of a deny-by-default egress policy is
+ *     that destinations without a functional need stay unreachable. It
+ *     WILL be denied under `enforce` — documented here so that's discovered
+ *     by reading this comment, not by a mystery failure.
+ *   - `"localhost"` — ADDED. cortex's OWN hook scripts
+ *     (`event-logger.hook.ts`, `path-guard.hook.ts`, `bash-guard.hook.ts`)
+ *     run AS the sandboxed child (they're `claude` CC hooks, invoked BY the
+ *     spawned `claude` process this proxy wraps) and POST their telemetry to
+ *     `http://localhost:8766/api/events/ingest` by default
+ *     (`CORTEX_INGEST_URL`, overridable). That's cortex's OWN control-plane
+ *     event pipeline reaching cortex's OWN daemon on the SAME host — the
+ *     opposite direction from what L3 defends against (a session
+ *     exfiltrating data OUT to an attacker-controlled host). Denying it
+ *     doesn't hold a security boundary; it just breaks cortex's own
+ *     instrumentation for every hardened session — the exact failure that
+ *     surfaced this whole bug (a real `audit` run showed this traffic being
+ *     killed even in report-only mode, before the `egress-proxy.ts` fix that
+ *     made `audit` non-terminating). Seeding it here means `enforce` won't
+ *     newly break it either, once enforcement is ever turned on.
+ *
+ *     SCOPE CAVEAT: {@link isHostAllowed} (`egress-proxy.ts`) matches on
+ *     HOSTNAME ONLY — `egressAllow` carries no port/path granularity. So
+ *     this allows a session to reach ANY port on loopback, not just 8766;
+ *     there's no mechanism today to say "8766 only." Same granularity every
+ *     other seed entry already has (`"api.anthropic.com"` is really "any
+ *     port on that host," every real client just happens to only use 443)
+ *     — not a new category of looseness, but worth naming since loopback is
+ *     more likely than a public hostname to have OTHER locally-run services
+ *     behind it on the principal's machine. Port/path-scoped allowlisting
+ *     would close that gap; it needs `egressAllow`/`isHostAllowed` to carry
+ *     an optional port (and the proxy to check it) — a real follow-up, not
+ *     something this fix does.
+ */
 export const SANDBOX_EGRESS_ALLOW_SEED: readonly string[] = Object.freeze([
   "api.anthropic.com",
   "github.com",
   "api.github.com",
   "codeload.github.com",
+  "mcp-proxy.anthropic.com",
+  "localhost",
 ]);
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a bug I found by running EBH-4's proxy in `audit` against a live session. Enforcement remains **off** by default — this fixes behaviour that only manifests once someone opts in, which is exactly the moment it is cheapest to fix.

## The bug

`denyFailClosed` killed the socket for anything the CONNECT-only parser couldn't understand — **in every mode, including `audit`**. Plain-HTTP absolute-URI requests (`POST http://host/path HTTP/1.1`, what `HTTP_PROXY` clients send, as opposed to `HTTPS_PROXY`'s `CONNECT`) were therefore terminated.

Real evidence from a live `mode: "audit"` session:

```
egress-denial mode=audit host=? port=0 blocked=true
  reason="unparseable proxy request (only CONNECT is supported):
          "POST http://localhost:8766/api/events/ingest HTTP/1.1""   (×3)
egress-denial mode=audit host=mcp-proxy.anthropic.com port=443 blocked=false
egress-denial mode=audit host=http-intake.logs.us5.datadoghq.com port=443 blocked=false
```

Note the asymmetry: allowlist misses correctly reported `blocked=false` (observe-only), but plain HTTP reported `blocked=true` **and was actually killed** — and the thing being killed was **cortex's own event-ingest pipeline**.

`audit` is meant to be a safe dry-run that predicts what `enforce` would do. It was instead breaking things itself, and breaking them *differently* from how `enforce` would — so it failed at the one job it has.

## The fix

Plain-HTTP absolute-URI is now parsed alongside CONNECT (RFC 7230 §5.3.2), rewritten to origin-form with a synthesized `Host` header where needed, and routed through the **same** allow/deny-by-mode path CONNECT already used.

The dividing line is now **"is there a determinable destination"**, not "which mode":
- **Genuinely unparseable** (garbage, unknown verb, bad port) → fails closed in every mode. There is no destination for `audit` to forward to, so failing closed *is* what `enforce` would do — `audit` still predicts correctly.
- **Known destination, not allowlisted** → follows mode. `audit` records `blocked:false` and forwards, terminating nothing. `enforce` refuses with 403.

Verified with real sockets, target not on the allowlist:

```
mode=audit   → client got "HTTP/1.1 200 OK … got-it!"   target saw the request: true
mode=enforce → client got "HTTP/1.1 403 Forbidden"      target saw the request: false
```

## Allowlist changes

- **`mcp-proxy.anthropic.com` — added.** claude.ai-connected MCP servers route through it; blocking it under `enforce` would silently break every MCP tool. A functional requirement, not a convenience.
- **`http-intake.logs.us5.datadoghq.com` — deliberately NOT added.** Third-party telemetry; a deny-by-default egress policy exists so unnecessary destinations stay unreachable. Documented as *will* be denied under `enforce`, so it is discovered by reading rather than by a mystery failure.
- **`localhost` — added.** cortex's own hooks POST to `localhost:8766` as the sandboxed child — traffic flowing *into* our own daemon, the opposite direction from what L3 defends against.

  **Caveat, disclosed not glossed:** `isHostAllowed` has no port granularity, so this permits any port on loopback, and a local forwarder could relay outward. That does not worsen the stated posture — L3 is already a cooperating-client boundary that a raw socket defeats entirely (claim C5 in the NWS round-2 spec) — but port/path-scoped allowlisting is named as a follow-up.

## Tests

Baseline (`8ed20b62`) 11119 pass / 15 fail → 11132 pass / 15 fail, **identical failing-name sets**, zero regressions. `egress-proxy.test.ts` 31/31, including pure-parser coverage and real-socket coverage of allowed / audit-denied / enforce-denied plain-HTTP forwarding. Two tests that had encoded the old buggy contract were rewritten. `tsc --noEmit` and lint clean.

The remaining 15 failures include the real-`claude`-spawn tests, still blocked by the exhausted weekly quota (resets Jul 29) — environmental, unchanged from baseline.

## Residual

Design docs still describe the proxy as "CONNECT-only" — left for a doc sweep rather than widened in a bugfix.
