### PR TITLE
chore: bump to v6.13.0 — execution-boundary hardening (epic #2341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Cortex — Changelog
 
+## 6.13.0 — 2026-07-26 — Execution-boundary hardening: the NWS review response (epic #2341)
+
+The response to NorthWoods Sentinel Labs' 2026-07-23 adversarial review is
+code-complete. That review had one diagnosis under every finding: **cortex
+enforced at the gate, not at execution** — boundaries were declared at
+load-time and prompt-time, but once an agent driven by untrusted content was
+running, most boundaries were an instruction the model was asked to obey rather
+than a wall that stopped it. This release turns the ladder prose → code →
+kernel.
+
+**Live by default:** the cortex-owned `PreToolUse` path guard for file tools and
+Bash read-command paths (nine adversarial rounds — each round closed a real
+bypass found by trying to break the previous one), read-only directories
+enforced through the dispatch seam, path containment applied even in
+principal-DM guard-off sessions, and persona-declared `allowedTools` enforced at
+dispatch instead of being decorative.
+
+**Shipped switched off, deliberately:** the session-sandbox choke point, the
+macOS `sandbox-exec` backend, the L3 egress allowlist proxy, plugin bundle
+signature verification, and the v2 `strict` posture. Building a boundary and
+enabling it are separate decisions with separate blast radius, so every one of
+these defaults to inert and no caller turns it on.
+
+The headline technical result is `strict`: `(deny default)` plus a derived allow
+set, where an out-of-scope path is refused **because nothing permits it** rather
+than because someone remembered to forbid it. Getting there meant root-causing
+why deny-default aborted every session — dyld's own bootstrap was being blocked
+before any denial could even be logged, found in the crash reporter rather than
+the security log, and fixed by importing Apple's own baseline fragments instead
+of loosening the boundary.
+
+Two honest limits are documented rather than papered over. The v1 `guarded`
+posture is a denylist and therefore **not** a boundary — a denylist cannot be
+completed by adding entries, and the docs say so. And the macOS keychain cannot
+be protected from the session at all: denying the read kills authentication
+outright, which is permanent, not a bug awaiting a fix.
+
+Also in: an `audit` mode that no longer terminates connections (it was killing
+cortex's own event ingest — found by running it against a live session), plugin
+reload brought under the same signature gate as boot after an adversarial pass
+found it bypassed the feature entirely, and test specifications for the second
+NWS adversarial round and for Linux field validation.
+
 ## 6.3.0 — 2026-07-07 — Federation payload swap (epic #1595)
 
 The operator-mode federation credential path — epic #1595's payload swap — is

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -12,7 +12,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.12.1"
+version: "6.13.0"
 type: component
 tier: community
 # Preview-scope description (cortex#2285 C1): states the supported envelope up


### PR DESCRIPTION
Release cut for the NWS review response. Version bump + changelog for the 5 commits since `v6.12.1`, the most significant being v2 `strict` (#2431), which was unreleased.

Covers epic #2341: L1 path guard (nine adversarial rounds), L2 choke point, macOS backend, L3 egress proxy, extended sensitive set, v2 `strict` deny-default posture, plugin signature verification, persona `allowedTools`, and the audit-mode egress fix.

**Most of it ships switched off by design.** Live by default: the path guard, read-only enforcement through the dispatch seam, guard-off path containment, and persona tool policy. Everything else is inert capability — building a boundary and enabling it are separate decisions.

Cutting this so the two test specs (#2433) hand over against a **version** rather than a moving `main` — findings that can't be attributed to a release are much harder to act on. Unblocks #2434 (NWS round 2) and #2435 (Linux field validation).