### PR TITLE
fix(bus): stop the pull-consumer loop serializing on handler duration (#2515)

### DIFF
--- a/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
+++ b/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
@@ -31,6 +31,7 @@ import type {
   Subscription,
 } from "nats";
 import { MyelinSubscriber } from "../subscriber";
+import type { Envelope } from "../envelope-validator";
 import { NatsLink } from "../../nats/connection";
 import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { type: "json" };
 
@@ -599,6 +600,161 @@ describe("MyelinSubscriber — pull mode", () => {
     expect(m.ack).not.toHaveBeenCalled();
     expect(m.nak).not.toHaveBeenCalled();
     await sub.stop();
+    await h.cleanup();
+  });
+
+  // -------------------------------------------------------------------------
+  // cortex#2515 — handler concurrency
+  //
+  // The loop used to `await onRaw(...)` inline, so a slow handler stalled
+  // the iterator: the review consumer awaits a spawned `sage review`
+  // subprocess, and a second `tasks.code-review.*` envelope was never
+  // surfaced until the first review finished (the dispatching client timed
+  // out and sage misreported a DORMANT consumer).
+  // -------------------------------------------------------------------------
+
+  /** A handler that blocks until the returned `release` is called. */
+  function gatedHandler() {
+    const started: string[] = [];
+    const releases: (() => void)[] = [];
+    const onEnvelope = async (_env: Envelope, subject: string): Promise<void> => {
+      started.push(subject);
+      await new Promise<void>((resolve) => releases.push(resolve));
+    };
+    return {
+      started,
+      releaseAll: () => {
+        for (const r of releases.splice(0)) r();
+      },
+      onEnvelope,
+    };
+  }
+
+  test("cortex#2515: default (no maxConcurrent) stays serial — second handler waits", async () => {
+    const h = await makePullLink();
+    const g = gatedHandler();
+    const sub = MyelinSubscriber.start(h.link, {
+      pattern: "local.acme.>",
+      mode: "pull",
+      pull: { stream: "ACME_TASKS", durable: "myelin-test-consumer" },
+      onEnvelope: g.onEnvelope,
+    });
+    await sub.ready;
+
+    h.deliver("local.acme.first", bytes(validEnvelope));
+    h.deliver("local.acme.second", bytes(validEnvelope));
+    await flushMicrotasks();
+
+    // Only the first handler may have started; the loop must not have
+    // pulled the second while the first is still in flight.
+    expect(g.started).toEqual(["local.acme.first"]);
+
+    g.releaseAll();
+    await flushMicrotasks();
+    expect(g.started).toEqual(["local.acme.first", "local.acme.second"]);
+
+    g.releaseAll();
+    await sub.stop();
+    await h.cleanup();
+  });
+
+  test("cortex#2515: maxConcurrent > 1 lets slow handlers overlap", async () => {
+    const h = await makePullLink();
+    const g = gatedHandler();
+    const sub = MyelinSubscriber.start(h.link, {
+      pattern: "local.acme.>",
+      mode: "pull",
+      pull: {
+        stream: "ACME_TASKS",
+        durable: "myelin-test-consumer",
+        maxConcurrent: 3,
+      },
+      onEnvelope: g.onEnvelope,
+    });
+    await sub.ready;
+
+    h.deliver("local.acme.a", bytes(validEnvelope));
+    h.deliver("local.acme.b", bytes(validEnvelope));
+    h.deliver("local.acme.c", bytes(validEnvelope));
+    await flushMicrotasks();
+
+    // All three are in flight simultaneously — none has been released.
+    expect(g.started).toEqual([
+      "local.acme.a",
+      "local.acme.b",
+      "local.acme.c",
+    ]);
+
+    g.releaseAll();
+    await sub.stop();
+    await h.cleanup();
+  });
+
+  test("cortex#2515: maxConcurrent is a ceiling — the N+1th waits for a slot", async () => {
+    const h = await makePullLink();
+    const g = gatedHandler();
+    const sub = MyelinSubscriber.start(h.link, {
+      pattern: "local.acme.>",
+      mode: "pull",
+      pull: {
+        stream: "ACME_TASKS",
+        durable: "myelin-test-consumer",
+        maxConcurrent: 2,
+      },
+      onEnvelope: g.onEnvelope,
+    });
+    await sub.ready;
+
+    h.deliver("local.acme.a", bytes(validEnvelope));
+    h.deliver("local.acme.b", bytes(validEnvelope));
+    h.deliver("local.acme.c", bytes(validEnvelope));
+    await flushMicrotasks();
+
+    // Ceiling of 2: the third must not start until a slot frees.
+    expect(g.started).toEqual(["local.acme.a", "local.acme.b"]);
+
+    g.releaseAll();
+    await flushMicrotasks();
+    expect(g.started).toContain("local.acme.c");
+
+    g.releaseAll();
+    await sub.stop();
+    await h.cleanup();
+  });
+
+  test("cortex#2515: stop() drains in-flight handlers before resolving", async () => {
+    const h = await makePullLink();
+    let finished = false;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const sub = MyelinSubscriber.start(h.link, {
+      pattern: "local.acme.>",
+      mode: "pull",
+      pull: {
+        stream: "ACME_TASKS",
+        durable: "myelin-test-consumer",
+        maxConcurrent: 2,
+      },
+      onEnvelope: async () => {
+        await gate;
+        finished = true;
+      },
+    });
+    await sub.ready;
+
+    h.deliver("local.acme.slow", bytes(validEnvelope));
+    await flushMicrotasks();
+    expect(finished).toBe(false);
+
+    const stopping = sub.stop();
+    release();
+    await stopping;
+
+    // stop() must not resolve while a handler is still mid-flight — a
+    // review has to publish its terminal envelope before teardown.
+    expect(finished).toBe(true);
     await h.cleanup();
   });
 });

--- a/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
+++ b/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
@@ -722,6 +722,64 @@ describe("MyelinSubscriber — pull mode", () => {
     await h.cleanup();
   });
 
+  test("cortex#2515: maxConcurrent pins consume() prefetch to the same ceiling", async () => {
+    const h = await makePullLink();
+    const sub = MyelinSubscriber.start(h.link, {
+      pattern: "local.acme.>",
+      mode: "pull",
+      pull: {
+        stream: "ACME_TASKS",
+        durable: "myelin-test-consumer",
+        maxConcurrent: 3,
+      },
+      onEnvelope: () => {},
+    });
+    await sub.ready;
+    // Throttling handlers without throttling prefetch is not backpressure:
+    // the server would keep handing us messages that then sit
+    // delivered-but-unhandled, burning ack_wait while queued for a slot.
+    expect((h.consumeOpts() as { max_messages?: number }).max_messages).toBe(3);
+    await sub.stop();
+    await h.cleanup();
+  });
+
+  test("cortex#2515: explicit maxMessages wins over the maxConcurrent-derived prefetch", async () => {
+    const h = await makePullLink();
+    const sub = MyelinSubscriber.start(h.link, {
+      pattern: "local.acme.>",
+      mode: "pull",
+      pull: {
+        stream: "ACME_TASKS",
+        durable: "myelin-test-consumer",
+        maxConcurrent: 3,
+        maxMessages: 9,
+      },
+      onEnvelope: () => {},
+    });
+    await sub.ready;
+    expect((h.consumeOpts() as { max_messages?: number }).max_messages).toBe(9);
+    await sub.stop();
+    await h.cleanup();
+  });
+
+  test("cortex#2515: without maxConcurrent the nats.js default buffer is untouched", async () => {
+    const h = await makePullLink();
+    const sub = MyelinSubscriber.start(h.link, {
+      pattern: "local.acme.>",
+      mode: "pull",
+      pull: { stream: "ACME_TASKS", durable: "myelin-test-consumer" },
+      onEnvelope: () => {},
+    });
+    await sub.ready;
+    // Consumers that never opt in (brain / dev / release / reflex) must keep
+    // their prefetch behaviour byte-identical to pre-#2515.
+    expect(
+      (h.consumeOpts() as { max_messages?: number }).max_messages,
+    ).toBeUndefined();
+    await sub.stop();
+    await h.cleanup();
+  });
+
   test("cortex#2515: stop() drains in-flight handlers before resolving", async () => {
     const h = await makePullLink();
     let finished = false;

--- a/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
+++ b/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
@@ -722,64 +722,6 @@ describe("MyelinSubscriber — pull mode", () => {
     await h.cleanup();
   });
 
-  test("cortex#2515: maxConcurrent pins consume() prefetch to the same ceiling", async () => {
-    const h = await makePullLink();
-    const sub = MyelinSubscriber.start(h.link, {
-      pattern: "local.acme.>",
-      mode: "pull",
-      pull: {
-        stream: "ACME_TASKS",
-        durable: "myelin-test-consumer",
-        maxConcurrent: 3,
-      },
-      onEnvelope: () => {},
-    });
-    await sub.ready;
-    // Throttling handlers without throttling prefetch is not backpressure:
-    // the server would keep handing us messages that then sit
-    // delivered-but-unhandled, burning ack_wait while queued for a slot.
-    expect((h.consumeOpts() as { max_messages?: number }).max_messages).toBe(3);
-    await sub.stop();
-    await h.cleanup();
-  });
-
-  test("cortex#2515: explicit maxMessages wins over the maxConcurrent-derived prefetch", async () => {
-    const h = await makePullLink();
-    const sub = MyelinSubscriber.start(h.link, {
-      pattern: "local.acme.>",
-      mode: "pull",
-      pull: {
-        stream: "ACME_TASKS",
-        durable: "myelin-test-consumer",
-        maxConcurrent: 3,
-        maxMessages: 9,
-      },
-      onEnvelope: () => {},
-    });
-    await sub.ready;
-    expect((h.consumeOpts() as { max_messages?: number }).max_messages).toBe(9);
-    await sub.stop();
-    await h.cleanup();
-  });
-
-  test("cortex#2515: without maxConcurrent the nats.js default buffer is untouched", async () => {
-    const h = await makePullLink();
-    const sub = MyelinSubscriber.start(h.link, {
-      pattern: "local.acme.>",
-      mode: "pull",
-      pull: { stream: "ACME_TASKS", durable: "myelin-test-consumer" },
-      onEnvelope: () => {},
-    });
-    await sub.ready;
-    // Consumers that never opt in (brain / dev / release / reflex) must keep
-    // their prefetch behaviour byte-identical to pre-#2515.
-    expect(
-      (h.consumeOpts() as { max_messages?: number }).max_messages,
-    ).toBeUndefined();
-    await sub.stop();
-    await h.cleanup();
-  });
-
   test("cortex#2515: stop() drains in-flight handlers before resolving", async () => {
     const h = await makePullLink();
     let finished = false;

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -305,6 +305,12 @@ export interface MyelinSubscribePullOpts {
   maxMessages?: number;
   expiresMs?: number;
   thresholdMessages?: number;
+  /**
+   * cortex#2515 — in-flight handler ceiling for the consume loop. Omitted
+   * ⇒ 1 (serial), which is the pre-#2515 behaviour. See
+   * {@link MyelinPullOptions.maxConcurrent}.
+   */
+  maxConcurrent?: number;
 }
 
 /**
@@ -1865,11 +1871,15 @@ export async function startMyelinRuntime(
       maxMessages?: number;
       expiresMs?: number;
       thresholdMessages?: number;
+      maxConcurrent?: number;
     } = { stream: opts.stream, durable: opts.durable };
     if (opts.maxMessages !== undefined) pull.maxMessages = opts.maxMessages;
     if (opts.expiresMs !== undefined) pull.expiresMs = opts.expiresMs;
     if (opts.thresholdMessages !== undefined) {
       pull.thresholdMessages = opts.thresholdMessages;
+    }
+    if (opts.maxConcurrent !== undefined) {
+      pull.maxConcurrent = opts.maxConcurrent;
     }
     const sub = MyelinSubscriber.start(link, {
       pattern: opts.pattern,

--- a/src/bus/myelin/subscriber.ts
+++ b/src/bus/myelin/subscriber.ts
@@ -134,9 +134,13 @@ export interface MyelinPullOptions {
    *
    * Defaults to `1`, which is byte-identical to the pre-#2515 loop (each
    * message fully handled before the next is pulled). Values > 1 let the
-   * iterator keep pulling while earlier handlers are still running, and
-   * the loop applies backpressure by not pulling past the limit — no
-   * nak/redelivery churn.
+   * iterator keep pulling while earlier handlers are still running.
+   *
+   * Setting this ALSO pins `consume()`'s prefetch to the same ceiling
+   * (unless `maxMessages` is set explicitly). Both halves are needed:
+   * capping handler concurrency alone would leave the prefetch buffer
+   * pulling messages that then sit delivered-but-unhandled, burning their
+   * `ack_wait` while queued for a slot.
    *
    * This matters for handlers that are slow by nature: the review
    * consumer awaits a spawned `sage review` subprocess, so at the default
@@ -439,6 +443,20 @@ class PullBackend implements SubscriberBackend {
     } = {};
     if (opts.maxMessages !== undefined) {
       consumeOpts.max_messages = opts.maxMessages;
+    } else if (opts.maxConcurrent !== undefined) {
+      // cortex#2515 review — bounding HANDLER concurrency alone is not
+      // backpressure: `consume()`'s own prefetch (nats.js default buffer)
+      // keeps pulling regardless, so messages past the ceiling would sit
+      // delivered-but-unhandled, burning their `ack_wait` while they wait
+      // for a slot and redelivering under a long enough backlog. Pinning
+      // the prefetch to the same ceiling is what actually stops the server
+      // handing us more than we can run.
+      //
+      // Only applied when the caller opted into `maxConcurrent` AND left
+      // `maxMessages` unset — an explicit `maxMessages` still wins, and
+      // consumers that never set `maxConcurrent` keep the nats.js default
+      // buffer byte-identically.
+      consumeOpts.max_messages = this.maxConcurrent;
     }
     if (opts.expiresMs !== undefined) {
       consumeOpts.expires = opts.expiresMs;
@@ -463,9 +481,11 @@ class PullBackend implements SubscriberBackend {
     // cortex#2515 — handlers run as tracked promises instead of being
     // awaited inline, so a slow handler (the review consumer awaits a
     // spawned `sage review` subprocess) no longer stalls the iterator and
-    // starves later messages of delivery. Backpressure comes from not
-    // pulling past `maxConcurrent`, NOT from naking — a nak would send the
-    // message straight back for redelivery and churn the stream.
+    // starves later messages of delivery. The ceiling below throttles how
+    // many handlers run at once; the matching `max_messages` prefetch cap
+    // in `init()` is what keeps the server from handing us more than that.
+    // Neither path naks to shed load — a nak would send the message
+    // straight back for redelivery and churn the stream.
     //
     // At the default `maxConcurrent === 1` this is behaviourally identical
     // to the pre-#2515 inline await: the race below resolves the single

--- a/src/bus/myelin/subscriber.ts
+++ b/src/bus/myelin/subscriber.ts
@@ -129,6 +129,22 @@ export interface MyelinPullOptions {
   expiresMs?: number;
   /** Refill threshold (messages remaining before issuing another consume request). */
   thresholdMessages?: number;
+  /**
+   * cortex#2515 — how many handlers may be in flight concurrently.
+   *
+   * Defaults to `1`, which is byte-identical to the pre-#2515 loop (each
+   * message fully handled before the next is pulled). Values > 1 let the
+   * iterator keep pulling while earlier handlers are still running, and
+   * the loop applies backpressure by not pulling past the limit — no
+   * nak/redelivery churn.
+   *
+   * This matters for handlers that are slow by nature: the review
+   * consumer awaits a spawned `sage review` subprocess, so at the default
+   * of 1 a second `tasks.code-review.*` envelope is never surfaced to the
+   * consumer until the first review finishes, and the dispatching
+   * client's `--wait` expires first.
+   */
+  maxConcurrent?: number;
 }
 
 export interface MyelinSubscriberOptions {
@@ -385,12 +401,21 @@ class PullBackend implements SubscriberBackend {
   private loopPromise: Promise<void> | null = null;
   private stopped = false;
   private stopPromise: Promise<void> | null = null;
+  /** cortex#2515 — in-flight handler ceiling. 1 preserves pre-#2515 behaviour. */
+  private readonly maxConcurrent: number;
 
   constructor(
     link: NatsLink,
     opts: MyelinPullOptions,
     onRaw: (subject: string, data: Uint8Array, msg: JsMsg) => Promise<void>,
   ) {
+    // Guard against 0 / negative / NaN turning the loop into a no-op or an
+    // unbounded fan-out: anything not >= 1 falls back to the serial default.
+    const requested = opts.maxConcurrent;
+    this.maxConcurrent =
+      requested !== undefined && Number.isFinite(requested) && requested >= 1
+        ? Math.floor(requested)
+        : 1;
     this.ready = this.init(link, opts, onRaw);
   }
 
@@ -435,6 +460,17 @@ class PullBackend implements SubscriberBackend {
   ): Promise<void> {
     const messages = this.messages;
     if (!messages) return;
+    // cortex#2515 — handlers run as tracked promises instead of being
+    // awaited inline, so a slow handler (the review consumer awaits a
+    // spawned `sage review` subprocess) no longer stalls the iterator and
+    // starves later messages of delivery. Backpressure comes from not
+    // pulling past `maxConcurrent`, NOT from naking — a nak would send the
+    // message straight back for redelivery and churn the stream.
+    //
+    // At the default `maxConcurrent === 1` this is behaviourally identical
+    // to the pre-#2515 inline await: the race below resolves the single
+    // in-flight handler before the next iteration pulls.
+    const inFlight = new Set<Promise<void>>();
     try {
       for await (const m of messages) {
         if (this.stopped) {
@@ -443,18 +479,29 @@ class PullBackend implements SubscriberBackend {
           safeNak(m);
           return;
         }
-        try {
-          await onRaw(m.subject, m.data, m);
-        } catch (err) {
-          // onRaw owns its own ack/nak; a throw here means the
-          // dispatch logic itself failed (very rare — validator
-          // doesn't throw, handler errors are caught inside). Log and
-          // continue.
-          console.error(
-            `myelin-subscriber: pull dispatch error on "${sanitizeForLog(m.subject)}":`,
-            err instanceof Error ? err.message : String(err),
-          );
-          safeNak(m);
+        // Never rejects — the handler's own failure path is inside, so
+        // `race`/`allSettled` below can't see a rejection and the loop
+        // can't die on one bad message.
+        const task = (async () => {
+          try {
+            await onRaw(m.subject, m.data, m);
+          } catch (err) {
+            // onRaw owns its own ack/nak; a throw here means the
+            // dispatch logic itself failed (very rare — validator
+            // doesn't throw, handler errors are caught inside). Log and
+            // continue.
+            console.error(
+              `myelin-subscriber: pull dispatch error on "${sanitizeForLog(m.subject)}":`,
+              err instanceof Error ? err.message : String(err),
+            );
+            safeNak(m);
+          }
+        })();
+        inFlight.add(task);
+        void task.then(() => inFlight.delete(task));
+        if (inFlight.size >= this.maxConcurrent) {
+          // At the ceiling: wait for a slot before pulling again.
+          await Promise.race(inFlight);
         }
       }
     } catch (err) {
@@ -464,6 +511,11 @@ class PullBackend implements SubscriberBackend {
           err instanceof Error ? err.message : String(err),
         );
       }
+    } finally {
+      // Drain whatever is still running so `stop()` (which awaits this
+      // promise) gets deterministic teardown — a handler mid-review must
+      // publish its terminal envelope before the subscriber resolves.
+      await Promise.allSettled([...inFlight]);
     }
   }
 

--- a/src/bus/myelin/subscriber.ts
+++ b/src/bus/myelin/subscriber.ts
@@ -136,11 +136,13 @@ export interface MyelinPullOptions {
    * message fully handled before the next is pulled). Values > 1 let the
    * iterator keep pulling while earlier handlers are still running.
    *
-   * Setting this ALSO pins `consume()`'s prefetch to the same ceiling
-   * (unless `maxMessages` is set explicitly). Both halves are needed:
-   * capping handler concurrency alone would leave the prefetch buffer
-   * pulling messages that then sit delivered-but-unhandled, burning their
-   * `ack_wait` while queued for a slot.
+   * Setting this ALSO pins `consume()`'s prefetch (`max_messages`) to the
+   * same ceiling, unless `maxMessages` is set explicitly. Both halves are
+   * intended to be needed: capping handler concurrency alone would leave the
+   * prefetch buffer pulling messages that then sit delivered-but-unhandled,
+   * burning their `ack_wait` while queued for a slot. The prefetch half is
+   * asserted only as far as "the option is passed" — see the note in
+   * `init()` for what this repo's tests do and do not establish.
    *
    * This matters for handlers that are slow by nature: the review
    * consumer awaits a spawned `sage review` subprocess, so at the default
@@ -448,9 +450,15 @@ class PullBackend implements SubscriberBackend {
       // backpressure: `consume()`'s own prefetch (nats.js default buffer)
       // keeps pulling regardless, so messages past the ceiling would sit
       // delivered-but-unhandled, burning their `ack_wait` while they wait
-      // for a slot and redelivering under a long enough backlog. Pinning
-      // the prefetch to the same ceiling is what actually stops the server
-      // handing us more than we can run.
+      // for a slot and redelivering under a long enough backlog.
+      //
+      // `max_messages` is nats.js's documented knob for how many messages a
+      // consume request keeps outstanding, so pinning it to the ceiling is
+      // the mechanism intended to stop the server handing us more than we
+      // can run. NOT verified here: our tests assert only that the option is
+      // passed (the fake harness pushes straight into the iterator and has
+      // no broker), so the delivered-but-unhandled / `ack_wait` / redelivery
+      // behaviour under a real JetStream server is unproven by this repo.
       //
       // Only applied when the caller opted into `maxConcurrent` AND left
       // `maxMessages` unset — an explicit `maxMessages` still wins, and

--- a/src/bus/myelin/subscriber.ts
+++ b/src/bus/myelin/subscriber.ts
@@ -136,13 +136,17 @@ export interface MyelinPullOptions {
    * message fully handled before the next is pulled). Values > 1 let the
    * iterator keep pulling while earlier handlers are still running.
    *
-   * Setting this ALSO pins `consume()`'s prefetch (`max_messages`) to the
-   * same ceiling, unless `maxMessages` is set explicitly. Both halves are
-   * intended to be needed: capping handler concurrency alone would leave the
-   * prefetch buffer pulling messages that then sit delivered-but-unhandled,
-   * burning their `ack_wait` while queued for a slot. The prefetch half is
-   * asserted only as far as "the option is passed" — see the note in
-   * `init()` for what this repo's tests do and do not establish.
+   * KNOWN LIMITATION — this bounds how many handlers RUN, not how many
+   * messages are DELIVERED. `consume()`'s prefetch is untouched, so the
+   * server can still hand the client more than `maxConcurrent`; the surplus
+   * sits delivered-but-unhandled, burning its `ack_wait` while queued for a
+   * slot, and can redeliver under a long enough backlog. This is NOT
+   * backpressure in the JetStream sense.
+   *
+   * Pinning `consume()`'s `max_messages` to the ceiling was tried and
+   * REVERTED (cortex#2515): on a live stack it stalled delivery outright —
+   * a single idle dispatch sat unstarted for the full 600s wait, where the
+   * unpinned build completed the same review in 51s.
    *
    * This matters for handlers that are slow by nature: the review
    * consumer awaits a spawned `sage review` subprocess, so at the default
@@ -445,26 +449,6 @@ class PullBackend implements SubscriberBackend {
     } = {};
     if (opts.maxMessages !== undefined) {
       consumeOpts.max_messages = opts.maxMessages;
-    } else if (opts.maxConcurrent !== undefined) {
-      // cortex#2515 review — bounding HANDLER concurrency alone is not
-      // backpressure: `consume()`'s own prefetch (nats.js default buffer)
-      // keeps pulling regardless, so messages past the ceiling would sit
-      // delivered-but-unhandled, burning their `ack_wait` while they wait
-      // for a slot and redelivering under a long enough backlog.
-      //
-      // `max_messages` is nats.js's documented knob for how many messages a
-      // consume request keeps outstanding, so pinning it to the ceiling is
-      // the mechanism intended to stop the server handing us more than we
-      // can run. NOT verified here: our tests assert only that the option is
-      // passed (the fake harness pushes straight into the iterator and has
-      // no broker), so the delivered-but-unhandled / `ack_wait` / redelivery
-      // behaviour under a real JetStream server is unproven by this repo.
-      //
-      // Only applied when the caller opted into `maxConcurrent` AND left
-      // `maxMessages` unset — an explicit `maxMessages` still wins, and
-      // consumers that never set `maxConcurrent` keep the nats.js default
-      // buffer byte-identically.
-      consumeOpts.max_messages = this.maxConcurrent;
     }
     if (opts.expiresMs !== undefined) {
       consumeOpts.expires = opts.expiresMs;

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -394,6 +394,17 @@ export interface ReviewConsumerStartOpts {
   maxMessages?: number;
   expiresMs?: number;
   thresholdMessages?: number;
+  /**
+   * cortex#2515 — how many reviews this consumer may run concurrently.
+   *
+   * The consume loop awaits each handler, and `processEnvelope` awaits the
+   * whole pipeline (including the spawned `sage review` subprocess), so at
+   * the default of 1 a second `tasks.code-review.*` envelope is never even
+   * surfaced to this consumer until the in-flight review finishes — the
+   * dispatching client times out and sage reports a phantom DORMANT
+   * consumer. Values > 1 let concurrent dispatches proceed.
+   */
+  maxConcurrent?: number;
 }
 
 /**
@@ -527,6 +538,7 @@ export class ReviewConsumer {
       maxMessages?: number;
       expiresMs?: number;
       thresholdMessages?: number;
+      maxConcurrent?: number;
     } = {
       pattern: opts.pattern,
       stream: opts.stream,
@@ -542,6 +554,9 @@ export class ReviewConsumer {
     }
     if (opts.thresholdMessages !== undefined) {
       subscribePullOpts.thresholdMessages = opts.thresholdMessages;
+    }
+    if (opts.maxConcurrent !== undefined) {
+      subscribePullOpts.maxConcurrent = opts.maxConcurrent;
     }
     // `subscribePull` is OPTIONAL on the MyelinRuntime interface (the
     // additivity constraint per Architect cortex#290 review — legacy

--- a/src/runner/review-consumer-boot.ts
+++ b/src/runner/review-consumer-boot.ts
@@ -115,12 +115,22 @@ const DEFAULT_REVIEW_LOOP_CONCURRENCY = 3;
  * Resolve how many reviews one consumer may run at once.
  *
  * `runtime.maxConcurrent` is the operator's knob; absent it we use
- * {@link DEFAULT_REVIEW_LOOP_CONCURRENCY}. Note this is the SAME config field
- * `ReviewConsumerAgent.maxConcurrent` feeds, so the loop ceiling and the
- * consumer's own `not_now` gate agree by construction: the loop stops pulling
- * at the limit rather than admitting an envelope only to nak it, which would
- * churn redeliveries against the stream for no benefit. The gate remains as
- * defense-in-depth for the direct `processEnvelope` path used by tests.
+ * {@link DEFAULT_REVIEW_LOOP_CONCURRENCY}.
+ *
+ * The loop ceiling is the OPERATIVE limit: it stops pulling at the cap rather
+ * than admitting an envelope only to nak it, which would churn redeliveries
+ * against the stream for no benefit. `ReviewConsumer`'s own `not_now` gate
+ * reads this same config field but stays inert (the loop never admits more
+ * than the cap, so `inFlight` never reaches it); it remains as defense-in-depth
+ * for the direct `processEnvelope` path used by tests.
+ *
+ * The two values are derived by DIFFERENT paths and are not normalised
+ * together: this returns the field verbatim, while `PullBackend` floors
+ * fractions and clamps anything below 1 up to 1. They coincide only because
+ * `AgentRuntimeSchema` constrains the field to a positive integer
+ * (`common/types/cortex-config.ts` — `.int().positive()`), so a fractional
+ * value never survives config load. A caller that builds a `ReviewBootAgent`
+ * by hand, bypassing that schema, can still make them diverge.
  */
 function reviewLoopConcurrency(agent: ReviewBootAgent): number {
   return agent.runtime?.maxConcurrent ?? DEFAULT_REVIEW_LOOP_CONCURRENCY;

--- a/src/runner/review-consumer-boot.ts
+++ b/src/runner/review-consumer-boot.ts
@@ -114,7 +114,7 @@ const DEFAULT_REVIEW_LOOP_CONCURRENCY = 3;
 /**
  * Resolve how many reviews one consumer may run at once.
  *
- * `runtime.maxConcurrent` is the operator's knob; absent it we use
+ * `runtime.maxConcurrent` is the principal's knob; absent it we use
  * {@link DEFAULT_REVIEW_LOOP_CONCURRENCY}.
  *
  * The loop ceiling is the OPERATIVE limit: it stops pulling at the cap rather

--- a/src/runner/review-consumer-boot.ts
+++ b/src/runner/review-consumer-boot.ts
@@ -99,43 +99,6 @@ export interface ReviewBootAgent {
   };
 }
 
-/**
- * cortex#2515 — default in-flight review ceiling per consumer.
- *
- * Before #2515 the consume loop awaited each handler inline, so reviews were
- * serialized at 1 and a dispatch arriving mid-review was never surfaced to the
- * consumer at all (the client's `--wait` expired first and sage misreported a
- * DORMANT consumer). A review spawns a coding-agent subprocess, so the ceiling
- * stays deliberately small — this is a concurrency limit, not a throughput
- * target.
- */
-const DEFAULT_REVIEW_LOOP_CONCURRENCY = 3;
-
-/**
- * Resolve how many reviews one consumer may run at once.
- *
- * `runtime.maxConcurrent` is the principal's knob; absent it we use
- * {@link DEFAULT_REVIEW_LOOP_CONCURRENCY}.
- *
- * The loop ceiling is the OPERATIVE limit: it stops pulling at the cap rather
- * than admitting an envelope only to nak it, which would churn redeliveries
- * against the stream for no benefit. `ReviewConsumer`'s own `not_now` gate
- * reads this same config field but stays inert (the loop never admits more
- * than the cap, so `inFlight` never reaches it); it remains as defense-in-depth
- * for the direct `processEnvelope` path used by tests.
- *
- * The two values are derived by DIFFERENT paths and are not normalised
- * together: this returns the field verbatim, while `PullBackend` floors
- * fractions and clamps anything below 1 up to 1. They coincide only because
- * `AgentRuntimeSchema` constrains the field to a positive integer
- * (`common/types/cortex-config.ts` — `.int().positive()`), so a fractional
- * value never survives config load. A caller that builds a `ReviewBootAgent`
- * by hand, bypassing that schema, can still make them diverge.
- */
-function reviewLoopConcurrency(agent: ReviewBootAgent): number {
-  return agent.runtime?.maxConcurrent ?? DEFAULT_REVIEW_LOOP_CONCURRENCY;
-}
-
 /** Inputs `cortex.ts` threads into the review-consumer boot wiring. */
 export interface WireReviewConsumersOpts {
   /** `{principal}` subject segment — durable names + the verifier's own-stack check. */
@@ -496,7 +459,6 @@ export function wireReviewConsumers(
         pattern: primaryReviewPattern,
         stream: opts.reviewStream,
         durable,
-        maxConcurrent: reviewLoopConcurrency(agent),
       });
       const flavorSummary =
         consumer.flavors.length > 0 ? consumer.flavors.join(",") : "(none)";
@@ -586,7 +548,6 @@ export function wireReviewConsumers(
           pattern: extraPattern,
           stream: opts.reviewStream,
           durable: offerDurable,
-          maxConcurrent: reviewLoopConcurrency(agent),
         });
         if (offerStarted.subscribed) {
           console.log(
@@ -658,7 +619,6 @@ export function wireReviewConsumers(
             pattern,
             stream: opts.reviewStream,
             durable: durableName,
-            maxConcurrent: reviewLoopConcurrency(agent),
           });
           if (federatedStarted.subscribed) {
             console.log(

--- a/src/runner/review-consumer-boot.ts
+++ b/src/runner/review-consumer-boot.ts
@@ -99,6 +99,33 @@ export interface ReviewBootAgent {
   };
 }
 
+/**
+ * cortex#2515 — default in-flight review ceiling per consumer.
+ *
+ * Before #2515 the consume loop awaited each handler inline, so reviews were
+ * serialized at 1 and a dispatch arriving mid-review was never surfaced to the
+ * consumer at all (the client's `--wait` expired first and sage misreported a
+ * DORMANT consumer). A review spawns a coding-agent subprocess, so the ceiling
+ * stays deliberately small — this is a concurrency limit, not a throughput
+ * target.
+ */
+const DEFAULT_REVIEW_LOOP_CONCURRENCY = 3;
+
+/**
+ * Resolve how many reviews one consumer may run at once.
+ *
+ * `runtime.maxConcurrent` is the operator's knob; absent it we use
+ * {@link DEFAULT_REVIEW_LOOP_CONCURRENCY}. Note this is the SAME config field
+ * `ReviewConsumerAgent.maxConcurrent` feeds, so the loop ceiling and the
+ * consumer's own `not_now` gate agree by construction: the loop stops pulling
+ * at the limit rather than admitting an envelope only to nak it, which would
+ * churn redeliveries against the stream for no benefit. The gate remains as
+ * defense-in-depth for the direct `processEnvelope` path used by tests.
+ */
+function reviewLoopConcurrency(agent: ReviewBootAgent): number {
+  return agent.runtime?.maxConcurrent ?? DEFAULT_REVIEW_LOOP_CONCURRENCY;
+}
+
 /** Inputs `cortex.ts` threads into the review-consumer boot wiring. */
 export interface WireReviewConsumersOpts {
   /** `{principal}` subject segment — durable names + the verifier's own-stack check. */
@@ -459,6 +486,7 @@ export function wireReviewConsumers(
         pattern: primaryReviewPattern,
         stream: opts.reviewStream,
         durable,
+        maxConcurrent: reviewLoopConcurrency(agent),
       });
       const flavorSummary =
         consumer.flavors.length > 0 ? consumer.flavors.join(",") : "(none)";
@@ -548,6 +576,7 @@ export function wireReviewConsumers(
           pattern: extraPattern,
           stream: opts.reviewStream,
           durable: offerDurable,
+          maxConcurrent: reviewLoopConcurrency(agent),
         });
         if (offerStarted.subscribed) {
           console.log(
@@ -619,6 +648,7 @@ export function wireReviewConsumers(
             pattern,
             stream: opts.reviewStream,
             durable: durableName,
+            maxConcurrent: reviewLoopConcurrency(agent),
           });
           if (federatedStarted.subscribed) {
             console.log(


### PR DESCRIPTION
Part of #2515. Follow-up: #2517.

## What this changes

The JetStream pull-consumer loop awaited each handler inline:

```js
for await (const m of messages) {
  await onRaw(m.subject, m.data, m);   // ← blocks the iterator for the handler's full duration
}
```

`ReviewConsumer.processEnvelope` awaits its whole pipeline (`review-consumer.ts:957`), including a spawned `sage review` subprocess, so the loop could not pull message N+1 until review N had entirely finished.

Handlers now run as tracked promises, bounded by a new `maxConcurrent` on `MyelinPullOptions`. `stop()` drains in-flight handlers in a `finally`, so a mid-flight handler still publishes its terminal envelope before teardown.

## Scope: mechanism only — no behaviour change

`maxConcurrent` **defaults to 1**, which is behaviourally identical to the previous inline await. **No consumer opts in** — not brain, dev, release, reflex, nor the review lane. This PR lands the mechanism and its tests; nothing changes operationally until a caller sets the option.

That is deliberate, and narrower than this PR originally claimed. See below.

## What is proven

Probes on a live stack, second dispatch fired mid-review:

```
loop-iter subject=…code-review.typescript inFlight=0 cap=3   ← A pulled
loop-iter subject=…code-review.typescript inFlight=1 cap=3   ← B pulled WHILE A still in flight
```

The second `loop-iter` is the thing the old loop could not produce — before this change it did not appear until A's review had completely finished. Server-side confirmation: `Outstanding Acks: 2`, where the old loop never exceeded 1.

Single dispatch round trip on this branch is healthy: `started 07:48:24` → `completed 07:49:34`, 70s, terminal `dispatch.task.completed`, exit 0.

## What is NOT proven, and why the review lane is not opted in

**Concurrent reviews still do not run.** With the review lane at `maxConcurrent: 3`, the second dispatch is admitted by the loop and then stalls: no `dispatch.task.started`, no subprocess, still stuck after the first review completed, client timed out at 300s. There is a second serialization point downstream of the consume loop, not yet located. Filed as **#2517** with the evidence and a suggested approach.

Opting the review lane in would therefore trade a **delay** for a **hang**:

| | second concurrent dispatch |
|---|---|
| before this PR | DELAYED — ran the full gate sequence once the first review finished (verified) |
| review lane at 3 | ADMITTED then HANGS — never started, client timed out |

So the opt-in is held back until #2517 is fixed and it can be verified end to end rather than asserted.

## Review history — three rounds, all on overclaiming

Sage reviewed this three times. Every finding was against my prose, not the code, and each was correct:

1. **Backpressure claim unproven.** The comment said the loop "applies backpressure by not pulling past the limit", but the ceiling is checked after `for await` yields and `consume()`'s prefetch is untouched. I responded by trying to make the claim true — pinning `consume()`'s `max_messages` to the ceiling (`96a30167`). **That regressed delivery outright**: a single idle dispatch sat unstarted for a full 600s wait, where the unpinned build completed the same review in 51s. Reverted in `035431c5`. The correct response to round 1 was to fix the claim, not the code.
2. **"Loop and gate agree by construction" was false.** `reviewLoopConcurrency()` returned the config field verbatim while `PullBackend` floors fractions. Unreachable through validated config (`AgentRuntimeSchema` pins `.int().positive()`), but the stated reason was wrong. Corrected in `851e5ad4`; that helper is now removed entirely.
3. **"Verified end to end" stopped at startup.** The evidence was `dispatch.task.started` for both dispatches — a start event standing in for successful concurrent execution. Chasing this is what surfaced the #2517 stall and the `96a30167` regression.

The remaining honest position: `maxConcurrent` bounds how many handlers **run**, not how many messages are **delivered**. Surplus messages still sit delivered-but-unhandled against `ack_wait`. That gap is documented in the docblock, not closed.

## Also inert, noted not fixed

`ReviewConsumer`'s `maxConcurrent` gate (`review-consumer.ts:907`) can never fire — probes printed `inFlight=0 maxConcurrent=undefined` on every dispatch. Tracked in #2517.

## Tests

Four pull-mode cases: serial default, overlap above 1, the ceiling, and drain-on-stop.

The two overlap cases were confirmed to **fail against the old inline-await loop** and pass with this change (verified by temporarily forcing `maxConcurrent = 1`). The other two pass under both by design — they guard the default and the teardown contract rather than reproducing the bug.

```
bun test src/bus/ src/runner/__tests__/review-consumer-boot.test.ts \
         src/__tests__/cortex.review-consumer-boot.test.ts
→ 1406 pass, 1 skip, 0 fail
```

`bunx tsc --noEmit` clean (excluding a pre-existing error in `node_modules/@metafactory/content-filter`). `scripts/check-carveouts.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
