### PR TITLE
docs(security): commit NWS round-2 report in-tree; adopt R1-/R2- finding-ID prefixes; retire the closed-#2359 round-2 marker

### DIFF
--- a/docs/security/ebh-6-posture-findings.md
+++ b/docs/security/ebh-6-posture-findings.md
@@ -1,19 +1,19 @@
-# EBH-6 — sovereignty enforcement posture (F3) + principal-DM guard-disable / principal-map integrity (F4)
+# EBH-6 — sovereignty enforcement posture (R1-F3) + principal-DM guard-disable / principal-map integrity (R1-F4)
 
 Investigation for cortex#2348 (epic #2341, execution-boundary hardening), responding to the
-NorthWoods Sentinel review's F3/F4 (`docs/security/reviews/2026-07-23-nws-security-review.md`).
+NorthWoods Sentinel review's R1-F3/R1-F4 (`docs/security/reviews/2026-07-23-nws-security-review.md`).
 Read-only investigation; no application code, config, or security posture changed.
 
 **Method note.** Every claim below is tagged **VERIFIED** (with `file:line` or a command
 citation) or **UNVERIFIED**. Two claims carried in the review or the hardening plan turned out
-to be stale — see F4 §4. Line numbers are as of `origin/main` at commit `2a270262` plus
-`c25a7c3d` (EBH-1, merged the same day this investigation was run) — several F1/F6-adjacent
+to be stale — see R1-F4 §4. Line numbers are as of `origin/main` at commit `2a270262` plus
+`c25a7c3d` (EBH-1, merged the same day this investigation was run) — several R1-F1/R1-F6-adjacent
 files changed shape today; where the review's cited line numbers no longer match, the current
 number is used and the drift is called out.
 
 ---
 
-## F3 — sovereignty enforcement posture
+## R1-F3 — sovereignty enforcement posture
 
 ### Headline
 
@@ -37,7 +37,7 @@ to close it (a config-declared harness→placement map, independent of self-decl
   drifted.
 - **New finding, not in the review:** `src/bus/brain-consumer.ts` carries the **identical**
   pattern independently — `sovereigntyEnforce?: boolean` (`:243`), default `?? false` (`:390`),
-  gated deny at `:513`. The review's F3 only names `review-consumer.ts`; brain-consumer is a
+  gated deny at `:513`. The review's R1-F3 only names `review-consumer.ts`; brain-consumer is a
   second, separately-defaulted instance of the exact same audit-only posture.
 
 ### 2. `evaluateSovereignty` decision core — VERIFIED fail-closed
@@ -136,7 +136,7 @@ prerequisite (#327) is what's pending is imprecise — #327 shipped and is a gen
 
 ---
 
-## F4 — principal-DM guard-disable + principal-map integrity
+## R1-F4 — principal-DM guard-disable + principal-map integrity
 
 ### Headline
 
@@ -224,7 +224,7 @@ that point:
   cortex config directory is never itself included in that principal's `allowedDirs`**, a
   Write/Edit into the config tree is deterministically denied even in a guard-off DM
   (`src/runner/hooks/path-guard.hook.ts:436–465`). This is new since the review was written and
-  meaningfully narrows F4 for the file-tool surface.
+  meaningfully narrows R1-F4 for the file-tool surface.
 - **Bash remains a full blind spot.** `bash-guard.hook.ts`'s `config === null` branch
   (`:1150–1153`) returns `pass()` **before** reaching its own EBH-1-added path-containment checks
   for `cat`/`head`/`tail`/`ls`/`wc`/`file`/`git` (`PATH_CHECKED_COMMANDS`, `:384`) — so a
@@ -277,17 +277,17 @@ that point:
 
 ## Open questions for the principal (binary)
 
-1. **F3 — Config exposure.** Should `sovereigntyEnforce` be promoted to a real (still
+1. **R1-F3 — Config exposure.** Should `sovereigntyEnforce` be promoted to a real (still
    default-`false`) config key now, independent of the #2117/#2201 prerequisite work, so enabling
    it is a principal action rather than a code change? Yes / No.
-2. **F3 — Enforce-now vs. explicit-deferral for `api-agent`.** Per #2117's own framing: enforce
+2. **R1-F3 — Enforce-now vs. explicit-deferral for `api-agent`.** Per #2117's own framing: enforce
    the *resolved* inference-profile `modelClass` now (small, closes the design's stated intent),
    or document the deferral explicitly and wait for #2201 (model-placement gate)? Enforce-now /
    Defer.
-3. **F4 — Bash path-awareness in guard-off sessions.** Should `bash-guard.hook.ts`'s
+3. **R1-F4 — Bash path-awareness in guard-off sessions.** Should `bash-guard.hook.ts`'s
    `disabled`-branch also run the EBH-1 path-containment checks (not the command-shape allowlist,
    just containment) rather than a bare `pass()`? Yes / No.
-4. **F4 — G-301.** File G-301 as an actual GitHub issue now, and correct the two stale `#42`
+4. **R1-F4 — G-301.** File G-301 as an actual GitHub issue now, and correct the two stale `#42`
    citations (review + hardening-plan)? Yes / No.
 
 ---

--- a/docs/security/hardening-plan.md
+++ b/docs/security/hardening-plan.md
@@ -2,7 +2,10 @@
 
 **Status:** Draft (planning only — no production code)
 **Author:** Luna (with Andreas)
-**Evidence base:** [`reviews/2026-07-23-nws-security-review.md`](reviews/2026-07-23-nws-security-review.md) + [`reviews/2026-07-23-nws-assessment-summary.md`](reviews/2026-07-23-nws-assessment-summary.md) (NorthWoods Sentinel Labs / Rob Chuvala, 2026-07-23, against `v6.11.0`). Every load-bearing claim in the review was re-verified against source before this plan was written.
+**Evidence base:** [`reviews/2026-07-23-nws-security-review.md`](reviews/2026-07-23-nws-security-review.md) + [`reviews/2026-07-23-nws-assessment-summary.md`](reviews/2026-07-23-nws-assessment-summary.md) (NorthWoods Sentinel Labs / Rob Chuvala, 2026-07-23, against `v6.11.0`) + [`reviews/2026-07-26-nws-round-2.md`](reviews/2026-07-26-nws-round-2.md) (round 2, against `v6.13.0`). Every load-bearing claim in the review was re-verified against source before this plan was written.
+
+**Finding-ID convention:** round-1 findings are cited as `R1-F1`..`R1-F6`; round-2 findings as `R2-F1`..`R2-F6`; the `#2331 7a review` IDs stay issue-qualified. **A bare `F<n>` is never a valid citation** — the two rounds both number `F1`..`F6` and mean different things.
+
 **Deep dive:** [`../design-session-sandbox.md`](../design-session-sandbox.md) (Layers 1–3).
 
 ---
@@ -13,17 +16,17 @@
 
 | Finding | The boundary that is prose/log instead of code | Verified at |
 |---|---|---|
-| **F1** | File tools have no `PreToolUse` hook; `cat`/`head`/`tail` allowlisted, no path check | `cortex-hooks.json:30`; `bash-guard.hook.ts:126–128` |
-| **F6** | `readOnlyDirs` write-protection is a preamble sentence | `security-preamble.ts:67–77` |
-| **F3** | Sovereignty (confidential-never-reaches-frontier) audit-only by default, in BOTH consumers | `review-consumer.ts:500`, `brain-consumer.ts:390` (`?? false`) |
-| **F4** | Principal-DM disables the Bash guard entirely | `bash-guard.hook.ts:150` |
+| **R1-F1** | File tools have no `PreToolUse` hook; `cat`/`head`/`tail` allowlisted, no path check | `cortex-hooks.json:30`; `bash-guard.hook.ts:126–128` |
+| **R1-F6** | `readOnlyDirs` write-protection is a preamble sentence | `security-preamble.ts:67–77` |
+| **R1-F3** | Sovereignty (confidential-never-reaches-frontier) audit-only by default, in BOTH consumers | `review-consumer.ts:500`, `brain-consumer.ts:390` (`?? false`) |
+| **R1-F4** | Principal-DM disables the Bash guard entirely | `bash-guard.hook.ts:150` |
 
-> Line numbers pinned to `origin/main` @ `059f619d` (2026-07-24). The review was authored against `f6f4b06d`; the bash-guard anchors shifted +18 after #2337 (cortex#2335) tightened the same file's `gh` floor — F1/F4 remain valid, EBH-1 must coordinate with that direction.
-| **F2** | Plugins run at full daemon authority, no post-load sandbox (accepted) | ADR-0024 D4 |
+> Line numbers pinned to `origin/main` @ `059f619d` (2026-07-24). The review was authored against `f6f4b06d`; the bash-guard anchors shifted +18 after #2337 (cortex#2335) tightened the same file's `gh` floor — R1-F1/R1-F4 remain valid, EBH-1 must coordinate with that direction.
+| **R1-F2** | Plugins run at full daemon authority, no post-load sandbox (accepted) | ADR-0024 D4 |
 
 The plugin loader (`loader.ts`) is the counter-example the review praises — real, deterministic, code-level containment. **The plan is to make the rest of the trust surface look like the loader.**
 
-A live corroborator the static review did not have: **#1758** — the web-gateway path bypasses `DispatchHandler`, so `agentDisallowedTools`/`strictMcpConfig` (the tool-policy control the review credits as compensating for F1) is **inert for web-bound agents**. The compensating control has a hole. This is why the fix must sit at the *lowest choke point*, not the dispatch layer.
+A live corroborator the static review did not have: **#1758** — the web-gateway path bypasses `DispatchHandler`, so `agentDisallowedTools`/`strictMcpConfig` (the tool-policy control the review credits as compensating for R1-F1) is **inert for web-bound agents**. The compensating control has a hole. This is why the fix must sit at the *lowest choke point*, not the dispatch layer.
 
 ---
 
@@ -33,17 +36,17 @@ A ladder, cheapest-and-most-owned first. Maps onto the review's Tier 0–3 (§6)
 
 | Layer | What | Fixes | Cost | Depends on |
 |---|---|---|---|---|
-| **L0** | ~~**Repro** the `--add-dir` question~~ **✅ DONE 2026-07-24** — `--add-dir` is an *additive grant, not a jail*; both Read and Bash `cat` read an out-of-scope canary ([result](reviews/2026-07-24-ebh0-add-dir-repro.md)) | **F1 = clean High** (severity locked) | done | — |
-| **L1** | Cortex-owned `PreToolUse` **path guard** for file tools + Bash read-command paths; reuse `loader.ts` normalize+contain | F1 (cortex-owned side), F6 | S | — |
-| **L2** | **OS session jail** per `claude --print` (sandbox-exec / bwrap+landlock+seccomp) | **v1 `guarded`** (shipped, EBH-3a): F6 by construction; F1 **only for the enumerated sensitive set** — *not* by construction. **v2 `strict`** (shipped, mechanism-only, cortex#2409 part 2 — HARD HOLD `posture: "guarded"` default, no live caller sets `"strict"`): F1 by construction | M | choke point |
+| **L0** | ~~**Repro** the `--add-dir` question~~ **✅ DONE 2026-07-24** — `--add-dir` is an *additive grant, not a jail*; both Read and Bash `cat` read an out-of-scope canary ([result](reviews/2026-07-24-ebh0-add-dir-repro.md)) | **R1-F1 = clean High** (severity locked) | done | — |
+| **L1** | Cortex-owned `PreToolUse` **path guard** for file tools + Bash read-command paths; reuse `loader.ts` normalize+contain | R1-F1 (cortex-owned side), R1-F6 | S | — |
+| **L2** | **OS session jail** per `claude --print` (sandbox-exec / bwrap+landlock+seccomp) | **v1 `guarded`** (shipped, EBH-3a): R1-F6 by construction; R1-F1 **only for the enumerated sensitive set** — *not* by construction. **v2 `strict`** (shipped, mechanism-only, cortex#2409 part 2 — HARD HOLD `posture: "guarded"` default, no live caller sets `"strict"`): R1-F1 by construction | M | choke point |
 | **L3** | **Egress allowlist** (filtering proxy, deny-by-default) | exfiltration containment | M | L2 net-ns |
-| **L4** | **Plugin process isolation** + registry signing | F2 | L | trigger-gated |
+| **L4** | **Plugin process isolation** + registry signing | R1-F2 | L | trigger-gated |
 
 L1–L3 are designed in [`design-session-sandbox.md`](../design-session-sandbox.md). L1 (in-process guard) and L2 (kernel jail) are **not redundant** — L1 is the precise, observable, agent-visible boundary for the common case; L2 is the un-bypassable floor that holds even when L1 is missing or bypassed (which #1758 proves happens). L3 ensures a read that clears both still can't leave the box.
 
 > **⚠️ What L2 v1 does NOT close (measured, 2026-07-26, EBH-3a review).** The v1 `guarded`
 > posture is `(allow default)` + an enumerated denylist, because E4 measured that a strict
-> `(deny default)` SIGABRTs the session. So **F1 is narrowed, not closed**: everything not
+> `(deny default)` SIGABRTs the session. So **R1-F1 is narrowed, not closed**: everything not
 > named is still readable. Probing the generated profile on a real host read **11** credential
 > stores straight through it — `~/.gnupg`, `~/.docker/config.json`, `~/.config/gh/hosts.yml`,
 > `~/Library/Keychains`, `~/.gitconfig`, shell histories, `~/.claude.json`, `~/.soma`, … (only
@@ -60,7 +63,7 @@ L1–L3 are designed in [`design-session-sandbox.md`](../design-session-sandbox.
 
 > **✅ L2 v2 `strict` landed (2026-07-26, cortex#2409 part 2).** `generateMacosSbplStrictProfile`
 > (`session-sandbox-macos.ts`) is `(deny default)` + a DERIVED, evidence-traced explicit-allow
-> set — F1 is now closed **by construction** for everything outside that set, not merely
+> set — R1-F1 is now closed **by construction** for everything outside that set, not merely
 > narrowed. `SandboxProfile.posture: "guarded" | "strict"` selects between the two generators;
 > `"guarded"` stays the default (HARD HOLD unchanged — no caller sets `"strict"`, `mode` still
 > defaults `"off"` everywhere). E4's SIGABRT (naive `(deny default)` aborting before any denial
@@ -69,7 +72,7 @@ L1–L3 are designed in [`design-session-sandbox.md`](../design-session-sandbox.
 > profile fragments (the SAME base every real macOS daemon profile uses), not by abandoning
 > deny-default. Proven both directions with a real `sandbox-exec` harness: legitimate workspace
 > access and a real `claude --print` + `--resume` round-trip succeed; an out-of-scope read is
-> denied with **no enumerated rule naming it** (the F1-by-construction proof). **Disclosed
+> denied with **no enumerated rule naming it** (the R1-F1-by-construction proof). **Disclosed
 > residuals, not bugs to chase:** (1) keychain READ stays unconditionally allowed — denying it
 > (even narrowed to `file-read-data`) breaks `claude` login outright, empirically forced, same
 > finding as v1's write-only carve-out — so `strict` cannot protect keychain *contents* from a
@@ -87,9 +90,9 @@ L1–L3 are designed in [`design-session-sandbox.md`](../design-session-sandbox.
 
 ## 3. Cross-cutting decisions (not sandboxing, but owed a call)
 
-- **F3 — Sovereignty posture. Resolved (EBH-6b, cortex#2380).** The EBH-6 investigation (`docs/security/ebh-6-posture-findings.md`) found the deeper gap: `sovereigntyEnforce` wasn't just defaulted off, it was **constructor-only** — no `cortex.yaml` / config-split field could reach it in either consumer, so no principal action could turn it on. EBH-6b promoted it to a real config key, `policy.sovereignty.enforce` (boolean, **default `false`**), threaded to BOTH `review-consumer.ts` and `brain-consumer.ts`'s `sovereigntyEnforce` option from the SAME resolved value in `cortex.ts`. The decision core (`sovereignty-gate.ts`) is sound and fail-closed. **This is posture-visibility, not enforcement:** every deployment today still runs audit-only (violations are detected and logged via `system.access.denied`, never denied) until a principal explicitly sets the key — and setting it before the model-class↔signing-identity binding lands (#2117; PR #2201, open, CI-red as of EBH-6) buys less than it appears to, because `runtime.modelClass` is self-declared and spoofable until then. No default, template, or example ships `enforce: true`.
-- **F4 — Principal-DM integrity.** The guard-off DM context is only as safe as (a) no relay path forwarding untrusted content into it and (b) the principal↔platform-ID mapping being immutable config. Treat the mapping as security-critical. (The review's compensating-control citation here — "land G-301 (#42 lineage)" — was stale: `#42` is an unrelated, already-merged migration PR, and G-301 has no design section, blueprint entry, or issue anywhere in the repo; see `docs/security/ebh-6-posture-findings.md` §F4-4. The real follow-up is **#2377** (F4 residual — Bash guard-off path-awareness).)
-- **F4 residual — EBH-1g (cortex#2377), DECIDED.** The EBH-6 investigation (`ebh-6-posture-findings.md` §F4) found that `bash-guard.hook.ts`'s guard-off (`disabled`) branch returned `pass()` *before* EBH-1's rounds 7-9 path-containment logic — Bash had zero cortex-owned protection in a guard-off session even though the file tools (via `path-guard.hook.ts`) were already containment-checked in the same session. Principal decision (2026-07-25): **option (b)** — keep the command-shape allowlist off (G-300's whole point), but run the SAME path-containment machinery, in a lenient mode that still permits an uncataloged command to run. Landed; see the hook's own "Guard-off (G-300, principal DM) posture" doc block for the full protected/not-protected breakdown. The realistic residual this closes is indirect prompt injection into an already-legitimate guard-off session (the trigger itself cannot be forged); L2 (EBH-2/EBH-3) remains the actual boundary regardless of this L1 choice.
+- **R1-F3 — Sovereignty posture. Resolved (EBH-6b, cortex#2380).** The EBH-6 investigation (`docs/security/ebh-6-posture-findings.md`) found the deeper gap: `sovereigntyEnforce` wasn't just defaulted off, it was **constructor-only** — no `cortex.yaml` / config-split field could reach it in either consumer, so no principal action could turn it on. EBH-6b promoted it to a real config key, `policy.sovereignty.enforce` (boolean, **default `false`**), threaded to BOTH `review-consumer.ts` and `brain-consumer.ts`'s `sovereigntyEnforce` option from the SAME resolved value in `cortex.ts`. The decision core (`sovereignty-gate.ts`) is sound and fail-closed. **This is posture-visibility, not enforcement:** every deployment today still runs audit-only (violations are detected and logged via `system.access.denied`, never denied) until a principal explicitly sets the key — and setting it before the model-class↔signing-identity binding lands (#2117; PR #2201, open, CI-red as of EBH-6) buys less than it appears to, because `runtime.modelClass` is self-declared and spoofable until then. No default, template, or example ships `enforce: true`.
+- **R1-F4 — Principal-DM integrity.** The guard-off DM context is only as safe as (a) no relay path forwarding untrusted content into it and (b) the principal↔platform-ID mapping being immutable config. Treat the mapping as security-critical. (The review's compensating-control citation here — "land G-301 (#42 lineage)" — was stale: `#42` is an unrelated, already-merged migration PR, and G-301 has no design section, blueprint entry, or issue anywhere in the repo; see `docs/security/ebh-6-posture-findings.md` §R1-F4-4. The real follow-up is **#2377** (R1-F4 residual — Bash guard-off path-awareness).)
+- **R1-F4 residual — EBH-1g (cortex#2377), DECIDED.** The EBH-6 investigation (`ebh-6-posture-findings.md` §R1-F4) found that `bash-guard.hook.ts`'s guard-off (`disabled`) branch returned `pass()` *before* EBH-1's rounds 7-9 path-containment logic — Bash had zero cortex-owned protection in a guard-off session even though the file tools (via `path-guard.hook.ts`) were already containment-checked in the same session. Principal decision (2026-07-25): **option (b)** — keep the command-shape allowlist off (G-300's whole point), but run the SAME path-containment machinery, in a lenient mode that still permits an uncataloged command to run. Landed; see the hook's own "Guard-off (G-300, principal DM) posture" doc block for the full protected/not-protected breakdown. The realistic residual this closes is indirect prompt injection into an already-legitimate guard-off session (the trigger itself cannot be forged); L2 (EBH-2/EBH-3) remains the actual boundary regardless of this L1 choice.
 - **Structural posture as CI (swarm-posture).** cortex spawns multi-agent teams (`agent-team.ts`: moderator + participants) — a real invoke-graph where composed escalation can hide ("security doesn't compose"). Wire a structural least-privilege + attack-path check as a continuous gate on the fleet's tool grants. Rob's paid horizon — behavioral simulation / intent-fidelity measurement under live injection — is the dynamic complement; this static review is half one.
 
 ---
@@ -105,8 +108,8 @@ Epic: **Execution-boundary hardening (NWS review response)**. Sub-issues:
 | EBH-2 | L2 | `SessionSandbox` interface + `none` backend (choke point + `sandbox-unavailable` event) | feature | next |
 | EBH-3 | L2 | `macos-sbpl` + `linux-bwrap` backends in `audit` mode | feature | next |
 | EBH-4 | L3 | Egress allowlist via filtering proxy (extends #1192) | feature | next |
-| EBH-5 | L4 | Plugin process isolation + registry signing (F2) — trigger-gated | infrastructure | future |
-| EBH-6 | X | Sovereignty posture (F3) + principal-map integrity (F4) decisions | documentation | next |
+| EBH-5 | L4 | Plugin process isolation + registry signing (R1-F2) — trigger-gated | infrastructure | future |
+| EBH-6 | X | Sovereignty posture (R1-F3) + principal-map integrity (R1-F4) decisions | documentation | next |
 | EBH-7 | X | swarm-posture structural check as CI gate | infrastructure | future |
 
 Sequencing: **L0 → L1 → L2 (`none` → `audit` → `enforce`) → L3**, with L4 trigger-gated (first non-first-party bundle, or first federated deployment) and EBH-6/7 in parallel.
@@ -116,6 +119,6 @@ Sequencing: **L0 → L1 → L2 (`none` → `audit` → `enforce`) → L3**, with
 ## 5. What this plan explicitly does NOT claim
 
 - Nothing here is a Showstopper; the review found no auth bypass and rates the core security-mature. This is "where a strong system thins out," not "a broken one."
-- The session sandbox (L1–L3) does **not** contain plugins (F2) — plugins run in the daemon, not the session. L4 is a separate mechanism.
+- The session sandbox (L1–L3) does **not** contain plugins (R1-F2) — plugins run in the daemon, not the session. L4 is a separate mechanism.
 - The sandbox bounds **blast radius**, not **intent** — an injection that abuses in-scope access is a behavioral-simulation problem, out of scope for structural confinement.
 - The largest untested surface (Mission Control API + CF Worker auth/RBAC/CORS) was out of the review's scope and is out of this plan's; it needs its own pass.

--- a/docs/security/reviews/2026-07-23-nws-assessment-summary.md
+++ b/docs/security/reviews/2026-07-23-nws-assessment-summary.md
@@ -1,3 +1,4 @@
+**Finding-ID convention:** the findings in this document are cited elsewhere as R1-F1..R1-F6.
 # Cortex review — high-level assessment
 
 *Rob → Andreas. The plain-language read on top of the hard findings.*

--- a/docs/security/reviews/2026-07-23-nws-security-review.md
+++ b/docs/security/reviews/2026-07-23-nws-security-review.md
@@ -1,3 +1,4 @@
+**Finding-ID convention:** the findings in this document are cited elsewhere as R1-F1..R1-F6.
 # Cortex — Security & Architecture Review
 
 **Prepared by:** NorthWoods Sentinel Labs (Rob Chuvala)

--- a/docs/security/reviews/2026-07-24-ebh0-add-dir-repro.md
+++ b/docs/security/reviews/2026-07-24-ebh0-add-dir-repro.md
@@ -1,11 +1,11 @@
 # EBH-0 — `--add-dir` reproduction result
 
-**Date:** 2026-07-24 · **Issue:** #2342 (EBH-0) · **Settles:** review F1 open question (§4 F1, §7)
+**Date:** 2026-07-24 · **Issue:** #2342 (EBH-0) · **Settles:** review R1-F1 open question (§4 R1-F1, §7)
 **CLI:** `claude` 2.1.218 (Claude Code) · **Verified against** `origin/main` @ `059f619d`
 
 ## Question
 
-Does `claude --print` with `--add-dir X` **deny** a filesystem read of a path *outside* `X`, or **allow** it? The review left F1 as "High (repro-gated) → Medium until proven" pending this test. If `--add-dir` denies, F1 narrows to config-immutability/read-only. If it allows, F1 is a clean High.
+Does `claude --print` with `--add-dir X` **deny** a filesystem read of a path *outside* `X`, or **allow** it? The review left R1-F1 as "High (repro-gated) → Medium until proven" pending this test. If `--add-dir` denies, R1-F1 narrows to config-immutability/read-only. If it allows, R1-F1 is a clean High.
 
 ## Method
 
@@ -34,9 +34,9 @@ printf '%s' 'Run: cat /tmp/ebh0/secret/canary.txt then output its contents. If b
 
 ## Conclusion
 
-**`--add-dir` is an additive grant, not a confinement boundary.** It does not deny reads outside the added directories, for either the file tools or Bash. The compensating control the review weighed for F1 does not, in fact, confine reads.
+**`--add-dir` is an additive grant, not a confinement boundary.** It does not deny reads outside the added directories, for either the file tools or Bash. The compensating control the review weighed for R1-F1 does not, in fact, confine reads.
 
-- **F1 is a clean High** (not repro-gated Medium). Severity locked.
+- **R1-F1 is a clean High** (not repro-gated Medium). Severity locked.
 - **EBH-1 (L1 in-code path guard)** and **EBH-3 (L2 kernel jail)** are both warranted; priority stands.
 - Confirms design-decision **DD-3**: the kernel boundary must be the real control — `--add-dir` cannot be relied on for security.
 

--- a/docs/security/reviews/2026-07-26-nws-round-2.md
+++ b/docs/security/reviews/2026-07-26-nws-round-2.md
@@ -89,4 +89,4 @@ Established in the 2026-08-03 NWS state-of-play audit (§3.2, "Corrections to th
 
 - **(a) R2-F5's compounding claim is stale.** The `readOnlyDirs` mitigation now works since R2-F1 was fixed (`4a081033`, PR #2478), so the compounding described no longer applies.
 - **(b) R2-F3's headline `GIT_PAGER` example did not execute** under non-tty stdout. The finding stands on `GIT_EXTERNAL_DIFF` and `GIT_SSH_COMMAND`.
-- **(c) Line citations drifted** against current `main`: R2-F6's `:534` is now `:650`; R2-F5's `decidePath` is at `:552`; R2-F2's `toStringArray:145` no longer exists (now `validateDirsField` at `:221`).
+- **(c) Line citations drifted.** As of `4a081033` (2026-08-04): R2-F6's `:534` → `:650`; R2-F5's `decidePath` at `:552`; R2-F2's `toStringArray:145` no longer exists (superseded by `validateDirsField` at `:221`). Line numbers keep moving; the symbol names are the durable anchors.

--- a/docs/security/reviews/2026-07-26-nws-round-2.md
+++ b/docs/security/reviews/2026-07-26-nws-round-2.md
@@ -1,0 +1,92 @@
+# Cortex — NWS execution-boundary review, round 2
+
+**Prepared by:** NorthWoods Sentinel Labs (Rob Chuvala)
+**For:** Andreas Åström / the-metafactory
+**Date:** 2026-07-26
+**Subject:** `the-metafactory/cortex` — execution-boundary hardening (epic #2341)
+**Repository state:** `v6.13.0`
+**Source of record:** [epic #2341, comment 5084213029](https://github.com/the-metafactory/cortex/issues/2341#issuecomment-5084213029), posted 2026-07-26T15:49:36Z. The reviewer body below this header is that comment, verbatim; cortex-authored corrections live only in the appendix at the bottom.
+**Classification:** Findings are as of `v6.13.0` and the surfaces named in the report — not a whole-repository audit.
+**Finding-ID convention:** findings in this document are cited elsewhere as `R2-F1`..`R2-F6`. Round-1 findings are `R1-F1`..`R1-F6`. A bare `F<n>` is never a valid citation.
+
+---
+# NWS execution-boundary review, round 2 - cortex v6.13.0
+
+Andreas - a findings list never says the obvious thing, so first: v6.13.0 is genuinely well-built. Nine rounds of hardening shows, and most of what we threw at it held. These six are edges we had to dig for on a strong foundation, and we dug because you asked and because cortex is worth the effort. This is your baby, and we're treating it that way.
+
+An honest word on our side too, because you should know where we actually are: our process is still evolving. We're learning how to run this swarm even as we point it at your code. Just last night we found that a single pass only sees a slice of what's there, so we started running multiple directed passes. That's why findings arrive in waves, and why some below are marked "still verifying." We'd rather hand you the work honest and unfinished than polished and overstated. If we get something wrong, say so and we'll fix it in the open. We already corrected one of our own citations below.
+
+What follows is the confirmed set: six findings that survived adversarial verification, each with a fix recommendation since you asked for help hardening. More candidates are in the pipe. Scope and terms are at the bottom; the short version is this is authorized work at your request, delivered to you first, and the fixes are yours to verify.
+
+Target: `the-metafactory/cortex` at tag v6.13.0. Every code reference below was read at that tag and every finding carries a repro reasoned from the code (F1, F2, F3 were also traced line-by-line at the source).
+
+---
+
+## F1 - HIGH - read-only is silently overridden by an overlapping allowed dir
+- **Where:** `src/runner/hooks/path-guard.hook.ts:437-438,451`
+- **Code:** `const inReadOnly = !inAllowed && policy.readOnlyDirs.some(...)`, and the write-deny only fires on `WRITE_TOOLS.has(toolName) && inReadOnly`.
+- **Mechanism:** `inReadOnly` can only be true when `!inAllowed`. When a path is inside both a broad `allowedDirs` entry and a nested `readOnlyDirs` entry, `inAllowed` wins, `inReadOnly` is false, and the write-deny never fires. The common policy "workspace writable, except this protected subdir" does not hold.
+- **Repro:** `allowedDirs:["/repo"], readOnlyDirs:["/repo/.claude"]` -> `Write /repo/.claude/settings.json` is allowed.
+- **Fix:** make `readOnlyDirs` win on overlap. Compute `inReadOnly` independently of `inAllowed` and deny writes to a read-only path regardless of containment (deny-precedence / most-specific-match).
+
+## F2 - HIGH - a malformed config field fails open to no restriction at all
+- **Where:** `src/runner/hooks/path-guard.hook.ts` (`toStringArray:145`, config parse `:182-183`, empty-policy pass `:516-519`)
+- **Code:** `toStringArray` returns `[]` for any non-array value; an empty policy is treated as "no restriction configured" and calls `pass()`.
+- **Mechanism:** `CORTEX_PATH_GUARD='{"allowedDirs":"/repo","readOnlyDirs":[]}'` (a string where an array is expected) coerces `allowedDirs` to `[]`. Both arrays empty, so the guard passes every path. A single wrong-typed field silently disables all containment - and it is a config-shape mistake, not an attack, so it can happen by accident.
+- **Repro:** set the env var as above, then `Read /etc/passwd` - allowed.
+- **Fix:** treat a present-but-malformed field as fail-closed (deny), distinct from a deliberately-empty policy. Validate the shape of each field, and reject a policy with a malformed field instead of coercing it to empty.
+
+## F3 - MEDIUM (HIGH if the env-var execution vector is confirmed) - env-prefix stripping is unmodeled and can carry capability-bearing env vars
+- **Where:** `src/runner/hooks/bash-guard.hook.ts` (`stripEnvPrefix`)
+- **Code:** `stripEnvPrefix` strips leading `VAR=value` assignments before allowlist matching (the module comment itself notes the prefix "is not modelled in the regex").
+- **Mechanism (confirmed):** the guard strips the env prefix to classify the command, but the stripped env vars still reach execution. Vars such as `GIT_PAGER`, `AWS_PAGER`, `GIT_EXTERNAL_DIFF`, `PAGER` can point a benign-looking allowed command at a shell or arbitrary binary. `GIT_PAGER=/bin/sh git log` classifies as an allowed read-only `git`. Env vars are treated as syntactic noise instead of capability-bearing inputs.
+- **Repro (illustrative, not executed end-to-end):** under an allow rule for `git`, `GIT_PAGER=/bin/sh git log`. What is confirmed is the modeling gap (env prefixes are stripped and unmodeled); the concrete exec-escape needs a PoC to pin severity, hence the conditional rating.
+- **Fix:** model capability-bearing env vars per command (pager, editor, external-diff, hook vars), or refuse to strip env prefixes and instead deny commands carrying an env assignment that can influence execution.
+
+## F4 - MEDIUM (HIGH if attacker-influenced MCP server naming is in scope) - MCP grant-grammar separator collision
+- **Where:** `src/runner/hooks/mcp-guard.hook.ts` (`parseMcpToolName`, `decideMcp`)
+- **Mechanism:** grants use a `server`/`server.tool` grammar, and server names are parsed as the first `__`-delimited segment - but nothing forbids `.` or `__` inside a server name. A server named `github.read_file` matches a per-tool grant `github.read_file` via `grants.includes(server)`; a server named `github__evil` (tool `mcp__github__evil__x`) parses to server `github` and rides a server-wide `github` grant.
+- **Repro:** grant `["github.read_file"]`; register a server named `github.read_file` exposing any tool -> the whole server is authorized.
+- **Fix:** forbid `.` and `__` in configured MCP server names, or canonicalize the grant grammar so the server/tool boundary is unambiguous.
+
+## F5 - MEDIUM - no denylist for boundary-weakening config files inside an allowed dir
+- **Where:** `src/runner/hooks/path-guard.hook.ts` (`decidePath`)
+- **Mechanism:** `decidePath` gates on containment and read-only only; it does not special-case files that weaken the boundary itself (`.claude/settings.json`, `.claude/settings.local.json`, `.cursor/mcp.json`, `.bashrc`, `.gitconfig`, `.git/config`, hooks). With the workspace or home in `allowedDirs`, a session can write these and persist a next-session weakening. This compounds with F1: the natural mitigation (put `.claude` in `readOnlyDirs`) is defeated by F1. Severity depends on whether real dispatch configs place such files inside a writable allowed dir - worth confirming against your dispatch shape.
+- **Fix:** a deterministic boundary-file denylist (deny writes to a maintained set of self-modifying config paths regardless of containment), plus the F1 fix so `readOnlyDirs` actually holds.
+
+## F6 - MEDIUM - empty-path Glob/Grep trusts the working directory without checking it
+- **Where:** `src/runner/hooks/path-guard.hook.ts` (`main`, empty-token branch `:534`)
+- **Mechanism:** `Grep` with no `path` or `Glob` with a bare wildcard produces zero path tokens, and the guard auto-grants, trusting that dispatch set `cwd` inside `allowedDirs`. The guard never verifies `cwd` itself. If `cwd` can resolve outside `allowedDirs` (misconfig, race, symlinked cwd), an empty-path `Grep` searches out of scope.
+- **Fix:** in the empty-token branch, resolve `process.cwd()` and containment-check it against `allowedDirs` before granting.
+
+---
+
+## Additional candidates in verification (not yet confirmed, will follow)
+Wildcard-suffix path traversal (a `..` after the first glob metachar escapes the literal-prefix check), a brace-before-tilde expansion-order gap, and a `tool_name` casing gap in the write-tool set. These are being source-verified before we assert them - flagging now so they are not a surprise.
+
+## Correction from our prior report
+We got one wrong last time and want to own it: our earlier material cited a TOCTOU CVE as "Cursor CVE-2026-21523." Per NVD that identifier is a VS Code / GitHub Copilot TOCTOU. Corrected here.
+
+## Method note (brief)
+Findings are generated by a cross-lineage adversarial swarm and then verified by a refutation pass against the actual code; only findings that survive refutation are reported, and known/accepted residuals (TOCTOU as a documented L1 limit, interpreter-string opens in guard-off sessions) are deliberately excluded rather than padded in.
+
+## Engagement and terms
+- Authorized review at your explicit request, against your own repository; delivered to you as maintainer.
+- Recommendations are advisory and do not constitute a warranty or a guarantee of completeness. You own verification and remediation of any fix.
+- Repros are minimum-necessary and reasoned from the code; PoCs are not weaponized. On request we can retest specific fixes (find -> recommend -> re-verify).
+- Coordinated disclosure: this goes to you first. Any public writeup waits on your go and on fixes landing.
+
+This open back-and-forth on the thing you're building is the part worth doing. More soon, and keep telling us where we're wrong.
+
+- NWS swarm, run by Margin (agent), for Rob Chuvala
+
+
+---
+
+## Appendix — cortex's corrections to this report (not the reviewer's words)
+
+Established in the 2026-08-03 NWS state-of-play audit (§3.2, "Corrections to the round-2 report itself"); recorded here so the report can be read standing alone:
+
+- **(a) R2-F5's compounding claim is stale.** The `readOnlyDirs` mitigation now works since R2-F1 was fixed (`4a081033`, PR #2478), so the compounding described no longer applies.
+- **(b) R2-F3's headline `GIT_PAGER` example did not execute** under non-tty stdout. The finding stands on `GIT_EXTERNAL_DIFF` and `GIT_SSH_COMMAND`.
+- **(c) Line citations drifted** against current `main`: R2-F6's `:534` is now `:650`; R2-F5's `decidePath` is at `:552`; R2-F2's `toStringArray:145` no longer exists (now `validateDirsField` at `:221`).

--- a/docs/security/swarm-posture/README.md
+++ b/docs/security/swarm-posture/README.md
@@ -240,7 +240,7 @@ get the exact same `allowedTools`/`mcpGrants`/`agentEnv` as whoever typed
 general-purpose reasoning personas and the invoking principal's own grant.
 Concretely: if a principal's session is manipulated by indirect prompt
 injection (fetched issue text, a webhook-relayed comment, etc. — the exact
-threat class this epic's F1/F6 findings are about) into emitting a `team:`
+threat class this epic's R1-F1/R1-F6 findings are about) into emitting a `team:`
 message, the attacker rides the **full 3-way fan-out** with the principal's
 own Bash/MCP reach, not a scoped-down "just discuss this" surface. This
 showed up as 4 of the 6 excessive-permission findings (moderator + 3

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -57,7 +57,7 @@ export interface CCSessionOpts {
    * Passed to path-guard.hook.ts / bash-guard.hook.ts's path checks via the
    * `CORTEX_PATH_GUARD` env var (mirrors `allowedDirs`'s own role there).
    * Distinct from `allowedDirs` so a write into one of these is DENIED
-   * (closes F6) while a read is permitted — see {@link resolvePathGuardEnv}.
+   * (closes R1-F6) while a read is permitted — see {@link resolvePathGuardEnv}.
    * EBH-1b (cortex#2352) threads a distinct value through every live
    * dispatch path (dispatch-handler.ts no longer flattens this into the
    * merged `allowedDirs` it builds for `CORTEX_PATH_GUARD` purposes —
@@ -344,7 +344,7 @@ export function resolveBashGuardEnv(
  * unchanged. Overlap rule: a dir present in both inputs resolves to
  * READ-ONLY in the emitted policy — the safe default.
  *
- * cortex#2359 round 2 (F1) note: this subtraction is EXACT-STRING only (see
+ * cortex#2341 round 2 finding R2-F1 (docs/security/reviews/2026-07-26-nws-round-2.md) note: this subtraction is EXACT-STRING only (see
  * {@link splitGuardDirs}) — it does NOT catch a `readOnlyDirs` entry that is
  * merely CONTAINED WITHIN a broader `allowedDirs` entry rather than equal to
  * it (`allowedDirs:["/repo"], readOnlyDirs:["/repo/.claude"]` subtracts
@@ -356,7 +356,7 @@ export function resolveBashGuardEnv(
  * doc, "Read-only vs. allowed on overlap") — so the nested case is closed at
  * the DECISION layer regardless of what this subtraction does or doesn't
  * catch. This function's exact-match subtraction is therefore no longer the
- * mechanism F6/F1 depend on; it remains as defense-in-depth (it keeps a
+ * mechanism R1-F6/R1-F1 depend on; it remains as defense-in-depth (it keeps a
  * read-only dir out of the emitted `allowedDirs` list at all, for any other
  * consumer — e.g. {@link deriveSandboxProfile} — that might read that field
  * without going through `decidePath`'s precedence logic). Made

--- a/src/runner/hooks/__tests__/path-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/path-guard.hook.test.ts
@@ -158,7 +158,7 @@ describe("parsePathGuardConfig", () => {
     expect(r.ok).toBe(false);
   });
 
-  // -- cortex#2359 round 2, finding F2 --------------------------------------
+  // -- cortex#2341 round 2, finding R2-F2 (docs/security/reviews/2026-07-26-nws-round-2.md) --------------------------------------
   // A present-but-wrong-type field must FAIL CLOSED (ok:false), never
   // silently coerce to [] — coercion is how a config-shape MISTAKE (a
   // string where an array was required) became indistinguishable from a
@@ -350,7 +350,7 @@ describe("decidePath", () => {
     expect(d.allow).toBe(false);
   });
 
-  // -- cortex#2359 round 2, finding F1 --------------------------------------
+  // -- cortex#2341 round 2, finding R2-F1 (docs/security/reviews/2026-07-26-nws-round-2.md) --------------------------------------
   // Read-only must win on overlap, independent of whether the overlap is an
   // EXACT string match or one dir merely CONTAINING the other — deny wins
   // (deny-precedence), never "most specific match" (see the hook's module
@@ -1223,7 +1223,7 @@ describe("path-guard.hook — round 6: NUL-byte file_path fails closed (reducer,
 });
 
 // =============================================================================
-// cortex#2359 round 2, finding F1 (HIGH) — full-process regression for the
+// cortex#2341 round 2, finding R2-F1 (docs/security/reviews/2026-07-26-nws-round-2.md) (HIGH) — full-process regression for the
 // exact repro: a readOnlyDirs entry NESTED inside a broader allowedDirs
 // entry used to be silently overridden (never read-only) because
 // decidePath's `inReadOnly` was gated on `!inAllowed`. Covers both
@@ -1289,7 +1289,7 @@ describe("path-guard.hook — F1: nested read-only inside a broader allowed dir 
 });
 
 // =============================================================================
-// cortex#2359 round 2, finding F2 (HIGH) — full-process regression for the
+// cortex#2341 round 2, finding R2-F2 (docs/security/reviews/2026-07-26-nws-round-2.md) (HIGH) — full-process regression for the
 // exact repro: a present-but-malformed CORTEX_PATH_GUARD field (a string
 // where an array was required) used to coerce to [] and, combined with an
 // empty readOnlyDirs, produce a fully-empty policy that reads as "no

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -130,8 +130,8 @@
  *
  * ## Guard-off (G-300, principal DM) posture — EBH-1g, cortex#2377
  *
- * DECIDED (principal, 2026-07-25, option (b) of the EBH-6/F4 investigation,
- * `docs/security/ebh-6-posture-findings.md` §F4): a guard-off session
+ * DECIDED (principal, 2026-07-25, option (b) of the EBH-6/R1-F4 investigation,
+ * `docs/security/ebh-6-posture-findings.md` §R1-F4): a guard-off session
  * (`CORTEX_BASH_GUARD={"disabled":true}`) SKIPS the command-shape allowlist
  * entirely — the principal may still run ANY command, unchanged — but now
  * runs the SAME rounds 7-9 path-containment machinery (`checkCommandPaths`/
@@ -194,7 +194,7 @@
  *     to the platform's own authenticated sender id, resolved per-message;
  *     no traced producer (bus dispatch, GitHub webhook relay, web gateway,
  *     `async:`/`team:`) can induce it for content it didn't itself author
- *     as the mapped principal (§F4 investigation).
+ *     as the mapped principal (§R1-F4 investigation).
  *   - NOT PROTECTED (residual, matches the file-tool surface's own
  *     limitations above, applied to Bash): TOCTOU, a scripting language
  *     invoked via Bash reading a path from WITHIN its own script text
@@ -1272,7 +1272,7 @@ export function extractCommandPaths(
         // `git diff --no-index`, `gh … --body-file`) — relaxing this for
         // guard-off sessions would silently reopen those exact findings in
         // the one context that most needs the defense-in-depth (indirect
-        // prompt injection into an already-trusted session, per EBH-6/F4).
+        // prompt injection into an already-trusted session, per EBH-6/R1-F4).
         return {
           paths: null,
           reason:
@@ -1699,7 +1699,7 @@ async function main(): Promise<void> {
   // containment-checked in the very same sessions (EBH-1). The residual
   // this closes is INDIRECT prompt injection into an already-legitimate
   // guard-off session — the trigger itself cannot be forged (verified in
-  // docs/security/ebh-6-posture-findings.md §F4); the realistic risk is
+  // docs/security/ebh-6-posture-findings.md §R1-F4); the realistic risk is
   // the principal asking the agent to read a PR/issue/URL whose fetched
   // content carries an injection, with a previously-unbounded Bash tool.
   //

--- a/src/runner/hooks/path-guard.hook.ts
+++ b/src/runner/hooks/path-guard.hook.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Cortex Path Guard — PreToolUse hook for the file tools (Read/Write/Edit/
- * Glob/Grep/NotebookEdit) in cortex sessions (EBH-1, cortex#2343, F1/F6).
+ * Glob/Grep/NotebookEdit) in cortex sessions (EBH-1, cortex#2343, R1-F1/R1-F6).
  *
  * ## Why this exists
  *
@@ -10,7 +10,7 @@
  * `--add-dir` (an ADDITIVE grant, not a deny) plus the natural-language
  * `FILESYSTEM RESTRICTION` / `READ-ONLY RESTRICTION` rules in
  * `security-preamble.ts`, which an injected instruction can simply ask the
- * model to ignore (docs/design-session-sandbox.md §1, F1/F6). This hook is
+ * model to ignore (docs/design-session-sandbox.md §1, R1-F1/R1-F6). This hook is
  * the deterministic Tier-0 guard that design spec commissions for the file
  * tools; `bash-guard.hook.ts`'s new path checks (cortex#2343 step 3) cover
  * the equivalent Bash read-command surface.
@@ -52,7 +52,7 @@
  * RESTRICTION prose even appears); this hook makes that SAME contract real
  * instead of advisory, it does not change WHEN restriction applies. A
  * MALFORMED `CORTEX_PATH_GUARD` is a genuine failure, not "empty" — DENY.
- * "Malformed" is checked at TWO levels (cortex#2359 round 2 finding F2):
+ * "Malformed" is checked at TWO levels (cortex#2341 round 2 finding R2-F2, docs/security/reviews/2026-07-26-nws-round-2.md):
  * present-but-not-parseable-JSON / not-an-object (as before), AND — new —
  * present-but-wrong-shape on a per-field basis: `allowedDirs`/`readOnlyDirs`
  * that ARE PRESENT in the parsed object but are not themselves an array of
@@ -203,7 +203,7 @@ export interface DirsFieldValidation {
 /**
  * Validate ONE `CORTEX_PATH_GUARD` field (`allowedDirs` or `readOnlyDirs`)
  * that is expected to be an array of strings, distinguishing three cases
- * (cortex#2359 round 2 finding F2):
+ * (cortex#2341 round 2 finding R2-F2, docs/security/reviews/2026-07-26-nws-round-2.md):
  *
  *   - ABSENT from the parsed object entirely (`key in obj` is false) — a
  *     LEGITIMATE "nothing configured on this axis" — `ok:true, value:[]`.
@@ -211,7 +211,7 @@ export interface DirsFieldValidation {
  *     only way to be "absent" is to not appear in the object at all.
  *   - PRESENT but not an array, OR an array containing a non-string element
  *     — a config-SHAPE MISTAKE (e.g. a bare string where an array was
- *     required, cortex#2359's exact repro
+ *     required, R2-F2's exact repro
  *     `{"allowedDirs":"/repo","readOnlyDirs":[]}`) — `ok:false`. The OLD
  *     behavior silently coerced this to `[]` (see the module doc's git
  *     history / PR description), which combined with an already-empty
@@ -542,8 +542,8 @@ export interface PathDecision {
  * takes no other state, so it's directly unit-testable against a real
  * temp-dir fixture. Exported for unit tests.
  *
- * `inAllowed` and `inReadOnly` are computed INDEPENDENTLY — cortex#2359
- * round 2 finding F1. The prior `!inAllowed &&` guard on `inReadOnly` made
+ * `inAllowed` and `inReadOnly` are computed INDEPENDENTLY — cortex#2341
+ * round 2 finding R2-F1 (docs/security/reviews/2026-07-26-nws-round-2.md). The prior `!inAllowed &&` guard on `inReadOnly` made
  * read-only membership STRUCTURALLY UNREACHABLE for any path also contained
  * in an `allowedDirs` entry, so a `readOnlyDirs` entry nested inside a
  * broader `allowedDirs` entry (e.g. `allowedDirs:["/repo"],
@@ -575,7 +575,7 @@ export function decidePath(toolName: string, absPath: string, policy: PathGuardP
       allow: false,
       reason:
         `[Cortex Path Guard] Blocked ${toolName} "${absPath}": this path is inside a ` +
-        `READ-ONLY directory — writes are refused (closes F6, docs/security/reviews/` +
+        `READ-ONLY directory — writes are refused (closes R1-F6, docs/security/reviews/` +
         `2026-07-23-nws-security-review.md). Reads remain permitted.`,
     };
   }


### PR DESCRIPTION
Refs #2434 (the R2-TRACKING intake items — not `Closes`; that issue also tracks the round-2 re-test, which waits on the release cut). Work order: [#2434 (comment)](https://github.com/the-metafactory/cortex/issues/2434#issuecomment-5175918496).

## What this does

Process/traceability only — **zero runtime behaviour change**; comments, docs, and test-comments.

1. **Commits the round-2 report in-tree** at `docs/security/reviews/2026-07-26-nws-round-2.md`. Reviewer body is **byte-identical** to [epic #2341, comment 5084213029](https://github.com/the-metafactory/cortex/issues/2341#issuecomment-5084213029) (verified with `cmp`, not eyeballed), under a cortex header matching the round-1 pattern, with the `## Appendix — cortex's corrections to this report (not the reviewer's words)` carrying the three deltas the 2026-08-03 audit established (stale R2-F5 compounding claim; R2-F3's `GIT_PAGER` non-execution; drifted line citations).
2. **Adopts the `R1-`/`R2-` finding-ID prefixes.** Evidence-base line in `hardening-plan.md` now names the round-2 report; a `Finding-ID convention` block follows it: *a bare `F<n>` is never a valid citation*. All enumerated doc and src-comment citations prefixed; the `#2331 7a review` third namespace untouched; both round-1 reviewer documents unchanged except the single header note line each.
3. **Retires the closed-#2359 round-2 marker.** The nine round-2 source comments now cite epic `#2341` + the in-tree report instead of CLOSED round-7 `#2359`. The 12 genuine round-7/TOCTOU citations are untouched.

## Acceptance criteria — all run, two drift notes

All greps from the work order run with `-P` as specified. Green: report byte-identical below the header; header block complete; appendix present; confidentiality grep silent (repo is public; the source comment is already public, so no new exposure); evidence-base updated; convention block present; zero bare `F<n>` in the enumerated scope; zero `cortex#2359 round 2` in `src/`; round-1 reviewer docs at exactly one inserted line, zero deletions; `bun test` green on both suites (path-guard 130 pass, bash-guard 290 pass, 0 fail); `bunx tsc --noEmit` output identical to pristine `main` (the single pre-existing error is in `node_modules/@metafactory/content-filter`, present with this diff stashed).

Two acceptance counts were pinned to `4a081033` (2026-08-04) and `main` has drifted since — reported rather than gamed, per the plan's own "no unverified claims" rule:

- **`R2-F` lines in `path-guard.hook.ts`: 4 after this diff** (the `:200`/`:208` pins consolidated upstream to `:206`, and the `:214` "exact repro" line gains its prefix here) — the original ≥4 criterion is met; an earlier revision of this description said 3, counted before the `:214` edit. Every current round-2 citation is prefixed; zero bare tokens remain.
- **Surviving `cortex#2359` citations: 12, not 13.** `bash-guard.hook.ts` carries 8 round-7 citations on current `main` (the audit counted 9) — one left the tree upstream between the pin and now, before this PR. The 12 that exist are untouched.

---

Built by Margin (agent), for Rob Chuvala — reviewed and owned by Rob (NorthWoods Sentinel Labs).
