### PR TITLE
fix(path-guard): NWS round-2 HIGHs — read-only overlap + malformed-config fail-open (#2341)

### DIFF
--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -339,14 +339,29 @@ export function resolveBashGuardEnv(
  * includes `readOnlyDirs` (kept that way deliberately so `--add-dir` still
  * grants read access to read-only dirs — see `claude-invoker.ts`, which
  * reads `opts.allowedDirs` UNCHANGED and never sees this function's output).
- * If this function emitted that union verbatim as the guard's `allowedDirs`,
- * a read-only dir would sit in BOTH lists, `decidePath`'s `inAllowed` check
- * would be `true`, and the write-deny branch (which requires `!inAllowed`)
- * would never fire — F6 would stay silently inert even with `readOnlyDirs`
- * populated. So the guard's `allowedDirs` is the caller's `allowedDirs`
- * MINUS `readOnlyDirs`; `readOnlyDirs` is carried unchanged. Overlap rule:
- * a dir present in both inputs resolves to READ-ONLY in the emitted policy —
- * the safe default.
+ * So the guard's `allowedDirs` is the caller's `allowedDirs` MINUS
+ * `readOnlyDirs` (exact-string membership); `readOnlyDirs` is carried
+ * unchanged. Overlap rule: a dir present in both inputs resolves to
+ * READ-ONLY in the emitted policy — the safe default.
+ *
+ * cortex#2359 round 2 (F1) note: this subtraction is EXACT-STRING only (see
+ * {@link splitGuardDirs}) — it does NOT catch a `readOnlyDirs` entry that is
+ * merely CONTAINED WITHIN a broader `allowedDirs` entry rather than equal to
+ * it (`allowedDirs:["/repo"], readOnlyDirs:["/repo/.claude"]` subtracts
+ * nothing, since neither string equals the other). That nested case used to
+ * be a live bypass because `decidePath`'s `inReadOnly` check was ALSO gated
+ * on `!inAllowed`, so the two gaps compounded. `decidePath` now computes
+ * `inAllowed`/`inReadOnly` independently and lets read-only win by
+ * CONTAINMENT, not exact-string overlap (see path-guard.hook.ts's module
+ * doc, "Read-only vs. allowed on overlap") — so the nested case is closed at
+ * the DECISION layer regardless of what this subtraction does or doesn't
+ * catch. This function's exact-match subtraction is therefore no longer the
+ * mechanism F6/F1 depend on; it remains as defense-in-depth (it keeps a
+ * read-only dir out of the emitted `allowedDirs` list at all, for any other
+ * consumer — e.g. {@link deriveSandboxProfile} — that might read that field
+ * without going through `decidePath`'s precedence logic). Made
+ * containment-aware here too would be redundant work for zero behavior
+ * change at the hook, so it was deliberately left as-is.
  */
 export function resolvePathGuardEnv(
   opts: Pick<CCSessionOpts, "allowedDirs" | "readOnlyDirs">,

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -35,6 +35,7 @@ import {
   parsePathGuardConfig,
   extractCandidatePaths,
   decidePath,
+  validateDirsField,
 } from "../path-guard.hook";
 import {
   expandUserPath,
@@ -157,10 +158,84 @@ describe("parsePathGuardConfig", () => {
     expect(r.ok).toBe(false);
   });
 
-  test("non-array allowedDirs value is coerced to [] (tolerant, still ok)", () => {
-    const r = parsePathGuardConfig(JSON.stringify({ allowedDirs: "not-an-array" }));
+  // -- cortex#2359 round 2, finding F2 --------------------------------------
+  // A present-but-wrong-type field must FAIL CLOSED (ok:false), never
+  // silently coerce to [] — coercion is how a config-shape MISTAKE (a
+  // string where an array was required) became indistinguishable from a
+  // deliberately empty policy and disabled all containment.
+
+  test("F2 exact repro: allowedDirs is a string (not an array) ⇒ ok:false, fail closed", () => {
+    // The literal shape from the NWS report:
+    // CORTEX_PATH_GUARD='{"allowedDirs":"/repo","readOnlyDirs":[]}'
+    const r = parsePathGuardConfig(JSON.stringify({ allowedDirs: "/repo", readOnlyDirs: [] }));
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("allowedDirs");
+  });
+
+  test("non-array readOnlyDirs value ⇒ ok:false, fail closed", () => {
+    const r = parsePathGuardConfig(JSON.stringify({ readOnlyDirs: "/repo" }));
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("readOnlyDirs");
+  });
+
+  test("array containing a non-string element ⇒ ok:false, fail closed", () => {
+    const r = parsePathGuardConfig(JSON.stringify({ allowedDirs: ["/repo", 123] }));
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("allowedDirs");
+  });
+
+  test("null value for a dirs field ⇒ ok:false, fail closed (not treated as absent)", () => {
+    const r = parsePathGuardConfig(JSON.stringify({ allowedDirs: null }));
+    expect(r.ok).toBe(false);
+  });
+
+  // -- still-permits controls: a malformed field must not break the
+  // legitimately-empty or well-formed cases ---------------------------------
+
+  test("a field simply ABSENT from the object (never mentioned) ⇒ still legitimate empty, ok:true", () => {
+    const r = parsePathGuardConfig(JSON.stringify({ readOnlyDirs: ["/b"] }));
     expect(r.ok).toBe(true);
-    expect(r.policy.allowedDirs).toEqual([]);
+    expect(r.policy).toEqual({ allowedDirs: [], readOnlyDirs: ["/b"] });
+  });
+
+  test("well-formed policy with both fields present ⇒ unchanged, ok:true", () => {
+    const r = parsePathGuardConfig(JSON.stringify({ allowedDirs: ["/a", "/c"], readOnlyDirs: ["/b"] }));
+    expect(r.ok).toBe(true);
+    expect(r.policy).toEqual({ allowedDirs: ["/a", "/c"], readOnlyDirs: ["/b"] });
+  });
+});
+
+describe("validateDirsField", () => {
+  test("key absent ⇒ ok:true, value:[]", () => {
+    expect(validateDirsField({}, "allowedDirs")).toEqual({ ok: true, value: [], reason: "" });
+  });
+
+  test("key present, well-formed array of strings ⇒ ok:true, value passed through", () => {
+    expect(validateDirsField({ allowedDirs: ["/a", "/b"] }, "allowedDirs")).toEqual({
+      ok: true,
+      value: ["/a", "/b"],
+      reason: "",
+    });
+  });
+
+  test("key present, empty array ⇒ ok:true, value:[] (deliberately empty, not malformed)", () => {
+    expect(validateDirsField({ allowedDirs: [] }, "allowedDirs")).toEqual({ ok: true, value: [], reason: "" });
+  });
+
+  test("key present, a string instead of an array ⇒ ok:false", () => {
+    const r = validateDirsField({ allowedDirs: "/repo" }, "allowedDirs");
+    expect(r.ok).toBe(false);
+    expect(r.value).toEqual([]);
+  });
+
+  test("key present, an object instead of an array ⇒ ok:false", () => {
+    const r = validateDirsField({ readOnlyDirs: { foo: "bar" } }, "readOnlyDirs");
+    expect(r.ok).toBe(false);
+  });
+
+  test("key present, a number instead of an array ⇒ ok:false", () => {
+    const r = validateDirsField({ allowedDirs: 42 }, "allowedDirs");
+    expect(r.ok).toBe(false);
   });
 });
 
@@ -275,12 +350,73 @@ describe("decidePath", () => {
     expect(d.allow).toBe(false);
   });
 
-  test("a dir listed in BOTH allowedDirs and readOnlyDirs ⇒ write allowed (allow wins)", () => {
+  // -- cortex#2359 round 2, finding F1 --------------------------------------
+  // Read-only must win on overlap, independent of whether the overlap is an
+  // EXACT string match or one dir merely CONTAINING the other — deny wins
+  // (deny-precedence), never "most specific match" (see the hook's module
+  // doc, "Read-only vs. allowed on overlap", for the full reasoning).
+
+  test("a dir listed in BOTH allowedDirs and readOnlyDirs (exact match) ⇒ write DENIED (deny wins, the safe default)", () => {
+    // This inverts the PRE-FIX behavior (which asserted allow-wins here) —
+    // deny-precedence generalizes cc-session.ts's already-documented
+    // exact-match overlap contract ("a dir in both wins as read-only") to
+    // decidePath itself, rather than relying solely on the caller-side
+    // subtraction to keep the two lists disjoint.
     const d = decidePath("Write", join(allowedDir, "f.txt"), {
       allowedDirs: [allowedDir],
       readOnlyDirs: [allowedDir],
     });
+    expect(d.allow).toBe(false);
+  });
+
+  test("F1 exact repro: readOnlyDirs nested INSIDE a broader allowedDirs ⇒ write DENIED", () => {
+    // The literal shape from the NWS report:
+    // allowedDirs:["/repo"], readOnlyDirs:["/repo/.claude"] →
+    // Write /repo/.claude/settings.json used to return allow:true.
+    const nestedReadOnly = join(allowedDir, ".claude");
+    mkdirSync(nestedReadOnly, { recursive: true });
+    const d = decidePath("Write", join(nestedReadOnly, "settings.json"), {
+      allowedDirs: [allowedDir],
+      readOnlyDirs: [nestedReadOnly],
+    });
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("READ-ONLY");
+  });
+
+  test("F1 still-permits #1: reads inside the nested read-only dir remain allowed", () => {
+    const nestedReadOnly = join(allowedDir, ".claude");
+    mkdirSync(nestedReadOnly, { recursive: true });
+    const d = decidePath("Read", join(nestedReadOnly, "settings.json"), {
+      allowedDirs: [allowedDir],
+      readOnlyDirs: [nestedReadOnly],
+    });
     expect(d.allow).toBe(true);
+  });
+
+  test("F1 still-permits #2: writes to the surrounding allowedDir (outside the nested read-only pocket) remain allowed", () => {
+    const nestedReadOnly = join(allowedDir, ".claude");
+    mkdirSync(nestedReadOnly, { recursive: true });
+    const d = decidePath("Write", join(allowedDir, "src", "index.ts"), {
+      allowedDirs: [allowedDir],
+      readOnlyDirs: [nestedReadOnly],
+    });
+    expect(d.allow).toBe(true);
+  });
+
+  test("deny-precedence (not most-specific-match): a writable dir nested INSIDE a broader read-only dir is still denied", () => {
+    // The scenario that distinguishes deny-precedence from most-specific-
+    // match: readOnlyDirs is the BROADER root, allowedDirs is a narrower
+    // dir nested inside it. Most-specific-match would let the narrower
+    // (deeper) allowedDirs entry win and permit the write; deny-precedence
+    // — the rule this hook deliberately implements — denies it regardless,
+    // because the path is still contained in a readOnlyDirs entry.
+    const writableCarveOut = join(readOnlyDir, "build-output");
+    mkdirSync(writableCarveOut, { recursive: true });
+    const d = decidePath("Write", join(writableCarveOut, "out.js"), {
+      allowedDirs: [writableCarveOut],
+      readOnlyDirs: [readOnlyDir],
+    });
+    expect(d.allow).toBe(false);
   });
 });
 
@@ -1083,5 +1219,165 @@ describe("path-guard.hook — round 6: NUL-byte file_path fails closed (reducer,
     );
     expect(r.status).toBe(0);
     expectDenyDecision(r.stdout);
+  });
+});
+
+// =============================================================================
+// cortex#2359 round 2, finding F1 (HIGH) — full-process regression for the
+// exact repro: a readOnlyDirs entry NESTED inside a broader allowedDirs
+// entry used to be silently overridden (never read-only) because
+// decidePath's `inReadOnly` was gated on `!inAllowed`. Covers both
+// directions (deny writes to the nested pocket; still permit reads there;
+// still permit writes to the surrounding allowed dir) per the spawned
+// process, not just the pure decidePath unit above.
+// =============================================================================
+describe("path-guard.hook — F1: nested read-only inside a broader allowed dir (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+  let nestedReadOnlyDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-f1-nested-"));
+    allowedDir = join(root, "repo");
+    nestedReadOnlyDir = join(allowedDir, ".claude");
+    mkdirSync(nestedReadOnlyDir, { recursive: true });
+    writeFileSync(join(nestedReadOnlyDir, "settings.json"), "{}\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function policyEnv(): Record<string, string> {
+    // The exact repro shape from the NWS report:
+    // allowedDirs:["/repo"], readOnlyDirs:["/repo/.claude"]
+    return {
+      CORTEX_CHANNEL: "test",
+      CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [nestedReadOnlyDir] }),
+    };
+  }
+
+  test("F1 exact repro: Write into the nested readOnlyDirs pocket ⇒ deny (was allow:true before the fix)", () => {
+    const r = runHook("Write", { file_path: join(nestedReadOnlyDir, "settings.json") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("READ-ONLY");
+  });
+
+  test("F1 exact repro: Edit into the nested readOnlyDirs pocket ⇒ deny", () => {
+    const r = runHook(
+      "Edit",
+      { file_path: join(nestedReadOnlyDir, "settings.json"), old_string: "{}", new_string: "{\"x\":1}" },
+      policyEnv(),
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("F1 still-permits: Read of the nested readOnlyDirs pocket ⇒ allow", () => {
+    const r = runHook("Read", { file_path: join(nestedReadOnlyDir, "settings.json") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("F1 still-permits: Write to the surrounding allowedDir (outside the nested pocket) ⇒ allow", () => {
+    const r = runHook("Write", { file_path: join(allowedDir, "src", "index.ts") }, policyEnv());
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+});
+
+// =============================================================================
+// cortex#2359 round 2, finding F2 (HIGH) — full-process regression for the
+// exact repro: a present-but-malformed CORTEX_PATH_GUARD field (a string
+// where an array was required) used to coerce to [] and, combined with an
+// empty readOnlyDirs, produce a fully-empty policy that reads as "no
+// restriction configured" — every path passed. Covers both directions
+// (malformed ⇒ deny; genuinely-empty/well-formed policies still work).
+// =============================================================================
+describe("path-guard.hook — F2: malformed CORTEX_PATH_GUARD field fails closed (spawned)", () => {
+  let root: string;
+  let allowedDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "path-guard-f2-malformed-"));
+    allowedDir = join(root, "repo");
+    outsideDir = join(root, "outside");
+    mkdirSync(allowedDir, { recursive: true });
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, "secret.txt"), "nope\n");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("F2 exact repro: allowedDirs is a string (not an array) ⇒ deny, not pass-through", () => {
+    // CORTEX_PATH_GUARD='{"allowedDirs":"/repo","readOnlyDirs":[]}' — the
+    // literal shape from the NWS report, with the real allowedDir path
+    // substituted for the fixture's temp dir.
+    const r = runHook(
+      "Read",
+      { file_path: join(outsideDir, "secret.txt") },
+      {
+        CORTEX_CHANNEL: "test",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: allowedDir, readOnlyDirs: [] }),
+      },
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("allowedDirs");
+  });
+
+  test("F2 still-permits #1: a genuinely empty policy ({}) still passes through with no restriction", () => {
+    const r = runHook(
+      "Read",
+      { file_path: join(outsideDir, "secret.txt") },
+      { CORTEX_CHANNEL: "test", CORTEX_PATH_GUARD: "{}" },
+    );
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("F2 still-permits #2: a genuinely empty policy (both fields explicitly []) still passes through", () => {
+    const r = runHook(
+      "Read",
+      { file_path: join(outsideDir, "secret.txt") },
+      {
+        CORTEX_CHANNEL: "test",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [], readOnlyDirs: [] }),
+      },
+    );
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("F2 still-permits #3: a well-formed policy behaves unchanged (containment still enforced)", () => {
+    const r = runHook(
+      "Read",
+      { file_path: join(outsideDir, "secret.txt") },
+      {
+        CORTEX_CHANNEL: "test",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+      },
+    );
+    expect(r.status).toBe(0);
+    expectDenyDecision(r.stdout);
+  });
+
+  test("F2 still-permits #4: a well-formed policy still ALLOWS an in-scope path", () => {
+    const r = runHook(
+      "Read",
+      { file_path: join(allowedDir, "ok.txt") },
+      {
+        CORTEX_CHANNEL: "test",
+        CORTEX_PATH_GUARD: JSON.stringify({ allowedDirs: [allowedDir], readOnlyDirs: [] }),
+      },
+    );
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
   });
 });

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -51,8 +51,53 @@
  * already encodes (`allDirs.length > 0` gates whether the FILESYSTEM
  * RESTRICTION prose even appears); this hook makes that SAME contract real
  * instead of advisory, it does not change WHEN restriction applies. A
- * MALFORMED `CORTEX_PATH_GUARD` (present but not parseable JSON, or not an
- * object) is a genuine failure, not "empty" — DENY.
+ * MALFORMED `CORTEX_PATH_GUARD` is a genuine failure, not "empty" — DENY.
+ * "Malformed" is checked at TWO levels (cortex#2359 round 2 finding F2):
+ * present-but-not-parseable-JSON / not-an-object (as before), AND — new —
+ * present-but-wrong-shape on a per-field basis: `allowedDirs`/`readOnlyDirs`
+ * that ARE PRESENT in the parsed object but are not themselves an array of
+ * strings (e.g. `{"allowedDirs":"/repo"}`, a string where an array was
+ * required) is a config-shape MISTAKE, not a deliberate empty policy, and
+ * must DENY rather than silently coerce to `[]` — see
+ * {@link validateDirsField}. A field that is simply ABSENT from the object
+ * (never mentioned at all) is unaffected — that's the legitimate "no
+ * restriction on this axis" case and still resolves to `[]`, `ok:true`.
+ *
+ * ## Read-only vs. allowed on overlap — deny wins (precedence, not specificity)
+ *
+ * When a candidate path is contained in BOTH an `allowedDirs` entry and a
+ * `readOnlyDirs` entry — whether because the two entries are the exact same
+ * string, or because one CONTAINS the other (a `readOnlyDirs` entry nested
+ * inside a broader `allowedDirs` entry, or vice versa) — {@link decidePath}
+ * resolves the overlap as READ-ONLY, unconditionally, for every write tool.
+ * This is DENY-PRECEDENCE, not "most specific match wins": a narrower
+ * *writable* carve-out nested inside a broader read-only root does NOT
+ * regain write access. Two reasons this is the correct rule, not just the
+ * simpler one:
+ *
+ *   1. It is the SAME contract `cc-session.ts`'s `resolvePathGuardEnv` /
+ *      `splitGuardDirs` already documents for the exact-match case ("a dir
+ *      in both wins as read-only, the safe default") — deny-precedence
+ *      generalizes that existing, deliberate policy to containment instead
+ *      of silently diverging from it for the nested case. There is no
+ *      config-authoring signal anywhere in this system that the ORDER or
+ *      NESTING of two directory entries is meant to encode "this narrower
+ *      grant overrides that broader restriction" — most-specific-match
+ *      would be inventing an override mechanism nothing currently expresses
+ *      or intends.
+ *   2. Most-specific-match is strictly MORE code and MORE state to get right
+ *      (computing "specificity" from two realpath'd strings, deciding ties,
+ *      documenting it, testing it) to buy a carve-out feature nobody asked
+ *      for and no live config uses — pure attack surface for a control that
+ *      has already needed nine adversarial rounds to reach fail-closed. A
+ *      principal who genuinely wants a writable exception inside an
+ *      otherwise read-only tree can express it today by NOT nesting the two
+ *      — list sibling directories instead of overlapping ones.
+ *
+ * If a future need for a genuine writable carve-out emerges, that should be
+ * its own deliberately-reviewed feature (an explicit third list, e.g.
+ * `writableExceptions`), not an implicit consequence of directory nesting
+ * order that a config author could get backwards without realizing it.
  *
  * ## Known limitations
  *
@@ -142,17 +187,68 @@ export interface PathGuardConfigResult {
   reason: string;
 }
 
-function toStringArray(v: unknown): string[] {
-  if (!Array.isArray(v)) return [];
-  return v.filter((x): x is string => typeof x === "string");
+export interface DirsFieldValidation {
+  /** false only when the field is PRESENT but the WRONG shape. */
+  ok: boolean;
+  value: string[];
+  reason: string;
+}
+
+/**
+ * Validate ONE `CORTEX_PATH_GUARD` field (`allowedDirs` or `readOnlyDirs`)
+ * that is expected to be an array of strings, distinguishing three cases
+ * (cortex#2359 round 2 finding F2):
+ *
+ *   - ABSENT from the parsed object entirely (`key in obj` is false) — a
+ *     LEGITIMATE "nothing configured on this axis" — `ok:true, value:[]`.
+ *     JSON has no `undefined`, so a present key is never `undefined`; the
+ *     only way to be "absent" is to not appear in the object at all.
+ *   - PRESENT but not an array, OR an array containing a non-string element
+ *     — a config-SHAPE MISTAKE (e.g. a bare string where an array was
+ *     required, cortex#2359's exact repro
+ *     `{"allowedDirs":"/repo","readOnlyDirs":[]}`) — `ok:false`. The OLD
+ *     behavior silently coerced this to `[]` (see the module doc's git
+ *     history / PR description), which combined with an already-empty
+ *     `readOnlyDirs` produced a fully-empty policy that reads as
+ *     "session author deliberately configured no restriction" — a
+ *     malformed value must never be indistinguishable from a deliberately
+ *     empty one.
+ *   - PRESENT, an array, every element a string — the well-formed case,
+ *     unchanged from before — `ok:true, value:[...]`.
+ *
+ * Exported for unit tests.
+ */
+export function validateDirsField(obj: Record<string, unknown>, key: string): DirsFieldValidation {
+  if (!(key in obj)) {
+    return { ok: true, value: [], reason: "" };
+  }
+  const v = obj[key];
+  if (!Array.isArray(v)) {
+    return {
+      ok: false,
+      value: [],
+      reason: `CORTEX_PATH_GUARD.${key} must be an array of strings (got ${v === null ? "null" : typeof v})`,
+    };
+  }
+  const badIndex = v.findIndex((x) => typeof x !== "string");
+  if (badIndex !== -1) {
+    return {
+      ok: false,
+      value: [],
+      reason: `CORTEX_PATH_GUARD.${key}[${badIndex}] must be a string (got ${typeof v[badIndex]})`,
+    };
+  }
+  return { ok: true, value: v as string[], reason: "" };
 }
 
 /**
  * Parse `CORTEX_PATH_GUARD`. Absence is a LEGITIMATE empty policy (not a
  * failure) — see the module doc's "Policy source" section. A present value
- * that isn't parseable JSON, or doesn't parse to an object, IS a failure —
- * `ok:false` — callers must DENY rather than silently substitute an empty
- * policy for a malformed one. Exported for unit tests.
+ * that isn't parseable JSON, doesn't parse to an object, or has a
+ * present-but-wrong-shape `allowedDirs`/`readOnlyDirs` field (see
+ * {@link validateDirsField}) IS a failure — `ok:false` — callers must DENY
+ * rather than silently substitute an empty policy for a malformed one.
+ * Exported for unit tests.
  */
 export function parsePathGuardConfig(raw: string | undefined): PathGuardConfigResult {
   if (raw === undefined || raw.trim() === "") {
@@ -176,12 +272,19 @@ export function parsePathGuardConfig(raw: string | undefined): PathGuardConfigRe
     };
   }
   const obj = parsed as Record<string, unknown>;
+
+  const allowedDirs = validateDirsField(obj, "allowedDirs");
+  if (!allowedDirs.ok) {
+    return { ok: false, policy: { allowedDirs: [], readOnlyDirs: [] }, reason: allowedDirs.reason };
+  }
+  const readOnlyDirs = validateDirsField(obj, "readOnlyDirs");
+  if (!readOnlyDirs.ok) {
+    return { ok: false, policy: { allowedDirs: [], readOnlyDirs: [] }, reason: readOnlyDirs.reason };
+  }
+
   return {
     ok: true,
-    policy: {
-      allowedDirs: toStringArray(obj.allowedDirs),
-      readOnlyDirs: toStringArray(obj.readOnlyDirs),
-    },
+    policy: { allowedDirs: allowedDirs.value, readOnlyDirs: readOnlyDirs.value },
     reason: "",
   };
 }
@@ -432,10 +535,23 @@ export interface PathDecision {
  * Pure — does its own realpath/containment I/O via `isContainedIn` but
  * takes no other state, so it's directly unit-testable against a real
  * temp-dir fixture. Exported for unit tests.
+ *
+ * `inAllowed` and `inReadOnly` are computed INDEPENDENTLY — cortex#2359
+ * round 2 finding F1. The prior `!inAllowed &&` guard on `inReadOnly` made
+ * read-only membership STRUCTURALLY UNREACHABLE for any path also contained
+ * in an `allowedDirs` entry, so a `readOnlyDirs` entry nested inside a
+ * broader `allowedDirs` entry (e.g. `allowedDirs:["/repo"],
+ * readOnlyDirs:["/repo/.claude"]`) was silently never read-only — `inAllowed`
+ * was true (the broader root contains it) and `inReadOnly` could then never
+ * even be evaluated. Computing both independently and letting read-only WIN
+ * on the write-tool check below (deny-precedence — see the module doc's
+ * "Read-only vs. allowed on overlap" section for why this, not
+ * most-specific-match, is correct) closes that gap for both the exact-match
+ * AND the nested case uniformly.
  */
 export function decidePath(toolName: string, absPath: string, policy: PathGuardPolicy): PathDecision {
   const inAllowed = policy.allowedDirs.some((d) => isContainedIn(d, absPath));
-  const inReadOnly = !inAllowed && policy.readOnlyDirs.some((d) => isContainedIn(d, absPath));
+  const inReadOnly = policy.readOnlyDirs.some((d) => isContainedIn(d, absPath));
 
   if (!inAllowed && !inReadOnly) {
     return {


### PR DESCRIPTION
Fixes the two HIGH findings from [NorthWoods Sentinel's round-2 review](https://github.com/the-metafactory/cortex/issues/2341#issuecomment-5084213029) of `v6.13.0`. Both verified at source and reproduced before any code was written. Epic #2341.

## F1 — HIGH — read-only silently overridden by an overlapping allowed dir

`decidePath` computed `inReadOnly = !inAllowed && ...`, so a `readOnlyDirs` entry **nested inside** a broader `allowedDirs` entry was structurally unreachable as read-only. The write-deny could never fire for it.

Reproduced before fixing — `allowedDirs:["/repo"], readOnlyDirs:["/repo/.claude"]` → `Write /repo/.claude/settings.json` returned **allow=true**.

This matters because *"workspace writable, except this protected subdir"* is exactly the policy shape we would recommend to anyone. It also defeats the natural mitigation for F5 (put `.claude` in `readOnlyDirs`).

Note EBH-1b's `resolvePathGuardEnv` subtracts `readOnlyDirs` from `allowedDirs` — but only on **exact** matches, which is why nested paths slipped through.

**Fix:** `inAllowed`/`inReadOnly` are now computed independently; read-only wins whenever a write-tool path is contained in any `readOnlyDirs` entry.

**Deny-precedence over most-specific-match**, deliberately. `splitGuardDirs` already documents the exact-match case as *"a dir in both wins as read-only, the safe default"* — this generalises that existing contract to containment. Most-specific-match would invent a "nesting order overrides restriction" mechanism the config format cannot express, and add specificity computation and tie-breaking to a control that has already survived nine adversarial rounds. A test locks in that a writable dir nested inside a read-only one is still denied, so the choice is recorded as deliberate rather than an oversight.

## F2 — HIGH — a malformed config field fails open to no restriction

`toStringArray` coerced any non-array to `[]`, making a present-but-wrong-type field indistinguishable from an absent one. Both arrays empty → the empty-policy branch calls `pass()` → every path allowed. This is a config-shape *mistake*, not an attack, so it can happen by accident.

**Fix:** `validateDirsField` fails closed for a field that is **present but not an array of strings** (including an array with a non-string element), while an **absent** field still resolves to `[]`. That distinction is load-bearing: an absent policy legitimately means "no restriction configured for this session" per the security-preamble contract, and breaking it would break every unrestricted session.

## Verified independently (mine, not the branch's tests)

**F1:**

| Case | Result |
|---|---|
| `Write` nested `.claude/settings.json` | denied |
| `Edit` nested `.claude/settings.json` | denied |
| `Read` the same file | still allowed |
| `Write` elsewhere in the allowed dir | still allowed |
| `Read` outside every configured dir | still denied |

**F2:**

| Config | Result |
|---|---|
| `allowedDirs` as a string (the NWS repro) | denied |
| `allowedDirs` containing a non-string | denied |
| `allowedDirs` as an object | denied |
| no `CORTEX_PATH_GUARD` at all | passes (correct — unrestricted session) |
| `{}` / explicitly empty arrays | passes (correct) |

## Residual found while looking for the next gap

The builder checked whether L2 (`deriveSandboxProfile`) shares the same containment gap — it projects from the same `splitGuardDirs` split, so **it does**. It is inert today (`sandboxMode` defaults `"off"`, no caller sets it), so there is no exposure, but it is flagged in the doc as a thing to fix before EBH-3 rollout rather than left to be rediscovered.

One pre-existing test asserting "exact overlap → allow wins" was **inverted** to "deny wins" — a narrowing consistent with the new documented contract, called out here so the change is not silent.

## Tests

Baseline `origin/main` 11150 pass / 14 fail → branch 11176 pass / 12 fail (+24 new). The 12 are a strict subset of the baseline 14, confirmed by name-diff — pre-existing `startCortex` boot-wiring and `SurfaceContext.hook` failures, unrelated. `tsc --noEmit` clean; lint 0 errors.

The NWS repro shapes are included verbatim as regression tests, at both the pure-function and spawned-process levels.
