### PR TITLE
fix(docs): retract the self-emission violation claim — it was a test fixture (#2506)

### DIFF
--- a/docs/adr/0024-pluggable-surface-adapters.md
+++ b/docs/adr/0024-pluggable-surface-adapters.md
@@ -12,7 +12,7 @@
 > |---|---|---|
 > | §4.6.1 platform-class table | **§OQ9 → *Platform classes*, below** | Definitional — pins a term §OQ9 already used without defining. Does not change the ratified decision. |
 > | §4.6.1 reload re-enforcement | **cortex#2504** (issue body carries the requirement verbatim) | A normative MUST §OQ9 never contained. **Deliberately NOT written into this ADR** — see below. |
-> | §4.6.2 self-emission anti-pattern | `src/bus/system-events.ts` module doc | Binding, and **currently violated** — `DiscordAdapter` publishes its own `system.adapter.degraded`. Tracked as cortex#2506. |
+> | §4.6.2 self-emission anti-pattern | `src/bus/system-events.ts` module doc | Binding, and **satisfied** — cortex#1797 (S12) moved envelope construction and `MyelinRuntime.publish` out of the adapters into cortex's `buildAdapterSystemEventPort`. *(An earlier revision of this row claimed it was violated; that was filed against a pre-extraction test fixture, not shipped code — see cortex#2506, closed as not-a-bug.)* |
 > | §7.6 "no direct NATS subscription" | `docs/architecture.md` §3.4 | Restated inline with its reason and its exception. |
 >
 > ⚠️ **The reload requirement is deliberately absent from this ADR.** An earlier draft of this erratum wrote it in as a MUST and called the change "purely additive". It is not: this ADR's status header says **accepted, ratified 2026-07-11**, and that ratification did not cover a reload requirement. Labelling a new MUST "pending" while it sits inside an accepted ADR still lets a reader cite it as ratified. It therefore lives in **cortex#2504** until the principal ratifies it, at which point it belongs here as an amendment with its own date.

--- a/src/adapters/__tests__/fixtures/metafactory-cortex-adapter-discord/src/index.ts
+++ b/src/adapters/__tests__/fixtures/metafactory-cortex-adapter-discord/src/index.ts
@@ -111,11 +111,21 @@ export interface AdapterPayloadFilter {
  * and a dedicated `kind: discord-channel` renderer lifts them out at
  * MIG-7.2d. Until then, `DiscordAdapter` reads them via `this.infra.*`.
  *
+ * ⚠️ **THIS FILE IS A FROZEN PRE-EXTRACTION SNAPSHOT — do not read it as the
+ * shipped adapter, and do not copy its `system.adapter.*` shape.** It exists
+ * to exercise the plugin loader against the MIG-3b-ii-era bundle layout. The
+ * real adapter lives in `metafactory-cortex-adapter-discord`, and since
+ * cortex#1797 (S12) it no longer publishes these envelopes at all — it calls
+ * the host-injected `AdapterSystemEventPort` and cortex publishes. cortex#2506
+ * was filed as a live self-emission bug against THIS FILE and closed as
+ * not-a-bug; if you are here because something pointed you at a violation,
+ * check the shipped bundle before filing.
+ *
  * Anti-pattern note (self-emission, `src/bus/system-events.ts`): a degraded adapter publishing its OWN
  * `degraded` event is the wrong long-term home — that belongs to a sibling
  * `connection-watcher` component. MIG-3b-ii intentionally took the shorter
- * path so the wiring exists end-to-end; the watcher refactor is tracked as
- * a follow-on iteration.
+ * path so the wiring exists end-to-end; the watcher refactor landed as
+ * cortex#1797's port extraction.
  */
 export interface DiscordAdapterInfra {
   /** Surface-router + log-prefix key. Cortex derives `${agent.id}-discord-${guildId}` while

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -45,9 +45,18 @@
  * Never call `publish(...)` from inside the component the event is ABOUT.
  * Publishers and subjects are decoupled by component boundary.
  *
- * ⚠ **Currently violated in-tree:** `DiscordAdapter.onDegraded` publishes its
- * own `system.adapter.degraded`. Tracked as cortex#2506 — do not copy that
- * shape into a new adapter.
+ * **How cortex satisfies this today (cortex#1797, S12).** Adapters do NOT build
+ * or publish these envelopes. They call the host-injected
+ * `AdapterSystemEventPort` (`src/adapters/plugin-support.ts`), which owns
+ * envelope construction and the `MyelinRuntime.publish` call. So the publisher
+ * is a cortex-side sibling and the publish path never traverses the degraded
+ * platform connection — which is the property this rule actually protects.
+ *
+ * A new adapter MUST follow that shape: signal the transition through the port,
+ * never `publish(...)` from inside the component the event is about. The
+ * pre-extraction fixtures under `src/adapters/__tests__/fixtures/` still show
+ * the old inline form — they are frozen snapshots for the loader tests, not a
+ * pattern to copy (cortex#2506 was filed against one by mistake).
  *
  * **Known contract gap — correlation_id format:**
  *   The correlation-id convention this module was designed against defines


### PR DESCRIPTION
## What

Retracts a claim I made in #2505 and repeated in two merged files: that `DiscordAdapter` violates the self-emission anti-pattern by publishing its own `system.adapter.degraded`.

**It does not.** What I grepped was `src/adapters/__tests__/fixtures/metafactory-cortex-adapter-discord/` — a frozen pre-extraction snapshot that exists to exercise the plugin loader against the MIG-3b-ii bundle layout.

## What actually ships

**cortex#1797 (S12)** already moved this, before I filed. From the real bundle (`metafactory-cortex-adapter-discord/src/index.ts:1533-1552`):

> *"the adapter no longer builds/publishes envelopes itself; it calls the host-injected `infra.systemEvents` port … Envelope construction + the `MyelinRuntime.publish` call … moved to `plugin-support.ts`'s `buildAdapterSystemEventPort` (cortex-side, not part of this bundle)."*

The adapter signals the transition; a **cortex-side sibling publishes**. That satisfies the rule for the reason the rule exists — the publish path never traverses the degraded platform connection. `src/adapters/` contains no `publishAdapterDegraded` call outside a comment.

Audited mattermost, slack and web at the same time: same port-based shape, no violations.

## Why this needed a PR and not just closing the issue

The false claim had already landed in `main`:

- **ADR-0024's erratum table** listed the rule as *"currently violated"* — in a ratified ADR.
- **`src/bus/system-events.ts`** carried a ⚠ pointing at #2506.

Both now say what is true, and the erratum row records that it previously said otherwise so the history stays legible rather than looking like it was always right.

The **fixture** gains a loud header: frozen snapshot, do not copy its `system.adapter.*` shape, #2506 was filed against it by mistake, check the shipped bundle before filing. That is the actual defect this leaves behind — a file that looks like a live violation to anyone grepping for one.

## What survives

The rule itself, carried over from the retired G-1111 §4.6.2, is worth having written down — cortex satisfies it deliberately, and a new adapter has to follow the same port-based shape. Only the claimed *instance* was wrong.

## Verification

- `bunx tsc --noEmit` — 0
- `bun run lint` — 0 errors
- `check-carveouts` — PASS · `xdg-audit` — GATED 0
- system-events + adapters suites — 294/294

Refs #2506 (closed as not-a-bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)