### PR TITLE
feat(quickstart): clone the granted repo into the workspace for code stacks (#2452)

### DIFF
--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -47,7 +47,9 @@ import type {
   ProvisionPort,
   QuickstartPorts,
   ServicePort,
+  WorkspacePort,
 } from "../quickstart-ports";
+import { canonicalWorkspaceDir } from "../../../../common/data-path";
 
 const SECRET_TOKEN = "THE-REAL-DISCORD-BOT-TOKEN-VALUE-abc123";
 
@@ -207,6 +209,10 @@ interface FakeOverrides {
   // what order relative to the restart).
   truncateLog?: (logPath: string) => void;
   provisionSeed?: () => CommandResult;
+  // cortex#2452 — code-stack workspace checkout seam. Default: clone succeeds
+  // (a chat-only stack never reaches it). A capturing override records the
+  // owner/repo + dest the orchestrator asks to clone.
+  cloneGrantedRepo?: (opts: { ownerRepo: string; dest: string }) => CommandResult;
   // cortex#2264 — takes the polled path so a test can return DIFFERENT content
   // for the main `.log` vs the `.error.log` sibling. Existing zero-arg lambdas
   // stay assignable (a `() => T` satisfies `(p: string) => T`).
@@ -237,6 +243,9 @@ function fakePorts(overrides: FakeOverrides = {}): QuickstartPorts {
   const provision: ProvisionPort = {
     provisionSeed: overrides.provisionSeed ?? (() => ({ exitCode: 0, stdout: "  ⊘ NKey already exists — reusing\n", stderr: "" })),
   };
+  const workspace: WorkspacePort = {
+    cloneGrantedRepo: overrides.cloneGrantedRepo ?? (() => ({ exitCode: 0, stdout: "Cloning…", stderr: "" })),
+  };
   const gate: GatePort = {
     readLog: overrides.readLog ?? (() => FULL_HEALTHY_LOG),
     fetchHealthz: overrides.fetchHealthz ?? (() => Promise.resolve(true)),
@@ -246,7 +255,7 @@ function fakePorts(overrides: FakeOverrides = {}): QuickstartPorts {
     },
     now: () => clock,
   };
-  return { preflight, service, provision, gate };
+  return { preflight, service, provision, workspace, gate };
 }
 
 /** Recursive snapshot of every file's size + mtime under `dirs` — used to
@@ -735,6 +744,106 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
     expect(res.exitCode).toBe(0);
     const loaded = loadConfigWithAgents(join(configDir, "work", "work.yaml"));
     expect(loaded.config.claude.bashAllowlist).toBeUndefined();
+  });
+
+  // cortex#2452 — a code stand-up must PRE-PLACE the granted repo in the
+  // workspace (the runtime allowlist has no clone verb, by design). The clone
+  // lands at `<canonicalWorkspaceDir(slug)>/<repo>` — the SAME dir the dispatch
+  // handler opens the CC session cwd in — using the operator's gh/git auth.
+  test("cortex#2452: code stack + granted repo → clones owner/repo into <workspace>/<repo>", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const cloneCalls: { ownerRepo: string; dest: string }[] = [];
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv({ CTX_SLUG: "codeclone", CTX_REPO: "the-metafactory/cortex" }), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () =>
+          fakePorts({
+            cloneGrantedRepo: (opts) => {
+              cloneCalls.push(opts);
+              return { exitCode: 0, stdout: "Cloning…", stderr: "" };
+            },
+          }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(cloneCalls).toHaveLength(1);
+    expect(cloneCalls[0]?.ownerRepo).toBe("the-metafactory/cortex");
+    // dest MUST be the dispatch-handler session-cwd fallback + the repo name.
+    expect(cloneCalls[0]?.dest).toBe(join(canonicalWorkspaceDir("codeclone"), "cortex"));
+    expect(res.stdout).toContain("cloned the-metafactory/cortex");
+  });
+
+  // cortex#2452 — IDEMPOTENT: an existing `<repo>/.git` checkout is left
+  // untouched (never re-cloned or clobbered on a re-run).
+  test("cortex#2452: existing checkout → skipped, clone NOT invoked", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    // Pre-place a checkout at the exact dest the orchestrator resolves.
+    const dest = join(canonicalWorkspaceDir("codeidem"), "cortex");
+    mkdirSync(join(dest, ".git"), { recursive: true });
+    const cloneCalls: { ownerRepo: string; dest: string }[] = [];
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv({ CTX_SLUG: "codeidem", CTX_REPO: "the-metafactory/cortex" }), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () =>
+          fakePorts({
+            cloneGrantedRepo: (opts) => {
+              cloneCalls.push(opts);
+              return { exitCode: 0, stdout: "", stderr: "" };
+            },
+          }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(cloneCalls).toHaveLength(0);
+    expect(res.stdout).toContain("workspace already has cortex");
+  });
+
+  // cortex#2452 — FAIL-SOFT: a clone failure WARNS prominently (with the exact
+  // by-hand command) but does NOT abort the already-stood-up stack.
+  test("cortex#2452: clone failure → warns + quickstart still succeeds", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv({ CTX_SLUG: "codefail", CTX_REPO: "the-metafactory/cortex" }), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () =>
+          fakePorts({
+            cloneGrantedRepo: () => ({ exitCode: 1, stdout: "", stderr: "repository not found" }),
+          }),
+        ),
+      ),
+    );
+    // Fail-soft: the whole run still succeeds.
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("WARNING");
+    expect(res.stdout).toContain("CODING LOOP WILL NOT WORK");
+    // The exact by-hand command the operator can run.
+    expect(res.stdout).toContain(`gh repo clone the-metafactory/cortex ${join(canonicalWorkspaceDir("codefail"), "cortex")}`);
+    // The underlying failure reason is surfaced.
+    expect(res.stdout).toContain("repository not found");
+  });
+
+  // cortex#2452 — a chat-only stack (no CTX_REPO) never reaches the clone step.
+  test("cortex#2452: chat-only stack (no CTX_REPO) → no clone invoked", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const cloneCalls: { ownerRepo: string; dest: string }[] = [];
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv({ CTX_SLUG: "codechat" }), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () =>
+          fakePorts({
+            cloneGrantedRepo: (opts) => {
+              cloneCalls.push(opts);
+              return { exitCode: 0, stdout: "", stderr: "" };
+            },
+          }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(0);
+    expect(cloneCalls).toHaveLength(0);
+    expect(res.stdout).not.toContain("Workspace checkout");
   });
 
   // cortex#2322 — the not-loaded path is no longer a printed skip. On a fresh

--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -749,7 +749,7 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
   // cortex#2452 — a code stand-up must PRE-PLACE the granted repo in the
   // workspace (the runtime allowlist has no clone verb, by design). The clone
   // lands at `<canonicalWorkspaceDir(slug)>/<repo>` — the SAME dir the dispatch
-  // handler opens the CC session cwd in — using the operator's gh/git auth.
+  // handler opens the CC session cwd in — using the principal's gh/git auth.
   test("cortex#2452: code stack + granted repo → clones owner/repo into <workspace>/<repo>", async () => {
     const configDir = freshDir();
     const natsDir = freshDir();
@@ -818,7 +818,7 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("WARNING");
     expect(res.stdout).toContain("CODING LOOP WILL NOT WORK");
-    // The exact by-hand command the operator can run.
+    // The exact by-hand command the principal can run.
     expect(res.stdout).toContain(`gh repo clone the-metafactory/cortex ${join(canonicalWorkspaceDir("codefail"), "cortex")}`);
     // The underlying failure reason is surfaced.
     expect(res.stdout).toContain("repository not found");

--- a/src/cli/cortex/commands/quickstart-adapters.ts
+++ b/src/cli/cortex/commands/quickstart-adapters.ts
@@ -282,17 +282,17 @@ function shellQuote(s: string): string {
 export function buildWorkspacePort(): WorkspacePort {
   return {
     cloneGrantedRepo(opts: { ownerRepo: string; dest: string }): CommandResult {
-      // cortex#2452 — PREFER `gh repo clone`: it reuses the operator's gh auth
+      // cortex#2452 — PREFER `gh repo clone`: it reuses the principal's gh auth
       // that is present at `cortex quickstart` time, so a PRIVATE granted repo
       // clones without a separately-configured git credential helper. `gh repo
       // clone owner/repo dest` is a distinct verb from the runtime allowlist's
-      // gh-pr rules — this runs as the OPERATOR at stand-up, never inside a
+      // gh-pr rules — this runs as the PRINCIPAL at stand-up, never inside a
       // dispatched agent session (the allowlist stays unchanged).
       const gh = runSync(["gh", "repo", "clone", opts.ownerRepo, opts.dest]);
       if (gh.exitCode === 0) return gh;
 
       // FALLBACK — plain `git clone` over HTTPS (a box with git auth but no gh,
-      // or a public repo). Surface BOTH failures' stderr so the operator sees
+      // or a public repo). Surface BOTH failures' stderr so the principal sees
       // why each path failed, not just the last one.
       const git = runSync(["git", "clone", `https://github.com/${opts.ownerRepo}`, opts.dest]);
       if (git.exitCode === 0) return git;

--- a/src/cli/cortex/commands/quickstart-adapters.ts
+++ b/src/cli/cortex/commands/quickstart-adapters.ts
@@ -26,6 +26,7 @@ import type {
   PreflightPorts,
   ProvisionPort,
   ServicePort,
+  WorkspacePort,
 } from "./quickstart-ports";
 
 // =============================================================================
@@ -275,6 +276,38 @@ function shellQuote(s: string): string {
 }
 
 // =============================================================================
+// Workspace checkout (cortex#2452, code stacks only)
+// =============================================================================
+
+export function buildWorkspacePort(): WorkspacePort {
+  return {
+    cloneGrantedRepo(opts: { ownerRepo: string; dest: string }): CommandResult {
+      // cortex#2452 — PREFER `gh repo clone`: it reuses the operator's gh auth
+      // that is present at `cortex quickstart` time, so a PRIVATE granted repo
+      // clones without a separately-configured git credential helper. `gh repo
+      // clone owner/repo dest` is a distinct verb from the runtime allowlist's
+      // gh-pr rules — this runs as the OPERATOR at stand-up, never inside a
+      // dispatched agent session (the allowlist stays unchanged).
+      const gh = runSync(["gh", "repo", "clone", opts.ownerRepo, opts.dest]);
+      if (gh.exitCode === 0) return gh;
+
+      // FALLBACK — plain `git clone` over HTTPS (a box with git auth but no gh,
+      // or a public repo). Surface BOTH failures' stderr so the operator sees
+      // why each path failed, not just the last one.
+      const git = runSync(["git", "clone", `https://github.com/${opts.ownerRepo}`, opts.dest]);
+      if (git.exitCode === 0) return git;
+      return {
+        exitCode: git.exitCode === 0 ? 1 : git.exitCode,
+        stdout: git.stdout,
+        stderr: [`gh repo clone failed: ${gh.stderr.trim()}`, `git clone failed: ${git.stderr.trim()}`]
+          .filter((l) => l.length > 0)
+          .join("\n"),
+      };
+    },
+  };
+}
+
+// =============================================================================
 // Gate (bounded healthy-boot wait)
 // =============================================================================
 
@@ -311,12 +344,14 @@ export function buildQuickstartPorts(): {
   preflight: PreflightPorts;
   service: ServicePort;
   provision: ProvisionPort;
+  workspace: WorkspacePort;
   gate: GatePort;
 } {
   return {
     preflight: buildPreflightPorts(),
     service: buildServicePort(),
     provision: buildProvisionPort(),
+    workspace: buildWorkspacePort(),
     gate: buildGatePort(),
   };
 }

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -208,7 +208,7 @@ export interface ProvisionPort {
  * repo in the workspace; without it the coding loop starts against an empty dir
  * with no way to fetch the code.
  *
- * `cortex quickstart` runs with the operator's own `gh`/`git` auth, so this is
+ * `cortex quickstart` runs with the principal's own `gh`/`git` auth, so this is
  * where the pre-placement belongs. The orchestrator handles idempotency (skip an
  * existing checkout) and fail-soft (a clone failure WARNS but never aborts the
  * already-stood-up stack); this port only performs the clone itself.
@@ -216,7 +216,7 @@ export interface ProvisionPort {
 export interface WorkspacePort {
   /**
    * Clone `owner/repo` into `dest` (an absolute `<workspace>/<repo>` path).
-   * Prefers `gh repo clone owner/repo dest` (reuses the operator's gh auth
+   * Prefers `gh repo clone owner/repo dest` (reuses the principal's gh auth
    * present at quickstart time) and falls back to
    * `git clone https://github.com/owner/repo dest`. Never throws — a clone
    * failure (auth, network, repo-not-found, missing binary) is reported as a

--- a/src/cli/cortex/commands/quickstart-ports.ts
+++ b/src/cli/cortex/commands/quickstart-ports.ts
@@ -196,6 +196,38 @@ export interface ProvisionPort {
 }
 
 // =============================================================================
+// Workspace checkout — step 4b (cortex#2452, code stacks only)
+// =============================================================================
+
+/**
+ * cortex#2452 — the coding-tier stand-up seam. A `code` stack scaffolded with a
+ * granted repo (`CTX_REPO`) gets a repo-scoped git-write + gh-pr bash allowlist,
+ * but the runtime allowlist DELIBERATELY excludes `clone`/`gh repo`/`gh api`
+ * (`review-session-lockdown.ts` — "cannot widen to gh repo clone") — an agent
+ * must not clone arbitrary repos. So the STAND-UP owns placing the one granted
+ * repo in the workspace; without it the coding loop starts against an empty dir
+ * with no way to fetch the code.
+ *
+ * `cortex quickstart` runs with the operator's own `gh`/`git` auth, so this is
+ * where the pre-placement belongs. The orchestrator handles idempotency (skip an
+ * existing checkout) and fail-soft (a clone failure WARNS but never aborts the
+ * already-stood-up stack); this port only performs the clone itself.
+ */
+export interface WorkspacePort {
+  /**
+   * Clone `owner/repo` into `dest` (an absolute `<workspace>/<repo>` path).
+   * Prefers `gh repo clone owner/repo dest` (reuses the operator's gh auth
+   * present at quickstart time) and falls back to
+   * `git clone https://github.com/owner/repo dest`. Never throws — a clone
+   * failure (auth, network, repo-not-found, missing binary) is reported as a
+   * non-zero `exitCode` so the orchestrator can WARN-and-continue. The caller
+   * has already ensured `dest`'s parent workspace dir exists (0700) and that
+   * `dest` is not an existing checkout.
+   */
+  cloneGrantedRepo(opts: { ownerRepo: string; dest: string }): CommandResult;
+}
+
+// =============================================================================
 // Gate — step 8 (bounded healthy-boot wait)
 // =============================================================================
 
@@ -222,5 +254,6 @@ export interface QuickstartPorts {
   preflight: PreflightPorts;
   service: ServicePort;
   provision: ProvisionPort;
+  workspace: WorkspacePort;
   gate: GatePort;
 }

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -503,7 +503,7 @@ async function runScaffold(opts: {
  * The coding-tier runtime allowlist DELIBERATELY excludes `clone`/`gh repo`/
  * `gh api` (`review-session-lockdown.ts` — an agent must not clone arbitrary
  * repos), so the STAND-UP owns placing the one granted repo. This runs with the
- * operator's own `gh`/`git` auth (present at `cortex quickstart` time) and lands
+ * principal's own `gh`/`git` auth (present at `cortex quickstart` time) and lands
  * the checkout at `<canonicalWorkspaceDir(slug)>/<repo>` — the SAME workspace
  * dir the dispatch handler opens the CC session's cwd in (dispatch-handler.ts's
  * `canonicalWorkspaceDir(this.stack)` fallback, cortex#2097), so the agent sees
@@ -511,7 +511,7 @@ async function runScaffold(opts: {
  *
  * ALWAYS returns `ok: true` — a clone failure is FAIL-SOFT (the stack is already
  * stood up; only the coding loop is degraded), surfaced as a prominent ⚠ with
- * the exact `gh repo clone` command the operator can run by hand. Idempotent: an
+ * the exact `gh repo clone` command the principal can run by hand. Idempotent: an
  * existing `<repo>/.git` checkout is skipped, never re-cloned or clobbered.
  */
 function runWorkspaceCheckout(
@@ -557,7 +557,7 @@ function runWorkspaceCheckout(
 
   // FAIL-SOFT — the stack is already stood up; a clone failure (auth, network,
   // repo-not-found) must NOT abort quickstart. WARN prominently: this means the
-  // coding loop can't start until the operator resolves it and clones by hand.
+  // coding loop can't start until the principal resolves it and clones by hand.
   return step("4b. Workspace checkout", true, [
     `  ⚠ WARNING: could not clone the granted repo ${ownerRepo} into the workspace.`,
     `    The stack is stood up, but the CODING LOOP WILL NOT WORK until the checkout`,
@@ -1159,7 +1159,7 @@ export async function dispatchQuickstart(
   // A `code` stack with a granted repo needs the repo PRE-PLACED in its
   // workspace: the runtime allowlist has no clone verb (by design — an agent
   // must not clone arbitrary repos), so the stand-up owns the checkout. Runs
-  // with the operator's own gh/git auth. FAIL-SOFT: a clone failure warns but
+  // with the principal's own gh/git auth. FAIL-SOFT: a clone failure warns but
   // never aborts the already-stood-up stack. Chat-only stacks skip this step.
   if (ctxRepo.length > 0) {
     reports.push(runWorkspaceCheckout(ports, { slug: s.slug, grantedRepo: ctxRepo }));

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -62,7 +62,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname } from "path";
+import { dirname, join } from "path";
 
 import { discoverStacks } from "./stack-lib";
 import { dispatchStack } from "./stack";
@@ -72,6 +72,7 @@ import { type ExitResult } from "./_shared/exit-result";
 
 import { CC_AUTH_FAILURE_MESSAGE, isCcAuthFailure } from "../../../runner/cc-failure-classifier";
 import type { CCSessionResult } from "../../../runner/cc-session";
+import { canonicalWorkspaceDir } from "../../../common/data-path";
 import { resolveConfigDir } from "../../../common/config/config-path";
 import { validateConfigLoads } from "../../../common/config/validate-on-write";
 import { expandTilde } from "../../../common/config/loader";
@@ -488,6 +489,84 @@ async function runScaffold(opts: {
   return step("4. Scaffold", false, [
     `  ✗ cortex stack create failed:`,
     ...create.stderr.split("\n").filter((l) => l.length > 0).map((l) => `    ${l}`),
+  ]);
+}
+
+// =============================================================================
+// Step 4b — workspace checkout (cortex#2452, code stacks only)
+// =============================================================================
+
+/**
+ * cortex#2452 — clone the granted repo into the stack's workspace so a coding
+ * stack starts against a real checkout, not an empty dir.
+ *
+ * The coding-tier runtime allowlist DELIBERATELY excludes `clone`/`gh repo`/
+ * `gh api` (`review-session-lockdown.ts` — an agent must not clone arbitrary
+ * repos), so the STAND-UP owns placing the one granted repo. This runs with the
+ * operator's own `gh`/`git` auth (present at `cortex quickstart` time) and lands
+ * the checkout at `<canonicalWorkspaceDir(slug)>/<repo>` — the SAME workspace
+ * dir the dispatch handler opens the CC session's cwd in (dispatch-handler.ts's
+ * `canonicalWorkspaceDir(this.stack)` fallback, cortex#2097), so the agent sees
+ * `<repo>/` as a subdir of its session cwd.
+ *
+ * ALWAYS returns `ok: true` — a clone failure is FAIL-SOFT (the stack is already
+ * stood up; only the coding loop is degraded), surfaced as a prominent ⚠ with
+ * the exact `gh repo clone` command the operator can run by hand. Idempotent: an
+ * existing `<repo>/.git` checkout is skipped, never re-cloned or clobbered.
+ */
+function runWorkspaceCheckout(
+  ports: QuickstartPorts,
+  opts: { slug: string; grantedRepo: string },
+): StepReport {
+  const ownerRepo = opts.grantedRepo;
+  const repoName = ownerRepo.slice(ownerRepo.indexOf("/") + 1);
+  // The SAME resolution dispatch-handler.ts uses for the session cwd fallback
+  // (canonicalWorkspaceDir(this.stack), off process.env.HOME) — the checkout
+  // MUST land where the agent's session actually opens or it won't see it.
+  const workspaceDir = canonicalWorkspaceDir(opts.slug);
+  const dest = join(workspaceDir, repoName);
+  const byHand = `gh repo clone ${ownerRepo} ${dest}`;
+
+  // IDEMPOTENT — an existing checkout (a `.git` dir) is left untouched. A
+  // re-run of quickstart never re-clones or clobbers local work.
+  if (existsSync(join(dest, ".git"))) {
+    return step("4b. Workspace checkout", true, [
+      `  ⊘ workspace already has ${repoName} (${dest}) — skip`,
+    ]);
+  }
+
+  // Ensure the workspace dir exists (0700, matching stack create + the dispatch
+  // fallback). `stack create --apply` already made it; this covers a
+  // hand-scaffolded or pre-#2097 stack.
+  try {
+    mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    return step("4b. Workspace checkout", true, [
+      `  ⚠ WARNING: could not create workspace dir ${workspaceDir}: ${errMsg(err)}`,
+      `    the coding loop will NOT work until the checkout is placed. Run by hand:`,
+      `      ${byHand}`,
+    ]);
+  }
+
+  const cloned = ports.workspace.cloneGrantedRepo({ ownerRepo, dest });
+  if (cloned.exitCode === 0) {
+    return step("4b. Workspace checkout", true, [
+      `  ✓ cloned ${ownerRepo} → ${dest}`,
+    ]);
+  }
+
+  // FAIL-SOFT — the stack is already stood up; a clone failure (auth, network,
+  // repo-not-found) must NOT abort quickstart. WARN prominently: this means the
+  // coding loop can't start until the operator resolves it and clones by hand.
+  return step("4b. Workspace checkout", true, [
+    `  ⚠ WARNING: could not clone the granted repo ${ownerRepo} into the workspace.`,
+    `    The stack is stood up, but the CODING LOOP WILL NOT WORK until the checkout`,
+    `    is placed (the runtime allowlist has no clone verb — by design). Run by hand:`,
+    `      ${byHand}`,
+    ...cloned.stderr
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => `    · ${l}`),
   ]);
 }
 
@@ -1074,6 +1153,16 @@ export async function dispatchQuickstart(
   reports.push(scaffoldReport);
   if (!scaffoldReport.ok) {
     return finish(reports, 1, flags.json);
+  }
+
+  // --- 4b. Workspace checkout (cortex#2452) ----------------------------------
+  // A `code` stack with a granted repo needs the repo PRE-PLACED in its
+  // workspace: the runtime allowlist has no clone verb (by design — an agent
+  // must not clone arbitrary repos), so the stand-up owns the checkout. Runs
+  // with the operator's own gh/git auth. FAIL-SOFT: a clone failure warns but
+  // never aborts the already-stood-up stack. Chat-only stacks skip this step.
+  if (ctxRepo.length > 0) {
+    reports.push(runWorkspaceCheckout(ports, { slug: s.slug, grantedRepo: ctxRepo }));
   }
 
   // --- 5. Patch configs from env ---------------------------------------------


### PR DESCRIPTION
The coding tier turned on but the workspace was empty and clone is deliberately not allowlisted → dead start (field test, Vincent). Fix: a new quickstart step 4b, when CTX_REPO is set, clones owner/repo into canonicalWorkspaceDir(slug)/<repo> using the operator's gh auth (git-clone fallback). Dest == the dispatch handler's session cwd (dispatch-handler.ts:1107, same canonicalWorkspaceDir resolver — asserted by a test), so the session opens ON the checkout. Idempotent (skip if .git exists), fail-soft (clone failure warns loudly with the manual command but quickstart still exits 0). Runtime allowlist UNCHANGED — agent works in the pre-placed checkout. 69 tests pass, tsc+eslint clean. Closes #2452.