### PR TITLE
chore: bump to v6.13.4 — bind the file-tool boundary for isolated sessions

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -12,7 +12,7 @@ name: "cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "6.13.3"
+version: 6.13.4
 type: component
 tier: community
 # Preview-scope description (cortex#2285 C1): states the supported envelope up


### PR DESCRIPTION
Patch release for the containment fix in #2499 (issue #2498 §0e). Verified by execution both ways; ships with the end-to-end join test.