### PR TITLE
fix(runner): register CortexPathGuard in curated settings — the file-tool boundary was never bound (R1-F1-A, #2482)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -126,9 +126,21 @@ provides:
     - source: src/runner/hooks/bash-guard.hook.ts
       target: ~/.claude/hooks/CortexBashGuard.hook.ts
     # EBH-1 (cortex#2343) — cortex-owned PreToolUse path guard for the file
-    # tools (Read/Write/Edit/Glob/Grep). Registered GLOBALLY below (unlike
-    # the Skill/MCP guards) because — like CortexBashGuard — it gates every
-    # bot session's file access, not a per-session grant list.
+    # tools (Read/Write/Edit/Glob/Grep/NotebookEdit). Registered GLOBALLY
+    # below (unlike the Skill/MCP guards) because — like CortexBashGuard —
+    # it gates every bot session's file access, not a per-session grant
+    # list. NOTE (cortex#2482): global registration here is NOT, by itself,
+    # sufficient for dispatched bot sessions — those spawn with an empty
+    # --setting-sources and load ONLY the curated file
+    # src/runner/session-settings.ts builds (buildCuratedSettings), never
+    # this manifest-driven principal-global settings.json. CortexBashGuard
+    # is registered in BOTH places (here AND buildCuratedSettings); this
+    # hook now is too. A hook that is manifest-registered but
+    # curated-file-absent is REGISTERED for the principal's own interactive
+    # sessions only — it does not run in a dispatched session at all. This
+    # exact gap (manifest registration without curated-file registration)
+    # was the R1-F1-A defect this issue closed; do not re-derive "global
+    # registration alone covers bot sessions" from this comment again.
     - source: src/runner/hooks/path-guard.hook.ts
       target: ~/.claude/hooks/CortexPathGuard.hook.ts
     # cortex#710 (C-701 Part B) — per-skill grant PreToolUse hook. Installed

--- a/src/runner/__tests__/hook-registration-parity.test.ts
+++ b/src/runner/__tests__/hook-registration-parity.test.ts
@@ -1,0 +1,179 @@
+// cortex#2482 (EBH-1 / R1-F1-A) — hook registration parity.
+//
+// Every hook `arc-manifest.yaml`'s `provides.hooks` registers UNCONDITIONALLY
+// (Bash guard, Path guard, EventLogger, Context) is meant to be session-scoped
+// too — but the manifest only reaches the PRINCIPAL's global, interactive
+// `~/.claude/settings.json`. A dispatched cortex session spawns with an EMPTY
+// `--setting-sources` (session-settings.ts) and loads ONLY the curated file
+// `buildCuratedSettings()` produces. A hook that is manifest-registered but
+// curated-file-absent therefore NEVER RUNS in a dispatched session, even
+// though every doc in the repo said it was live — exactly the R1-F1-A defect
+// this issue closed (`CortexPathGuard` was registered in the manifest and
+// nowhere else for ~1 release). This test makes that class of gap fail CI
+// instead of shipping silently.
+//
+// Pattern copied from scripts/__tests__/manifest-hooks-casing.test.ts: yaml-
+// parse the manifest, sanity-check non-empty BEFORE asserting (guards against
+// a parse regression silently passing everything), and throw a diagnostic
+// Error carrying the concrete mismatch rather than a bare `expect` failure —
+// same style as that file's `:60-72`.
+//
+// Rationale for a DEDICATED test, not folded into manifest-hooks-casing.test.ts:
+// that test only diffs `provides.hooks` against `provides.files` basenames (a
+// filesystem-casing guard). Nothing anywhere compared `provides.hooks` against
+// the curated settings a dispatched session actually loads. Same argument one
+// layer up — `provides.files` vs the repo checkout — in
+// src/taps/cc-events/__tests__/hook-compat-symlinks.test.ts:13-15.
+//
+// Do NOT assert against src/settings/cortex-hooks.json. Its own `_comment`
+// says arc auto-DERIVES it from provides.hooks at install time and that it
+// must never be manually merged into settings.json — it writes nothing to a
+// live session and is not a source of truth for what a dispatched session
+// loads.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse } from "yaml";
+import { buildCuratedSettings } from "../session-settings";
+
+const MANIFEST_PATH = join(import.meta.dir, "..", "..", "..", "arc-manifest.yaml");
+
+interface ManifestHook {
+  event: string;
+  command: string;
+  matcher?: string;
+}
+
+interface Manifest {
+  provides: {
+    files: { source: string; target: string }[];
+    hooks: ManifestHook[];
+  };
+}
+
+interface CuratedHookEntry {
+  matcher?: string;
+  hooks: { type: string; command: string }[];
+}
+
+interface CuratedSettings {
+  hooks: Record<string, CuratedHookEntry[]>;
+}
+
+function basename(p: string): string {
+  return p.split("/").pop() ?? p;
+}
+
+/**
+ * Hooks that are DELIBERATELY absent from provides.hooks — per-session grant
+ * hooks that would gate the PRINCIPAL's own tool use if registered globally
+ * in the manifest/settings.json. See arc-manifest.yaml:134-140 (Skill Guard,
+ * cortex#710) and :143-148 (MCP Guard, cortex#2111) for the rationale each
+ * carries inline. This set is the closed allowlist step 3 of cortex#2482
+ * requires: a THIRD per-session-only hook added later has to be declared
+ * here explicitly, or this test fails.
+ */
+const DELIBERATELY_MANIFEST_ABSENT = new Set<string>([
+  "CortexSkillGuard.hook.ts",
+  "CortexMcpGuard.hook.ts",
+]);
+
+describe("hook registration parity — arc-manifest.yaml provides.hooks vs buildCuratedSettings (cortex#2482)", () => {
+  const manifest = parse(readFileSync(MANIFEST_PATH, "utf-8")) as Manifest;
+
+  test("sanity — manifest declares at least one hook (guards against a parse regression silently passing everything)", () => {
+    expect(manifest.provides.hooks.length).toBeGreaterThan(0);
+  });
+
+  test("every provides.hooks[] entry is registered in buildCuratedSettings under the same event, with a byte-identical PreToolUse matcher", () => {
+    // No skill/mcp grants — this is the FLOOR every dispatched session gets.
+    // The manifest-registered (unconditional) hooks must be a subset of it.
+    const curated = buildCuratedSettings("/fake/.claude") as unknown as CuratedSettings;
+
+    for (const manifestHook of manifest.provides.hooks) {
+      const wantBasename = basename(manifestHook.command);
+      const eventEntries = curated.hooks[manifestHook.event];
+      if (eventEntries === undefined) {
+        throw new Error(
+          `provides.hooks entry for event "${manifestHook.event}" (command ` +
+            `"${manifestHook.command}") has NO corresponding event key in ` +
+            `buildCuratedSettings' output at all. Curated events present: ` +
+            `[${Object.keys(curated.hooks).join(", ")}].`,
+        );
+      }
+
+      const matchingEntry = eventEntries.find((entry) =>
+        entry.hooks.some((h) => basename(h.command) === wantBasename),
+      );
+      if (matchingEntry === undefined) {
+        const curatedCommands = eventEntries
+          .flatMap((e) => e.hooks.map((h) => basename(h.command)))
+          .join(", ");
+        throw new Error(
+          `provides.hooks[] declares "${manifestHook.command}" (basename ` +
+            `"${wantBasename}") under event "${manifestHook.event}", but ` +
+            `buildCuratedSettings("/fake/.claude") registers NO hook with that ` +
+            `basename under "${manifestHook.event}" — curated commands there: ` +
+            `[${curatedCommands || "(none)"}]. A hook registered in the manifest ` +
+            `but absent from the curated settings NEVER RUNS in a dispatched ` +
+            `session — the manifest only reaches the principal's global, ` +
+            `interactive settings.json (cortex#2482 / R1-F1-A).`,
+        );
+      }
+
+      if (manifestHook.event === "PreToolUse") {
+        const curatedMatcher = matchingEntry.matcher;
+        if (curatedMatcher !== manifestHook.matcher) {
+          throw new Error(
+            `PreToolUse matcher mismatch for "${wantBasename}": arc-manifest.yaml ` +
+              `matcher is "${manifestHook.matcher}", buildCuratedSettings' matcher ` +
+              `is "${curatedMatcher}" — these must be byte-identical (cortex#2482 ` +
+              `acceptance criteria).`,
+          );
+        }
+      }
+    }
+  });
+
+  test("the curated-only hook set (present in buildCuratedSettings, absent from provides.hooks) is EXACTLY the deliberate per-session grant hooks", () => {
+    // Grant BOTH conditional hooks so the full curated surface is visible.
+    const curated = buildCuratedSettings(
+      "/fake/.claude",
+      ["some-skill"],
+      [],
+    ) as unknown as CuratedSettings;
+
+    const curatedBasenames = new Set(
+      Object.values(curated.hooks)
+        .flat()
+        .flatMap((entry) => entry.hooks.map((h) => basename(h.command))),
+    );
+    const manifestBasenames = new Set(manifest.provides.hooks.map((h) => basename(h.command)));
+
+    const curatedOnly = [...curatedBasenames].filter((b) => !manifestBasenames.has(b));
+    const missing = [...DELIBERATELY_MANIFEST_ABSENT].filter((b) => !curatedOnly.includes(b));
+    const unexpected = curatedOnly.filter((b) => !DELIBERATELY_MANIFEST_ABSENT.has(b));
+
+    if (missing.length > 0 || unexpected.length > 0) {
+      throw new Error(
+        `Curated-only hook set (registered in buildCuratedSettings, absent from ` +
+          `arc-manifest.yaml's provides.hooks) must equal EXACTLY ` +
+          `{${[...DELIBERATELY_MANIFEST_ABSENT].join(", ")}} — the two per-session ` +
+          `grant hooks that are deliberately manifest-absent (arc-manifest.yaml` +
+          `:134-140 Skill Guard, :143-148 MCP Guard; registering either globally ` +
+          `would gate the principal's OWN Skill/MCP tool use). Found instead: ` +
+          `[${curatedOnly.join(", ") || "(none)"}].` +
+          (missing.length > 0 ? ` Missing (expected but not found): [${missing.join(", ")}].` : "") +
+          (unexpected.length > 0
+            ? ` Unexpected (found but not declared deliberate): [${unexpected.join(", ")}] — ` +
+              `if this is a genuine new per-session-only hook, add it to ` +
+              `DELIBERATELY_MANIFEST_ABSENT in this test with a comment explaining why ` +
+              `it must never be manifest-registered; otherwise it belongs in ` +
+              `arc-manifest.yaml's provides.hooks instead.`
+            : ""),
+      );
+    }
+
+    expect(curatedOnly.sort()).toEqual([...DELIBERATELY_MANIFEST_ABSENT].sort());
+  });
+});

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -158,8 +158,14 @@ interface HookInput {
 }
 
 /**
- * Tools this hook governs. Matches the `cortex-hooks.json` matcher exactly.
- * `NotebookEdit` added per cortex#2343 adversarial review finding B4: it is
+ * Tools this hook governs. Matches the PreToolUse matcher string exactly in
+ * BOTH places that register it: `src/runner/session-settings.ts`
+ * (`buildCuratedSettings` — LOAD-BEARING; this is the settings file every
+ * dispatched cortex session actually loads) and `src/settings/cortex-hooks.json`
+ * (an inert reference/fallback that arc auto-derives from
+ * `arc-manifest.yaml`'s `provides.hooks` — it writes nothing itself, per its
+ * own `_comment`; see cortex#2482). `NotebookEdit` added per cortex#2343
+ * adversarial review finding B4: it is
  * a grantable, mutating file tool (`src/common/policy/tool-inventory.ts`)
  * that was previously omitted entirely — any stack granting it got
  * unchecked arbitrary-path read/write via `notebook_path`. `MultiEdit` is

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -28,11 +28,12 @@
  * principal's global settings (hooks, skills, plugins, permissions) — and
  * nothing from the working-repo cwd — is loaded. We then layer cortex's OWN
  * curated settings on top via `--settings <path>`, containing only cortex's
- * hooks (EventLogger, bash-guard, context) plus, when the session is granted
- * skills, the Skill Guard PreToolUse hook (cortex#710). See the "Why drop
- * `project` and `local`, not just `user`?" self-check below for why the
- * tighter empty-source default (rather than `project,local`) is the only
- * sound posture.
+ * hooks (EventLogger, bash-guard, path-guard, context) plus, when the
+ * session is granted skills, the Skill Guard PreToolUse hook (cortex#710),
+ * and, when the session carries an MCP grant decision, the MCP Guard
+ * PreToolUse hook (cortex#2111). See the "Why drop `project` and `local`,
+ * not just `user`?" self-check below for why the tighter empty-source
+ * default (rather than `project,local`) is the only sound posture.
  *
  * ### Why `--setting-sources ` (empty) and not `--bare`?
  *
@@ -403,6 +404,22 @@ function restoreWritableTree(path: string): void {
  * passes an EMPTY `--setting-sources` so no ambient source (`user`,
  * `project`, `local`) loads alongside it.
  *
+ * ## Path gating (EBH-1, cortex#2343 / R1-F1-A)
+ *
+ * The **Path Guard** PreToolUse hook (see its matcher string on the
+ * registration below) is registered UNCONDITIONALLY — exactly like the Bash
+ * guard above, and NOT gated on any parameter this function receives (no
+ * `allowedDirs`/`readOnlyDirs` param exists here).
+ * The allowed/read-only directory POLICY itself does not live in this
+ * file: it reaches the hook via the `CORTEX_PATH_GUARD` env var, set on the
+ * child by `cc-session.ts` (also unconditionally). The hook self-gates to a
+ * no-op pass-through when either `CORTEX_CHANNEL` is unset (not a cortex
+ * session) or the resolved policy is empty (no `allowedDirs`/`readOnlyDirs`
+ * configured) — see `path-guard.hook.ts`'s two pass-through gates. Before
+ * this entry existed (cortex#2482), the env var was projected onto every
+ * session but no curated hook ever read it — registration and policy were
+ * disjoint, and the boundary failed OPEN silently.
+ *
  * ## Skill gating (cortex#710, Part B)
  *
  * When `skillGrants` is a NON-EMPTY array, the session is meant to have
@@ -454,11 +471,24 @@ export function buildCuratedSettings(
     command: `${claudeDir}/hooks/${name}`,
   });
 
-  // PreToolUse always carries the Bash guard. When the session is granted
-  // skills, ALSO register the Skill guard (matcher `Skill`) — the per-skill
-  // gate that backs the broad `Skill` allow the caller layers in.
+  // PreToolUse always carries the Bash guard AND the Path guard (EBH-1,
+  // cortex#2343 / R1-F1-A). When the session is granted skills, ALSO
+  // register the Skill guard (matcher `Skill`) — the per-skill gate that
+  // backs the broad `Skill` allow the caller layers in.
   const preToolUse: { matcher: string; hooks: ReturnType<typeof hook>[] }[] = [
     { matcher: "Bash", hooks: [hook("CortexBashGuard.hook.ts")] },
+    // EBH-1 (cortex#2343) / R1-F1-A — the file-tool half of the path
+    // boundary. Registered UNCONDITIONALLY, mirroring the Bash guard above:
+    // cc-session.ts:631 writes CORTEX_PATH_GUARD onto every session
+    // unconditionally, and arc-manifest.yaml:188-190 registers this hook
+    // unconditionally in the principal's global settings. Before this entry
+    // the policy was projected onto a child that never ran the hook that
+    // reads it — the mirror image of the MCP guard's stated atomicity rule
+    // (cc-session.ts:605-609), and it failed OPEN.
+    // The matcher string is byte-identical to arc-manifest.yaml:190 and
+    // src/settings/cortex-hooks.json:39 — enforced by
+    // src/runner/__tests__/hook-registration-parity.test.ts.
+    { matcher: "Read|Write|Edit|Glob|Grep|NotebookEdit", hooks: [hook("CortexPathGuard.hook.ts")] },
   ];
   if (skillGrants !== undefined && skillGrants.length > 0) {
     preToolUse.push({ matcher: "Skill", hooks: [hook("CortexSkillGuard.hook.ts")] });
@@ -472,8 +502,15 @@ export function buildCuratedSettings(
 
   // Mirrors src/settings/cortex-hooks.json (the reference fallback) but
   // pinned to ABSOLUTE installed paths so it stands alone without relying
-  // on the principal's settings.json having registered anything. These are
-  // cortex's hooks and ONLY cortex's hooks.
+  // on the principal's settings.json having registered anything. As of
+  // EBH-1 / R1-F1-A the PreToolUse set here is a genuine mirror of
+  // cortex-hooks.json's Bash + path-guard entries (previously the path
+  // guard was manifest-registered but curated-file-absent — a defect,
+  // cortex#2482). The mirror is deliberately NOT total: the Skill and MCP
+  // guards are PER-SESSION grants, registered ONLY here, and NEVER in the
+  // manifest/global settings.json (arc-manifest.yaml:134-140 and :143-148 —
+  // registering them globally would gate the principal's own Skill/MCP tool
+  // use). These are cortex's hooks and ONLY cortex's hooks.
   return {
     hooks: {
       SessionStart: [{ hooks: [hook("CortexContext.hook.ts")] }],


### PR DESCRIPTION
Closes #2482. Part of epic #2492.

## The defect

The file-tool path guard was built, unit-tested, and documented as live in four places — and ran in **zero** production sessions. Three independent legs, all re-confirmed by the implementer before any code changed:

| Session type | Why it was inert |
|---|---|
| interactive `claude` | no `CORTEX_CHANNEL` → `path-guard.hook.ts:588` passes immediately |
| `cldyo-live` | sets `CORTEX_CHANNEL` (`:45`) and `CORTEX_BASH_GUARD` (`:57`) but **no** `CORTEX_PATH_GUARD` |
| dispatched | gets the policy (`cc-session.ts:631`) but `buildCuratedSettings` registered **zero** file-tool matchers |

Registration and policy were disjoint. This is NWS round-1 F1, open on the file-tool surface since the epic began.

## The fix

One matcher line — `Read|Write|Edit|Glob|Grep|NotebookEdit` → `CortexPathGuard.hook.ts`, registered unconditionally beside Bash.

Plus the part that matters more: a **parity test** (`hook-registration-parity.test.ts`) asserting every session-scoped hook in `arc-manifest.yaml`'s `provides.hooks` is actually registered in the curated settings. None existed. This is what stops the next hook being built-but-not-bound.

And the rationale comment at `arc-manifest.yaml:128-131` is corrected — it stated the belief that produced the defect ("global registration alone covers bot sessions").

## Proof it fires — not merely that it is registered

A real dispatched `CCSession` against a real `claude` subprocess, raw stdout captured:

- Read / Glob / Grep / Edit **inside** `allowedDirs` → SUCCESS
- Read **outside** `allowedDirs` → **BLOCKED**: `[Cortex Path Guard] Blocked Read "…/denied/secret.txt": path resolves outside every configured allowedDirs/readOnlyDirs entry.`

Registration alone could not produce that denial text in a real transcript.

The parity test was also proven to bite: deleting the entry fails it with a diagnostic naming the missing hook; altering the matcher by one character fails it too.

## Scope discipline

**No guard decision logic changed.** The only diff in `path-guard.hook.ts` is a doc comment; `bash-guard.hook.ts` and `path-containment.ts` are untouched. Those files carry nine adversarial rounds — mixing that risk profile into a wiring fix would have been wrong. `sandboxMode`, `--setting-sources ""` and the isolation model are unchanged.

The implementer also **overrode my brief correctly**: I asked for three doc corrections the issue explicitly lists as out of scope, and it followed the issue instead. Right call.

## Residual, flagged not fixed

Now the boundary is live for the first time, a pre-existing rule is newly exercised: `path-containment.ts` (~:416-423) refuses any wildcard token whose literal prefix is absolute or contains `..`, regardless of whether it lands in scope. So a model that naturally passes an absolute path to `Glob` will hit a denial even when the target is in-bounds. Not a regression and not one of R2-F3..F6 — but worth watching for friction, and worth its own issue if it bites.

## Tests

47 pass / 0 fail scoped; 209 pass / 0 fail across 7 related files. `tsc --noEmit` and `lint:errors` clean.