### PR TITLE
test(runner): pin the curated-settings file-tool gate end to end (cortex#2498 §0e)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -126,9 +126,21 @@ provides:
     - source: src/runner/hooks/bash-guard.hook.ts
       target: ~/.claude/hooks/CortexBashGuard.hook.ts
     # EBH-1 (cortex#2343) — cortex-owned PreToolUse path guard for the file
-    # tools (Read/Write/Edit/Glob/Grep). Registered GLOBALLY below (unlike
-    # the Skill/MCP guards) because — like CortexBashGuard — it gates every
-    # bot session's file access, not a per-session grant list.
+    # tools (Read/Write/Edit/Glob/Grep/NotebookEdit). Registered GLOBALLY
+    # below (unlike the Skill/MCP guards) because — like CortexBashGuard —
+    # it gates every bot session's file access, not a per-session grant
+    # list. NOTE (cortex#2482): global registration here is NOT, by itself,
+    # sufficient for dispatched bot sessions — those spawn with an empty
+    # --setting-sources and load ONLY the curated file
+    # src/runner/session-settings.ts builds (buildCuratedSettings), never
+    # this manifest-driven principal-global settings.json. CortexBashGuard
+    # is registered in BOTH places (here AND buildCuratedSettings); this
+    # hook now is too. A hook that is manifest-registered but
+    # curated-file-absent is REGISTERED for the principal's own interactive
+    # sessions only — it does not run in a dispatched session at all. This
+    # exact gap (manifest registration without curated-file registration)
+    # was the R1-F1-A defect this issue closed; do not re-derive "global
+    # registration alone covers bot sessions" from this comment again.
     - source: src/runner/hooks/path-guard.hook.ts
       target: ~/.claude/hooks/CortexPathGuard.hook.ts
     # cortex#710 (C-701 Part B) — per-skill grant PreToolUse hook. Installed

--- a/src/runner/__tests__/curated-settings-path-gate.test.ts
+++ b/src/runner/__tests__/curated-settings-path-gate.test.ts
@@ -1,0 +1,316 @@
+/**
+ * cortex#2498 §0e / #2482 (R1-F1-A) — the file-tool gate, END TO END through
+ * the settings an isolated session actually loads.
+ *
+ * ## Why this file exists alongside the two tests that already touch this
+ *
+ * Three assertions are needed to know the file-tool boundary is live, and
+ * until now only two were made — by different tests, neither of which met
+ * the other:
+ *
+ *   1. `hook-registration-parity.test.ts` (cortex#2482) asserts the guard is
+ *      REGISTERED — it compares `arc-manifest.yaml`'s `provides.hooks`
+ *      against `buildCuratedSettings`' return value as STRINGS. It never
+ *      runs a hook, so it cannot tell a registration that gates a `Write`
+ *      from one that gates nothing (a matcher of `"Wriet"` passes it, so
+ *      long as the manifest has the same typo).
+ *   2. `hooks/__tests__/path-guard.hook.test.ts` (cortex#2343) asserts the
+ *      guard DECIDES correctly — it spawns the hook directly with a
+ *      hand-built payload. It never reads the curated settings, so it
+ *      passed for the entire period the guard was registered NOWHERE a
+ *      dispatched session could load it.
+ *
+ * Both were green throughout the R1-F1-A defect window. The missing
+ * assertion is the JOIN: that the settings file `createIsolatedSettings`
+ * WRITES routes a `Write` to the guard, and that the guard then decides it.
+ * That is what this file asserts, by resolving the matcher out of the
+ * written file and executing whatever it names.
+ *
+ * ## Why the matcher is re-implemented here
+ *
+ * Claude Code resolves a PreToolUse matcher as a regex, full-matched against
+ * the tool name. Cortex does not own that engine, so this file models it
+ * ({@link hooksMatching}) and treats the RESULT as the thing under test. A
+ * matcher that stops covering `Write` — by edit, by typo, by a future
+ * refactor that drops the entry — resolves to zero hooks here and the
+ * behavioural assertions below fail, which is the point.
+ *
+ * ## What fails without the fix
+ *
+ * On the pre-#2482 code every test in this file fails: `buildCuratedSettings`
+ * registers no file-tool matcher, `hooksMatching("Write")` returns `[]`, and
+ * a `Write` — in bounds or out — reaches no cortex hook at all. In bounds
+ * that means the CLI's own permission prompt, unanswerable under `--print`
+ * (the cortex#2498 incident, attempt 2→3). Out of bounds, once `Write` is in
+ * `--allowedTools`, it means the write simply lands.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { spawnSync } from "child_process";
+import { mkdtempSync, mkdirSync, symlinkSync, readFileSync, rmSync, realpathSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createIsolatedSettings } from "../session-settings";
+import { resolvePathGuardEnv } from "../cc-session";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..");
+
+/**
+ * The installed-hook symlinks arc lays down under the cortex-owned `.claude`
+ * dir (`arc-manifest.yaml`'s `provides.files`). `buildCuratedSettings` emits
+ * `${claudeDir}/hooks/<Name>` paths, so the curated file is only executable
+ * if these exist — building them here keeps the test self-contained and
+ * independent of whether arc has run on the machine.
+ */
+const INSTALLED_HOOKS: Record<string, string> = {
+  "CortexBashGuard.hook.ts": "src/runner/hooks/bash-guard.hook.ts",
+  "CortexPathGuard.hook.ts": "src/runner/hooks/path-guard.hook.ts",
+  "CortexSkillGuard.hook.ts": "src/runner/hooks/skill-guard.hook.ts",
+  "CortexMcpGuard.hook.ts": "src/runner/hooks/mcp-guard.hook.ts",
+  "CortexContext.hook.ts": "src/taps/cc-events/hooks/surface-context.hook.ts",
+  "CortexEventLogger.hook.ts": "src/taps/cc-events/hooks/event-logger.hook.ts",
+};
+
+/**
+ * Surface env keys the hook reads. The test process may itself be running
+ * inside a cortex agent session, so every spawn starts from a slate with
+ * these stripped and applies only what the case sets — the same defence
+ * `path-guard.hook.test.ts`'s `SURFACE_ENV_KEYS` makes.
+ */
+const SURFACE_ENV_KEYS = [
+  "CORTEX_CHANNEL",
+  "CORTEX_AGENT_ID",
+  "CORTEX_AGENT_NAME",
+  "CORTEX_NETWORK",
+  "CORTEX_PROJECT",
+  "CORTEX_ENTITY",
+  "CORTEX_PRINCIPAL",
+  "CORTEX_PATH_GUARD",
+  "GROVE_CHANNEL",
+  "GROVE_AGENT_ID",
+  "GROVE_AGENT_NAME",
+  "GROVE_NETWORK",
+  "GROVE_PROJECT",
+  "GROVE_ENTITY",
+  "GROVE_OPERATOR",
+];
+
+interface CuratedEntry {
+  matcher?: string;
+  hooks: { type: string; command: string }[];
+}
+
+let claudeDir: string;
+let inBoundsDir: string;
+let outOfBoundsDir: string;
+let pathGuardEnv: string;
+let curatedPreToolUse: CuratedEntry[];
+let cleanupSettings: () => void;
+
+beforeAll(() => {
+  claudeDir = mkdtempSync(join(tmpdir(), "cortex-curatedgate-claude-"));
+  mkdirSync(join(claudeDir, "hooks"));
+  for (const [installed, source] of Object.entries(INSTALLED_HOOKS)) {
+    symlinkSync(join(REPO_ROOT, source), join(claudeDir, "hooks", installed));
+  }
+
+  // realpath: on macOS `/var/folders/...` is a symlink to `/private/var/...`,
+  // and the guard realpath's every candidate before the containment check —
+  // so the POLICY must be stated in realpath'd form too, or an in-bounds
+  // path would spuriously read as out-of-bounds and this test would pass for
+  // the wrong reason.
+  inBoundsDir = realpathSync(mkdtempSync(join(tmpdir(), "cortex-curatedgate-in-")));
+  outOfBoundsDir = realpathSync(mkdtempSync(join(tmpdir(), "cortex-curatedgate-out-")));
+
+  // Produced by the SAME function cc-session.ts:631 uses to write
+  // CORTEX_PATH_GUARD onto every spawned session — not a hand-built literal,
+  // so a change to the policy projection is caught here too.
+  pathGuardEnv = resolvePathGuardEnv({ allowedDirs: [inBoundsDir], readOnlyDirs: [] });
+
+  // The settings an isolated session actually loads: read back off DISK from
+  // the file createIsolatedSettings wrote, not from buildCuratedSettings'
+  // in-memory return value. `mcpGrants: []` mirrors a policy-resolved
+  // dispatch (the common case); skill grants are irrelevant to the file-tool
+  // gate and left undefined.
+  const isolated = createIsolatedSettings(claudeDir, undefined, []);
+  cleanupSettings = isolated.cleanup;
+  const written = JSON.parse(readFileSync(isolated.settingsPath, "utf-8")) as {
+    hooks: { PreToolUse?: CuratedEntry[] };
+  };
+  curatedPreToolUse = written.hooks.PreToolUse ?? [];
+});
+
+afterAll(() => {
+  cleanupSettings?.();
+  for (const dir of [claudeDir, inBoundsDir, outOfBoundsDir]) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Model Claude Code's PreToolUse matcher resolution: the matcher is a regex,
+ * full-matched against the tool name; an absent/empty/`*` matcher matches
+ * every tool. Returns the hook commands that would run for `toolName`.
+ */
+function hooksMatching(toolName: string): string[] {
+  const commands: string[] = [];
+  for (const entry of curatedPreToolUse) {
+    const matcher = entry.matcher;
+    if (matcher === undefined || matcher === "" || matcher === "*") {
+      commands.push(...entry.hooks.map((h) => h.command));
+      continue;
+    }
+    let re: RegExp;
+    try {
+      re = new RegExp(`^(?:${matcher})$`);
+    } catch (err) {
+      throw new Error(
+        `curated PreToolUse matcher ${JSON.stringify(matcher)} is not a valid regex ` +
+          `(${err instanceof Error ? err.message : String(err)}) — Claude Code compiles ` +
+          `matchers as regexes, so an uncompilable one silently gates nothing.`,
+        { cause: err },
+      );
+    }
+    if (re.test(toolName)) commands.push(...entry.hooks.map((h) => h.command));
+  }
+  return commands;
+}
+
+interface Decision {
+  permissionDecision?: string;
+  permissionDecisionReason?: string;
+  passedThrough: boolean;
+}
+
+/** Execute one curated hook command with the real PreToolUse stdin contract. */
+function runCuratedHook(
+  command: string,
+  toolName: string,
+  toolInput: Record<string, unknown>,
+): Decision {
+  const stripped = new Set(SURFACE_ENV_KEYS);
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && !stripped.has(k)) env[k] = v;
+  }
+  env.CORTEX_CHANNEL = "curated-gate-test";
+  env.CORTEX_PATH_GUARD = pathGuardEnv;
+  // Point telemetry at a closed port: the guard's block event is best-effort
+  // and must never reach a real ingest endpoint from a test.
+  env.CORTEX_INGEST_URL = "http://127.0.0.1:1/none";
+
+  const result = spawnSync("bun", [command], {
+    encoding: "utf-8",
+    input: JSON.stringify({
+      session_id: "curated-gate-test",
+      tool_name: toolName,
+      tool_input: toolInput,
+    }),
+    env,
+    cwd: inBoundsDir,
+  });
+
+  const stdout = result.stdout.trim();
+  if (stdout === "") {
+    throw new Error(
+      `curated hook ${command} produced no stdout for ${toolName} — a PreToolUse hook ` +
+        `must always emit a decision object. stderr: ${result.stderr}`,
+    );
+  }
+  const parsed = JSON.parse(stdout.split("\n").at(-1) ?? "{}") as {
+    continue?: boolean;
+    hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string };
+  };
+  return {
+    permissionDecision: parsed.hookSpecificOutput?.permissionDecision,
+    permissionDecisionReason: parsed.hookSpecificOutput?.permissionDecisionReason,
+    passedThrough: parsed.continue === true,
+  };
+}
+
+/**
+ * Resolve the single hook that gates `toolName` in the curated settings and
+ * run it. Fails loudly (rather than skipping) when nothing matches — "no
+ * hook is registered for this tool" IS the R1-F1-A defect, so it must read
+ * as a failure, never as a vacuous pass.
+ */
+function decideVia(toolName: string, toolInput: Record<string, unknown>): Decision {
+  const commands = hooksMatching(toolName);
+  if (commands.length === 0) {
+    throw new Error(
+      `the settings an isolated session loads register NO PreToolUse hook matching ` +
+        `"${toolName}" — matchers present: ` +
+        `[${curatedPreToolUse.map((e) => JSON.stringify(e.matcher)).join(", ")}]. ` +
+        `A file tool that reaches no cortex hook is decided entirely by the Claude CLI: ` +
+        `in bounds it dies at an unanswerable permission prompt under --print, and out of ` +
+        `bounds — once the tool is in --allowedTools — it is auto-approved with no cortex ` +
+        `containment at all (cortex#2498 §0e / #2482 R1-F1-A).`,
+    );
+  }
+  expect(commands).toHaveLength(1);
+  expect(commands[0]).toContain("CortexPathGuard.hook.ts");
+  return runCuratedHook(commands[0]!, toolName, toolInput);
+}
+
+describe("curated settings — the file-tool gate is bound (cortex#2498 §0e / #2482)", () => {
+  test("the path guard IS present in the settings an isolated session loads", () => {
+    const commands = curatedPreToolUse.flatMap((e) => e.hooks.map((h) => h.command));
+    expect(commands.some((c) => c.endsWith("/hooks/CortexPathGuard.hook.ts"))).toBe(true);
+  });
+
+  test("every governed file tool resolves to the path guard through the written matcher", () => {
+    // Executable coverage of the matcher, tool by tool — the string-equality
+    // parity test cannot distinguish a matcher that covers these from one
+    // that covers nothing.
+    for (const tool of ["Read", "Write", "Edit", "Glob", "Grep", "NotebookEdit"]) {
+      const commands = hooksMatching(tool);
+      expect(
+        commands.some((c) => c.endsWith("/hooks/CortexPathGuard.hook.ts")),
+      ).toBe(true);
+    }
+  });
+
+  test("a Write INSIDE bounds is auto-approved BY THE GUARD — no permission prompt", () => {
+    // The `allow` decision is what spares a dispatched session the CLI's
+    // permission prompt. Under `--print` that prompt cannot be answered, so
+    // an unguarded in-bounds Write does not merely warn — it kills the turn.
+    // This is the exact mechanism of the cortex#2498 incident's attempt 2→3.
+    const decision = decideVia("Write", {
+      file_path: join(inBoundsDir, "note.md"),
+      content: "hello",
+    });
+    expect(decision.passedThrough).toBe(false);
+    expect(decision.permissionDecision).toBe("allow");
+    expect(decision.permissionDecisionReason).toContain("Cortex Path Guard");
+  });
+
+  test("a Write OUTSIDE bounds is refused BY THE GUARD — not merely by the CLI", () => {
+    // The assertion that matters for containment is the AUTHOR of the
+    // refusal. Once `Write` is in `--allowedTools` the CLI refuses nothing,
+    // so only a cortex-authored deny keeps the boundary. Asserting the
+    // `[Cortex Path Guard]` prefix pins that authorship: a refusal that
+    // merely happens is indistinguishable from the CLI's own, and the CLI's
+    // own is exactly what is absent here.
+    const decision = decideVia("Write", {
+      file_path: join(outOfBoundsDir, "escaped.md"),
+      content: "owned",
+    });
+    expect(decision.passedThrough).toBe(false);
+    expect(decision.permissionDecision).toBe("deny");
+    expect(decision.permissionDecisionReason).toContain("[Cortex Path Guard]");
+    expect(decision.permissionDecisionReason).toContain(outOfBoundsDir);
+  });
+
+  test("an Edit OUTSIDE bounds is refused too — Write is not the only mutating file tool", () => {
+    // Write/Edit/NotebookEdit all bypass Bash, so bash-guard's containment
+    // (which imports the same path checks) never sees them. Edit is pinned
+    // separately so a matcher narrowed to `Write` alone still fails.
+    const decision = decideVia("Edit", {
+      file_path: join(outOfBoundsDir, "escaped.md"),
+      old_string: "a",
+      new_string: "b",
+    });
+    expect(decision.permissionDecision).toBe("deny");
+    expect(decision.permissionDecisionReason).toContain("[Cortex Path Guard]");
+  });
+});

--- a/src/runner/__tests__/hook-registration-parity.test.ts
+++ b/src/runner/__tests__/hook-registration-parity.test.ts
@@ -1,0 +1,179 @@
+// cortex#2482 (EBH-1 / R1-F1-A) — hook registration parity.
+//
+// Every hook `arc-manifest.yaml`'s `provides.hooks` registers UNCONDITIONALLY
+// (Bash guard, Path guard, EventLogger, Context) is meant to be session-scoped
+// too — but the manifest only reaches the PRINCIPAL's global, interactive
+// `~/.claude/settings.json`. A dispatched cortex session spawns with an EMPTY
+// `--setting-sources` (session-settings.ts) and loads ONLY the curated file
+// `buildCuratedSettings()` produces. A hook that is manifest-registered but
+// curated-file-absent therefore NEVER RUNS in a dispatched session, even
+// though every doc in the repo said it was live — exactly the R1-F1-A defect
+// this issue closed (`CortexPathGuard` was registered in the manifest and
+// nowhere else for ~1 release). This test makes that class of gap fail CI
+// instead of shipping silently.
+//
+// Pattern copied from scripts/__tests__/manifest-hooks-casing.test.ts: yaml-
+// parse the manifest, sanity-check non-empty BEFORE asserting (guards against
+// a parse regression silently passing everything), and throw a diagnostic
+// Error carrying the concrete mismatch rather than a bare `expect` failure —
+// same style as that file's `:60-72`.
+//
+// Rationale for a DEDICATED test, not folded into manifest-hooks-casing.test.ts:
+// that test only diffs `provides.hooks` against `provides.files` basenames (a
+// filesystem-casing guard). Nothing anywhere compared `provides.hooks` against
+// the curated settings a dispatched session actually loads. Same argument one
+// layer up — `provides.files` vs the repo checkout — in
+// src/taps/cc-events/__tests__/hook-compat-symlinks.test.ts:13-15.
+//
+// Do NOT assert against src/settings/cortex-hooks.json. Its own `_comment`
+// says arc auto-DERIVES it from provides.hooks at install time and that it
+// must never be manually merged into settings.json — it writes nothing to a
+// live session and is not a source of truth for what a dispatched session
+// loads.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse } from "yaml";
+import { buildCuratedSettings } from "../session-settings";
+
+const MANIFEST_PATH = join(import.meta.dir, "..", "..", "..", "arc-manifest.yaml");
+
+interface ManifestHook {
+  event: string;
+  command: string;
+  matcher?: string;
+}
+
+interface Manifest {
+  provides: {
+    files: { source: string; target: string }[];
+    hooks: ManifestHook[];
+  };
+}
+
+interface CuratedHookEntry {
+  matcher?: string;
+  hooks: { type: string; command: string }[];
+}
+
+interface CuratedSettings {
+  hooks: Record<string, CuratedHookEntry[]>;
+}
+
+function basename(p: string): string {
+  return p.split("/").pop() ?? p;
+}
+
+/**
+ * Hooks that are DELIBERATELY absent from provides.hooks — per-session grant
+ * hooks that would gate the PRINCIPAL's own tool use if registered globally
+ * in the manifest/settings.json. See arc-manifest.yaml:134-140 (Skill Guard,
+ * cortex#710) and :143-148 (MCP Guard, cortex#2111) for the rationale each
+ * carries inline. This set is the closed allowlist step 3 of cortex#2482
+ * requires: a THIRD per-session-only hook added later has to be declared
+ * here explicitly, or this test fails.
+ */
+const DELIBERATELY_MANIFEST_ABSENT = new Set<string>([
+  "CortexSkillGuard.hook.ts",
+  "CortexMcpGuard.hook.ts",
+]);
+
+describe("hook registration parity — arc-manifest.yaml provides.hooks vs buildCuratedSettings (cortex#2482)", () => {
+  const manifest = parse(readFileSync(MANIFEST_PATH, "utf-8")) as Manifest;
+
+  test("sanity — manifest declares at least one hook (guards against a parse regression silently passing everything)", () => {
+    expect(manifest.provides.hooks.length).toBeGreaterThan(0);
+  });
+
+  test("every provides.hooks[] entry is registered in buildCuratedSettings under the same event, with a byte-identical PreToolUse matcher", () => {
+    // No skill/mcp grants — this is the FLOOR every dispatched session gets.
+    // The manifest-registered (unconditional) hooks must be a subset of it.
+    const curated = buildCuratedSettings("/fake/.claude") as unknown as CuratedSettings;
+
+    for (const manifestHook of manifest.provides.hooks) {
+      const wantBasename = basename(manifestHook.command);
+      const eventEntries = curated.hooks[manifestHook.event];
+      if (eventEntries === undefined) {
+        throw new Error(
+          `provides.hooks entry for event "${manifestHook.event}" (command ` +
+            `"${manifestHook.command}") has NO corresponding event key in ` +
+            `buildCuratedSettings' output at all. Curated events present: ` +
+            `[${Object.keys(curated.hooks).join(", ")}].`,
+        );
+      }
+
+      const matchingEntry = eventEntries.find((entry) =>
+        entry.hooks.some((h) => basename(h.command) === wantBasename),
+      );
+      if (matchingEntry === undefined) {
+        const curatedCommands = eventEntries
+          .flatMap((e) => e.hooks.map((h) => basename(h.command)))
+          .join(", ");
+        throw new Error(
+          `provides.hooks[] declares "${manifestHook.command}" (basename ` +
+            `"${wantBasename}") under event "${manifestHook.event}", but ` +
+            `buildCuratedSettings("/fake/.claude") registers NO hook with that ` +
+            `basename under "${manifestHook.event}" — curated commands there: ` +
+            `[${curatedCommands || "(none)"}]. A hook registered in the manifest ` +
+            `but absent from the curated settings NEVER RUNS in a dispatched ` +
+            `session — the manifest only reaches the principal's global, ` +
+            `interactive settings.json (cortex#2482 / R1-F1-A).`,
+        );
+      }
+
+      if (manifestHook.event === "PreToolUse") {
+        const curatedMatcher = matchingEntry.matcher;
+        if (curatedMatcher !== manifestHook.matcher) {
+          throw new Error(
+            `PreToolUse matcher mismatch for "${wantBasename}": arc-manifest.yaml ` +
+              `matcher is "${manifestHook.matcher}", buildCuratedSettings' matcher ` +
+              `is "${curatedMatcher}" — these must be byte-identical (cortex#2482 ` +
+              `acceptance criteria).`,
+          );
+        }
+      }
+    }
+  });
+
+  test("the curated-only hook set (present in buildCuratedSettings, absent from provides.hooks) is EXACTLY the deliberate per-session grant hooks", () => {
+    // Grant BOTH conditional hooks so the full curated surface is visible.
+    const curated = buildCuratedSettings(
+      "/fake/.claude",
+      ["some-skill"],
+      [],
+    ) as unknown as CuratedSettings;
+
+    const curatedBasenames = new Set(
+      Object.values(curated.hooks)
+        .flat()
+        .flatMap((entry) => entry.hooks.map((h) => basename(h.command))),
+    );
+    const manifestBasenames = new Set(manifest.provides.hooks.map((h) => basename(h.command)));
+
+    const curatedOnly = [...curatedBasenames].filter((b) => !manifestBasenames.has(b));
+    const missing = [...DELIBERATELY_MANIFEST_ABSENT].filter((b) => !curatedOnly.includes(b));
+    const unexpected = curatedOnly.filter((b) => !DELIBERATELY_MANIFEST_ABSENT.has(b));
+
+    if (missing.length > 0 || unexpected.length > 0) {
+      throw new Error(
+        `Curated-only hook set (registered in buildCuratedSettings, absent from ` +
+          `arc-manifest.yaml's provides.hooks) must equal EXACTLY ` +
+          `{${[...DELIBERATELY_MANIFEST_ABSENT].join(", ")}} — the two per-session ` +
+          `grant hooks that are deliberately manifest-absent (arc-manifest.yaml` +
+          `:134-140 Skill Guard, :143-148 MCP Guard; registering either globally ` +
+          `would gate the principal's OWN Skill/MCP tool use). Found instead: ` +
+          `[${curatedOnly.join(", ") || "(none)"}].` +
+          (missing.length > 0 ? ` Missing (expected but not found): [${missing.join(", ")}].` : "") +
+          (unexpected.length > 0
+            ? ` Unexpected (found but not declared deliberate): [${unexpected.join(", ")}] — ` +
+              `if this is a genuine new per-session-only hook, add it to ` +
+              `DELIBERATELY_MANIFEST_ABSENT in this test with a comment explaining why ` +
+              `it must never be manifest-registered; otherwise it belongs in ` +
+              `arc-manifest.yaml's provides.hooks instead.`
+            : ""),
+      );
+    }
+
+    expect(curatedOnly.sort()).toEqual([...DELIBERATELY_MANIFEST_ABSENT].sort());
+  });
+});

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -158,8 +158,14 @@ interface HookInput {
 }
 
 /**
- * Tools this hook governs. Matches the `cortex-hooks.json` matcher exactly.
- * `NotebookEdit` added per cortex#2343 adversarial review finding B4: it is
+ * Tools this hook governs. Matches the PreToolUse matcher string exactly in
+ * BOTH places that register it: `src/runner/session-settings.ts`
+ * (`buildCuratedSettings` — LOAD-BEARING; this is the settings file every
+ * dispatched cortex session actually loads) and `src/settings/cortex-hooks.json`
+ * (an inert reference/fallback that arc auto-derives from
+ * `arc-manifest.yaml`'s `provides.hooks` — it writes nothing itself, per its
+ * own `_comment`; see cortex#2482). `NotebookEdit` added per cortex#2343
+ * adversarial review finding B4: it is
  * a grantable, mutating file tool (`src/common/policy/tool-inventory.ts`)
  * that was previously omitted entirely — any stack granting it got
  * unchecked arbitrary-path read/write via `notebook_path`. `MultiEdit` is

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -28,11 +28,12 @@
  * principal's global settings (hooks, skills, plugins, permissions) — and
  * nothing from the working-repo cwd — is loaded. We then layer cortex's OWN
  * curated settings on top via `--settings <path>`, containing only cortex's
- * hooks (EventLogger, bash-guard, context) plus, when the session is granted
- * skills, the Skill Guard PreToolUse hook (cortex#710). See the "Why drop
- * `project` and `local`, not just `user`?" self-check below for why the
- * tighter empty-source default (rather than `project,local`) is the only
- * sound posture.
+ * hooks (EventLogger, bash-guard, path-guard, context) plus, when the
+ * session is granted skills, the Skill Guard PreToolUse hook (cortex#710),
+ * and, when the session carries an MCP grant decision, the MCP Guard
+ * PreToolUse hook (cortex#2111). See the "Why drop `project` and `local`,
+ * not just `user`?" self-check below for why the tighter empty-source
+ * default (rather than `project,local`) is the only sound posture.
  *
  * ### Why `--setting-sources ` (empty) and not `--bare`?
  *
@@ -403,6 +404,22 @@ function restoreWritableTree(path: string): void {
  * passes an EMPTY `--setting-sources` so no ambient source (`user`,
  * `project`, `local`) loads alongside it.
  *
+ * ## Path gating (EBH-1, cortex#2343 / R1-F1-A)
+ *
+ * The **Path Guard** PreToolUse hook (see its matcher string on the
+ * registration below) is registered UNCONDITIONALLY — exactly like the Bash
+ * guard above, and NOT gated on any parameter this function receives (no
+ * `allowedDirs`/`readOnlyDirs` param exists here).
+ * The allowed/read-only directory POLICY itself does not live in this
+ * file: it reaches the hook via the `CORTEX_PATH_GUARD` env var, set on the
+ * child by `cc-session.ts` (also unconditionally). The hook self-gates to a
+ * no-op pass-through when either `CORTEX_CHANNEL` is unset (not a cortex
+ * session) or the resolved policy is empty (no `allowedDirs`/`readOnlyDirs`
+ * configured) — see `path-guard.hook.ts`'s two pass-through gates. Before
+ * this entry existed (cortex#2482), the env var was projected onto every
+ * session but no curated hook ever read it — registration and policy were
+ * disjoint, and the boundary failed OPEN silently.
+ *
  * ## Skill gating (cortex#710, Part B)
  *
  * When `skillGrants` is a NON-EMPTY array, the session is meant to have
@@ -454,11 +471,24 @@ export function buildCuratedSettings(
     command: `${claudeDir}/hooks/${name}`,
   });
 
-  // PreToolUse always carries the Bash guard. When the session is granted
-  // skills, ALSO register the Skill guard (matcher `Skill`) — the per-skill
-  // gate that backs the broad `Skill` allow the caller layers in.
+  // PreToolUse always carries the Bash guard AND the Path guard (EBH-1,
+  // cortex#2343 / R1-F1-A). When the session is granted skills, ALSO
+  // register the Skill guard (matcher `Skill`) — the per-skill gate that
+  // backs the broad `Skill` allow the caller layers in.
   const preToolUse: { matcher: string; hooks: ReturnType<typeof hook>[] }[] = [
     { matcher: "Bash", hooks: [hook("CortexBashGuard.hook.ts")] },
+    // EBH-1 (cortex#2343) / R1-F1-A — the file-tool half of the path
+    // boundary. Registered UNCONDITIONALLY, mirroring the Bash guard above:
+    // cc-session.ts:631 writes CORTEX_PATH_GUARD onto every session
+    // unconditionally, and arc-manifest.yaml:188-190 registers this hook
+    // unconditionally in the principal's global settings. Before this entry
+    // the policy was projected onto a child that never ran the hook that
+    // reads it — the mirror image of the MCP guard's stated atomicity rule
+    // (cc-session.ts:605-609), and it failed OPEN.
+    // The matcher string is byte-identical to arc-manifest.yaml:190 and
+    // src/settings/cortex-hooks.json:39 — enforced by
+    // src/runner/__tests__/hook-registration-parity.test.ts.
+    { matcher: "Read|Write|Edit|Glob|Grep|NotebookEdit", hooks: [hook("CortexPathGuard.hook.ts")] },
   ];
   if (skillGrants !== undefined && skillGrants.length > 0) {
     preToolUse.push({ matcher: "Skill", hooks: [hook("CortexSkillGuard.hook.ts")] });
@@ -472,8 +502,15 @@ export function buildCuratedSettings(
 
   // Mirrors src/settings/cortex-hooks.json (the reference fallback) but
   // pinned to ABSOLUTE installed paths so it stands alone without relying
-  // on the principal's settings.json having registered anything. These are
-  // cortex's hooks and ONLY cortex's hooks.
+  // on the principal's settings.json having registered anything. As of
+  // EBH-1 / R1-F1-A the PreToolUse set here is a genuine mirror of
+  // cortex-hooks.json's Bash + path-guard entries (previously the path
+  // guard was manifest-registered but curated-file-absent — a defect,
+  // cortex#2482). The mirror is deliberately NOT total: the Skill and MCP
+  // guards are PER-SESSION grants, registered ONLY here, and NEVER in the
+  // manifest/global settings.json (arc-manifest.yaml:134-140 and :143-148 —
+  // registering them globally would gate the principal's own Skill/MCP tool
+  // use). These are cortex's hooks and ONLY cortex's hooks.
   return {
     hooks: {
       SessionStart: [{ hooks: [hook("CortexContext.hook.ts")] }],


### PR DESCRIPTION
Stacked on #2496 (base is `fix/2482-register-path-guard`, not `main` — the assertions here cannot pass without that fix). References #2498 §0e; closes nothing on its own.

## Independent verification of the #2498 §0e defect

I was asked to verify the §0e suspicion by execution before fixing anything. It reproduces, and #2496 already fixes it — so this PR adds only the coverage #2496 does not have, rather than a duplicate fix.

**Reproduction, against the real Claude Code CLI (2.1.222), on `origin/main` @ `4a081033`:** a real `claude --print` spawned under exactly the settings an isolated cortex session loads (`createIsolatedSettings` → empty `--setting-sources` + the curated `--settings` file), with `Write` in `--allowedTools` and `CORTEX_PATH_GUARD` scoped to a work dir, asked to write **outside** that dir:

```
curated PreToolUse matchers: ["Bash","mcp__.*"]
RESULT: out-of-bounds file EXISTS — WRITE LANDED, NO CORTEX CONTAINMENT
contents: "owned\n"
```

The same harness on #2496's branch:

```
curated PreToolUse matchers: ["Bash","Read|Write|Edit|Glob|Grep|NotebookEdit","mcp__.*"]
> [Cortex Path Guard] Blocked Write `…/PWNED.txt`: path resolves outside every
> configured allowedDirs/readOnlyDirs entry. This is a hard security boundary
RESULT: out-of-bounds file ABSENT — the write was refused
```

Both §0e consequences confirmed: the in-bounds auto-approve (`path-guard.hook.ts:686-689`) never fired, and out-of-bounds file-tool writes had no cortex containment once `Write` was granted. `CORTEX_PATH_GUARD` was projected onto every session at `cc-session.ts:631` the whole time — registration and policy were disjoint.

**Session classes affected:** isolated sessions only — which is every dispatched bot session, since `isolate = settingsIsolation !== false` (`cc-session.ts:475`) and no production path sets it `false` (`brain-compose.ts:136` and `review-session-lockdown.ts:214` both pin it `true`). Non-isolated sessions load the principal's `user` source, where `arc-manifest.yaml`'s `provides.hooks` already registers the guard. The guard was live exactly where it was least needed and absent exactly where it was.

**Same shape elsewhere:** the path guard was the only one. Every other entry in `src/settings/cortex-hooks.json` (Context, EventLogger ×3, BashGuard) is present in `buildCuratedSettings`; Skill and MCP guards are deliberately curated-only. #2496's parity test now enforces that both directions.

## What this PR adds

Three assertions are needed to know the boundary is live. #2496 makes one of them, `path-guard.hook.test.ts` makes another, and neither meets the other — both were green for the entire defect window:

| test | asserts | blind to |
|---|---|---|
| `hook-registration-parity.test.ts` (#2496) | the guard is REGISTERED | compares strings; never runs a hook. A matcher of `"Wriet"` passes it if the manifest has the same typo |
| `hooks/__tests__/path-guard.hook.test.ts` (#2343) | the guard DECIDES correctly | never reads the curated settings; passed throughout the window the guard was loadable by nobody |

The missing assertion is the **join**: that the settings file `createIsolatedSettings` *writes* routes a `Write` to the guard, and that the guard then decides it. This resolves the PreToolUse matcher out of the written file (modelling Claude Code's regex full-match) and executes whatever it names:

- a `Write` **inside** bounds is auto-approved **by the guard** — the `allow` that spares a `--print` session the unanswerable permission prompt, i.e. the #2498 attempt 2→3 mechanism
- a `Write` **outside** bounds is denied **by the guard**, asserted on the `[Cortex Path Guard]` authorship prefix. Authorship is the load-bearing part: once `Write` is in `--allowedTools` the CLI refuses nothing, so a refusal that merely happens is not containment
- `Edit` pinned separately, so a matcher narrowed to `Write` alone still fails
- every governed file tool resolves through the written matcher — executable coverage the string-equality parity test cannot give

The policy comes from `resolvePathGuardEnv`, the same function `cc-session.ts:631` uses, so a change to the policy projection is caught here too.

**All five fail on pre-#2496 code**, with a diagnostic naming both consequences:

```
error: the settings an isolated session loads register NO PreToolUse hook matching
"Write" — matchers present: ["Bash", "mcp__.*"]. A file tool that reaches no cortex
hook is decided entirely by the Claude CLI: in bounds it dies at an unanswerable
permission prompt under --print, and out of bounds — once the tool is in
--allowedTools — it is auto-approved with no cortex containment at all.
```

## Scope

Test-only: one new file, no source, no policy, no guard decision logic, no change to what counts as in-bounds.

## Checks

`bunx tsc --noEmit` clean · `bun run lint:errors` clean · `bun test src/runner/__tests__/` 1040 pass / 0 fail. Full `bun test` on the base branch: 11177 pass / 14 fail, all 14 pre-existing on `origin/main` (verified in a separate baseline worktree — real `sandbox-exec`, a live team run, arc-symlink-dependent SurfaceContext, and boot wire-up tests; none related to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011B4YUhSGGV9pmmx2mzdBEN