### PR TITLE
fix(runner): detect the auth failure CC writes to stdout, not stderr

### DIFF
--- a/src/runner/__tests__/cc-failure-classifier.test.ts
+++ b/src/runner/__tests__/cc-failure-classifier.test.ts
@@ -202,6 +202,27 @@ describe("isCcAuthFailure", () => {
     expect(isCcAuthFailure(failed({ response: "You are not logged in." }))).toBe(true);
   });
 
+  // The stdout spelling. Measured against a config dir with no credential:
+  //   CLAUDE_CONFIG_DIR=<dir> claude -p "say ok"
+  //   → exit 1 · stdout "Not logged in · Please run /login" · stderr EMPTY
+  // We spawn with --output-format stream-json, so that line is not an event
+  // and cc-session used to drop it: response empty, stderr empty, empty
+  // haystack, no detection. Three futile retries, then the generic apology —
+  // the outcome #2055 exists to prevent, reached by a channel it did not read.
+  test("detects the auth error when CC writes it to STDOUT, not stderr", () => {
+    expect(
+      isCcAuthFailure(
+        failed({ rawStdout: "Not logged in · Please run /login", stderr: "" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("the pre-fix shape is exactly what used to escape detection", () => {
+    // Same failure, rawStdout dropped: this is what the classifier saw before
+    // cc-session retained unparseable stdout, and why it returned false.
+    expect(isCcAuthFailure(failed({ response: "", stderr: "" }))).toBe(false);
+  });
+
   test("does NOT fire on a clean success", () => {
     expect(isCcAuthFailure(successResult())).toBe(false);
   });
@@ -210,6 +231,10 @@ describe("isCcAuthFailure", () => {
     expect(isCcAuthFailure(failed({ stderr: "TypeError: cannot read property 'x' of undefined" }))).toBe(false);
     expect(isCcAuthFailure(failed({ stderr: "" }))).toBe(false);
     expect(isCcAuthFailure(failed({ response: "partial answer then crash" }))).toBe(false);
+    // rawStdout widened the haystack; it must not have widened what matches.
+    expect(
+      isCcAuthFailure(failed({ rawStdout: "Compiling... done in 1.2s" })),
+    ).toBe(false);
   });
 
   test("CC_AUTH_FAILURE_MESSAGE is actionable (names the fix: run claude to re-login)", () => {

--- a/src/runner/cc-failure-classifier.ts
+++ b/src/runner/cc-failure-classifier.ts
@@ -145,9 +145,10 @@ export function isTransientFailure(
  * patterns let the chat path detect it, skip the retries, and tell the
  * principal what to actually do.
  *
- * Matched case-insensitively against `response + stderr`. Kept broad because
- * the exact wording varies by CLI version (OAuth vs API-key, login-expired vs
- * invalid-key), but every variant is principal-recoverable the same way.
+ * Matched case-insensitively against `response + stderr + rawStdout`. Kept
+ * broad because the exact wording varies by CLI version (OAuth vs API-key,
+ * login-expired vs invalid-key), but every variant is principal-recoverable
+ * the same way.
  */
 const CC_AUTH_FAILURE_SIGNATURES: readonly RegExp[] = [
   /authentication_failed/i,
@@ -170,13 +171,31 @@ export const CC_AUTH_FAILURE_MESSAGE =
 
 /**
  * cortex#2055 — True when a `CCSessionResult` bears the fingerprint of an auth
- * failure (checks the captured stderr and any partial response). The chat path
- * uses this to classify the failure as terminal (no retry) and to swap the
- * opaque apology for `CC_AUTH_FAILURE_MESSAGE`.
+ * failure. The chat path uses this to classify the failure as terminal (no
+ * retry) and to swap the opaque apology for `CC_AUTH_FAILURE_MESSAGE`.
+ *
+ * Reads three fields, and the third is the one that took a night to find.
+ * #2055 checked `response` and `stderr`, which covers the spelling where CC
+ * writes the auth error to stderr. It does not cover this one, measured
+ * against a config dir with no credential:
+ *
+ *   exit 1 · stdout "Not logged in · Please run /login" · stderr EMPTY
+ *
+ * We spawn with `--output-format stream-json`, so that plain-text line was
+ * dropped by `processLine` as an unparseable event and never reached a
+ * result field. Both `response` and `stderr` came back empty, the
+ * empty-haystack short-circuit below returned `false`, and the dispatch was
+ * classified `not_now` — three futile retries, then the generic apology.
+ * Exactly the outcome the comment above says this function prevents.
+ *
+ * `rawStdout` (cc-session) now retains those discarded lines, so the stdout
+ * spelling is visible to the same signature list as the stderr one. The fix
+ * is at the haystack rather than in the signatures on purpose: the bug was
+ * never a missing pattern, it was a channel nobody was listening on.
  */
 export function isCcAuthFailure(result: CCSessionResult): boolean {
   if (result.success) return false;
-  const haystack = `${result.response}\n${result.stderr ?? ""}`;
+  const haystack = `${result.response}\n${result.stderr ?? ""}\n${result.rawStdout ?? ""}`;
   if (!haystack.trim()) return false;
   return CC_AUTH_FAILURE_SIGNATURES.some((re) => re.test(haystack));
 }

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -226,6 +226,28 @@ export interface CCSessionResult {
    * (e.g. `authentication_failed`) that exit non-zero with no stdout response.
    */
   stderr?: string;
+  /**
+   * Stdout lines that were NOT parseable as stream-json (empty/absent when
+   * every line parsed). Bounded — see `RAW_STDOUT_CAP`.
+   *
+   * We ask CC for `--output-format stream-json`, so `processLine` drops
+   * anything that is not an event. That is right for the happy path and
+   * wrong for the failure path: some substrate-level errors are written to
+   * STDOUT as plain prose, exit non-zero, and put nothing on stderr at all.
+   * Measured, for a config dir with no credential:
+   *
+   *   exit 1 · stdout "Not logged in · Please run /login" · stderr empty
+   *
+   * With that line discarded, `response` and `stderr` are both empty, so
+   * `isCcAuthFailure` had an empty haystack and could not fire — the chat
+   * path retried three times and showed the generic apology, which is the
+   * exact outcome cortex#2055 was written to prevent. It guarded the stderr
+   * spelling of the error; this is the stdout spelling.
+   *
+   * Kept as raw text rather than parsed: the point is to stop throwing away
+   * the one string that names the fault, not to model CC's prose.
+   */
+  rawStdout?: string;
 }
 
 /**
@@ -435,6 +457,16 @@ export function deriveSandboxProfile(
   };
 }
 
+/**
+ * Upper bound on retained non-stream-json stdout (`CCSessionResult.rawStdout`).
+ *
+ * Sized for a diagnostic line or a short stack trace, not a transcript: this
+ * exists so a failure classifier can read the reason a session died, and a
+ * process that writes prose to stdout indefinitely must not be able to grow
+ * a cortex-side buffer while doing it.
+ */
+const RAW_STDOUT_CAP = 8192;
+
 export class CCSession extends EventEmitter {
   private proc: ReturnType<typeof Bun.spawn> | null = null;
   private timeoutId: Timer | null = null;
@@ -442,6 +474,8 @@ export class CCSession extends EventEmitter {
   private startTime = 0;
   private stdoutDone: Promise<void> = Promise.resolve();
   private stderrDone: Promise<void> = Promise.resolve();
+  /** Non-stream-json stdout text, surfaced on the result as `rawStdout`. */
+  private rawStdoutText = "";
   /** cortex#2055 — accumulated stderr text, surfaced on the result so callers
    *  can detect substrate-level failures (e.g. `authentication_failed`) that
    *  never reach the stdout stream. */
@@ -916,6 +950,7 @@ export class CCSession extends EventEmitter {
           durationMs,
           usage: this.usage,
           ...(this.stderrText && { stderr: this.stderrText }),
+          ...(this.rawStdoutText && { rawStdout: this.rawStdoutText }),
           ...(this.timedOut && { aborted: true, abortReason: "timeout" as const }),
         });
       });
@@ -930,6 +965,7 @@ export class CCSession extends EventEmitter {
           durationMs,
           usage: this.usage,
           ...(this.stderrText && { stderr: this.stderrText }),
+          ...(this.rawStdoutText && { rawStdout: this.rawStdoutText }),
           // The exit path can also be reached on inactivity timeout —
           // wireExit() races with the error listener and may win when CC
           // exits in response to SIGINT before the error has been emitted.
@@ -1058,7 +1094,21 @@ export class CCSession extends EventEmitter {
 
   private processLine(line: string): void {
     const event = parseStreamLine(line);
-    if (!event) return;
+    if (!event) {
+      // Not a stream-json event. Almost always noise, occasionally the only
+      // record of WHY the session died (see `rawStdout`). Retained rather
+      // than dropped, capped so a chatty non-JSON writer cannot grow this
+      // without bound, and deliberately NOT treated as liveness: a process
+      // spraying prose is not making progress, so the inactivity timer is
+      // left alone (only a parsed event resets it, as before).
+      const text = line.trim();
+      if (text && this.rawStdoutText.length < RAW_STDOUT_CAP) {
+        this.rawStdoutText +=
+          (this.rawStdoutText ? "\n" : "") +
+          text.slice(0, RAW_STDOUT_CAP - this.rawStdoutText.length);
+      }
+      return;
+    }
 
     // Any parsed event = CC is alive. Reset inactivity timer.
     this.resetInactivityTimer();


### PR DESCRIPTION
A Luna dispatch on the `manda` stack failed with the generic apology and an opaque `exit code: 1`. Diagnosing it took an evening. The reason was on the floor the whole time.

## Measured

Against a config dir with no credential:

```
$ CLAUDE_CONFIG_DIR=<dir> claude -p "say ok"
exit code : 1
STDOUT    : Not logged in · Please run /login
STDERR    : <empty>
```

## Why nothing surfaced it

We spawn CC with `--output-format stream-json`, and `processLine` drops any line that is not a parseable event:

```ts
const event = parseStreamLine(line);
if (!event) return;        // ← the only record of WHY the session died
```

So `response` came back empty and `stderr` came back empty. `isCcAuthFailure` hit its empty-haystack short-circuit and returned `false`. The failure classified as `not_now`, the chat path retried three times — auth does not self-heal — and the principal got the generic apology.

Which is exactly the outcome cortex#2055's own comment says it prevents:

> the generic classifier buckets it as `not_now` → the chat path retries 3× (all futile — auth won't self-heal) and then surfaces the opaque "couldn't process that (exit code: 1)"

**#2055 was not wrong.** It guarded the spelling where CC writes the auth error to **stderr**. This is a different spelling, on a channel nobody was listening on. The pattern `/not (?:logged|signed) in/i` was already in the signature list and already correct — it never saw the text.

## The fix, at the haystack rather than the patterns

- **`cc-session`** retains unparseable stdout as `CCSessionResult.rawStdout`, capped at 8 KB — a diagnostic line or short stack trace, not a transcript, so a process spraying prose to stdout cannot grow a cortex-side buffer while doing it. Deliberately **not** treated as liveness: only a parsed event still resets the inactivity timer, since a process emitting prose is not making progress.
- **`isCcAuthFailure`** reads `response + stderr + rawStdout`.

Fixing the signature list instead would have papered over the real defect: a whole output channel was being discarded before any classifier could read it. Any future substrate error CC prints to stdout is now visible to the same machinery.

## Verified, not assumed

With the haystack change reverted, the new stdout test fails and the other 17 pass:

```
(fail) isCcAuthFailure > detects the auth error when CC writes it to STDOUT, not stderr
 17 pass, 1 fail
```

Restored: 18 pass. The test catches the bug, not the fix.

A negative case pins the widening — `rawStdout: "Compiling... done in 1.2s"` must not match — because widening what a detector *reads* is the easy way to accidentally widen what it *fires on*.

`tsc --noEmit` clean. cc-session, cc-failure-classifier and dispatch-handler suites: **115 pass / 0 fail**.

## Effect

This failure now short-circuits the three futile retries and surfaces `CC_AUTH_FAILURE_MESSAGE`, which names the fix instead of apologising.

## Not covered here

The underlying operational issue is separate: `manda` and `work` both set `substrates.claude-code.configHome: ~/.claude-soma`, and that config dir has no credential (`oauthAccount` absent, `hasCompletedOnboarding: false`), while every other stack uses the logged-in vendor default. That needs a `/login`, not a code change. This PR only ensures the next person is told which of the two it is.