### PR TITLE
fix(quickstart): anchored CTX_REPO validation before scaffold+clone (#2462)

### DIFF
--- a/src/cli/cortex/commands/__tests__/quickstart.test.ts
+++ b/src/cli/cortex/commands/__tests__/quickstart.test.ts
@@ -846,6 +846,58 @@ describe("dispatchQuickstart — cortex#2282 macOS gate (unified log paths)", ()
     expect(res.stdout).not.toContain("Workspace checkout");
   });
 
+  // cortex#2462 — defense-in-depth: a malformed CTX_REPO FAILS the scaffold step
+  // LOUD (exit 1) BEFORE scaffolding or cloning, independently of stack-create's
+  // own check. This closes the idempotent-re-run gap where runScaffold's
+  // principal/slug-keyed "already exists" skip would let a changed/hostile
+  // CTX_REPO reach the clone unvalidated. A `..` segment and a leading `-` are
+  // both rejected; the clone port is NEVER invoked and no config dir is written.
+  for (const badRepo of ["-x/y", "a/../b", "x/y.", "foo/bar; rm"]) {
+    test(`cortex#2462: malformed CTX_REPO "${badRepo}" fails step 4, never clones or scaffolds`, async () => {
+      const configDir = freshDir();
+      const natsDir = freshDir();
+      const cloneCalls: { ownerRepo: string; dest: string }[] = [];
+      const res = await withPlatform("linux", () =>
+        withEnv(validCtxEnv({ CTX_SLUG: "codebad", CTX_REPO: badRepo }), () =>
+          dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir], () =>
+            fakePorts({
+              cloneGrantedRepo: (opts) => {
+                cloneCalls.push(opts);
+                return { exitCode: 0, stdout: "", stderr: "" };
+              },
+            }),
+          ),
+        ),
+      );
+      // Loud failure — NOT a fail-soft warn.
+      expect(res.exitCode).toBe(1);
+      expect(res.stdout).toContain("is not a valid");
+      expect(res.stdout).toContain("refusing to scaffold or clone");
+      // The clone port was never reached.
+      expect(cloneCalls).toHaveLength(0);
+      // Nothing was scaffolded (aborted before stack create).
+      expect(existsSync(join(configDir, "codebad"))).toBe(false);
+    });
+  }
+
+  // cortex#2462 — the --json trace records the loud failure too (exit 1 + the
+  // erroring step surfaced), not a green skip.
+  test("cortex#2462: malformed CTX_REPO surfaces as a --json error envelope", async () => {
+    const configDir = freshDir();
+    const natsDir = freshDir();
+    const res = await withPlatform("linux", () =>
+      withEnv(validCtxEnv({ CTX_SLUG: "codebadjson", CTX_REPO: "-x/y" }), () =>
+        dispatchQuickstart(["--config-dir", configDir, "--nats-dir", natsDir, "--json"], () =>
+          fakePorts({
+            cloneGrantedRepo: () => ({ exitCode: 0, stdout: "", stderr: "" }),
+          }),
+        ),
+      ),
+    );
+    expect(res.exitCode).toBe(1);
+    expect(res.stdout).toContain("4. Scaffold");
+  });
+
   // cortex#2322 — the not-loaded path is no longer a printed skip. On a fresh
   // Mac (launchd service NOT loaded AND no backstop daemon running) it STARTS
   // the daemon directly via the `cortex start --config <pointer>` backstop,

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { dispatchStack } from "../stack";
+import { dispatchStack, isValidRepoFullName } from "../stack";
 import { loadConfigWithAgents } from "../../../../common/config/loader";
 import { __setPromptFilterLoadErrorForTests } from "../../../../runner/prompt-filter";
 
@@ -495,6 +495,69 @@ describe("create --capability code", () => {
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toContain("owner/repo");
     expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+
+  // cortex#2462 — the tightened, anchored REPO_FULLNAME grammar: each side is
+  // alphanumeric-anchored at BOTH ends (no leading/trailing `-`/`.`/`_`) with
+  // no `..` segment. A legitimate slug with INTERNAL `-`/`.`/`_` must still pass.
+  test("a --repo with a leading '-' is rejected (was permitted pre-#2462)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--capability", "code",
+      "--repo", "-x/y", "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("owner/repo");
+    expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+
+  test("a --repo with a '..' segment is rejected (was permitted pre-#2462)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--capability", "code",
+      "--repo", "a/../b", "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("owner/repo");
+    expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+});
+
+// =============================================================================
+// isValidRepoFullName — the anchored owner/repo grammar (cortex#2462)
+// =============================================================================
+
+describe("isValidRepoFullName (cortex#2462 anchored grammar)", () => {
+  test("accepts legitimate owner/repo slugs (internal -/./_ allowed)", () => {
+    for (const ok of [
+      "the-metafactory/cortex",
+      "vpzed-dev/gir-test",
+      "a.b_c/d-e.f",
+      "the-metafactory/metafactory-cortex-agent-luna-stack",
+      "a/b", // single-char sides
+    ]) {
+      expect(isValidRepoFullName(ok)).toBe(true);
+    }
+  });
+
+  test("rejects leading/trailing junk, '..' segments, whitespace, and shell metachars", () => {
+    for (const bad of [
+      "-x/y", // leading '-' on owner
+      "x/-y", // leading '-' on repo
+      "x/y.", // trailing '.' on repo
+      "x.-/y", // trailing junk on owner
+      "a/../b", // '..' path segment (also two slashes)
+      "a/..", // '..' as the whole repo
+      "foo/bar; rm", // shell metachars + space
+      "x/y ", // trailing space
+      " x/y", // leading space
+      "x/y/z", // too many segments
+      "xy", // no slash
+      "/y", // empty owner
+      "x/", // empty repo
+    ]) {
+      expect(isValidRepoFullName(bad)).toBe(false);
+    }
   });
 });
 

--- a/src/cli/cortex/commands/quickstart.ts
+++ b/src/cli/cortex/commands/quickstart.ts
@@ -65,7 +65,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 
 import { discoverStacks } from "./stack-lib";
-import { dispatchStack } from "./stack";
+import { dispatchStack, isValidRepoFullName } from "./stack";
 import { CliArgsError } from "./_shared/arg-error";
 import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
 import { type ExitResult } from "./_shared/exit-result";
@@ -1144,6 +1144,29 @@ export async function dispatchQuickstart(
   // one repo you name"). Absent ⇒ a chat-only stack (unchanged). A malformed
   // value is rejected by `cortex stack create --repo` (surfaced as a step fail).
   const ctxRepo = (process.env.CTX_REPO ?? "").trim();
+
+  // cortex#2462 — defense-in-depth: validate CTX_REPO HERE, before BOTH the
+  // scaffold (step 4) and the clone (step 4b), independently of what
+  // `cortex stack create --repo` does. On an idempotent RE-run, runScaffold
+  // maps create's non-zero exit to an ok:true "already exists" skip keyed only
+  // on principal/slug — repo-INDEPENDENT — so a changed/hostile CTX_REPO would
+  // otherwise sail past stack-create's own validation and reach the clone
+  // unchecked. CTX_REPO is the coding grant (config, not code) and cannot be
+  // trusted: a bad value FAILS this step LOUD (we refuse to scaffold or clone
+  // an unvalidated grant) rather than silently proceeding. Anchored grammar +
+  // `..`-segment rejection live in `isValidRepoFullName` (shared with
+  // stack-create, a pure predicate — no coupling to its runtime path).
+  if (ctxRepo.length > 0 && !isValidRepoFullName(ctxRepo)) {
+    reports.push(
+      step("4. Scaffold", false, [
+        `  ✗ CTX_REPO "${ctxRepo}" is not a valid "owner/repo" GitHub full name`,
+        `    each side must be alphanumeric-anchored at both ends ([A-Za-z0-9._-] only internally) with no ".." segment`,
+        `    refusing to scaffold or clone an unvalidated code-repo grant`,
+      ]),
+    );
+    return finish(reports, 1, flags.json);
+  }
+
   const scaffoldReport = await runScaffold({
     slug: s.slug,
     principal: s.principal,

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -177,8 +177,28 @@ function listValueFlag(flags: FlagMap, name: string): string[] {
  *  carries the software-factory bash allowlist). */
 const KNOWN_EXTRA_CAPABILITIES = new Set(["code"]);
 
-/** `owner/repo` shape for `--repo` (GitHub full-name grammar, permissive). */
-const REPO_FULLNAME_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+/**
+ * `owner/repo` shape for `--repo` (GitHub full-name grammar, anchored).
+ *
+ * cortex#2462 — each side is anchored alphanumeric at BOTH ends, with
+ * `[A-Za-z0-9._-]` permitted only internally, so a leading/trailing `-`/`.`/`_`
+ * is rejected. Paired with `isValidRepoFullName`, which also rejects any `..`
+ * segment. The old form (`/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/`) admitted a
+ * leading `-` and `..` — both closed here.
+ */
+export const REPO_FULLNAME_RE =
+  /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?\/[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+
+/**
+ * True iff `repo` is a well-formed `owner/repo` GitHub full name: anchored
+ * alphanumeric on both ends of each side, no `..` path segment. Shared by
+ * `cortex stack create --repo` and `cortex quickstart`'s CTX_REPO gate so both
+ * enforce the SAME grammar. A pure predicate — sharing it does NOT couple
+ * quickstart's check to stack-create's (non-idempotent) runtime validation.
+ */
+export function isValidRepoFullName(repo: string): boolean {
+  return REPO_FULLNAME_RE.test(repo) && !repo.includes("..");
+}
 
 /**
  * `create` writes to disk; the DEFAULT is dry-run (safe). `--apply` opts into
@@ -319,7 +339,7 @@ function runCreate(
 
   const grantedRepos: string[] = [];
   for (const repo of listValueFlag(flags, "--repo")) {
-    if (!REPO_FULLNAME_RE.test(repo)) {
+    if (!isValidRepoFullName(repo)) {
       return usageError(
         "create",
         `--repo "${repo}" must be an "owner/repo" GitHub full name`,


### PR DESCRIPTION
Defense-in-depth from the #2452 review: on idempotent re-runs quickstart didn't re-validate a changed CTX_REPO before the clone (stack-create's validation is repo-independent on the 'already exists' skip). Fix: shared isValidRepoFullName (anchored owner/repo, both sides alnum-anchored so no leading/trailing -/.; rejects any .. segment), gated in quickstart BEFORE scaffold+clone (malformed → loud exit 1, clone never reached), and REPO_FULLNAME_RE itself tightened so stack-create is strict too. Only 2 call sites (both updated). Matrix: the-metafactory/metafactory-cortex-agent-luna-stack, vpzed-dev/gir-test, a.b_c/d-e.f PASS; -x/y, x/-y, a/../b, 'foo/bar; rm' FAIL. 117 tests pass. Closes #2462.